### PR TITLE
Fix high-bitrate decode choppiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.16.0#191c9a4e188dffabc17b99fb4110f0e9666f4510"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.17.0#7c0313a7cbbdb3b42265a89c6ec003b1b5744dd2"
 
 [[package]]
 name = "fiat-crypto"
@@ -1040,8 +1040,8 @@ dependencies = [
 
 [[package]]
 name = "punktfunk-core"
-version = "0.16.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.16.0#191c9a4e188dffabc17b99fb4110f0e9666f4510"
+version = "0.17.0"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.17.0#7c0313a7cbbdb3b42265a89c6ec003b1b5744dd2"
 dependencies = [
  "aes-gcm",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,17 @@ tracing-subscriber = "0.3"
 # pf-client-core's session::start() (see session.rs docs for why we don't use that).
 # Pinned to a tagged punktfunk release (not a branch tip) this client was
 # developed/tested against — bump deliberately, not automatically, since
-# punktfunk-core's wire/ABI surface can move. Currently v0.16.0 — WIRE_VERSION 2
-# (unchanged since this pin's previous v0.9.2-based commit; no protocol migration
-# needed here), ABI_VERSION 9 (irrelevant to us: we link the Rust `client` API
-# directly, not the C ABI in `abi.rs`, and that module's signatures are unchanged
-# across the whole v0.9.2..v0.16.0 range).
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.16.0", features = [
+# punktfunk-core's wire/ABI surface can move. Currently v0.17.0 (bumped from
+# v0.16.0) — WIRE_VERSION unchanged, and `client::NativeClient`'s public surface is
+# identical, so this is a behavior-only bump. Pulled in for `VIDEO_CAP_STREAMED_AU`
+# (added post-v0.16.0): the host's Linux direct-NVENC encoder can now stream a
+# multi-slice frame's tail overlapped with packetize/FEC/pacing instead of waiting
+# for the whole frame to encode first, cutting large-frame pipeline latency —
+# helps most exactly where bigger (higher-bitrate) frames used to fall behind.
+# No client code change needed: this crate already OR's the cap bit into every
+# `Hello` unconditionally, it was just a no-op against an older host/core. The
+# host machine's punktfunk-host needs to be on v0.17.0+ too, or it ignores the bit.
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.17.0", features = [
     "quic",
 ] }
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,13 @@ tracing-subscriber = "0.3"
 # No client code change needed: this crate already OR's the cap bit into every
 # `Hello` unconditionally, it was just a no-op against an older host/core. The
 # host machine's punktfunk-host needs to be on v0.17.0+ too, or it ignores the bit.
+#
+# Pending bump: the maintainer is adding ChaCha20-Poly1305 to the wire protocol (see
+# docs/NOTES.md's high-bitrate decode entry — the CX's Cortex-A9 has no AES hardware,
+# so software AES-GCM is a real decode-choppiness contributor at high bitrate). This
+# client has no cipher-specific code of its own (crypto is internal to this crate,
+# behind `NativeClient`) — when that lands, just bump the tag; do NOT add a
+# client-side setting/toggle for it, it's the one cipher this client speaks.
 punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.17.0", features = [
     "quic",
 ] }

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -167,6 +167,52 @@ narrowed per request, not removed outright.
 `-Z build-std` would close that gap but is a bigger toolchain change, worth it only if profiling
 still shows cost unexplained by the app's own draw calls.
 
