### PR TITLE
Fix perpetual update nag; version dev builds off latest release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
+          # Full history + tags: dev builds version themselves off the latest
+          # release tag (task native:package's LATEST_TAG, via `git describe`).
+          fetch-depth: 0
 
       - name: Install Rust (stable, prebuilt) + cross target
         uses: dtolnay/rust-toolchain@stable

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,19 +1,8 @@
-# The front door for building/packaging pf-webos. Local development always goes
-# through Docker (`build`/`check`/`package` below) — the webOS cross-toolchain
-# only ships a Linux aarch64 build (see `taskfiles/toolchain.yml`), so a Linux
-# aarch64 container is the one supported environment for humans, regardless of
-# host OS/arch. The `native:*` tasks are the real, un-containerized logic; they
-# exist for CI (`.github/workflows/build.yml`), whose runner already *is* Linux
-# aarch64 — no point nesting another container inside GitHub Actions' own.
-#
-# The webOS-specific plumbing (fetching the cross-toolchain, staging + invoking
-# ares-package, the Docker wrapper) lives in `taskfiles/toolchain.yml`, kept
-# separate so this file stays short — run `task --list-all` to see everything,
-# including that file's tasks under the `toolchain:` namespace.
-#
-# The only shell scripts left outside Task entirely are `scripts/cc-shim.sh`/
-# `cxx-shim.sh` — Cargo's `linker`/`CC`/`CXX` config needs an actual executable
-# path it invokes directly with a full compiler argv, not a task name.
+# `build`/`check`/`package` (local dev) always run inside Docker, since the
+# webOS cross-toolchain only ships a Linux aarch64 build. `native:*` is the
+# same logic without Docker, used by CI (already a Linux aarch64 runner).
+# webOS-specific plumbing lives in `taskfiles/toolchain.yml`, kept separate so
+# this file stays short.
 version: '3'
 
 # TV_HOST (used by deploy/deploy:log below) can live in a local, gitignored .env

--- a/taskfiles/toolchain.yml
+++ b/taskfiles/toolchain.yml
@@ -1,33 +1,29 @@
-# The webOS-specific "help utils" — fetching the cross-toolchain, staging/packaging
-# the .ipk, and the Docker plumbing. Kept out of the root Taskfile.yml so that one
-# stays short and readable; these are the building blocks it delegates to (via
-# `deps: [toolchain:all]` etc.) rather than something you usually invoke directly,
-# except `ares-package`/`fetch-device-libs`, which are useful standalone.
-#
-# Shared vars (NDK_DIR, SYSROOT, TARGET, RUST_IMAGE) are passed in explicitly from
-# the root Taskfile's `includes:` block — Task doesn't share `vars:` between a
-# parent and an included Taskfile by default.
+# webOS-specific plumbing: cross-toolchain fetch, staging/packaging the .ipk, and
+# the Docker wrapper. Kept out of the root Taskfile.yml so that one stays short.
+# Vars are passed in explicitly from the root Taskfile's `includes:` block — Task
+# doesn't share `vars:` between a parent and an included Taskfile by default.
 version: '3'
 
 vars:
   SDL2_BACKPORT_RELEASE: release-2.30.12-webos.5
   SDL2_BACKPORT_VERSION: 2.30.12
   SDL2_BACKPORT_SONAME: libSDL2-2.0.so.0.3000.12
-  # Resolved once per invocation and referenced by `{{.GIT_SHA}}`/`{{.RELEASE_TAG}}`
-  # in stage-and-package below, instead of re-deriving them inline in that task's
-  # shell every time — the one place that knows "is this a tagged release build".
-  # GITHUB_REF_TYPE/GITHUB_REF_NAME are set automatically by GitHub Actions on
-  # every job, tag or not; empty RELEASE_TAG just means "not a release build".
   GIT_SHA:
     sh: git rev-parse --short=8 HEAD 2>/dev/null || echo unknown
+  # Non-empty only on a tagged release build (GITHUB_REF_TYPE/GITHUB_REF_NAME are
+  # set by GitHub Actions on every job).
   RELEASE_TAG:
     sh: |
       if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
         echo "${GITHUB_REF_NAME#v}"
       fi
