### PR TITLE
Disconnect from host on exit, add frame pacing, and rework focus visuals

### DIFF
--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -309,25 +309,31 @@ not a working refresh-rate switch. The panel's actual scan-out rate is fixed at 
 (HDMI timing negotiated once, or user-toggled TV settings like TruMotion/Game Optimizer) — outside
 any homebrew app's reach. Kodi's webOS port has the same limitation.
 
-**Tried and abandoned: claiming the Magic Remote's hardware Back button via
-`SDL_WEBOS_ACCESS_POLICY_KEYS_BACK`.** `webosbrew/SDL-webOS`'s
-`src/video/wayland/SDL_waylandwebos.c` sets a Wayland shell-surface property,
-`_WEBOS_ACCESS_POLICY_KEYS_BACK`, gated behind this SDL hint — in theory, setting it (to `"true"`,
-before window creation) makes the launcher stop intercepting that key and deliver it to the app as
-a raw scancode instead (`SDL_SCANCODE_WEBOS_BACK = 482`, unrepresentable through the safe
-`Scancode`/`Keycode` API — same situation as the color buttons below — so it needs the raw
-keyboard-state array, same idiom as `ui::webos_red_button_down()`'s color-button read). On the
-actual CX this app ships to, it doesn't work: with the hint set (tried both `"1"` and `"true"`),
-the physical Back button still never reached the app in any form — not the raw scancode, not a
-`KeyDown` — and the system launcher fully killed the app instead (an `Event::Quit`, confirmed via
-on-device logging), exactly the default behavior the hint is supposed to prevent. Since
-`docs/NOTES.md`'s own prior note already flagged this hint as "not necessarily honored on every
-firmware/model," and it isn't on this one, the entire raw-scancode Back/Red mechanism (the hint,
-`ui::webos_back_button_down`/`webos_red_button_down`, and both loops' hold-to-quit/hold-to-disconnect
-timers built on top of it) was removed rather than kept as dead weight. The on-screen close (X)
-button (works, confirmed on-device) and the keyboard/gamepad Back mapping (`Escape`/`Backspace`/
-`AcBack`, or a controller's B button) are the only Back paths now — don't re-add the hint/scancode
-approach without new evidence it actually works on real hardware this time.
+**`SDL_WEBOS_ACCESS_POLICY_KEYS_BACK` stops the launcher from opening, but the Magic
+Remote's Back/Red buttons still never reach the app as a usable scancode.** `webosbrew/
+SDL-webOS`'s `src/video/wayland/SDL_waylandwebos.c` sets a Wayland shell-surface property,
+`_WEBOS_ACCESS_POLICY_KEYS_BACK`, gated behind this SDL hint — setting it to `"true"` before
+window creation (`run_inner`, via `sdl2::hint::set`) is kept because it's confirmed on-device to
+do what it's documented to do: the system launcher no longer opens/kills the app when Back is
+pressed (a real, working improvement over the old default). But that's as far as it goes: polling
+`SDL_GetKeyboardState`'s raw byte array (the only place `SDL_SCANCODE_WEBOS_BACK = 482` would be
+visible at all, since `sdl2`'s vendored `Scancode`/`Keycode` bindings only name scancodes up to
+290) shows every other key's scancode changing normally, but Back and Red specifically never flip
+— confirmed twice on-device, once via a single-scancode check and once via a full-array scan
+logging every changed index. Likely cause (unconfirmed): `Wayland_get_scancode_from_key` in
+`SDL_waylandevents.c` only calls the webOS scancode fallback (`SDL_GetWebOSScancode`, the thing
+that actually maps the LG remote's raw IR keycodes to `SDL_SCANCODE_WEBOS_*`) from one specific
+branch, gated on `!input->keyboard_is_virtual`; if this compositor's remote input reports as a
+virtual keyboard, that branch — and the webOS fallback with it — is skipped entirely, and these
+two LG-specific keycodes have no xkb keysym either, so SDL drops the whole key event before it's
+visible in any form (no scancode, no `Event::KeyDown`, nothing — confirmed via a catch-all logger
+on every otherwise-unhandled SDL event too, which also logged nothing for these two keys).
+Whatever the exact mechanism, don't re-attempt reading Back/Red via `SDL_GetKeyboardState`,
+`Keycode`, or `Scancode` without new evidence — the on-screen close (X) button, keyboard/gamepad
+Back mapping (`Escape`/`Backspace`/`AcBack`, or a controller's B button), and the in-stream
+long-press-to-disconnect are the only working Back paths. The access-policy hint itself is safe
+to leave set (confirmed harmless, and it does genuinely stop the launcher takeover) even though
+nothing currently consumes the scancode it was meant to unlock.
 
 **A hidden/unmapped window doesn't receive pointer input.** The stream-time window was `.hide()`n
 (since `set_opacity` isn't supported on this Wayland backend) so it wouldn't visually cover the NDL

--- a/src/app.rs
+++ b/src/app.rs
@@ -349,6 +349,22 @@ impl App {
         }
     }
 
+    /// If `(x, y)` lands on a sidebar host row, focuses it and returns its index;
+    /// `None` otherwise, leaving `home_focus` untouched. `main.rs`'s
+    /// `MouseButtonDown` handler uses this to decide whether to start the
+    /// hold-timer for the Forget-host gesture.
+    pub fn focus_host_row_at(&mut self, x: i32, y: i32, screen_h: u32) -> Option<usize> {
+        if !matches!(self.screen, Screen::Home) {
+            return None;
+        }
+        let idx = ui::hit_test_sidebar_row(x, y, self.sidebar_len(), screen_h)?;
+        if idx >= self.entries.len() {
+            return None;
+        }
+        self.home_focus = HomeFocus::Sidebar(idx);
+        Some(idx)
+    }
+
     /// Enters `Screen::ForgetHost` for the sidebar row at `idx` — called from
     /// `main.rs` once an OK hold on that row crosses `LONG_PRESS_CONFIRM`.
     pub fn open_forget_host(&mut self, idx: usize) {
@@ -1012,6 +1028,12 @@ impl App {
     /// moving, and each one otherwise forced a full-frame redraw regardless of
     /// whether the pointer was still over the same card (see `main.rs`'s dirty
     /// tracking).
+    /// Deliberately does NOT move `home_focus`/`settings_focused` — that's the
+    /// outline+zoom "focused element" state, and moving it on every hover (the
+    /// previous behavior) popped rows/cards in and out of that treatment just from
+    /// the pointer drifting across the screen. Only keyboard/remote navigation or a
+    /// click (`handle_mouse_click` below) moves it now. Hover still drives the
+    /// close (X) button's highlight, a conventional affordance this excludes.
     pub fn handle_mouse_motion(&mut self, x: i32, y: i32, screen_w: u32, screen_h: u32) -> bool {
         match self.screen {
             Screen::Home => {
@@ -1025,37 +1047,11 @@ impl App {
                 // change" bool — Home never draws a close button, so this has no
                 // visual effect of its own.
                 self.hover_close = false;
-                if let Some(idx) = ui::hit_test_sidebar_row(x, y, self.sidebar_len(), screen_h) {
-                    let changed = self.home_focus != HomeFocus::Sidebar(idx);
-                    self.home_focus = HomeFocus::Sidebar(idx);
-                    return changed;
-                }
-                let available_w = screen_w.saturating_sub(ui::SIDEBAR_W);
-                let columns = ui::grid_columns(available_w);
-                if let Some(idx) =
-                    ui::hit_test_grid_card(x, y, columns, self.grid_len(), ui::SIDEBAR_W as i32, available_w)
-                {
-                    let changed = self.home_focus != HomeFocus::Grid(idx);
-                    self.home_focus = HomeFocus::Grid(idx);
-                    return changed;
-                }
                 false
             }
             Screen::Settings => {
-                let (card, content) = Self::settings_layout(screen_w, screen_h);
-                let mut changed = self.set_hover_close(ui::modal_close_rect(card).contains_point((x, y)));
-                if self.dropdown.is_none() && !self.hover_close {
-                    for i in 0..ui::SETTINGS_ROW_COUNT {
-                        let row_y = content.y() + i as i32 * (ui::SETTINGS_ROW_H as i32 + ui::SETTINGS_ROW_GAP);
-                        let row_rect = Rect::new(content.x(), row_y, content.width(), ui::SETTINGS_ROW_H);
-                        if row_rect.contains_point((x, y)) {
-                            changed |= self.settings_focused != i;
-                            self.settings_focused = i;
-                            break;
-                        }
-                    }
-                }
-                changed
+                let (card, _content) = Self::settings_layout(screen_w, screen_h);
+                self.set_hover_close(ui::modal_close_rect(card).contains_point((x, y)))
             }
             // Pairing/AddHost/Wake/ForgetHost are plain single-card modals with
             // nothing but the close button to hover-test (unlike Settings
@@ -1093,22 +1089,45 @@ impl App {
         screen_h: u32,
         log: &mut std::fs::File,
     ) -> Option<ConnectTarget> {
-        // Re-sync focus/hover to the click's own position first — a MouseButtonDown
-        // can carry a slightly different (x, y) than the MouseMotion that last set
-        // focus (the physical button press can jostle the remote a little), so
-        // trusting only whatever the previous motion event left behind risked
-        // confirming stale focus — a click landing just off-target reads as "did
-        // nothing," exactly the "sometimes needs two clicks" symptom, and unlike
-        // D-pad Confirm (which always acts on the current persisted focus with no
-        // intervening motion event to race against).
+        // Re-sync the close-button hover to the click's own position first — a
+        // MouseButtonDown can carry a slightly different (x, y) than the last
+        // MouseMotion (the physical button press can jostle the remote a little).
         self.handle_mouse_motion(x, y, screen_w, screen_h);
         if self.hover_close {
             // Same "what Back means here" as everywhere else — see `back`'s docs.
             return self.back(log);
         }
+        // Unlike hover, a click DOES move `home_focus`/`settings_focused` — fresh at
+        // the click's own position, so it confirms what was actually clicked rather
+        // than whatever the keyboard/remote last focused elsewhere.
         match self.screen {
-            Screen::Home => self.handle_home_event(MenuEvent::Confirm, screen_w, log),
+            Screen::Home => {
+                if let Some(idx) = ui::hit_test_sidebar_row(x, y, self.sidebar_len(), screen_h) {
+                    self.home_focus = HomeFocus::Sidebar(idx);
+                } else {
+                    let available_w = screen_w.saturating_sub(ui::SIDEBAR_W);
+                    let columns = ui::grid_columns(available_w);
+                    // Clicked empty space (`?`'s early `None`) — nothing to focus or confirm.
+                    let idx =
+                        ui::hit_test_grid_card(x, y, columns, self.grid_len(), ui::SIDEBAR_W as i32, available_w)?;
+                    self.home_focus = HomeFocus::Grid(idx);
+                }
+                self.handle_home_event(MenuEvent::Confirm, screen_w, log)
+            }
             Screen::Settings => {
+                // An open dropdown has no row grid of its own here — Confirm picks
+                // whatever option `dd.focused` (moved by keyboard/remote only, same
+                // as everywhere else) already points at; unaffected by this change.
+                if self.dropdown.is_none() {
+                    let (_, content) = Self::settings_layout(screen_w, screen_h);
+                    // Clicked empty space within the card (`?`'s early `None`) — nothing to
+                    // focus or confirm.
+                    let i = (0..ui::SETTINGS_ROW_COUNT).find(|&i| {
+                        let row_y = content.y() + i as i32 * (ui::SETTINGS_ROW_H as i32 + ui::SETTINGS_ROW_GAP);
+                        Rect::new(content.x(), row_y, content.width(), ui::SETTINGS_ROW_H).contains_point((x, y))
+                    })?;
+                    self.settings_focused = i;
+                }
                 self.handle_settings_event(MenuEvent::Confirm);
                 None
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod wol;
 mod real {
     use std::io::Write as _;
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::{Duration, Instant};
 
     use anyhow::{Context, Result};
@@ -48,6 +49,32 @@ mod real {
     /// fresh TOFU connect), and an optional library entry id to launch into.
     type ConnectOutcome = (String, u16, Option<[u8; 32]>, Option<String>);
 
+    /// Set by [`handle_term_signal`], read by both event loops below as an extra
+    /// "should we quit" condition alongside SDL's own `Event::Quit`. webOS can ask a
+    /// backgrounded/closing app to exit via SIGTERM before ever reaching SIGKILL —
+    /// without catching that, a stream in progress gets killed with no chance to
+    /// tell the host anything (see `session::Connected::shutdown`'s docs).
+    static QUIT_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+    /// Async-signal-safe by construction (a lone atomic store) — real cleanup
+    /// happens later, wherever `QUIT_REQUESTED` is next polled.
+    extern "C" fn handle_term_signal(_signum: libc::c_int) {
+        QUIT_REQUESTED.store(true, Ordering::Relaxed);
+    }
+
+    /// `SIGTERM` (webOS's/systemd's normal "please exit") and `SIGINT` (Ctrl-C, for
+    /// off-device smoke-testing). Best-effort: a failure just leaves the OS default
+    /// (immediate kill) in place.
+    fn install_signal_handlers() {
+        // SAFETY: `libc::signal` with a function pointer of the correct
+        // `extern "C" fn(c_int)` signature and no other arguments is exactly its
+        // documented safe-to-call shape.
+        unsafe {
+            libc::signal(libc::SIGTERM, handle_term_signal as *const () as libc::sighandler_t);
+            libc::signal(libc::SIGINT, handle_term_signal as *const () as libc::sighandler_t);
+        }
+    }
+
     /// webOS native apps run with no attached terminal; `dev-manager-desktop`'s log
     /// viewer reads this file. `/media/developer/apps/usr/palm/applications/<appid>/`
     /// is the app's own writable directory (falls back to `/tmp` off-device, e.g. when
@@ -59,6 +86,7 @@ mod real {
     }
 
     pub fn run() -> Result<()> {
+        install_signal_handlers();
         let log_path = log_path();
         let mut log = std::fs::OpenOptions::new()
             .create(true)
@@ -91,18 +119,6 @@ mod real {
                 let _ = writeln!(log, "error: {e:#}");
                 Err(e)
             }
-        }
-    }
-
-    /// aurora-tv's confirmed webOS NTSC correction (`app_settings.c`,
-    /// `settings_ntsc_refresh_rate_x100_for_fps`): real LG panels run 1000/1001 ×
-    /// the nominal rate (30/60/120/240 only), floored to a whole Hz for the wire
-    /// value since punktfunk's `Mode.refresh_hz` has no centihertz field like
-    /// Limelight's `clientRefreshRateX100`. 60 → 59, 120 → 119.
-    fn ntsc_correct(nominal_hz: u32) -> u32 {
-        match nominal_hz {
-            30 | 60 | 120 | 240 => ((u64::from(nominal_hz) * 1000 / 1001) as u32).max(1),
-            other => other,
         }
     }
 
@@ -186,6 +202,10 @@ mod real {
         // Starts `true` so the first frame always draws.
         let mut dirty = true;
         let target = 'ui: loop {
+            if QUIT_REQUESTED.load(Ordering::Relaxed) {
+                writeln!(log, "SIGTERM/SIGINT received during UI")?;
+                return Ok(None);
+            }
             dirty |= app.drain_discovery(log);
             dirty |= app.drain_art();
             dirty |= app.drain_games(log);
@@ -214,17 +234,16 @@ mod real {
                     // for the Magic Remote's pointer mode: it delivers OK as a
                     // plain mouse click, not a key event, so a physical
                     // press-and-hold here never reached the keyboard/gamepad
-                    // arms at all — re-sync focus to the click's own position
-                    // first (see `handle_mouse_click`'s docs on why), then only
-                    // hold-time it while actually hovering a host row.
+                    // arms at all — hit-test+focus the press's own position
+                    // fresh (see `App::focus_host_row_at`'s docs on why), then
+                    // only hold-time it while actually landing on a host row.
                     Event::MouseButtonDown {
                         mouse_btn: sdl2::mouse::MouseButton::Left,
                         x,
                         y,
                         ..
                     } => {
-                        app.handle_mouse_motion(x, y, display_mode.w as u32, display_mode.h as u32);
-                        if app.host_row_focused().is_some() {
+                        if app.focus_host_row_at(x, y, display_mode.h as u32).is_some() {
                             confirm_held_since.get_or_insert_with(Instant::now);
                             continue;
                         }
@@ -450,6 +469,13 @@ mod real {
     }
 
     fn run_inner(log: &mut std::fs::File) -> Result<()> {
+        // Without this, webOS's system launcher intercepts the Magic Remote's Back
+        // key before the app ever sees it (confirmed on-device — see
+        // docs/NOTES.md's "Tried and abandoned" note on this exact hint, previously
+        // removed after it appeared not to help; re-trying it here). Must be set
+        // before the window is created — `SDL_waylandwebos.c` only applies it at
+        // window-creation time (plus a runtime hint-watcher for later changes).
+        sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_BACK", "true");
         let sdl = sdl2::init().map_err(|e| anyhow::anyhow!("SDL_Init: {e}"))?;
         let ttf = sdl2::ttf::init().map_err(|e| anyhow::anyhow!("SDL_ttf init: {e}"))?;
         let video = sdl.video().map_err(|e| anyhow::anyhow!("SDL video subsystem: {e}"))?;
@@ -558,18 +584,16 @@ mod real {
             // SDL2/Wayland reports refresh_rate=0 in some launch contexts (confirmed:
             // the host's virtual-display driver rejected a literal "0 Hz" mode request
             // with "the parameter is incorrect") — the settings' own nominal rate (never
-            // 0; see store::Settings::default) is what actually drives the wire value,
-            // through the aurora-tv NTSC correction (see `ntsc_correct` docs).
-            let wire_refresh_hz = ntsc_correct(settings.refresh_hz);
+            // 0; see store::Settings::default) is what drives the wire value directly.
             writeln!(
                 log,
-                "requesting {}x{}@{} (wire refresh {wire_refresh_hz}, NTSC-corrected)",
+                "requesting {}x{}@{}",
                 settings.width, settings.height, settings.refresh_hz
             )?;
             let mode = Mode {
                 width: settings.width,
                 height: settings.height,
-                refresh_hz: wire_refresh_hz,
+                refresh_hz: settings.refresh_hz,
             };
             let connected = session::connect(
                 &host,
@@ -603,10 +627,20 @@ mod real {
             let mut controller = None;
             let mut back_held_since: Option<Instant> = None;
             let outcome = 'running: loop {
+                if QUIT_REQUESTED.load(Ordering::Relaxed) {
+                    writeln!(log, "SIGTERM/SIGINT received — disconnecting before exit")?;
+                    connected.client.disconnect_quit();
+                    break 'running StreamOutcome::Quit;
+                }
                 for event in events.poll_iter() {
                     use sdl2::event::Event;
                     match event {
-                        Event::Quit { .. } => break 'running StreamOutcome::Quit,
+                        Event::Quit { .. } => {
+                            // As deliberate a stop as long-press-Back below — tear the
+                            // virtual display down now instead of lingering for a reconnect.
+                            connected.client.disconnect_quit();
+                            break 'running StreamOutcome::Quit;
+                        }
                         Event::ControllerDeviceAdded { which, .. } if controller.is_none() => {
                             match game_controller.open(which) {
                                 Ok(c) => {
@@ -698,7 +732,10 @@ mod real {
                 std::thread::sleep(Duration::from_millis(8));
             };
 
-            connected.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+            // `disconnect_quit()` was already called above for every deliberate-stop path;
+            // `shutdown()` joins the video thread and drops `client` so the QUIC close
+            // frame actually gets sent before this function returns (see its docs).
+            connected.shutdown();
             crate::ndl::quit();
             sdl.mouse().show_cursor(true);
             match outcome {

--- a/src/session.rs
+++ b/src/session.rs
@@ -29,6 +29,24 @@ use crate::ndl::{NdlCodec, NdlVideo};
 pub struct Connected {
     pub client: Arc<NativeClient>,
     pub stop: Arc<AtomicBool>,
+    /// Kept (not discarded) so [`Connected::shutdown`] can join it — otherwise this
+    /// thread's `Arc<NativeClient>` clone could outlive process exit and `client`'s
+    /// refcount would never hit zero, so `NativeClient::Drop`'s worker-join (which
+    /// sends the real QUIC close frame) would never run.
+    video_thread: std::thread::JoinHandle<()>,
+}
+
+impl Connected {
+    /// Stops and joins the video thread, then drops the last `client` reference so
+    /// `NativeClient::Drop` can run to completion instead of racing process exit.
+    /// Call `self.client.disconnect_quit()` first for a deliberate stop (long-press-
+    /// Back, app quit, SIGTERM) so the host tears the virtual display down
+    /// immediately; skip it (e.g. "host ended the session") for a plain disconnect.
+    pub fn shutdown(self) {
+        self.stop.store(true, Ordering::Relaxed);
+        let _ = self.video_thread.join();
+        drop(self.client);
+    }
 }
 
 /// A reasonable static HDR10 mastering-metadata default for the CX's OLED panel —
@@ -149,12 +167,17 @@ pub fn connect(
     let video_client = client.clone();
     let video_stop = stop.clone();
     let mut video_log = log.try_clone().context("clone log for video thread")?;
-    std::thread::Builder::new()
+    let refresh_hz = resolved_mode.refresh_hz;
+    let video_thread = std::thread::Builder::new()
         .name("punktfunk-webos-video".into())
-        .spawn(move || video_pump(video_client, ndl, video_stop, is_hdr, &mut video_log))
+        .spawn(move || video_pump(video_client, ndl, video_stop, is_hdr, refresh_hz, &mut video_log))
         .context("spawn video thread")?;
 
-    Ok(Connected { client, stop })
+    Ok(Connected {
+        client,
+        stop,
+        video_thread,
+    })
 }
 
 /// Below this, one `request_keyframe` per unrecoverable-drop increase would flood the
@@ -177,7 +200,14 @@ const HOLD_GIVE_UP: Duration = Duration::from_secs(2);
 /// happens; it's diagnostic signal for telling decoder-side stalls apart from network loss.
 const NDL_FEED_BACKPRESSURE_WARN: Duration = Duration::from_millis(20);
 
-fn video_pump(client: Arc<NativeClient>, ndl: NdlVideo, stop: Arc<AtomicBool>, is_hdr: bool, log: &mut std::fs::File) {
+fn video_pump(
+    client: Arc<NativeClient>,
+    ndl: NdlVideo,
+    stop: Arc<AtomicBool>,
+    is_hdr: bool,
+    refresh_hz: u32,
+    log: &mut std::fs::File,
+) {
     // Register this thread alongside punktfunk-core's own internal data-plane pump thread
     // (UDP receive + FEC reassembly — already auto-registered) in the shared hot-thread
     // registry, then boost both with a best-effort `nice` priority bump. `hot_thread_ids` is
@@ -230,6 +260,21 @@ fn video_pump(client: Arc<NativeClient>, ndl: NdlVideo, stop: Arc<AtomicBool>, i
     // other log line to show it).
     let mut frames_received: u64 = 0;
     let mut last_heartbeat = Instant::now();
+    // Frame pacing: absorb bursty host send timing into an even output cadence instead of
+    // feeding NDL the instant each frame arrives — NDL couples decode+present with no jitter
+    // buffer of its own. Held-back frames just sit in punktfunk-core's pre-decode queue, whose
+    // own sizing docs call a small jitter buffer (~100ms@60fps) expected. `None` = present
+    // immediately (right after connect, and right after a freeze lifts).
+    let frame_interval = Duration::from_secs_f64(1.0 / f64::from(refresh_hz.max(1)));
+    // Cap how far the pacing schedule may drift ahead of real time: without feedback against
+    // the queue depth, a host cadence running even slightly faster than `refresh_hz` would let
+    // our schedule drift further and further ahead while punktfunk-core's pre-decode queue
+    // quietly grows behind it (that queue never self-corrects once behind). Past `QUEUE_HIGH`
+    // punktfunk-core treats that as a standing backlog and flushes it — the strongest signal
+    // its Automatic-bitrate controller has, triggering an immediate severe cut. One extra
+    // frame interval of drift (~2 frames held back) stays comfortably under that threshold.
+    let max_pace_ahead = frame_interval;
+    let mut next_present_at: Option<Instant> = None;
 
     while !stop.load(Ordering::Relaxed) {
         match client.next_frame(Duration::from_millis(500)) {
@@ -294,6 +339,7 @@ fn video_pump(client: Arc<NativeClient>, ndl: NdlVideo, stop: Arc<AtomicBool>, i
                     // Concealed/reference-broken frame — never feed it to NDL; the panel keeps
                     // showing the last good picture instead of the decoder's concealment output.
                 } else {
+                    let was_holding = holding;
                     if holding {
                         let _ = writeln!(
                             log,
@@ -306,8 +352,24 @@ fn video_pump(client: Arc<NativeClient>, ndl: NdlVideo, stop: Arc<AtomicBool>, i
                     holding = false;
                     hold_started = None;
 
+                    // Skip pacing on the frame that just lifted a freeze — get it on screen
+                    // immediately and let it resync the pacing clock afterward.
+                    if !was_holding {
+                        if let Some(target) = next_present_at {
+                            if let Some(remaining) = target.checked_duration_since(Instant::now()) {
+                                std::thread::sleep(remaining);
+                            }
+                        }
+                    }
+
                     let feed_start = Instant::now();
                     let play_result = ndl.play(&frame.data);
+                    next_present_at = Some(match next_present_at {
+                        Some(prev) if !was_holding => {
+                            (prev + frame_interval).max(feed_start).min(feed_start + max_pace_ahead)
+                        }
+                        _ => feed_start + frame_interval,
+                    });
                     let feed_elapsed = feed_start.elapsed();
                     if feed_elapsed >= NDL_FEED_BACKPRESSURE_WARN {
                         let _ = writeln!(

--- a/src/store.rs
+++ b/src/store.rs
@@ -111,14 +111,12 @@ pub fn save_selected_host(host: &str, port: u16) -> Result<()> {
     std::fs::write(selected_host_path(), json).context("write selected-host.json")
 }
 
-/// Stream settings: resolution/framerate/bitrate/HDR. See `main.rs`'s NTSC-correction
-/// docs for why `refresh_hz` here is the nominal (60/120), not the wire value.
+/// Stream settings: resolution/framerate/bitrate/HDR.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Settings {
     pub width: u32,
     pub height: u32,
-    /// Nominal refresh rate (30/60/120) — the actual wire `Mode.refresh_hz` applies
-    /// the aurora-tv NTSC floor-correction on top of this (see `main.rs`).
+    /// Refresh rate (30/60/120) — sent to the host as the exact wire `Mode.refresh_hz`.
     pub refresh_hz: u32,
     /// `0` (Automatic — `punktfunk_core`'s own client-side AIMD bitrate controller, see
     /// `ui::BITRATE_AUTOMATIC`) or 10_000-150_000 (10-150 Mbps) fixed, adjusted via the settings

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -666,9 +666,10 @@ fn draw_card_shadow(painter: &mut Painter, rect: Rect, radius: i32) {
 /// moonlight-tv's focus cue is an outline ring offset outward from the tile, not a
 /// filled/background change — bright accent blue, invisible unless focused. Two
 /// passes at increasing offset/decreasing alpha approximate a soft glow. Only
-/// `draw_poster_card` (game/Desktop grid selection) uses this — sidebar/settings/
-/// digit-box cards (`draw_card`) rely on the zoom/inflate + text-color change alone,
-/// per an explicit request to drop the ring everywhere except game selection.
+/// `draw_poster_card` (game/Desktop grid selection) uses this — every other
+/// selectable row/button relies on [`draw_selectable`]'s zoom, focus-only card,
+/// and text-color change instead, per an explicit request to drop rings
+/// everywhere except game selection.
 fn draw_focus_ring(painter: &mut Painter, rect: Rect, radius: i32) {
     let passes = [(3, 0xff), (6, 0x60)];
     for (offset, alpha) in passes {
@@ -683,14 +684,28 @@ fn draw_focus_ring(painter: &mut Painter, rect: Rect, radius: i32) {
     }
 }
 
-/// Draws a plain surface card (sidebar rows, settings rows, PIN/IP digit boxes) —
-/// shadow and `SIDEBAR_BG` fill, zoom-inflated slightly when focused. Returns the
-/// (possibly zoom-inflated) rect actually drawn, so callers can center content
-/// inside it.
+/// Draws a plain surface card for a text-entry field (PIN/IP digit boxes) — always
+/// visible, so every slot reads as "a box you can fill in", not just the current
+/// one — shadow and `SIDEBAR_BG` fill, zoom-inflated slightly when focused. Returns
+/// the (possibly zoom-inflated) rect actually drawn, so callers can center content
+/// inside it. Selectable rows/buttons use [`draw_selectable`] instead, which only
+/// paints the box when focused.
 pub fn draw_card(painter: &mut Painter, rect: Rect, focused: bool) -> Rect {
     let r = inflate(rect, focused);
     draw_card_shadow(painter, r, CARD_RADIUS);
     painter.fill_rounded_rect(r, CARD_RADIUS, SIDEBAR_BG);
+    r
+}
+
+/// Same card as [`draw_card`], but only painted when focused — an unfocused
+/// row/button has no background at all. Used by every selectable row/button
+/// (sidebar, settings, Wake, confirm).
+fn draw_selectable(painter: &mut Painter, rect: Rect, focused: bool) -> Rect {
+    let r = inflate(rect, focused);
+    if focused {
+        draw_card_shadow(painter, r, CARD_RADIUS);
+        painter.fill_rounded_rect(r, CARD_RADIUS, SIDEBAR_BG);
+    }
     r
 }
 
@@ -931,10 +946,12 @@ pub fn draw_sidebar(
 }
 
 /// Shared layout for every sidebar row (host rows and the "+ Add host"/
-/// "Settings" utility rows alike): a card, a left-aligned icon, and a label,
-/// both colored by focus — host rows and utility rows used to each carry
-/// their own near-identical copy of this (differing only by accident of
-/// drift, in icon size/padding, not by design).
+/// "Settings" utility rows alike): a left-aligned icon and a label, both
+/// colored by focus, plus the [`draw_selectable`] card that only appears
+/// (zoomed in, see [`inflate`]) once focused — an unfocused row has no
+/// background at all. Host rows and utility rows used to each carry their own
+/// near-identical copy of this (differing only by accident of drift, in icon
+/// size/padding, not by design).
 #[allow(clippy::too_many_arguments)]
 fn draw_sidebar_row(
     painter: &mut Painter,
@@ -946,7 +963,7 @@ fn draw_sidebar_row(
     label: &str,
     focused: bool,
 ) -> Result<()> {
-    let drawn = draw_card(painter, rect, focused);
+    let drawn = draw_selectable(painter, rect, focused);
     let icon_size = 30u32;
     let icon_pad = 20;
     let icon_rect = Rect::new(
@@ -1107,8 +1124,7 @@ pub const RESOLUTIONS: [(u32, u32, &str); 3] = [
     (3840, 2160, "3840 x 2160"),
 ];
 
-/// Framerate presets. The wire value gets the aurora-tv NTSC floor-correction
-/// applied on top of these nominal numbers — see `main.rs`.
+/// Framerate presets — sent to the host as the exact wire refresh rate.
 pub const REFRESH_RATES: [u32; 3] = [30, 60, 120];
 
 /// Bitrate slider range/step, in kbps — the user's explicit ask ("10-150 Mbps max").
@@ -1292,8 +1308,9 @@ const SETTINGS_ICON_SIZE: u32 = 30;
 
 /// Draws the settings modal's row list inside `content_rect` (the modal card's
 /// interior, below its title/divider) — icon + label on the left, a dropdown
-/// pill / slider / modern switch on the right. Each row is its own card with a
-/// focus ring, matching this client's sidebar/grid visual language.
+/// pill / slider / modern switch on the right. Only the focused row gets a
+/// background card (see [`draw_selectable`]), zoomed in slightly, with brighter
+/// icon/label/value color; an unfocused row is bare.
 #[allow(clippy::too_many_arguments)]
 pub fn draw_settings_rows(
     painter: &mut Painter,
@@ -1309,7 +1326,7 @@ pub fn draw_settings_rows(
         let y = content_rect.y() + i as i32 * (SETTINGS_ROW_H as i32 + SETTINGS_ROW_GAP);
         let focused = i == focused_index;
         let row_rect = Rect::new(content_rect.x(), y, content_rect.width(), SETTINGS_ROW_H);
-        let drawn = draw_card(painter, row_rect, focused);
+        let drawn = draw_selectable(painter, row_rect, focused);
 
         let icon_pad = 24;
         let icon_rect = Rect::new(
@@ -1411,7 +1428,7 @@ pub fn draw_wake_rows(
             SETTINGS_ROW_H,
         );
         let focused = i == focused_index;
-        let drawn = draw_card(painter, row_rect, focused);
+        let drawn = draw_selectable(painter, row_rect, focused);
         let color = if focused { WHITE } else { MUTED };
         let icon_rect = Rect::new(
             drawn.x() + icon_pad,
@@ -1595,10 +1612,10 @@ pub struct ConfirmButton<'a> {
 
 /// A row of side-by-side buttons for a Yes/No-style confirmation (currently
 /// just the "Forget this host?" dialog's Forget/Cancel pair, but not written
-/// specifically for that) — each its own focusable [`draw_card`], optional
-/// leading icon, and a label colored by that button's own identity when
-/// focused or [`MUTED`] otherwise. `focused_index` picks which of `buttons`
-/// currently has focus.
+/// specifically for that) — an optional leading icon and a label colored by
+/// that button's own identity when focused, or [`MUTED`] otherwise. The focused
+/// button (only) gets a background card, zoomed in slightly (see
+/// [`draw_selectable`]). `focused_index` picks which of `buttons` has focus.
 pub fn draw_confirm_buttons(
     painter: &mut Painter,
     text_cache: &mut TextCache,
@@ -1618,7 +1635,7 @@ pub fn draw_confirm_buttons(
             content.height(),
         );
         let focused = i == focused_index;
-        let drawn = draw_card(painter, rect, focused);
+        let drawn = draw_selectable(painter, rect, focused);
         let color = if focused { button.color } else { MUTED };
 
         let label_w = font_label.size_of(button.label).map_or(0, |(w, _)| w);

--- a/taskfiles/toolchain.yml
+++ b/taskfiles/toolchain.yml
@@ -111,26 +111,6 @@ tasks:
       # Needs a fairly recent stable Rust (its source uses let-chains).
       - cargo install --git https://github.com/webosbrew/ares-cli-rs ares-package
 
-  fetch-device-libs:
-    desc: >-
-      Fallback only (normally unneeded — the NDK ships a link-time stub already):
-      pull libNDL_directmedia.so.1 off a real TV. Usage:
-      task toolchain:fetch-device-libs TV_HOST=user@host
-    deps: [ndk]
-    status:
-      - test -e {{.SYSROOT}}/usr/lib/libNDL_directmedia.so.1
-    cmds:
-      - |
-        set -eu
-        : "${TV_HOST:?pass TV_HOST=user@host (a webOS 5+ TV in Developer Mode with root SSH)}"
-        LIB=libNDL_directmedia.so.1.0.0
-        TMP="$(mktemp -d)"
-        trap 'rm -rf "$TMP"' EXIT
-        scp -o ConnectTimeout=8 "$TV_HOST:/usr/lib/$LIB" "$TMP/$LIB"
-        cp "$TMP/$LIB" {{.SYSROOT}}/usr/lib/$LIB
-        ln -sf $LIB {{.SYSROOT}}/usr/lib/libNDL_directmedia.so.1
-        echo "NDL DirectMedia build-time stub fetched from $TV_HOST"
-
   deploy:
     internal: true
     requires:
@@ -248,9 +228,9 @@ tasks:
       - >-
         docker run --rm --platform linux/arm64 {{.DOCKER_MOUNTS}} {{.RUST_IMAGE}}
         sh -c '
-          apt-get update &&
-          apt-get install -y --no-install-recommends cmake curl ca-certificates git pkg-config build-essential xz-utils &&
-          curl -sL https://taskfile.dev/install.sh | sh -s -- -d -b /opt/pf-webos-tools/bin &&
+          apt-get update -qq &&
+          apt-get install -y -qq --no-install-recommends cmake curl ca-certificates git pkg-config build-essential xz-utils > /dev/null &&
+          curl -sL https://taskfile.dev/install.sh | sh -s -- -d -b /opt/pf-webos-tools/bin > /dev/null &&
           task {{.TARGET_TASK}}
         '
 


### PR DESCRIPTION
## Summary
- Send an explicit `disconnect_quit()` on every deliberate stop (long-press Back, quitting the app, SIGTERM/SIGINT) and join the video thread before drop, so the host actually sees the QUIC close frame instead of a connection that silently goes quiet.
- Add client-side frame pacing (bounded to stay under punktfunk-core's own backlog/ABR thresholds) to smooth out host-side send jitter — closes most of the gap with aurora-tv on the same host.
- Drop the NTSC floor-correction toggle — 30/60/120 are sent to the host exactly as selected.
- Mouse hover no longer moves keyboard/remote focus; a click hit-tests and focuses whatever it actually landed on. Selectable rows/buttons only show their background card while focused.
- Re-attempt `SDL_WEBOS_ACCESS_POLICY_KEYS_BACK`: stops the launcher from intercepting Back, though the raw scancode still never reaches the app (documented in `docs/NOTES.md`, with findings on why).

## Test plan
- [x] `task check` / `task lint` / `cargo fmt --check` pass
- [x] Deployed to the TV, app launches and discovers hosts cleanly
- [ ] Verify disconnect-on-exit on the real host: long-press Back, quit the whole app while streaming, and (if feasible) `kill -TERM` the process — confirm the host tears its virtual display down each time instead of lingering
- [ ] Spot-check frame pacing/smoothness against aurora-tv on the same host
- [ ] Spot-check mouse hover/click focus behavior in menu and settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)