+## High-bitrate video decode choppiness (2026-07-21)
+
+Symptom: decode visibly lags the stream and framerate gets choppy above ~80 Mbps, unusable
+above ~100 Mbps — despite the CX's hardware decoder being confirmed capable of 150+ Mbps
+butter-smooth by aurora-tv, over the *same host*, via its GameStream-compatibility protocol
+path. Root-caused by reading aurora-tv's source/history and the `punktfunk-core`/
+`punktfunk-host` source directly, not just this client.
+
+Two real, fixed contributors:
+- **Frame pacer regression (85b6ef5)**: `video_pump` slept to a fixed `next_present_at`
+  schedule before every `ndl.play()`, withholding an already-available frame from the decoder
+  until a scheduled instant. `NDL_DirectVideoPlay` couples decode+present with no decode-ahead
+  of its own, so this shrank exactly the head start large (high-bitrate) frames need. Removed —
+  feed NDL immediately on every frame, same as before that commit.
+- **`punktfunk-core` was pinned to v0.16.0, missing `VIDEO_CAP_STREAMED_AU`** (added
+  post-v0.16.0, default-on for the host's Linux direct-NVENC encoder as of v0.17.0): lets the
+  host stream a multi-slice frame's tail overlapped with packetize/FEC/pacing instead of
+  waiting for the whole frame to finish encoding — upstream's own gate numbers show p99
+  encode-to-send latency 8527→5363µs on large frames. Bumped the pin to v0.17.0;
+  `NativeClient`'s public API is unchanged, so no client code changes were needed — this crate
+  already sent the capability bit unconditionally, it was just a no-op against an older
+  host/core. Requires the host machine's own `punktfunk-host` rebuilt to v0.17.0+ too, or it
+  ignores the bit.
+
+Confirmed on-device: 100 Mbps went from choppy/unusable to usable and mostly stable.
+
+**Known remaining gap, not yet fixed — the likely dominant remaining cost**: punktfunk's
+*native* protocol (what this client speaks) negotiates AES-128-GCM on every video datagram
+(`punktfunk-host/src/native.rs`), decrypted client-side per packet. The CX's SoC is
+Cortex-A9/ARMv7-A — the ARM Crypto Extensions (dedicated AES instructions) only exist on
+ARMv8+, so this runs as constant-time software AES-GCM on a single core, an O(bytes) cost that
+scales with bitrate. aurora-tv's GameStream-compatibility path is explicitly plaintext
+(`punktfunk-host/src/gamestream/video.rs`: "AES-GCM video encryption is negotiated off for
+now") — zero decrypt cost, part of why it sustains 150+ Mbps.
+
+The fix is **not** disabling encryption: swap to **ChaCha20-Poly1305** (RFC 8439, same
+security tier as AES-GCM, a standard TLS 1.3 AEAD). Its core is 32-bit add/rotate/xor — no
+S-box lookups, no GHASH carry-less multiply — so it stays fast in pure software on a CPU with
+no crypto instructions at all (why Google/BoringSSL default to it on ARM devices without an
+AES-NI equivalent). `punktfunk-core/src/crypto.rs` already builds on RustCrypto's `aead` traits
+around `Aes128Gcm`; `chacha20poly1305` is the same crate family with the same trait shape, so
+the in-crate change is close to a type swap. The real work is the wire-visible part: needs a
+capability/version negotiation (every client and host must agree, so not a silent swap), and
+the key grows from 16 to 32 bytes. This is a `punktfunk-core`/`punktfunk-host` change — affects
+every client, not just this one — intentionally deferred, not part of this pass.
+
 ## Runtime/deploy gotchas (LG CX specifics)
 
 - Homebrew apps install to `/media/developer/apps/usr/palm/applications/<appid>/`; the jailer

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -211,7 +211,15 @@ around `Aes128Gcm`; `chacha20poly1305` is the same crate family with the same tr
 the in-crate change is close to a type swap. The real work is the wire-visible part: needs a
 capability/version negotiation (every client and host must agree, so not a silent swap), and
 the key grows from 16 to 32 bytes. This is a `punktfunk-core`/`punktfunk-host` change — affects
-every client, not just this one — intentionally deferred, not part of this pass.
+every client, not just this one.
+
+**Status (2026-07-21): the punktfunk maintainer has confirmed ChaCha20-Poly1305 is coming to
+the protocol.** Nothing to do in pf-webos yet — this client has no cipher-specific code of its
+own (it never touches `SessionCrypto`/`Aes128Gcm` directly; all of it is internal to
+`punktfunk-core`, invisible behind the `NativeClient` API this client consumes). Once
+punktfunk-core ships it and pf-webos bumps its pin, wire it in as the **sole** cipher — no
+client-side setting/toggle for encryption algorithm, same way codec/HDR/bitrate capability bits
+are just sent, not exposed as a user choice between wire-level options.
 
 ## Runtime/deploy gotchas (LG CX specifics)
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -167,10 +167,9 @@ pub fn connect(
     let video_client = client.clone();
     let video_stop = stop.clone();
     let mut video_log = log.try_clone().context("clone log for video thread")?;
-    let refresh_hz = resolved_mode.refresh_hz;
     let video_thread = std::thread::Builder::new()
         .name("punktfunk-webos-video".into())
-        .spawn(move || video_pump(video_client, ndl, video_stop, is_hdr, refresh_hz, &mut video_log))
+        .spawn(move || video_pump(video_client, ndl, video_stop, is_hdr, &mut video_log))
         .context("spawn video thread")?;
 
     Ok(Connected {
@@ -200,14 +199,7 @@ const HOLD_GIVE_UP: Duration = Duration::from_secs(2);
 /// happens; it's diagnostic signal for telling decoder-side stalls apart from network loss.
 const NDL_FEED_BACKPRESSURE_WARN: Duration = Duration::from_millis(20);
 
-fn video_pump(
-    client: Arc<NativeClient>,
-    ndl: NdlVideo,
-    stop: Arc<AtomicBool>,
-    is_hdr: bool,
-    refresh_hz: u32,
-    log: &mut std::fs::File,
-) {
+fn video_pump(client: Arc<NativeClient>, ndl: NdlVideo, stop: Arc<AtomicBool>, is_hdr: bool, log: &mut std::fs::File) {
     // Register this thread alongside punktfunk-core's own internal data-plane pump thread
     // (UDP receive + FEC reassembly — already auto-registered) in the shared hot-thread
     // registry, then boost both with a best-effort `nice` priority bump. `hot_thread_ids` is
@@ -260,21 +252,6 @@ fn video_pump(
     // other log line to show it).
     let mut frames_received: u64 = 0;
     let mut last_heartbeat = Instant::now();
-    // Frame pacing: absorb bursty host send timing into an even output cadence instead of
-    // feeding NDL the instant each frame arrives — NDL couples decode+present with no jitter
-    // buffer of its own. Held-back frames just sit in punktfunk-core's pre-decode queue, whose
-    // own sizing docs call a small jitter buffer (~100ms@60fps) expected. `None` = present
-    // immediately (right after connect, and right after a freeze lifts).
-    let frame_interval = Duration::from_secs_f64(1.0 / f64::from(refresh_hz.max(1)));
-    // Cap how far the pacing schedule may drift ahead of real time: without feedback against
-    // the queue depth, a host cadence running even slightly faster than `refresh_hz` would let
-    // our schedule drift further and further ahead while punktfunk-core's pre-decode queue
-    // quietly grows behind it (that queue never self-corrects once behind). Past `QUEUE_HIGH`
-    // punktfunk-core treats that as a standing backlog and flushes it — the strongest signal
-    // its Automatic-bitrate controller has, triggering an immediate severe cut. One extra
-    // frame interval of drift (~2 frames held back) stays comfortably under that threshold.
-    let max_pace_ahead = frame_interval;
-    let mut next_present_at: Option<Instant> = None;
 
     while !stop.load(Ordering::Relaxed) {
         match client.next_frame(Duration::from_millis(500)) {
@@ -339,7 +316,6 @@ fn video_pump(
                     // Concealed/reference-broken frame — never feed it to NDL; the panel keeps
                     // showing the last good picture instead of the decoder's concealment output.
                 } else {
-                    let was_holding = holding;
                     if holding {
                         let _ = writeln!(
                             log,
@@ -352,24 +328,8 @@ fn video_pump(
                     holding = false;
                     hold_started = None;
 
-                    // Skip pacing on the frame that just lifted a freeze — get it on screen
-                    // immediately and let it resync the pacing clock afterward.
-                    if !was_holding {
-                        if let Some(target) = next_present_at {
-                            if let Some(remaining) = target.checked_duration_since(Instant::now()) {
-                                std::thread::sleep(remaining);
-                            }
-                        }
-                    }
-
                     let feed_start = Instant::now();
                     let play_result = ndl.play(&frame.data);
-                    next_present_at = Some(match next_present_at {
-                        Some(prev) if !was_holding => {
-                            (prev + frame_interval).max(feed_start).min(feed_start + max_pace_ahead)
-                        }
-                        _ => feed_start + frame_interval,
-                    });
                     let feed_elapsed = feed_start.elapsed();
                     if feed_elapsed >= NDL_FEED_BACKPRESSURE_WARN {
                         let _ = writeln!(


### PR DESCRIPTION
## Summary
- Removes the client-side frame pacer added in 85b6ef5: it delayed feeding NDL until a fixed presentation schedule, fighting `NDL_DirectVideoPlay`'s coupled decode+present and shrinking the decoder's head start on larger (higher-bitrate) frames.
- Bumps `punktfunk-core` v0.16.0 → v0.17.0 to pick up `VIDEO_CAP_STREAMED_AU`: the host's Linux direct-NVENC encoder can now stream a multi-slice frame's tail overlapped with packetize/FEC/pacing instead of waiting for the whole frame to encode, cutting large-frame pipeline latency. No client code change needed — this crate already sends the capability bit unconditionally, it was a no-op against the older host/core. `NativeClient`'s public surface is unchanged between the two tags.

Confirmed on-device: 100 Mbps is now usable and mostly stable (previously choppy/unusable above ~80-100 Mbps).

## Test plan
- [x] `task check` / `task lint` clean on `armv7-unknown-linux-gnueabi`
- [x] `cargo fmt --check` clean
- [x] `task package` builds successfully
- [x] Deployed to LG CX, confirmed 100 Mbps now usable/stable (previously choppy/unusable)
- [ ] Host machine rebuilt against punktfunk-host v0.17.0+ (required for the streamed-AU benefit to take effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)