-  # Shared by docker-run/docker-shell below — caches live in named volumes, never
-  # `/usr/local/cargo`/`/usr/local/rustup` themselves (a volume mount over either
-  # would blow away the base image's own Rust install).
+  # Most recent published release, for dev builds to version themselves off of
+  # (see stage-and-package below). Needs the repo's tags fetched — CI's checkout
+  # step uses fetch-depth: 0 for this.
+  LATEST_TAG:
+    sh: git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 0.0.1
+  # Named volumes, never `/usr/local/cargo`/`/usr/local/rustup` themselves — a
+  # mount over either would blow away the base image's own Rust install.
   DOCKER_MOUNTS: >-
     -v {{.ROOT_DIR}}:/workspace
     -v pf-webos-toolchains:/workspace/.toolchains
@@ -49,14 +45,10 @@ tasks:
     cmds:
       - |
         set -eu
-        # webosbrew/native-toolchain's releases only ever publish a Linux
-        # aarch64 build for Linux (confirmed via its GitHub releases API, every
-        # release back to 2023 — there has never been a linux-x86_64 build).
-        # This task only ever runs inside the Linux/arm64 Docker build
-        # container (see docker-run below, always forced to --platform
-        # linux/arm64) or on an aarch64 CI runner, so that's the only case
-        # handled — no macOS/darwin branch needed since local dev never runs
-        # this natively on the host anymore.
+        # Only a Linux aarch64 build exists (confirmed via the GitHub releases
+        # API back to 2023 — no linux-x86_64 ever shipped). This always runs
+        # inside the Docker container (forced to --platform linux/arm64) or on
+        # an aarch64 CI runner, so that's the only case handled.
         case "$(uname -s)-$(uname -m)" in
             Linux-aarch64|Linux-arm64) PLATFORM=linux-aarch64 ;;
             *)
@@ -73,9 +65,8 @@ tasks:
         curl -sL -o "$TMP/$ASSET" "$URL"
         tar xjf "$TMP/$ASSET" -C "$(dirname {{.NDK_DIR}})"
         sh {{.NDK_DIR}}/relocate-sdk.sh
