### PR TITLE
Upgrade punktfunk-core, fix stream loss-recovery, and improve pacing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1074,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "image",
+ "libc",
  "mdns-sd",
  "opus",
  "punktfunk-core",
@@ -1073,6 +1083,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tiny-skia",
+ "tracing",
+ "tracing-subscriber",
  "ureq",
 ]
 
@@ -1521,6 +1533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1580,12 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket-pktinfo"
@@ -1673,6 +1700,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.2",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1806,7 +1842,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1816,6 +1864,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1885,6 +1959,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayref"
@@ -130,9 +130,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.1"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
@@ -165,9 +165,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -186,9 +186,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder-lite"
@@ -216,16 +216,16 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.119",
  "tempfile",
  "toml",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -241,9 +241,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -268,18 +268,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -404,7 +404,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -422,17 +422,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -471,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdeflate"
@@ -487,7 +476,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=76594f27c1da50676b33f5f3d96b67b0949ff952#76594f27c1da50676b33f5f3d96b67b0949ff952"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.16.0#191c9a4e188dffabc17b99fb4110f0e9666f4510"
 
 [[package]]
 name = "fiat-crypto"
@@ -535,15 +524,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,27 +531,27 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -669,107 +649,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.2.0"
+name = "http"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
+ "bytes",
+ "itoa",
 ]
 
 [[package]]
-name = "icu_locale_core"
-version = "2.2.0"
+name = "httparse"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
-
-[[package]]
-name = "icu_properties"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
-
-[[package]]
-name = "icu_provider"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "if-addrs"
@@ -864,7 +757,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -883,7 +776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -932,12 +825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
-name = "litemap"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,9 +847,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mdns-sd"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb75febbe5fa1837a52fdbd1c735e168286c5c645fc2ddd31526f65c49941c2e"
+checksum = "f18d8ec9d1869796fb2910d95f4d957072df0b6a22e247a1d760d8b4c805e17a"
 dependencies = [
  "fastrand",
  "flume",
@@ -991,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "log",
@@ -1093,7 +980,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1114,18 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "potential_utf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
-dependencies = [
- "zerovec",
-]
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "powerfmt"
@@ -1144,17 +1022,17 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "punktfunk-core"
-version = "0.9.2"
-source = "git+https://git.unom.io/unom/punktfunk?rev=76594f27c1da50676b33f5f3d96b67b0949ff952#76594f27c1da50676b33f5f3d96b67b0949ff952"
+version = "0.16.0"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.16.0#191c9a4e188dffabc17b99fb4110f0e9666f4510"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -1264,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1413,7 +1291,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1422,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1556,7 +1434,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1581,9 +1459,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1591,29 +1469,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1650,15 +1528,15 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -1683,12 +1561,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "smallvec"
-version = "1.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
 name = "socket-pktinfo"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1723,18 +1595,12 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strict-num"
@@ -1756,9 +1622,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1766,14 +1632,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
+name = "syn"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1791,29 +1657,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1854,16 +1720,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,9 +1736,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
 dependencies = [
  "libc",
  "mio",
@@ -1894,13 +1750,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1933,14 +1789,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -1992,37 +1848,37 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
- "flate2",
  "log",
- "once_cell",
+ "percent-encoding",
  "rustls",
  "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
 ]
 
 [[package]]
-name = "url"
-version = "2.5.8"
+name = "ureq-proto"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
+ "base64",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
-name = "utf8_iter"
-version = "1.0.4"
+name = "utf8-zero"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8parse"
@@ -2099,7 +1955,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -2124,27 +1980,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.8",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2263,9 +2110,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"
@@ -2274,41 +2121,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "writeable"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
 name = "yasna"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
-]
-
-[[package]]
-name = "yoke"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -2328,28 +2146,7 @@ checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2359,43 +2156,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
-name = "zerotrie"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,14 @@ suspicious_operation_groupings = "warn" # caught a real field-name mismatch risk
 
 [dependencies]
 anyhow = "1"
+# Surfaces punktfunk-core's own internal `tracing` diagnostics (ABR/probe decisions, RFI
+# recovery internals — see main.rs's subscriber setup) into our log file. Without this, every
+# `tracing::info!`/`warn!` call inside punktfunk-core is silently dropped (no-op absent a
+# subscriber) — the exact link-capacity-probe/ABR-ceiling messages needed to tell "the network
+# genuinely can't sustain more" apart from "something else is capping quality" were invisible
+# for this whole client until this was added.
+tracing = "0.1"
+tracing-subscriber = "0.3"
 # Pure Rust + libc (unix), portable — no FFmpeg/PipeWire/SDL3 baggage, unlike
 # pf-client-core's session::start() (see session.rs docs for why we don't use that).
 # Pinned to a tagged punktfunk release (not a branch tip) this client was
@@ -91,3 +99,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 # already-decoded buffers (SDL2_ttf glyph surfaces, `image`-decoded covers), never
 # loads a `.png` through tiny-skia itself.
 tiny-skia = { version = "0.12", default-features = false, features = ["std"] }
+# `setpriority` for the video pump's scheduling-priority boost (session.rs) — already a
+# transitive dependency (punktfunk-core itself uses `libc::gettid` for its hot-thread
+# registry), pulled in directly since we call our own libc function against those ids.
+libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,14 @@ suspicious_operation_groupings = "warn" # caught a real field-name mismatch risk
 anyhow = "1"
 # Pure Rust + libc (unix), portable — no FFmpeg/PipeWire/SDL3 baggage, unlike
 # pf-client-core's session::start() (see session.rs docs for why we don't use that).
-# Pinned to the punktfunk commit this client was developed/tested against — bump
-# deliberately, not automatically, since punktfunk-core's wire/ABI surface can move.
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "76594f27c1da50676b33f5f3d96b67b0949ff952", features = [
+# Pinned to a tagged punktfunk release (not a branch tip) this client was
+# developed/tested against — bump deliberately, not automatically, since
+# punktfunk-core's wire/ABI surface can move. Currently v0.16.0 — WIRE_VERSION 2
+# (unchanged since this pin's previous v0.9.2-based commit; no protocol migration
+# needed here), ABI_VERSION 9 (irrelevant to us: we link the Rust `client` API
+# directly, not the C ABI in `abi.rs`, and that module's signatures are unchanged
+# across the whole v0.9.2..v0.16.0 range).
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.16.0", features = [
     "quic",
 ] }
 serde = { version = "1", features = ["derive"] }
