### PR TITLE
Push NDL HDR info eagerly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   cross-build:
     runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
-/target
-/dist/
+target
+dist/
 
 # webOS cross-toolchain (webosbrew/native-toolchain release tarball, ~140MB) —
 # fetched by `task toolchain`, not committed.
-/.toolchains/
+.toolchains/
 
 # Local machine-specific defaults for Task (e.g. TV_HOST for `task deploy`) —
 # see .env.example.
-/.env
+.env

--- a/src/session.rs
+++ b/src/session.rs
@@ -119,13 +119,24 @@ pub fn connect(
         resolved_mode.width, resolved_mode.height
     )?;
 
-    // transfer=16 is SMPTE ST.2084 (PQ) — the host only resolves this when it
-    // actually negotiated an HDR encode (our video_caps request above). Metadata
-    // isn't fetched here as a one-shot: the host can emit updated mastering info
-    // over the life of the session (e.g. different content), so `video_pump` polls
-    // continuously below instead — see the embedding guide's §9 ("apply the
-    // latest to your display").
-    let is_hdr = client.color.transfer == 16;
+    // `color.is_hdr()` (PQ or HLG transfer) only resolves true when the host actually
+    // negotiated an HDR encode (our video_caps request above).
+    let is_hdr = client.color.is_hdr();
+
+    // NDL never picks up the TV's HDR picture mode from the bitstream itself — only
+    // an explicit `NDL_DirectVideoSetHDRInfo` call flips it, and it needs to land
+    // before/at the first frames NDL renders, not whenever the host's per-content
+    // HdrMeta datagram (best-effort, "one near session start") happens to arrive.
+    // Waiting on that alone left the TV in SDR picture mode indefinitely whenever
+    // that one datagram was lost. So set a reasonable default immediately here —
+    // same mastering values already advertised in `Hello::display_hdr` — and let
+    // `video_pump`'s continuous poll below refine it once/if the host's real
+    // per-content metadata shows up.
+    if is_hdr {
+        if let Err(e) = ndl.set_hdr_info(&cx_display_hdr(), client.color) {
+            writeln!(log, "NDL set_hdr_info (initial) failed: {e:#}")?;
+        }
+    }
 
     let stop = Arc::new(AtomicBool::new(false));
     let video_client = client.clone();

--- a/taskfiles/toolchain.yml
+++ b/taskfiles/toolchain.yml
@@ -197,18 +197,28 @@ tasks:
         cp packaging/appinfo.json packaging/icon.png packaging/icon_large.png packaging/splash.png "$STAGE_DIR/"
 
         # The checked-in appinfo.json version stays a fixed 0.0.1 always — webOS
-        # itself never sees a "real" version, only the Homebrew Channel manifest
-        # below does (its `version` is the only place the release tag lands).
-        # The .ipk filename is instead always traceable to an exact build via the
-        # HEAD commit's short sha (`{{.GIT_SHA}}`), release or not.
+        # itself never sees a "real" version. ares-package names the .ipk after
+        # that fixed version, so it's rewritten here: on a release build the
+        # release tag replaces "0.0.1" outright (the asset name webosbrew's
+        # Homebrew Channel and the manifest below expect is just
+        # "<id>_<version>_arm.ipk" — no git-sha suffix); otherwise the HEAD
+        # commit's short sha (`{{.GIT_SHA}}`) is appended so dev builds stay
+        # traceable to an exact commit.
         mkdir -p dist
         ares-package "$STAGE_DIR" -o dist --force-arch arm
 
+        {{if .RELEASE_TAG}}
+        for f in dist/*_0.0.1_arm.ipk; do
+          [ -e "$f" ] || continue
+          mv "$f" "${f%_0.0.1_arm.ipk}_{{.RELEASE_TAG}}_arm.ipk"
+        done
+        {{else}}
         for f in dist/*_arm.ipk; do
           [ -e "$f" ] || continue
           case "$f" in *"+git.{{.GIT_SHA}}"*) continue ;; esac
           mv "$f" "${f%_arm.ipk}+git.{{.GIT_SHA}}_arm.ipk"
         done
+        {{end}}
 
         {{if .RELEASE_TAG}}
         # Homebrew Channel manifest (see README's "Installing via Homebrew Channel"


### PR DESCRIPTION
## Summary
- `NDL_DirectVideoSetHDRInfo` is the only call that flips the TV's HDR picture
  mode, but it was only ever invoked reactively once the host's best-effort
  `HdrMeta` datagram arrived. Under punktfunk's infinite-GOP stream (no
  periodic keyframes to retry on), losing that one datagram left the TV in
  SDR indefinitely. Now pushed eagerly with a sane default as soon as
  `is_hdr` is known, still refined later by the same reactive poll.
- Switched the HDR check to `color.is_hdr()` (covers HLG, not just PQ).
- Release `.ipk`s are now named `<id>_<tag>_arm.ipk` (matching the Homebrew
  manifest's `ipkUrl`) instead of carrying the fixed `0.0.1` baseline version.
- CI: `contents: write` permission for the release-attach step;
  `.gitignore` patterns now match at any depth.

Note: root-caused a related but separate host-side issue in the same
investigation — HDR is also gated behind the host's `PUNKTFUNK_10BIT` env
var (`punktfunk-host`'s `punktfunk1.rs`/`config.rs`), independent of this
client-side fix.