-        # This toolchain build's baked-in default --sysroot points at a build-time
-        # path segment that doesn't exist post-relocate — cc-shim.sh/cxx-shim.sh
-        # pass --sysroot explicitly, so this is just a sanity check it can link at all.
+        # Baked-in default --sysroot is stale post-relocate (cc-shim.sh/
+        # cxx-shim.sh pass it explicitly) — this is just a link sanity check.
         echo 'int main(void) { return 0; }' | {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-gcc \
             --sysroot={{.SYSROOT}} -x c -o "$TMP/probe" -
         echo "webOS NDK ready at {{.NDK_DIR}}"
@@ -88,13 +79,10 @@ tasks:
     cmds:
       - |
         set -eu
-        # The NDK's own bundled SDL2 is a generic buildroot package — it lacks
-        # webOS's custom Wayland shell-integration protocol
-        # (QT_WAYLAND_SHELL_INTEGRATION=webos), so its Wayland driver can't get a
-        # surface from the TV's compositor even with every env var webOS sets
-        # correctly (confirmed live on an LG CX). Every other native webOS SDL2
-        # app (aurora-tv/moonlight-tv, RetroArch-webOS) bundles this exact fork
-        # for the same reason.
+        # The NDK's own bundled SDL2 lacks webOS's Wayland shell-integration
+        # protocol, so its driver can't get a surface from the TV's compositor
+        # (confirmed live on an LG CX) — every other native webOS SDL2 app
+        # bundles this same fork for the same reason.
         TMP="$(mktemp -d)"
         trap 'rm -rf "$TMP"' EXIT
         ASSET="SDL2-{{.SDL2_BACKPORT_VERSION}}-webos.tar.gz"
@@ -148,8 +136,6 @@ tasks:
     requires:
       vars: [TV_HOST]
     vars:
-      # The .ipk filename varies with the version scheme above (git-sha or release
-      # tag), so it's resolved once here rather than guessed/hardcoded.
       IPK_PATH:
         sh: ls -t dist/*.ipk | head -1
       IPK_NAME:
@@ -157,13 +143,10 @@ tasks:
     cmds:
       - echo "installing {{.IPK_NAME}} on {{.TV_HOST}}"
       - scp {{.IPK_PATH}} {{.TV_HOST}}:/tmp/
-      # -tt: luna-send needs a real PTY to print anything over a non-interactive
-      # SSH exec (see docs/NOTES.md) — without it this silently returns nothing
-      # even on success, easy to mistake for a hang. `-n 1` only waits for the
-      # *first* subscribed event (an ack that the install started, not that it
-      # finished) — installing is asynchronous, so launching immediately after
-      # can race it and get back "app is locked". The sleep below is the same
-      # margin the manually-verified deploy recipe in docs/NOTES.md used.
+      # -tt: luna-send needs a real PTY over non-interactive SSH or it silently
+      # swallows output (see docs/NOTES.md). install is async — `-n 1` only
+      # acks that it started, so launching too soon races it into "app is
+      # locked"; the sleep is the same margin the hand-verified recipe used.
       - >-
         ssh -tt {{.TV_HOST}}
         "luna-send -i -n 1 -f luna://com.webos.appInstallService/dev/install
@@ -188,31 +171,33 @@ tasks:
         mkdir -p "$STAGE_DIR/bin" "$STAGE_DIR/lib"
         cp target/{{.TARGET}}/release/punktfunk-webos "$STAGE_DIR/bin/"
         {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-strip "$STAGE_DIR/bin/punktfunk-webos"
-        # The CX's on-device libSDL2 is 2.0.10 — missing ABI symbols this binary
-        # needs. Bundle the exact .so the binary linked against (from the NDK
-        # sysroot, resolved to its real file behind the dev symlinks) under the
-        # SONAME the dynamic linker looks for, loaded via the $ORIGIN/../lib
-        # rpath build.rs sets.
+        # On-device libSDL2 (2.0.10) is missing ABI symbols this binary needs —
+        # bundle the exact .so it linked against under the SONAME the dynamic
+        # linker looks for, loaded via the $ORIGIN/../lib rpath build.rs sets.
         cp -L {{.SYSROOT}}/usr/lib/libSDL2-2.0.so.0 "$STAGE_DIR/lib/libSDL2-2.0.so.0"
         {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-strip "$STAGE_DIR/lib/libSDL2-2.0.so.0"
         cp packaging/appinfo.json packaging/icon.png packaging/icon_large.png packaging/splash.png "$STAGE_DIR/"
 
-        # The checked-in appinfo.json version stays a fixed 0.0.1 always — webOS
-        # itself never sees a "real" version. ares-package names the .ipk after
-        # that fixed version, so it's rewritten here: on a release build the
-        # release tag replaces "0.0.1" outright (the asset name webosbrew's
-        # Homebrew Channel and the manifest below expect is just
-        # "<id>_<version>_arm.ipk" — no git-sha suffix); otherwise the HEAD
-        # commit's short sha (`{{.GIT_SHA}}`) is appended so dev builds stay
-        # traceable to an exact commit.
+        # webOS/Homebrew Channel reads the *installed* app's own appinfo.json
+        # version (not just the manifest below) to decide if an update is
+        # available — so it must be patched to a real version before
+        # packaging, not left at the checked-in 0.0.1, or every install looks
+        # perpetually outdated. Release builds get the release tag; dev builds
+        # get the latest published release instead, with the HEAD commit's
+        # short sha (`{{.GIT_SHA}}`) appended to the *filename* for traceability
+        # (the version field itself must stay a plain x.x.x).
+        {{if .RELEASE_TAG}}
+        sed -i.bak 's/"version": "0.0.1"/"version": "{{.RELEASE_TAG}}"/' "$STAGE_DIR/appinfo.json"
+        {{else}}
+        sed -i.bak 's/"version": "0.0.1"/"version": "{{.LATEST_TAG}}"/' "$STAGE_DIR/appinfo.json"
+        {{end}}
+        rm -f "$STAGE_DIR/appinfo.json.bak"
         mkdir -p dist
         ares-package "$STAGE_DIR" -o dist --force-arch arm
 
         {{if .RELEASE_TAG}}
-        for f in dist/*_0.0.1_arm.ipk; do
-          [ -e "$f" ] || continue
-          mv "$f" "${f%_0.0.1_arm.ipk}_{{.RELEASE_TAG}}_arm.ipk"
-        done
+        # Nothing to rename — ares-package already names the .ipk after the
+        # patched appinfo.json version above.
         {{else}}
         for f in dist/*_arm.ipk; do
           [ -e "$f" ] || continue
@@ -222,15 +207,10 @@ tasks:
         {{end}}
 
         {{if .RELEASE_TAG}}
-        # Homebrew Channel manifest (see README's "Installing via Homebrew Channel"
-        # section and repo.json at the repo root) — the released .ipk needs a
-        # sibling manifest.json describing it (schema:
-        # webosbrew/docs/schemas/HomebrewPackageManifest.schema.json) so repo.json's
-        # `manifestUrl` (pinned to .../releases/latest/download/...) resolves to
-        # something. GITHUB_REPOSITORY/GITHUB_REF_NAME are only set inside Actions;
-        # this whole block only ever runs there too, since RELEASE_TAG is only
-        # non-empty on a tagged release build (see release.yml).
-        IPK_FILE="$(ls dist/*_arm.ipk)"
+        # Homebrew Channel manifest (schema: webosbrew/docs/schemas/
+        # HomebrewPackageManifest.schema.json) — repo.json's manifestUrl
+        # resolves to this. Only generated on a tagged release build.
+        IPK_FILE="$(ls dist/*_{{.RELEASE_TAG}}_arm.ipk)"
         IPK_SHA256="$(sha256sum "$IPK_FILE" | cut -d' ' -f1)"
         REPO="${GITHUB_REPOSITORY:-dyptan-io/pf-webos}"
         cat > dist/io.dyptan.punktfunk.webos.manifest.json <<EOF
@@ -254,14 +234,11 @@ tasks:
         ls -lh dist/*.ipk
 
   # ------------------------------------------------------------------- docker --
-  # Every `docker-*` task runs an ephemeral `docker run --rm` against the stock
-  # `rust` image (no custom Dockerfile) and re-invokes the root `native:*` tasks
-  # inside the container via a nested `task` install — no build logic is
-  # duplicated between CI's native path and this one. Only `dist/*.ipk` lands on
-  # the host. Forced to `--platform linux/arm64` regardless of host arch: the
-  # webOS NDK has no linux-x86_64 build, so an Intel/amd64 host transparently
-  # runs the container under QEMU emulation instead of failing outright — same
-  # effective environment (Linux aarch64) everywhere, host OS/arch aside.
+  # Ephemeral `docker run --rm` against the stock `rust` image, re-invoking the
+  # root `native:*` tasks inside via a nested `task` install — no build logic
+  # duplicated between CI's native path and this one. Forced to
+  # --platform linux/arm64 regardless of host arch: the webOS NDK has no
+  # linux-x86_64 build, so an amd64 host runs it under QEMU instead of failing.
 
   docker-run:
     internal: true


### PR DESCRIPTION
## Summary
- Release `.ipk`s were built with `appinfo.json`'s `version` still baked in as the checked-in `0.0.1` — only the filename and Homebrew Channel manifest got the real release tag. webOS/Homebrew Channel reads the *installed* app's own `appinfo.json` version to check for updates, so every release looked older than any published version and the TV nagged to update forever, even right after updating.
- Release builds now patch the staged `appinfo.json` to the real release tag before `ares-package` runs, so the installed app reports its actual version.
- Dev builds now version themselves off the latest published release (`git describe --tags --abbrev=0`) instead of the fixed `0.0.1`, with the commit sha appended to the *filename* only (e.g. `0.2.0+git.<sha>`) — `appinfo.json`'s version field stays a plain `x.x.x` as webOS requires.
- CI's checkout step now fetches full history/tags (`fetch-depth: 0`) so `git describe` can resolve the latest tag.

## Test plan
- [x] Simulated a release build locally (`GITHUB_REF_TYPE=tag GITHUB_REF_NAME=0.3.0 task native:package`) — produced `io.dyptan.punktfunk.webos_0.3.0_arm.ipk`, extracted it and confirmed `appinfo.json` inside reads `"version": "0.3.0"`.
- [x] Ran a dev build (`task native:package`) — produced `io.dyptan.punktfunk.webos_0.2.0+git.<sha>_arm.ipk` (latest tag is `0.2.0`), extracted and confirmed `appinfo.json` reads `"version": "0.2.0"`.
- [ ] Confirm the CI `native:package` run on this PR still builds/packages successfully with `fetch-depth: 0`.