@@ -72,7 +77,7 @@ opus = "0.3"
 # upstream repo's pf-client-core crate — see session.rs docs). `ring` cross-compiles
 # cleanly for this target (already proven transitively via punktfunk-core's `quic`
 # feature above).
-ureq = "2"
+ureq = { version = "3", features = ["rustls"], default-features = false }
 rustls = { version = "0.23", features = ["ring"] }
 # Decodes the management API's cover art (Steam CDN capsules/headers, custom-store
 # art) into raw RGBA for a `tiny_skia::Pixmap` (library.rs/art.rs) — pure Rust codecs,

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -209,6 +209,21 @@ still shows cost unexplained by the app's own draw calls.
   `video_pump` calls `client.note_frame_index()` on every frame (cheap, idempotent, fires a
   throttled RFI request internally on a forward gap) plus a throttled `request_keyframe()`
   backstop when `frames_dropped()` climbs.
+- **Freeze-until-reanchor, adapted for NDL**: `note_frame_index`'s forward-gap return and a
+  `frames_dropped` climb both arm a `holding` flag in `video_pump`; while held, frames are never
+  fed to `ndl.play` at all (so the panel just keeps showing its last rendered picture instead of
+  a concealed/corrupted one) until one arrives with `FLAG_SOF` (a real IDR) or
+  `USER_FLAG_RECOVERY_ANCHOR` (LTR-RFI's clean single-frame recovery) set. Upstream
+  `punktfunk_core::reanchor::ReanchorGate` (added in punktfunk v0.10.0) does the equivalent
+  decision assuming a decode/present split every other client has — Linux/Windows FFmpeg, Android
+  MediaCodec, Apple VideoToolbox — but `NDL_DirectVideoPlay` (checked against the webOS 5.6 SDK
+  sysroot's `NDL_directmedia_v2.h`, the latest API version webOS offers; there's no v3) decodes
+  and presents in one opaque call with no hook to decode without displaying, so this client can't
+  use `ReanchorGate` as designed and reimplements just the skip-until-reanchor subset directly.
+  One real gap versus the shared gate: a host's intra-refresh `USER_FLAG_RECOVERY_POINT` wave
+  can't be consumed this way (that healing needs every intervening frame actually decoded, which
+  holding skips) — hosts limited to that fallback instead heal via the `frames_dropped` keyframe
+  backstop forcing a real IDR, which takes longer than the two-mark intra-refresh path would.
 - HDR mastering metadata can change over a session (different content, different mastering
   values) — `video_pump` drains `next_hdr_meta` every frame (non-blocking) and applies whatever
   arrives to NDL, rather than fetching it once at connect time.

