### PR TITLE
Magic Remote & controller input passthrough

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Native LG webOS TV client for [punktfunk](https://git.unom.io/unom/punktfunk) (low-latency desktop/game
+streaming). Targets webOS 5.x+, developed and verified live on an LG CX (webOS 5.6). Built directly on
+`punktfunk-core` (pinned git dependency, see `Cargo.toml`) — deliberately *not* on upstream's
+`pf-client-core` crate, whose Linux dependency table drags in FFmpeg/PipeWire/SDL3 (see `session.rs`
+module docs).
+
+Read `docs/NOTES.md` before touching video decode, rendering performance, the toolchain, or input
+handling — it documents hard-won on-device findings and lists things *not* to re-attempt (e.g. reading
+Back/Red via the safe SDL2 event API, an in-stream diagnostics overlay, blanket `clippy::pedantic`).
+
+## Commands
+
+Everything is a [go-task](https://taskfile.dev) target (`Taskfile.yml`); run `task --list` for the
+full list. **Only Docker is required for local dev** — the webOS cross-toolchain only ships a Linux
+aarch64 build, so `build`/`check`/`package`/`lint` run inside an ephemeral `docker run --rm` (works on
+amd64 hosts too, via QEMU). First run fetches the toolchain (~150MB); cached in Docker volumes after
+that. CI skips Docker and calls the `native:*` tasks directly (its runner is already Linux aarch64).
+
+| Task | What it does |
+| --- | --- |
+| `task package` | Build + package `dist/*.ipk` — the one you usually want |
+| `task build` / `task check` | Faster inner loop: just compile, or just `cargo check` |
+| `task lint` / `task fmt` | `cargo clippy` (Docker) / `cargo fmt` (native) |
+| `task deploy TV_HOST=root@<tv-ip>` | Build, package, install, and launch on a real TV over SSH |
+| `task deploy:log TV_HOST=root@<tv-ip>` | Tail the app's log (`/tmp/punktfunk-webos.log`) on the TV |
+| `task shell` | Interactive shell in the Docker build container (debugging) |
+| `task clean` / `task clean:all` | Remove `dist/`, or everything (toolchain/target/Docker volumes) |
+
+Set `TV_HOST` once in a local `.env` (copy `.env.example`) to skip typing it every time.
+
+No test suite (no `#[test]`s) — verify via `task deploy` + `task deploy:log` on real hardware, or a
+native `cargo check`/`cargo build` off-target as a quick syntax/type sanity check (macOS/Windows build
+green via a stub `main()`, see below).
+
+**Versioning**: `Cargo.toml`/`packaging/appinfo.json` stay a fixed `0.0.1` — every `.ipk` gets the HEAD
+commit's short sha in its filename instead; the real release version only appears in the Homebrew
+Channel manifest, generated from the GitHub Release tag (`.github/workflows/build.yml`).
+
+## Architecture
+
+**Platform gating**: almost the entire crate (`app`, `art`, `audio`, `discovery`, `gamepad`,
+`keyboard`, `library`, `mouse`, `ndl`, `session`, `store`, `ui`, `wol`) is gated
+`#[cfg(target_os = "linux")]` in `main.rs`. The webOS cross target (`armv7-unknown-linux-gnueabi`)
+reports `target_os = "linux"`, same as a native Linux dev box. `main.rs` has a real `mod real` for
+Linux and a stub (`anyhow::bail!`) otherwise, so `cargo build`/`check` stays green on macOS/Windows
+without SDL2 installed.
+
+**Two independent decode paths, no shared decode/present split**: video is hardware-decoded via
+webOS's NDL DirectMedia API (`ndl.rs`) — one opaque call that decodes *and* presents, with no hook to
+decode without displaying. Audio is decoded client-side via Opus (`audio.rs`) and played through plain
+SDL2/PulseAudio; NDL's own audio path is unused. This matters for loss recovery: `session.rs`'s
+`video_pump` reimplements a "freeze-until-reanchor" subset directly (holding frames back from
+`ndl.play` during a gap until a real IDR or recovery-anchor frame arrives), since upstream
+`punktfunk_core::reanchor::ReanchorGate` assumes a decode/present split this client doesn't have.
+
+**Two runtime phases in `main.rs`, looped**: a pre-stream UI flow (`run_ui_flow`) and a streaming
+event loop (in `run_inner`), alternating on `StreamOutcome::ReturnToMenu` vs. `Quit`.
+
+- **Pre-stream UI** (`app.rs` + `ui.rs`): `app.rs` owns the screen state machine (`Screen::Home` —
+  sidebar of known hosts + game grid — with `Pairing`/`Settings`/`AddHost`/`Wake`/`ForgetHost` as
+  modals over it); `ui.rs` owns drawing primitives and key-to-`MenuEvent` mapping; `store.rs` owns
+  persistence (identity/hosts/settings JSON); `discovery.rs` owns mDNS LAN discovery. Rendering goes
+  through `ui::Painter` (`tiny_skia`-backed software framebuffer — no Skia/Vulkan/LVGL on webOS):
+  `App::render` draws each screen into one `Painter` per dirty tick, `main.rs` uploads it to one
+  persistent SDL2 texture and presents. Redraw-on-change (`dirty` flag), not unconditional-every-tick
+  — this UI has no time-based animation, so pixels change only on an SDL event or a background
+  discovery/art/library result.
+- **Streaming** (`session.rs` + `ndl.rs` + `audio.rs` + `keyboard.rs`/`mouse.rs`/`gamepad.rs`):
+  `session::connect` spawns the video pump thread (feeds decoded access units to NDL); audio is pumped
+  from the *main* thread each tick instead (`AudioQueue` isn't `Send`); the input modules map SDL2
+  events to punktfunk wire `InputEvent`s forwarded to the host live.
+
+**Networking/auth is a trimmed, standalone port, not a shared dependency**: `discovery.rs` (mDNS) and
+`library.rs` (mTLS game-library REST fetch, client-cert auth) mirror `pf-client-core`'s shape as
+direct, independent implementations, again to avoid its dependency tree. `art.rs` fetches/decodes
+cover art on a background thread into owned `tiny_skia::Pixmap`s, so nothing GPU-texture-shaped needs
+cross-thread sync.
+
+**Toolchain fragility** (full detail in `docs/NOTES.md`): `armv7-unknown-linux-gnueabi` defaults to
+software-emulated floating point, not just a soft-float calling convention — `.cargo/config.toml`
+overrides this (`-C target-feature=+neon,+vfp3,-soft-float`), the single highest-impact perf fix found
+(~300ms → ~30ms per UI render). `src/glibc_compat_shim.c` + `build.rs` backfill `getauxval`/`gettid`/
+`sendmmsg`, missing from webOS's ~2.12 glibc. SDL2 must be the `webosbrew/SDL-webOS` fork, not generic
+SDL2 or the on-device system copy (too old) — the `.ipk` bundles its own `libSDL2-2.0.so.0`.

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -59,13 +59,17 @@ pub fn button_event(button: Button, pressed: bool, pad: u8) -> InputEvent {
     }
 }
 
-/// SDL2 sticks are already i16 (−32768..32767, **+y = up** for Y per SDL2's own
-/// convention matching the wire's), so `value` passes straight through unchanged.
-/// Triggers arrive as SDL2's 0..32767 range — punktfunk wants 0..255, so those are
-/// rescaled.
+/// SDL2 sticks are already i16 (−32768..32767) matching the wire's range, so X passes
+/// straight through. Y does not: confirmed on-device (`DualSense` over Bluetooth, this
+/// webOS/Linux SDL2 build) that pushing a stick up/forward reports a *negative* raw
+/// value — the opposite of the wire's XInput/Moonlight "+y = up" convention — so both
+/// sticks' Y axes are negated before sending (`saturating_neg` since raw `i16::MIN`
+/// has no positive counterpart in range). Triggers arrive as SDL2's 0..32767 range —
+/// punktfunk wants 0..255, so those are rescaled.
 pub fn axis_event(axis: Axis, value: i16, pad: u8) -> InputEvent {
     let scaled = match axis {
         Axis::TriggerLeft | Axis::TriggerRight => (i32::from(value) * 255) / 32767,
+        Axis::LeftY | Axis::RightY => i32::from(value.saturating_neg()),
         _ => i32::from(value),
     };
     InputEvent {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1,0 +1,31 @@
+//! Maps SDL2 keyboard events to punktfunk's wire `InputEvent`s. The webOS Magic
+//! Remote's 5-way pad surfaces as plain SDL2 `Keycode::Up/Down/Left/Right` (same as
+//! any desktop arrow key), forwarded to the host as real key presses during a stream
+//! so directional navigation drives the host UI instead of only the local menu (see
+//! `ui::menu_event_for_key`, used pre-stream for the same keycodes).
+use punktfunk_core::input::{InputEvent, InputKind};
+use sdl2::keyboard::Keycode;
+
+/// Windows VK code `punktfunk-host`'s injector expects in a `KeyDown`/`KeyUp`'s `code`
+/// (confirmed via `vk_to_evdev` in `punktfunk-host/pf-inject/src/inject/keymap.rs`).
+/// `None` for any key not yet forwarded during streaming.
+fn vk_code(keycode: Keycode) -> Option<u32> {
+    match keycode {
+        Keycode::Left => Some(0x25),
+        Keycode::Up => Some(0x26),
+        Keycode::Right => Some(0x27),
+        Keycode::Down => Some(0x28),
+        _ => None,
+    }
+}
+
+pub fn key_event(keycode: Keycode, pressed: bool) -> Option<InputEvent> {
+    Some(InputEvent {
+        kind: if pressed { InputKind::KeyDown } else { InputKind::KeyUp },
+        _pad: [0; 3],
+        code: vk_code(keycode)?,
+        x: 0,
+        y: 0,
+        flags: 0,
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -521,6 +521,13 @@ mod real {
         // before the window is created — `SDL_waylandwebos.c` only applies it at
         // window-creation time (plus a runtime hint-watcher for later changes).
         sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_BACK", "true");
+        // SDL2 disables "extended" HID reports for PS4/PS5 pads over Bluetooth by
+        // default — and rumble is only carried in the extended report, so a
+        // Bluetooth DualSense/DualShock4 otherwise never vibrates no matter what
+        // `GameController::set_rumble` is called with. Must be set before the game
+        // controller subsystem opens the pad (SDL reads these at HIDAPI driver init).
+        sdl2::hint::set("SDL_JOYSTICK_HIDAPI_PS5_RUMBLE", "1");
+        sdl2::hint::set("SDL_JOYSTICK_HIDAPI_PS4_RUMBLE", "1");
         let sdl = sdl2::init().map_err(|e| anyhow::anyhow!("SDL_Init: {e}"))?;
         let ttf = sdl2::ttf::init().map_err(|e| anyhow::anyhow!("SDL_ttf init: {e}"))?;
         let video = sdl.video().map_err(|e| anyhow::anyhow!("SDL video subsystem: {e}"))?;
@@ -806,6 +813,7 @@ mod real {
                     ok_promoted = true;
                 }
                 session::pump_audio_once(&connected.client, &mut audio_player, log);
+                session::pump_rumble_once(&connected.client, &mut controller, log);
                 if connected.client.is_session_ended() {
                     writeln!(log, "host ended the session")?;
                     break 'running StreamOutcome::ReturnToMenu;

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ mod real {
 
     use anyhow::{Context, Result};
     use punktfunk_core::config::Mode;
+    use sdl2::controller::GameController;
     use sdl2::mouse::MouseButton;
 
     use crate::app::{App, Screen};
@@ -142,6 +143,39 @@ mod real {
     /// not to feel unresponsive, long enough that a normal tap never triggers it.
     const LONG_PRESS_CONFIRM: Duration = Duration::from_millis(500);
 
+    /// Edge-triggers Back off `held`: a repeat/OS-resent press while already held
+    /// produces nothing, so a single physical press dispatches Back exactly once no
+    /// matter how SDL reports (or misreports) repeats for it — e.g. a *held* Back
+    /// would otherwise cascade through every level of menu navigation in one go
+    /// (closing a dropdown, then the very next repeat exiting the screen it was on)
+    /// instead of stopping at the first. Shared by the menu loop's keyboard and
+    /// controller arms, which debounce identically.
+    fn edge_trigger_back(ev: Option<MenuEvent>, held: &mut bool) -> Option<MenuEvent> {
+        if ev != Some(MenuEvent::Back) {
+            return ev;
+        }
+        if *held {
+            None
+        } else {
+            *held = true;
+            ev
+        }
+    }
+
+    /// Starts/clears the streaming loop's Back long-press timer (see
+    /// `LONG_PRESS_BACK`) — shared by the keyboard and controller arms, which
+    /// otherwise repeat this identically.
+    fn track_back_hold(is_back: bool, pressed: bool, held_since: &mut Option<Instant>) {
+        if !is_back {
+            return;
+        }
+        if pressed {
+            held_since.get_or_insert_with(Instant::now);
+        } else {
+            *held_since = None;
+        }
+    }
+
     enum StreamOutcome {
         /// The system asked the app to close (not just this stream) — exit fully.
         Quit,
@@ -162,6 +196,7 @@ mod real {
         painter: &mut crate::ui::Painter,
         events: &mut sdl2::EventPump,
         game_controller: &sdl2::GameControllerSubsystem,
+        controller: &mut Option<GameController>,
         identity: &(String, String),
         display_mode: sdl2::video::DisplayMode,
         font_label: &sdl2::ttf::Font,
@@ -201,6 +236,7 @@ mod real {
         // press dispatches Back exactly once no matter how SDL reports (or
         // misreports) repeats for it.
         let mut menu_back_down = false;
+        let mut stick_nav = crate::ui::StickMenuNav::default();
         // Redraw-on-change: this screen has no time-based animation at all (no
         // spinner/blink/marquee), so every pixel that can change only ever changes
         // as a reaction to one of: an SDL event or a Discovery/art/library
@@ -373,26 +409,8 @@ mod real {
                     _ => {}
                 }
                 let menu_ev = match event {
-                    // Back is edge-triggered off `menu_back_down` (our own
-                    // tracked press/release state) rather than SDL's `repeat`
-                    // flag: OS key-repeat re-sends `KeyDown` for a key that's
-                    // still held, and without this a *held* Back cascaded
-                    // through every level of navigation in one go (e.g.
-                    // closing a Settings dropdown, then — from the very next
-                    // repeat, milliseconds later — Settings itself exiting to
-                    // Home) instead of stopping at the first.
                     Event::KeyDown { keycode: Some(k), .. } => {
-                        let ev = crate::ui::menu_event_for_key(k);
-                        if ev == Some(MenuEvent::Back) {
-                            if menu_back_down {
-                                None
-                            } else {
-                                menu_back_down = true;
-                                ev
-                            }
-                        } else {
-                            ev
-                        }
+                        edge_trigger_back(crate::ui::menu_event_for_key(k), &mut menu_back_down)
                     }
                     Event::KeyUp { keycode: Some(k), .. } => {
                         if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back) {
@@ -401,17 +419,7 @@ mod real {
                         None
                     }
                     Event::ControllerButtonDown { button, .. } => {
-                        let ev = crate::ui::menu_event_for_button(button);
-                        if ev == Some(MenuEvent::Back) {
-                            if menu_back_down {
-                                None
-                            } else {
-                                menu_back_down = true;
-                                ev
-                            }
-                        } else {
-                            ev
-                        }
+                        edge_trigger_back(crate::ui::menu_event_for_button(button), &mut menu_back_down)
                     }
                     Event::ControllerButtonUp { button, .. } => {
                         if crate::ui::menu_event_for_button(button) == Some(MenuEvent::Back) {
@@ -419,10 +427,21 @@ mod real {
                         }
                         None
                     }
-                    Event::ControllerDeviceAdded { which, .. } => {
-                        let _ = game_controller.open(which);
+                    Event::ControllerDeviceAdded { which, .. } if controller.is_none() => {
+                        match game_controller.open(which) {
+                            Ok(c) => {
+                                writeln!(log, "controller connected: {}", c.name())?;
+                                *controller = Some(c);
+                            }
+                            Err(e) => writeln!(log, "controller open failed: {e}")?,
+                        }
                         None
                     }
+                    Event::ControllerDeviceRemoved { .. } => {
+                        *controller = None;
+                        None
+                    }
+                    Event::ControllerAxisMotion { axis, value, .. } => stick_nav.axis_event(axis, value),
                     _ => None,
                 };
                 let Some(menu_ev) = menu_ev else { continue };
@@ -561,6 +580,13 @@ mod real {
         let font_title = crate::ui::load_font(&ttf, display_mode.h as u32, 40)?;
         let icon_font = crate::ui::load_icon_font(&ttf)?;
 
+        // Owned here, at the top of the menu/stream cycle, rather than re-declared in
+        // each: `ControllerDeviceAdded` only fires once per physical (re)connection, so
+        // a pad already open from the menu (or a previous stream) needs to carry
+        // straight through a screen transition instead of waiting for a replug neither
+        // side will ever see.
+        let mut controller: Option<GameController> = None;
+
         loop {
             let Some((host, port, fp, launch)) = run_ui_flow(
                 &mut canvas,
@@ -568,6 +594,7 @@ mod real {
                 &mut painter,
                 &mut events,
                 &game_controller,
+                &mut controller,
                 &identity,
                 display_mode,
                 &font_label,
@@ -650,7 +677,6 @@ mod real {
                 audio_player.spec()
             )?;
 
-            let mut controller = None;
             let mut back_held_since: Option<Instant> = None;
             let mut ok_held_since: Option<Instant> = None;
             let mut ok_promoted = false;
@@ -683,32 +709,28 @@ mod real {
                             controller = None;
                         }
                         Event::KeyDown { keycode: Some(k), .. } => {
-                            if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back) {
-                                back_held_since.get_or_insert_with(Instant::now);
-                            }
+                            let is_back = crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back);
+                            track_back_hold(is_back, true, &mut back_held_since);
                             if let Some(ev) = keyboard::key_event(k, true) {
                                 let _ = session::send_input(&connected.client, &ev);
                             }
                         }
                         Event::KeyUp { keycode: Some(k), .. } => {
-                            if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back) {
-                                back_held_since = None;
-                            }
+                            let is_back = crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back);
+                            track_back_hold(is_back, false, &mut back_held_since);
                             if let Some(ev) = keyboard::key_event(k, false) {
                                 let _ = session::send_input(&connected.client, &ev);
                             }
                         }
                         Event::ControllerButtonDown { button, .. } => {
-                            if crate::ui::menu_event_for_button(button) == Some(MenuEvent::Back) {
-                                back_held_since.get_or_insert_with(Instant::now);
-                            }
+                            let is_back = crate::ui::menu_event_for_button(button) == Some(MenuEvent::Back);
+                            track_back_hold(is_back, true, &mut back_held_since);
                             let ev = gamepad::button_event(button, true, 0);
                             let _ = session::send_input(&connected.client, &ev);
                         }
                         Event::ControllerButtonUp { button, .. } => {
-                            if crate::ui::menu_event_for_button(button) == Some(MenuEvent::Back) {
-                                back_held_since = None;
-                            }
+                            let is_back = crate::ui::menu_event_for_button(button) == Some(MenuEvent::Back);
+                            track_back_hold(is_back, false, &mut back_held_since);
                             let ev = gamepad::button_event(button, false, 0);
                             let _ = session::send_input(&connected.client, &ev);
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ mod discovery;
 #[cfg(target_os = "linux")]
 mod gamepad;
 #[cfg(target_os = "linux")]
+mod keyboard;
+#[cfg(target_os = "linux")]
 mod library;
 #[cfg(target_os = "linux")]
 mod mouse;
@@ -37,9 +39,11 @@ mod real {
 
     use anyhow::{Context, Result};
     use punktfunk_core::config::Mode;
+    use sdl2::mouse::MouseButton;
 
     use crate::app::{App, Screen};
     use crate::gamepad;
+    use crate::keyboard;
     use crate::mouse;
     use crate::session;
     use crate::store;
@@ -127,6 +131,10 @@ mod real {
     /// normal game-input tap of the same physical button (many games use
     /// B/Back-ish buttons) never triggers it.
     const LONG_PRESS_BACK: Duration = Duration::from_millis(1500);
+    /// How long the Magic Remote's OK button (the pointer's left click) must be held
+    /// before it's promoted to a right click — long enough that a normal click never
+    /// trips it, short enough to feel deliberate rather than sluggish.
+    const LONG_PRESS_OK: Duration = Duration::from_millis(500);
 
     /// How long OK must be held on a sidebar host row before it opens
     /// `Screen::ForgetHost` instead of that row's normal short-press action
@@ -644,6 +652,9 @@ mod real {
 
             let mut controller = None;
             let mut back_held_since: Option<Instant> = None;
+            let mut ok_held_since: Option<Instant> = None;
+            let mut ok_promoted = false;
+            let mut scroll_acc = mouse::ScrollAccumulator::default();
             let outcome = 'running: loop {
                 if QUIT_REQUESTED.load(Ordering::Relaxed) {
                     writeln!(log, "SIGTERM/SIGINT received — disconnecting before exit")?;
@@ -671,15 +682,21 @@ mod real {
                         Event::ControllerDeviceRemoved { .. } => {
                             controller = None;
                         }
-                        Event::KeyDown { keycode: Some(k), .. }
-                            if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back) =>
-                        {
-                            back_held_since.get_or_insert_with(Instant::now);
+                        Event::KeyDown { keycode: Some(k), .. } => {
+                            if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back) {
+                                back_held_since.get_or_insert_with(Instant::now);
+                            }
+                            if let Some(ev) = keyboard::key_event(k, true) {
+                                let _ = session::send_input(&connected.client, &ev);
+                            }
                         }
-                        Event::KeyUp { keycode: Some(k), .. }
-                            if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back) =>
-                        {
-                            back_held_since = None;
+                        Event::KeyUp { keycode: Some(k), .. } => {
+                            if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back) {
+                                back_held_since = None;
+                            }
+                            if let Some(ev) = keyboard::key_event(k, false) {
+                                let _ = session::send_input(&connected.client, &ev);
+                            }
                         }
                         Event::ControllerButtonDown { button, .. } => {
                             if crate::ui::menu_event_for_button(button) == Some(MenuEvent::Back) {
@@ -708,23 +725,38 @@ mod real {
                             let _ = session::send_input(&connected.client, &ev);
                         }
                         Event::MouseButtonDown { mouse_btn, .. } => {
+                            if mouse_btn == MouseButton::Left {
+                                ok_held_since = Some(Instant::now());
+                                ok_promoted = false;
+                            }
                             if let Some(ev) = mouse::button_event(mouse_btn, true) {
                                 let _ = session::send_input(&connected.client, &ev);
                             }
                         }
                         Event::MouseButtonUp { mouse_btn, .. } => {
-                            if let Some(ev) = mouse::button_event(mouse_btn, false) {
+                            let released = if mouse_btn == MouseButton::Left && ok_promoted {
+                                MouseButton::Right
+                            } else {
+                                mouse_btn
+                            };
+                            if mouse_btn == MouseButton::Left {
+                                ok_held_since = None;
+                                ok_promoted = false;
+                            }
+                            if let Some(ev) = mouse::button_event(released, false) {
                                 let _ = session::send_input(&connected.client, &ev);
                             }
                         }
                         Event::MouseWheel { x, y, .. } => {
                             if y != 0 {
-                                let ev = mouse::scroll_event(y, false);
-                                let _ = session::send_input(&connected.client, &ev);
+                                if let Some(ev) = scroll_acc.scroll_event(y, false) {
+                                    let _ = session::send_input(&connected.client, &ev);
+                                }
                             }
                             if x != 0 {
-                                let ev = mouse::scroll_event(x, true);
-                                let _ = session::send_input(&connected.client, &ev);
+                                if let Some(ev) = scroll_acc.scroll_event(x, true) {
+                                    let _ = session::send_input(&connected.client, &ev);
+                                }
                             }
                         }
                         _ => {}
@@ -740,6 +772,16 @@ mod real {
                     // client, which closes with the "may reconnect" code instead.
                     connected.client.disconnect_quit();
                     break 'running StreamOutcome::ReturnToMenu;
+                }
+                if !ok_promoted && ok_held_since.is_some_and(|t| t.elapsed() >= LONG_PRESS_OK) {
+                    // Release left before pressing right so the host never sees both held.
+                    if let Some(ev) = mouse::button_event(MouseButton::Left, false) {
+                        let _ = session::send_input(&connected.client, &ev);
+                    }
+                    if let Some(ev) = mouse::button_event(MouseButton::Right, true) {
+                        let _ = session::send_input(&connected.client, &ev);
+                    }
+                    ok_promoted = true;
                 }
                 session::pump_audio_once(&connected.client, &mut audio_player, log);
                 if connected.client.is_session_ended() {

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -66,16 +66,34 @@ pub fn move_event(x: i32, y: i32, client_w: u32, client_h: u32) -> InputEvent {
     }
 }
 
-/// `code` distinguishes the scroll axis (`0` = vertical, `1` = horizontal — see
-/// `punktfunk-host`'s `SCROLL_HORIZONTAL`); `delta` is the signed scroll amount,
-/// SDL2's `MouseWheelEvent.y`/`.x` passed straight through.
-pub fn scroll_event(delta: i32, horizontal: bool) -> InputEvent {
-    InputEvent {
-        kind: InputKind::MouseScroll,
-        _pad: [0; 3],
-        code: u32::from(horizontal),
-        x: delta,
-        y: 0,
-        flags: 0,
+/// Rescales SDL2's ~±1-per-notch wheel delta to the wire's `GameStream`
+/// `WHEEL_DELTA(120)`-per-notch convention (confirmed via `punktfunk-host`'s
+/// `pf-inject` `sendinput.rs`/`wlr.rs`), carrying the fractional remainder across
+/// calls so a run of small deltas doesn't round away to nothing.
+#[derive(Default)]
+pub struct ScrollAccumulator {
+    x: f64,
+    y: f64,
+}
+
+impl ScrollAccumulator {
+    /// `code` distinguishes the scroll axis (`0` = vertical, `1` = horizontal).
+    /// `None` while the accumulated remainder hasn't reached a whole wire unit.
+    pub fn scroll_event(&mut self, delta: i32, horizontal: bool) -> Option<InputEvent> {
+        let acc = if horizontal { &mut self.x } else { &mut self.y };
+        *acc += f64::from(delta) * 120.0;
+        let notches = acc.trunc() as i32;
+        if notches == 0 {
+            return None;
+        }
+        *acc -= f64::from(notches);
+        Some(InputEvent {
+            kind: InputKind::MouseScroll,
+            _pad: [0; 3],
+            code: u32::from(horizontal),
+            x: notches,
+            y: 0,
+            flags: 0,
+        })
     }
 }

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -43,18 +43,6 @@ pub fn button_event(button: MouseButton, pressed: bool) -> Option<InputEvent> {
 /// it before mapping into the output region (see `InputKind::MouseMoveAbs` docs) —
 /// the same absolute-pointer path the pre-stream menu's hover/click already rides,
 /// just forwarded to the host instead of used for local UI focus.
-///
-/// A previous attempt applied a fixed `SENSITIVITY` scale here (<1.0, centered on
-/// the reported client size) to make the host cursor feel "slower." Symptom: the
-/// cursor got stuck around the middle of the screen, never reaching anywhere near
-/// the edges — much more restricted than the scale factor alone should produce.
-/// Likely cause: the remote's own pointer already has *some* system-level gain
-/// applied before these coordinates ever reach SDL2 (i.e. `x`/`y` may not actually
-/// span the full `0..client_w`/`0..client_h` range even when physically pointing at
-/// the panel's true edges) — layering an *additional* scale on top of an
-/// already-restricted range compounds instead of just slowing things down. Reverted
-/// to plain passthrough until the real range is confirmed; re-derive any
-/// "sensitivity" adjustment from that, not from an assumed full-range span.
 pub fn move_event(x: i32, y: i32, client_w: u32, client_h: u32) -> InputEvent {
     InputEvent {
         kind: InputKind::MouseMoveAbs,

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,6 +23,7 @@ use punktfunk_core::config::{CompositorPref, Mode};
 use punktfunk_core::input::InputEvent;
 use punktfunk_core::packet::{FLAG_SOF, USER_FLAG_RECOVERY_ANCHOR};
 use punktfunk_core::quic;
+use sdl2::controller::GameController;
 
 use crate::ndl::{NdlCodec, NdlVideo};
 
@@ -452,6 +453,21 @@ pub fn pump_audio_once(client: &NativeClient, audio: &mut crate::audio::AudioPla
             }
             Err(e) => {
                 let _ = writeln!(log, "audio play error (seq {}): {e:#}", packet.seq);
+            }
+        }
+    }
+}
+
+/// Drains every pending rumble command from the shared policy engine (non-blocking,
+/// like `pump_audio_once`) and applies it to the currently open controller. A single
+/// pad is all this client tracks (see `gamepad.rs`), so `cmd.pad` is ignored rather
+/// than matched against one; a command that arrives with no controller open is just
+/// dropped.
+pub fn pump_rumble_once(client: &NativeClient, controller: &mut Option<GameController>, log: &mut std::fs::File) {
+    while let Ok(cmd) = client.next_rumble_command(Duration::ZERO) {
+        if let Some(c) = controller {
+            if let Err(e) = c.set_rumble(cmd.low, cmd.high, cmd.backstop_ms) {
+                let _ = writeln!(log, "controller rumble failed: {e}");
             }
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -138,9 +138,8 @@ impl StickMenuNav {
         use sdl2::controller::Axis;
         match axis {
             Axis::LeftX => Self::edge(&mut self.x, value, MenuEvent::Left, MenuEvent::Right),
-            // Positive Y is up on SDL2's GameController axis (see `gamepad.rs`'s
-            // `axis_event` docs), so a positive tilt maps to `Up`, not `Down`.
-            Axis::LeftY => Self::edge(&mut self.y, value, MenuEvent::Down, MenuEvent::Up),
+            // Negative is up (see `gamepad.rs`'s `axis_event` docs for why).
+            Axis::LeftY => Self::edge(&mut self.y, value, MenuEvent::Up, MenuEvent::Down),
             _ => None,
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -119,6 +119,48 @@ pub fn menu_event_for_button(button: sdl2::controller::Button) -> Option<MenuEve
     })
 }
 
+/// Left-stick tilt past this fraction of full deflection (of i16's ±32768) counts as
+/// a directional press — well past center-rest noise.
+const STICK_MENU_DEADZONE: i16 = 16_000;
+
+/// Edge-detects the left stick's X/Y axes into `MenuEvent`s, per-axis, so a hold
+/// fires once on crossing the deadzone and doesn't repeat until the stick passes back
+/// through center — the same one-shot-per-press behavior a D-pad button already has
+/// (SDL2 doesn't auto-repeat `ControllerButtonDown` while held).
+#[derive(Default)]
+pub struct StickMenuNav {
+    x: Option<MenuEvent>,
+    y: Option<MenuEvent>,
+}
+
+impl StickMenuNav {
+    pub fn axis_event(&mut self, axis: sdl2::controller::Axis, value: i16) -> Option<MenuEvent> {
+        use sdl2::controller::Axis;
+        match axis {
+            Axis::LeftX => Self::edge(&mut self.x, value, MenuEvent::Left, MenuEvent::Right),
+            // Positive Y is up on SDL2's GameController axis (see `gamepad.rs`'s
+            // `axis_event` docs), so a positive tilt maps to `Up`, not `Down`.
+            Axis::LeftY => Self::edge(&mut self.y, value, MenuEvent::Down, MenuEvent::Up),
+            _ => None,
+        }
+    }
+
+    fn edge(state: &mut Option<MenuEvent>, value: i16, neg: MenuEvent, pos: MenuEvent) -> Option<MenuEvent> {
+        let dir = if value <= -STICK_MENU_DEADZONE {
+            Some(neg)
+        } else if value >= STICK_MENU_DEADZONE {
+            Some(pos)
+        } else {
+            None
+        };
+        if dir == *state {
+            return None;
+        }
+        *state = dir;
+        dir
+    }
+}
+
 /// The Magic Remote's number buttons (0-9) surface as plain keyboard digit keys —
 /// used for direct PIN entry (type a digit, auto-advance) instead of cycling each
 /// digit with left/right.


### PR DESCRIPTION
## Summary
- Forward the Magic Remote's arrow keys, scroll wheel, and OK button to the host during a stream (previously only mouse pointer/click and gamepad buttons were wired up).
- Long-pressing OK promotes a left click to a right click.
- Fix the scroll wheel forwarding, which was structurally wired but sent SDL2's raw ~±1-per-notch delta unscaled instead of the host's expected GameStream `WHEEL_DELTA(120)`-per-notch units (scrolls were ~120x too weak to notice).
- Add wireless game controller passthrough during streaming, and fix the pre-stream menu so a controller navigates it too (D-pad, left stick, A/B/Y) — the menu loop was opening the controller and immediately closing it again, so navigation never actually worked past the first tick.
- De-duplicate the Back long-press debounce that was repeated across keyboard/controller arms in both the menu and streaming loops.
- Fix inverted analog sticks: SDL2 reports a negative Y value for "up/forward" on this DualSense-over-Bluetooth/webOS setup, the opposite of the wire's XInput/Moonlight convention — both sticks' Y axis is now negated before sending.
- Add controller rumble: poll `next_rumble_command()` and apply it via `GameController::set_rumble`, plus the SDL hints needed to enable extended HID reports (required for rumble on a Bluetooth PS4/PS5 pad, disabled by SDL2 by default).

## Test plan
- [x] `cargo check`/`cargo clippy --target armv7-unknown-linux-gnueabi -- -D warnings` clean
- [x] On-device: arrow keys navigate the host during a stream
- [x] On-device: scroll wheel now produces a noticeable scroll on the host
- [x] On-device: long-pressing OK right-clicks instead of left-clicking
- [x] On-device: a paired controller navigates the pre-stream menu (D-pad + left stick + A/B/Y) and its inputs forward to the host once streaming
- [x] On-device: a controller connected before the menu loads still works once streaming starts (and vice versa)
- [x] On-device: left/right stick movement and camera look are no longer inverted
- [x] On-device: controller rumble works during a stream