--- a/src/app.rs
+++ b/src/app.rs
@@ -100,6 +100,13 @@ pub struct App {
     pub screen: Screen,
     pub known_hosts: Vec<KnownHost>,
     pub discovered: std::sync::mpsc::Receiver<crate::discovery::DiscoveredHost>,
+    /// `None` if `discovery::browse` couldn't even start (`ServiceDaemon::new` failed —
+    /// `discovered` is then a permanently-empty channel, harmless for `drain_discovery`'s
+    /// `try_recv` loop). `Some` lets `Drop` shut the background mDNS thread down explicitly
+    /// instead of relying on `discovered` being dropped — dropping the receiver alone doesn't
+    /// reliably stop it (see `discovery::browse`'s docs), and it was confirmed still burning
+    /// CPU/network well into active game-streaming sessions, long after this `App` was gone.
+    discovery_daemon: Option<mdns_sd::ServiceDaemon>,
     pub entries: Vec<HostEntry>,
     pub home_focus: HomeFocus,
     /// The sidebar host whose games are shown in the grid — `None` until one is
@@ -157,6 +164,14 @@ pub struct App {
     home_dirty: bool,
 }
 
+impl Drop for App {
+    fn drop(&mut self) {
+        if let Some(daemon) = &self.discovery_daemon {
+            let _ = daemon.shutdown();
+        }
+    }
+}
+
 impl App {
     pub fn new(identity: (String, String), log: &mut std::fs::File) -> Self {
         let known_hosts = store::load_known_hosts();
@@ -165,10 +180,15 @@ impl App {
         // `main.rs::log_path`) for the mdns background thread to log through, since
         // it can't share this `&mut File` across threads.
         let discovery_log = log.try_clone().expect("clone log file handle for mdns thread");
+        let (discovered, discovery_daemon) = match crate::discovery::browse(discovery_log) {
+            Some((rx, daemon)) => (rx, Some(daemon)),
+            None => (std::sync::mpsc::channel().1, None),
+        };
         let mut app = Self {
             screen: Screen::Home,
             known_hosts,
-            discovered: crate::discovery::browse(discovery_log),
+            discovered,
+            discovery_daemon,
             entries,
             home_focus: HomeFocus::Sidebar(0),
             selected_host: None,
@@ -1307,7 +1327,15 @@ impl App {
         // as the gap this heading had to the subtitle beneath it, which is
         // what actually read as "misaligned" rather than just crowded.
         let title_y = card.y() + 36;
-        ui::draw_text(painter, text_cache, font_label, "Pair with host", card.x() + 32, title_y, ui::WHITE)?;
+        ui::draw_text(
+            painter,
+            text_cache,
+            font_label,
+            "Pair with host",
+            card.x() + 32,
+            title_y,
+            ui::WHITE,
+        )?;
 
         let subtitle_y = title_y + font_label.height() + 18;
         ui::draw_text(
@@ -1472,7 +1500,12 @@ impl App {
         // A blinkless text-cursor bar right after what's typed so far — there's
         // no fixed-width mask anymore to show *where* editing happens, so this
         // stands in for it.
-        let caret = Rect::new(text_x + text_w as i32 + 6, drawn.y() + 16, 3, drawn.height().saturating_sub(32));
+        let caret = Rect::new(
+            text_x + text_w as i32 + 6,
+            drawn.y() + 16,
+            3,
+            drawn.height().saturating_sub(32),
+        );
         painter.fill_rect(caret, ui::ACCENT_BRIGHT);
         Ok(())
     }
@@ -1554,7 +1587,11 @@ impl App {
         screen_w: u32,
         screen_h: u32,
     ) -> Result<()> {
-        let Some(name) = self.host_menu_index.and_then(|i| self.entries.get(i)).map(HostEntry::name) else {
+        let Some(name) = self
+            .host_menu_index
+            .and_then(|i| self.entries.get(i))
+            .map(HostEntry::name)
+        else {
             return Ok(());
         };
         let card = Self::forget_host_card_rect(screen_w, screen_h);

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -21,25 +21,33 @@ pub struct DiscoveredHost {
     pub mac: Vec<String>,
 }
 
-/// Browse continuously; the thread exits when the receiver is dropped. `log` is a
-/// second handle onto the app's own log file (see `main.rs::log_path`) — every
-/// failure/event point here is logged, since this previously failed completely
-/// silently: a `ServiceDaemon::new()`/`browse()` error, or every non-`ServiceResolved`
-/// event, was just dropped with no trace, making "no hosts showed up" undiagnosable
-/// from the log alone (was it a permissions/socket failure, wrong interface, or
-/// genuinely nothing advertising?).
-pub fn browse(mut log: std::fs::File) -> std::sync::mpsc::Receiver<DiscoveredHost> {
+/// Browse continuously. The spawned thread does NOT reliably exit just because the
+/// returned `Receiver<DiscoveredHost>` is dropped: only a `ServiceEvent::ServiceResolved`
+/// checks `tx.send(..).is_err()` to notice that and stop — every other event kind
+/// (in practice, an endless stream of `SearchStarted`) loops forever regardless,
+/// burning a thread's worth of CPU/network activity for the rest of the process's
+/// life. Confirmed live: `mdns: SearchStarted(...)` kept appearing throughout active
+/// game-streaming sessions, well after the menu (and its `App`) was long gone. The
+/// returned `ServiceDaemon` handle is `Clone` and lets a caller call `shutdown()`
+/// explicitly once discovery is no longer needed (see `App`'s `Drop` impl) — that
+/// unblocks the thread's `receiver.recv()` promptly instead of waiting on a lucky
+/// future resolution event. `log` is a second handle onto the app's own log file
+/// (see `main.rs::log_path`) — every failure/event point here is logged, since this
+/// previously failed completely silently: a `ServiceDaemon::new()`/`browse()` error,
+/// or every non-`ServiceResolved` event, was just dropped with no trace, making "no
+/// hosts showed up" undiagnosable from the log alone (was it a permissions/socket
+/// failure, wrong interface, or genuinely nothing advertising?).
+pub fn browse(mut log: std::fs::File) -> Option<(std::sync::mpsc::Receiver<DiscoveredHost>, ServiceDaemon)> {
     let (tx, rx) = std::sync::mpsc::channel();
+    let daemon = ServiceDaemon::new()
+        .inspect_err(|e| {
+            let _ = writeln!(log, "mdns: ServiceDaemon::new failed: {e}");
+        })
+        .ok()?;
+    let daemon_handle = daemon.clone();
     std::thread::Builder::new()
         .name("punktfunk-webos-mdns".into())
         .spawn(move || {
-            let daemon = match ServiceDaemon::new() {
-                Ok(d) => d,
-                Err(e) => {
-                    let _ = writeln!(log, "mdns: ServiceDaemon::new failed: {e}");
-                    return;
-                }
-            };
             let receiver = match daemon.browse("_punktfunk._udp.local.") {
                 Ok(r) => r,
                 Err(e) => {
@@ -94,5 +102,5 @@ pub fn browse(mut log: std::fs::File) -> std::sync::mpsc::Receiver<DiscoveredHos
             let _ = daemon.shutdown();
         })
         .expect("spawn mdns thread");
-    rx
+    Some((rx, daemon_handle))
 }

--- a/src/library.rs
+++ b/src/library.rs
@@ -4,11 +4,15 @@
 //! A trimmed port of `pf-client-core::library` (same wire shape, same mTLS pinning
 //! verifier) rather than a dependency on that crate — see `session.rs`'s module docs
 //! for why this client doesn't pull in `pf-client-core` at all.
-use std::io::Read as _;
+use std::io::{Read as _, Write as _};
 use std::sync::Arc;
 use std::time::Duration;
 
 use serde::Deserialize;
+use ureq::unversioned::resolver::DefaultResolver;
+use ureq::unversioned::transport::{
+    Buffers, ConnectionDetails, Connector, Either, LazyBuffers, NextTimeout, TcpConnector, Transport, TransportAdapter,
+};
 
 /// The management API's default port — matches the host's `mgmt::DEFAULT_PORT`. A
 /// discovered host may advertise a different one via its mDNS `mgmt` TXT record
@@ -102,11 +106,18 @@ pub fn agent(identity: &(String, String), pin: Option<[u8; 32]>) -> Result<ureq:
     let cfg = builder
         .with_client_auth_cert(vec![cert], key)
         .map_err(|e| bad("client auth", &e))?;
-    Ok(ureq::AgentBuilder::new()
-        .tls_config(Arc::new(cfg))
-        .timeout_connect(Duration::from_secs(5))
-        .timeout(Duration::from_secs(10))
-        .build())
+
+    // ureq 3.x's own `TlsConfig`/`RustlsConnector` only build a `rustls::ClientConfig`
+    // from a fixed CA-chain/platform-verifier menu — no hook for `cfg`'s custom
+    // fingerprint-pinning `PinVerify` above. So we skip that layer entirely and hand
+    // `cfg` to our own minimal TLS-wrapping `Connector` (`PinnedTlsConnector` below,
+    // modeled on ureq's own `RustlsConnector`), chained onto the stock `TcpConnector`.
+    let connector = TcpConnector::default().chain(PinnedTlsConnector { config: Arc::new(cfg) });
+    let config = ureq::Agent::config_builder()
+        .timeout_connect(Some(Duration::from_secs(5)))
+        .timeout_global(Some(Duration::from_secs(10)))
+        .build();
+    Ok(ureq::Agent::with_parts(config, connector, DefaultResolver::default()))
 }
 
 /// Fetch the host's unified library. Errors are pre-classified for the UI (401/403 →
@@ -121,9 +132,10 @@ fn fetch_games(
 ) -> Result<Vec<GameEntry>, LibraryError> {
     let agent = agent(identity, pin)?;
     let url = format!("{}/api/v1/library", base_url(addr, mgmt_port));
-    let body = match agent.get(&url).call() {
-        Ok(resp) => resp
-            .into_string()
+    let body = match agent.get(url.as_str()).call() {
+        Ok(mut resp) => resp
+            .body_mut()
+            .read_to_string()
             .map_err(|e| LibraryError::Unreachable(format!("read body: {e}")))?,
         Err(e) => return Err(classify(e)),
     };
@@ -181,29 +193,108 @@ pub fn load_games_async(
 /// handshake per call. Decoding happens in `art.rs`, off this module's REST concern.
 pub fn fetch_art(agent: &ureq::Agent, addr: &str, mgmt_port: u16, art_path: &str) -> Result<Vec<u8>, LibraryError> {
     let url = format!("{}{art_path}", base_url(addr, mgmt_port));
-    let mut buf = Vec::new();
-    match agent.get(&url).call() {
-        Ok(resp) => resp
-            .into_reader()
-            .read_to_end(&mut buf)
-            .map_err(|e| LibraryError::Unreachable(format!("read art body: {e}")))?,
-        Err(e) => return Err(classify(e)),
-    };
-    Ok(buf)
+    match agent.get(url.as_str()).call() {
+        Ok(mut resp) => resp
+            .body_mut()
+            .read_to_vec()
+            .map_err(|e| LibraryError::Unreachable(format!("read art body: {e}"))),
+        Err(e) => Err(classify(e)),
+    }
 }
 
 fn classify(e: ureq::Error) -> LibraryError {
     match e {
-        ureq::Error::Status(401 | 403, _) => LibraryError::NotPaired,
-        ureq::Error::Status(code, _) => LibraryError::Http(code),
-        ureq::Error::Transport(t) => {
-            let msg = t.to_string();
-            if msg.contains("ApplicationVerificationFailure") || msg.contains("InvalidCertificate") {
-                LibraryError::PinMismatch
-            } else {
-                LibraryError::Unreachable(msg)
-            }
+        ureq::Error::StatusCode(401 | 403) => LibraryError::NotPaired,
+        ureq::Error::StatusCode(code) => LibraryError::Http(code),
+        // The one rejection our own `PinVerify` (below) actually raises on a mismatch —
+        // matched on the typed `rustls::Error` ureq 3.x's `Error::Rustls` now carries,
+        // instead of the string-matching `Transport(t)` message-sniffing ureq 2.x forced.
+        ureq::Error::Rustls(rustls::Error::InvalidCertificate(
+            rustls::CertificateError::ApplicationVerificationFailure,
+        )) => LibraryError::PinMismatch,
+        other => LibraryError::Unreachable(other.to_string()),
+    }
+}
+
+/// Wraps a chained (TCP) transport in TLS using a caller-supplied `rustls::ClientConfig`
+/// verbatim — modeled directly on ureq 3.x's own (crate-private) `RustlsConnector`
+/// (`ureq` crate, `src/tls/rustls.rs`), minus its `TlsConfig`-driven `build_config` step,
+/// since that step has no way to install `PinVerify`'s fingerprint-pinning verifier.
+struct PinnedTlsConnector {
+    config: Arc<rustls::ClientConfig>,
+}
+
+impl std::fmt::Debug for PinnedTlsConnector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PinnedTlsConnector").finish()
+    }
+}
+
+impl<In: Transport> Connector<In> for PinnedTlsConnector {
+    type Out = Either<In, PinnedTlsTransport>;
+
+    fn connect(&self, details: &ConnectionDetails, chained: Option<In>) -> Result<Option<Self::Out>, ureq::Error> {
+        let Some(transport) = chained else {
+            panic!("PinnedTlsConnector requires a chained transport");
+        };
+        if !details.needs_tls() || transport.is_tls() {
+            return Ok(Some(Either::A(transport)));
         }
+
+        let name: rustls::pki_types::ServerName<'_> = details
+            .uri
+            .authority()
+            .expect("uri authority for tls")
+            .host()
+            .try_into()
+            .map_err(|_| ureq::Error::Tls("invalid DNS name"))?;
+        let conn = rustls::ClientConnection::new(self.config.clone(), name.to_owned())?;
+        let stream = rustls::StreamOwned {
+            conn,
+            sock: TransportAdapter::new(transport.boxed()),
+        };
+        let buffers = LazyBuffers::new(details.config.input_buffer_size(), details.config.output_buffer_size());
+        Ok(Some(Either::B(PinnedTlsTransport { buffers, stream })))
+    }
+}
+
+struct PinnedTlsTransport {
+    buffers: LazyBuffers,
+    stream: rustls::StreamOwned<rustls::ClientConnection, TransportAdapter>,
+}
+
+impl std::fmt::Debug for PinnedTlsTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PinnedTlsTransport").finish()
+    }
+}
+
+impl Transport for PinnedTlsTransport {
+    fn buffers(&mut self) -> &mut dyn Buffers {
+        &mut self.buffers
+    }
+
+    fn transmit_output(&mut self, amount: usize, timeout: NextTimeout) -> Result<(), ureq::Error> {
+        self.stream.get_mut().set_timeout(timeout);
+        let output = &self.buffers.output()[..amount];
+        self.stream.write_all(output)?;
+        Ok(())
+    }
+
+    fn await_input(&mut self, timeout: NextTimeout) -> Result<bool, ureq::Error> {
+        self.stream.get_mut().set_timeout(timeout);
+        let input = self.buffers.input_append_buf();
+        let amount = self.stream.read(input)?;
+        self.buffers.input_appended(amount);
+        Ok(amount > 0)
+    }
+
+    fn is_open(&mut self) -> bool {
+        self.stream.get_mut().get_mut().is_open()
+    }
+
+    fn is_tls(&self) -> bool {
+        true
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,22 @@ mod real {
             .with_context(|| format!("open log file {}", log_path.display()))?;
         writeln!(log, "punktfunk-webos starting")?;
 
+        // Without this, punktfunk-core's own `tracing::info!`/`warn!` calls — including the
+        // startup link-capacity probe's measured throughput and the ABR ceiling it derives from
+        // it — are silent no-ops (nothing installs a subscriber by default). A fresh handle to
+        // the same file, not `log.try_clone()`, since this subscriber outlives `run_inner`'s
+        // `&mut log` borrow for the whole process.
+        let tracing_log = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+            .with_context(|| format!("open log file {} for tracing", log_path.display()))?;
+        tracing_subscriber::fmt()
+            .with_writer(std::sync::Mutex::new(tracing_log))
+            .with_ansi(false)
+            .with_target(false)
+            .init();
+
         // Errors from here on only ever reached stderr, which is invisible for a
         // webOS native app with no attached terminal.
         match run_inner(&mut log) {

--- a/src/session.rs
+++ b/src/session.rs
@@ -21,6 +21,7 @@ use anyhow::{Context, Result};
 use punktfunk_core::client::NativeClient;
 use punktfunk_core::config::{CompositorPref, Mode};
 use punktfunk_core::input::InputEvent;
+use punktfunk_core::packet::{FLAG_SOF, USER_FLAG_RECOVERY_ANCHOR};
 use punktfunk_core::quic;
 
 use crate::ndl::{NdlCodec, NdlVideo};
@@ -102,8 +103,14 @@ pub fn connect(
     });
     writeln!(
         log,
-        "connected: codec={} compositor={:?} audio_channels={} color={:?} fingerprint={fp_hex}",
-        client.codec, client.resolved_compositor, client.audio_channels, client.color
+        "connected: codec={} compositor={:?} audio_channels={} color={:?} resolved_bitrate_kbps={} \
+         wants_decode_latency={} fingerprint={fp_hex}",
+        client.codec,
+        client.resolved_compositor,
+        client.audio_channels,
+        client.color,
+        client.resolved_bitrate_kbps,
+        client.wants_decode_latency()
     )?;
 
     let resolved_mode = client.mode();
@@ -156,6 +163,14 @@ pub fn connect(
 /// "≤ ~1/100ms" guidance).
 const KEYFRAME_REQUEST_MIN_INTERVAL: Duration = Duration::from_millis(100);
 
+/// Longest `video_pump` will withhold frames from NDL waiting for a clean re-anchor before
+/// giving up and resuming anyway. Generous relative to a real recovery round-trip (RTT plus
+/// encode plus decode, sub-second on any live link), but bounded so a request that's lost,
+/// ignored, or answered without the reanchor flag we expect can never turn into a permanently
+/// frozen picture. Worst case reverts to showing one concealed or corrupted frame, the
+/// pre-freeze-until-reanchor behavior, instead of hanging forever.
+const HOLD_GIVE_UP: Duration = Duration::from_secs(2);
+
 /// Above this, `NDL_DirectVideoPlay` is applying backpressure rather than accepting the
 /// access unit promptly — worth a log line even though (per aurora-tv's own investigation
 /// of the same NDL backend, see `docs/NOTES.md`) there's no known client-side fix once it
@@ -163,58 +178,180 @@ const KEYFRAME_REQUEST_MIN_INTERVAL: Duration = Duration::from_millis(100);
 const NDL_FEED_BACKPRESSURE_WARN: Duration = Duration::from_millis(20);
 
 fn video_pump(client: Arc<NativeClient>, ndl: NdlVideo, stop: Arc<AtomicBool>, is_hdr: bool, log: &mut std::fs::File) {
+    // Register this thread alongside punktfunk-core's own internal data-plane pump thread
+    // (UDP receive + FEC reassembly — already auto-registered) in the shared hot-thread
+    // registry, then boost both with a best-effort `nice` priority bump. `hot_thread_ids` is
+    // the same registry the Android client feeds to an ADPF hint session so the CPU governor
+    // favors the whole video pipeline; Linux (this OS) has no automatic consumer for it, so we
+    // are the consumer. No CAP_SYS_NICE here for real SCHED_FIFO priority, so this is the
+    // closest available substitute — on a weak ARM SoC juggling UI/audio/network/decode
+    // threads, an unprioritized decode thread getting occasionally preempted is exactly the
+    // kind of thing that shows up as uneven frame pacing distinct from network loss.
+    client.register_hot_thread();
+    for tid in client.hot_thread_ids() {
+        // SAFETY: `setpriority` takes a plain tid and priority value, no pointers involved.
+        if unsafe { libc::setpriority(libc::PRIO_PROCESS, tid as libc::id_t, -10) } != 0 {
+            let _ = writeln!(
+                log,
+                "setpriority(tid={tid}, -10) failed (expected without CAP_SYS_NICE): {}",
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+
     let mut last_keyframe_request: Option<Instant> = None;
     let mut last_dropped_seen = client.frames_dropped();
+    // Constant for the session (Automatic bitrate, non-PyroWave) — check once, not per frame.
+    let wants_decode_latency = client.wants_decode_latency();
+    // Freeze-until-reanchor: under punktfunk's infinite-GOP stream, unrecoverable loss doesn't
+    // fail decode — it produces reference-missing delta frames NDL *silently conceals* (the
+    // "mpeg breakup" artifact), and it never self-heals without a clean re-anchor. Upstream
+    // punktfunk-core ships a shared `reanchor::ReanchorGate` for this (decode every frame, but
+    // only *present* the concealed ones — every other client has a decode/present split to do
+    // that with), but NDL_DirectVideoPlay (webOS's DirectMedia API 2, the latest available on
+    // this OS — there is no v3) couples decode and present into one opaque call, with no way to
+    // decode without displaying. So instead of presenting: while `holding`, skip calling
+    // `ndl.play` entirely — the punch-through plane just keeps showing whatever it last rendered
+    // — and resume only once a frame arrives that's independently decodable against the picture
+    // NDL already has: a real IDR (`FLAG_SOF`) or an LTR-RFI `USER_FLAG_RECOVERY_ANCHOR` (both
+    // default-on loss recovery on modern NVENC/Vulkan-Video hosts). A host's intra-refresh
+    // `USER_FLAG_RECOVERY_POINT` wave can't be consumed this way — that healing needs every
+    // intervening frame actually decoded, which holding skips — so those marks are ignored here;
+    // on hosts limited to that fallback, the `frames_dropped` keyframe backstop below eventually
+    // forces a real IDR instead.
+    let mut holding = false;
+    // First-observed-loss timestamp for the current hold — NOT reset by a fresh gap/drop while
+    // already holding, so a run of small hiccups can't keep pushing the give-up deadline out
+    // forever. `None` whenever `holding` is `false`.
+    let mut hold_started: Option<Instant> = None;
+    // Diagnostic heartbeat — cheap proof, independent of every other counter below, that AUs are
+    // actually arriving from the session at all (vs. e.g. the host never starting an encode under
+    // Automatic bitrate, which would silently loop on `PunktfunkError::NoFrame` forever with no
+    // other log line to show it).
+    let mut frames_received: u64 = 0;
+    let mut last_heartbeat = Instant::now();
 
     while !stop.load(Ordering::Relaxed) {
         match client.next_frame(Duration::from_millis(500)) {
             Ok(frame) => {
+                frames_received += 1;
+                if last_heartbeat.elapsed() >= Duration::from_secs(2) {
+                    last_heartbeat = Instant::now();
+                    let _ = writeln!(
+                        log,
+                        "video heartbeat: {frames_received} AUs received, holding={holding}, frames_dropped={}",
+                        client.frames_dropped()
+                    );
+                }
                 // Loss recovery — the part the embedding guide calls out as the one to
                 // get right under punktfunk's infinite-GOP stream (no periodic IDRs,
                 // so unrecoverable loss otherwise never self-heals). Cheap+idempotent;
                 // call for every frame. `note_frame_index` itself throttles the RFI
-                // request it may fire; `frames_dropped` is the backstop for when even
-                // the recovery frame was lost, throttled here the same way.
-                client.note_frame_index(frame.frame_index);
+                // request it may fire and returns whether it saw a forward gap — the
+                // embedding guide's cue to start freezing. `frames_dropped` is the
+                // backstop for when even the recovery frame was lost, throttled here
+                // the same way.
+                let gap = client.note_frame_index(frame.frame_index);
                 let dropped_now = client.frames_dropped();
-                if dropped_now > last_dropped_seen {
+                let dropped = dropped_now > last_dropped_seen;
+                if dropped {
                     last_dropped_seen = dropped_now;
-                    if last_keyframe_request.is_none_or(|t| t.elapsed() >= KEYFRAME_REQUEST_MIN_INTERVAL) {
-                        let _ = client.request_keyframe();
-                        // Drop whatever NDL still has buffered so the recovery
-                        // keyframe doesn't sit head-of-line blocked behind stale
-                        // pre-loss frames once it arrives.
-                        let _ = ndl.flush();
-                        last_keyframe_request = Some(Instant::now());
-                    }
                 }
-
-                let feed_start = Instant::now();
-                let play_result = ndl.play(&frame.data);
-                let feed_elapsed = feed_start.elapsed();
-                if feed_elapsed >= NDL_FEED_BACKPRESSURE_WARN {
+                if (gap || dropped) && !holding {
+                    holding = true;
+                    hold_started = Some(Instant::now());
                     let _ = writeln!(
                         log,
-                        "NDL_DirectVideoPlay slow: {:.1}ms (frame {}) — decoder backpressure, not network loss",
-                        feed_elapsed.as_secs_f32() * 1000.0,
+                        "loss detected (gap={gap} dropped={dropped}, frame {}) — freezing display",
                         frame.frame_index
                     );
+                    // Drop whatever NDL still has buffered so a held frame — or the eventual
+                    // re-anchor — doesn't sit head-of-line blocked behind stale pre-loss frames.
+                    let _ = ndl.flush();
                 }
-                if let Err(e) = play_result {
-                    let _ = writeln!(log, "NDL play error (frame {}): {e:#}", frame.frame_index);
-                    // NDL rejected this access unit outright (e.g. a transient decoder hiccup
-                    // around an HDR/mode change) — request a fresh keyframe so later P-frames
-                    // don't decode against a reference NDL never actually accepted. Same throttle
-                    // as the network-loss path above; matches the recovery aurora-tv added for
-                    // its ss4s frontend's NOT_READY feed results left otherwise uncorrected.
-                    if last_keyframe_request.is_none_or(|t| t.elapsed() >= KEYFRAME_REQUEST_MIN_INTERVAL) {
-                        let _ = client.request_keyframe();
-                        let _ = ndl.flush();
-                        last_keyframe_request = Some(Instant::now());
+                // Keep re-asking on the same throttle for as long as we're still frozen, not just
+                // once on the initial loss edge — a single lost/delayed keyframe request (or one
+                // that lands but for whatever reason doesn't come back reanchor-flagged) must never
+                // freeze the picture permanently. Mirrors `punktfunk_core::reanchor::ReanchorGate`'s
+                // own backstop, which keeps re-requesting for as long as `is_holding()`.
+                if holding && last_keyframe_request.is_none_or(|t| t.elapsed() >= KEYFRAME_REQUEST_MIN_INTERVAL) {
+                    if let Err(e) = client.request_keyframe() {
+                        let _ = writeln!(log, "request_keyframe failed while holding: {e:#}");
+                    }
+                    last_keyframe_request = Some(Instant::now());
+                }
+
+                let is_reanchor =
+                    frame.flags & u32::from(FLAG_SOF) != 0 || frame.flags & USER_FLAG_RECOVERY_ANCHOR != 0;
+                // Never hold the picture forever: if this hold has run past `HOLD_GIVE_UP` with
+                // no clean re-anchor observed (host never answered `request_keyframe`, the
+                // answer never arrived reanchor-flagged, or NDL itself is the problem — any of
+                // which turned into an indefinite freeze before this cap existed), resume feeding
+                // NDL anyway. Worst case is back to the pre-freeze-until-reanchor behavior of a
+                // moment of visible corruption; that beats a permanent frozen picture.
+                let gave_up = hold_started.is_some_and(|t| t.elapsed() >= HOLD_GIVE_UP);
+                if holding && !is_reanchor && !gave_up {
+                    // Concealed/reference-broken frame — never feed it to NDL; the panel keeps
+                    // showing the last good picture instead of the decoder's concealment output.
+                } else {
+                    if holding {
+                        let _ = writeln!(
+                            log,
+                            "resuming feed after {:.0}ms holding (frame {}, flags=0x{:x}, reanchor={is_reanchor}, gave_up={gave_up})",
+                            hold_started.map_or(0.0, |t| t.elapsed().as_secs_f32() * 1000.0),
+                            frame.frame_index,
+                            frame.flags
+                        );
+                    }
+                    holding = false;
+                    hold_started = None;
+
+                    let feed_start = Instant::now();
+                    let play_result = ndl.play(&frame.data);
+                    let feed_elapsed = feed_start.elapsed();
+                    if feed_elapsed >= NDL_FEED_BACKPRESSURE_WARN {
+                        let _ = writeln!(
+                            log,
+                            "NDL_DirectVideoPlay slow: {:.1}ms (frame {}) — decoder backpressure, not network loss",
+                            feed_elapsed.as_secs_f32() * 1000.0,
+                            frame.frame_index
+                        );
+                    }
+                    // Feed the Automatic-bitrate controller's decode signal (see
+                    // `punktfunk_core::abr` docs) — NDL couples decode+present into one opaque
+                    // call, so `feed_elapsed` (this call's own duration, not counting any vsync
+                    // wait since NDL_DirectVideoPlay doesn't block on presentation) is the closest
+                    // proxy this backend can offer to the "decode-stage latency" the controller
+                    // wants. Only for frames NDL actually accepted — a rejected AU never decoded.
+                    if wants_decode_latency && play_result.is_ok() {
+                        client.report_decode_us(u32::try_from(feed_elapsed.as_micros()).unwrap_or(u32::MAX));
+                    }
+                    if let Err(e) = play_result {
+                        let _ = writeln!(log, "NDL play error (frame {}): {e:#}", frame.frame_index);
+                        // NDL rejected this access unit outright (e.g. a transient decoder hiccup
+                        // around an HDR/mode change) — request a fresh keyframe so later P-frames
+                        // don't decode against a reference NDL never actually accepted. Same throttle
+                        // as the network-loss path above; matches the recovery aurora-tv added for
+                        // its ss4s frontend's NOT_READY feed results left otherwise uncorrected.
+                        if last_keyframe_request.is_none_or(|t| t.elapsed() >= KEYFRAME_REQUEST_MIN_INTERVAL) {
+                            let _ = client.request_keyframe();
+                            let _ = ndl.flush();
+                            last_keyframe_request = Some(Instant::now());
+                            holding = true;
+                            hold_started.get_or_insert_with(Instant::now);
+                        }
                     }
                 }
             }
-            Err(punktfunk_core::PunktfunkError::NoFrame) => {}
+            Err(punktfunk_core::PunktfunkError::NoFrame) => {
+                if last_heartbeat.elapsed() >= Duration::from_secs(2) {
+                    last_heartbeat = Instant::now();
+                    let _ = writeln!(
+                        log,
+                        "video heartbeat: {frames_received} AUs received (idle — none pending)"
+                    );
+                }
+            }
             Err(e) => {
                 let _ = writeln!(log, "video pump ending: {e:#}");
                 break;

--- a/src/store.rs
+++ b/src/store.rs
@@ -120,8 +120,9 @@ pub struct Settings {
     /// Nominal refresh rate (30/60/120) — the actual wire `Mode.refresh_hz` applies
     /// the aurora-tv NTSC floor-correction on top of this (see `main.rs`).
     pub refresh_hz: u32,
-    /// 10_000-150_000 (10-150 Mbps), adjusted via the settings slider — see
-    /// `ui::BITRATE_MIN_KBPS`/`BITRATE_MAX_KBPS`.
+    /// `0` (Automatic — `punktfunk_core`'s own client-side AIMD bitrate controller, see
+    /// `ui::BITRATE_AUTOMATIC`) or 10_000-150_000 (10-150 Mbps) fixed, adjusted via the settings
+    /// slider — see `ui::BITRATE_MIN_KBPS`/`BITRATE_MAX_KBPS`.
     pub bitrate_kbps: u32,
     pub hdr_enabled: bool,
     /// Whether a Wake-on-LAN magic packet is sent automatically (no prompt) when a
@@ -140,9 +141,11 @@ impl Default for Settings {
             width: 3840,
             height: 2160,
             refresh_hz: 60,
-            // aurora-tv's own moonlight-tv wiki calls ~35-40 Mbps the practical sweet
-            // spot for this decode path — a sane default within the 10-150 slider range.
-            bitrate_kbps: 40_000,
+            // Automatic: a fixed number, however carefully picked (aurora-tv's own
+            // moonlight-tv wiki calls ~35-40 Mbps the practical sweet spot for this decode
+            // path), never adapts to a link that degrades mid-session the way punktfunk's
+            // own client-side AIMD controller does — see `ui::BITRATE_AUTOMATIC`.
+            bitrate_kbps: 0,
             hdr_enabled: true,
             wol_auto_send: false,
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -993,7 +993,11 @@ fn draw_utility_row(
     label: &str,
     focused: bool,
 ) -> Result<()> {
-    let glyph = if label.starts_with('+') { ICON_ADD } else { ICON_SETTINGS };
+    let glyph = if label.starts_with('+') {
+        ICON_ADD
+    } else {
+        ICON_SETTINGS
+    };
     let label = label.trim_start_matches('+').trim();
     draw_sidebar_row(painter, text_cache, font_label, icon_font, rect, glyph, label, focused)
 }
@@ -1111,6 +1115,13 @@ pub const REFRESH_RATES: [u32; 3] = [30, 60, 120];
 pub const BITRATE_MIN_KBPS: u32 = 10_000;
 pub const BITRATE_MAX_KBPS: u32 = 150_000;
 pub const BITRATE_STEP_KBPS: u32 = 5_000;
+/// Sentinel one notch below `BITRATE_MIN_KBPS` on the slider: `punktfunk_core::client::NativeClient`
+/// arms its own client-side AIMD bitrate controller (`punktfunk_core::abr`) precisely when it's
+/// asked to connect with `bitrate_kbps == 0` — it reacts to unrecoverable frames, heavy loss,
+/// one-way-delay rise, and (via `session.rs`'s `report_decode_us` call) decode latency, backing off
+/// or climbing every ~750ms. A fixed Mbps number, however carefully picked, never adapts to a link
+/// that degrades mid-session — this does.
+pub const BITRATE_AUTOMATIC: u32 = 0;
 /// Above this, aurora-tv's own moonlight-tv wiki notes stability drops off on
 /// typical Wi-Fi — shown as an amber caution, matching the reference's settings
 /// pane (not a hard cap, the slider still allows up to `BITRATE_MAX_KBPS`).
@@ -1152,8 +1163,11 @@ fn resolution_label(width: u32, height: u32) -> String {
 }
 
 pub fn settings_rows(settings: &Settings) -> Vec<SettingsRow> {
-    let bitrate_frac =
-        (settings.bitrate_kbps.saturating_sub(BITRATE_MIN_KBPS)) as f32 / (BITRATE_MAX_KBPS - BITRATE_MIN_KBPS) as f32;
+    let bitrate_frac = if settings.bitrate_kbps == BITRATE_AUTOMATIC {
+        0.0
+    } else {
+        (settings.bitrate_kbps.saturating_sub(BITRATE_MIN_KBPS)) as f32 / (BITRATE_MAX_KBPS - BITRATE_MIN_KBPS) as f32
+    };
     vec![
         SettingsRow {
             label: "Resolution".into(),
@@ -1169,7 +1183,11 @@ pub fn settings_rows(settings: &Settings) -> Vec<SettingsRow> {
         },
         SettingsRow {
             label: "Bitrate".into(),
-            value: format!("{} Mbps", settings.bitrate_kbps / 1000),
+            value: if settings.bitrate_kbps == BITRATE_AUTOMATIC {
+                "Automatic".into()
+            } else {
+                format!("{} Mbps", settings.bitrate_kbps / 1000)
+            },
             kind: RowKind::Slider,
             fraction: bitrate_frac,
         },
@@ -1242,10 +1260,19 @@ pub fn adjust_setting(settings: &mut Settings, row_index: usize, forward: bool) 
             true
         }
         ROW_BITRATE => {
-            let delta = i64::from(BITRATE_STEP_KBPS) * if forward { 1 } else { -1 };
-            let next = (i64::from(settings.bitrate_kbps) + delta)
-                .clamp(i64::from(BITRATE_MIN_KBPS), i64::from(BITRATE_MAX_KBPS));
-            settings.bitrate_kbps = next as u32;
+            if settings.bitrate_kbps == BITRATE_AUTOMATIC {
+                if forward {
+                    settings.bitrate_kbps = BITRATE_MIN_KBPS;
+                }
+                // Already at the floor going backward from Automatic — nothing below it.
+            } else if !forward && settings.bitrate_kbps == BITRATE_MIN_KBPS {
+                settings.bitrate_kbps = BITRATE_AUTOMATIC;
+            } else {
+                let delta = i64::from(BITRATE_STEP_KBPS) * if forward { 1 } else { -1 };
+                let next = (i64::from(settings.bitrate_kbps) + delta)
+                    .clamp(i64::from(BITRATE_MIN_KBPS), i64::from(BITRATE_MAX_KBPS));
+                settings.bitrate_kbps = next as u32;
+            }
             true
         }
         ROW_HDR => {


### PR DESCRIPTION
## Summary

Two commits, one continuous investigation that started as a dependency upgrade and turned into fixing a real streaming-quality bug it exposed:

**`2fc0993` — Upgrade punktfunk-core to v0.16.0 and ureq to 3.x**
- Repin `punktfunk-core` from a mid-development commit to the tagged `v0.16.0` release. `WIRE_VERSION` is unchanged across the whole range (no protocol migration needed); `ABI_VERSION` only affects the C ABI for non-Rust embedders, not the Rust `client::NativeClient` API this crate links directly.
- Bump `ureq` 2.x → 3.x. Its `TlsConfig` dropped support for a custom `ServerCertVerifier`, which `library.rs`'s mTLS fingerprint-pinning relied on — added a small `Connector`/`Transport` modeled on ureq's own `RustlsConnector` to keep using our own `rustls::ClientConfig`.
- Bump sdl2, opus, image, tiny-skia, mdns-sd, serde, anyhow, rustls to latest within existing semver ranges.

**`b43d31e` — Fix loss-recovery freeze, use punktfunk's Automatic bitrate, and stop idle background work during streaming**
- **Freeze-until-reanchor loss recovery**: `video_pump` previously fed every received frame straight to NDL regardless of loss, showing visible corruption ("mpeg breakup") for the whole recovery window. It now withholds concealed/reference-broken frames from NDL until a real IDR or LTR-RFI recovery frame arrives, with a 2s hard give-up so a missed recovery can never freeze the picture permanently.
- **Automatic bitrate**: wired up punktfunk-core's own client-side AIMD bitrate controller (`bitrate_kbps: 0`, now the Settings default) plus `report_decode_us` decode-latency feedback. This is what actually fixed sustained packet loss at high configured bitrates — a fixed bitrate never adapts to a link that degrades mid-session.
- **Real diagnostics**: installed a `tracing_subscriber` writing into the app's log file — punktfunk-core's internal `tracing::info!`/`warn!` calls (ABR/probe decisions, RFI internals) were previously silent no-ops with no subscriber installed.
- **Frame pacing**: mDNS discovery now explicitly shuts down when entering a stream (it previously kept polling in the background for the whole session), and the video pump thread registers itself for a best-effort `nice` priority boost alongside punktfunk-core's own internal data-plane thread (`register_hot_thread`/`hot_thread_ids`, previously only consumed by Android's ADPF hint session).

## Test plan
- [x] `task check` / `task lint` clean against the real armv7 webOS cross target
- [x] Deployed and verified live on an LG CX (webOS 5.6): loss-recovery freeze/resume confirmed via log (arm → resume within ms, no permanent freeze), Automatic bitrate confirmed armed and adapting, mDNS `SearchStopped`/daemon shutdown confirmed on stream entry
- [ ] Extended real-world play session to confirm overall smoothness/quality subjectively

🤖 Generated with [Claude Code](https://claude.com/claude-code)