### PR TITLE
Cut streaming latency, tune codegen for ARMv8 TVs, and negotiate ChaCha20-Poly1305

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,7 +16,17 @@ linker = "scripts/cc-shim.sh"
 # `-soft-float` here only removes that LLVM codegen feature (computation uses real
 # VFP/NEON instructions); it does not change the calling convention, so FFI calls
 # into the sysroot's softfp-ABI libraries stay correct.
-rustflags = ["-C", "target-feature=+neon,+vfp3,-soft-float", "-C", "target-cpu=cortex-a9"]
+#
+# `target-cpu=cortex-a53`, not the vendor toolchain's `-mcpu=cortex-a9`: that vendor
+# default is a lowest-common-denominator for webOS generations back to genuinely
+# ARMv7 silicon, but this client targets webOS 5.x+ (see README), where every LG SoC
+# (α5/α7/α9 gen 3+, and the MTK-based budget models) is an ARMv8-A core running
+# 32-bit userland. Tuning for the A53 (the conservative in-order baseline — fine on
+# the bigger A73-class cores too) additionally unlocks ARMv8's A32 instruction set:
+# hardware integer divide (cortex-a9 codegen calls `__aeabi_idiv` instead) and
+# VFPv4 fused multiply-add. ABI is unchanged (still softfp, as above). If a
+# pre-ARMv8 webOS device ever needs supporting, revert this one value to cortex-a9.
+rustflags = ["-C", "target-feature=+neon,+vfp3,-soft-float", "-C", "target-cpu=cortex-a53"]
 
 [env]
 CC_armv7_unknown_linux_gnueabi = { value = "scripts/cc-shim.sh", relative = true }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,17 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
@@ -257,6 +268,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,6 +288,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -476,7 +501,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.16.0#191c9a4e188dffabc17b99fb4110f0e9666f4510"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.17.2#87e7c82cbc453551c201843f863c3b81ab9c827f"
 
 [[package]]
 name = "fiat-crypto"
@@ -997,6 +1022,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,12 +1076,13 @@ dependencies = [
 
 [[package]]
 name = "punktfunk-core"
-version = "0.16.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.16.0#191c9a4e188dffabc17b99fb4110f0e9666f4510"
+version = "0.17.2"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.17.2#87e7c82cbc453551c201843f863c3b81ab9c827f"
 dependencies = [
  "aes-gcm",
  "bytes",
  "cbindgen",
+ "chacha20poly1305",
  "fec-rs",
  "hmac",
  "if-addrs 0.13.4",
@@ -1189,7 +1226,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.1",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,14 @@ tracing-subscriber = "0.3"
 # pf-client-core's session::start() (see session.rs docs for why we don't use that).
 # Pinned to a tagged punktfunk release (not a branch tip) this client was
 # developed/tested against — bump deliberately, not automatically, since
-# punktfunk-core's wire/ABI surface can move. Currently v0.16.0 — WIRE_VERSION 2
-# (unchanged since this pin's previous v0.9.2-based commit; no protocol migration
-# needed here), ABI_VERSION 9 (irrelevant to us: we link the Rust `client` API
-# directly, not the C ABI in `abi.rs`, and that module's signatures are unchanged
-# across the whole v0.9.2..v0.16.0 range).
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.16.0", features = [
+# punktfunk-core's wire/ABI surface can move. Currently v0.17.2 — bumped from
+# v0.16.0 for the ChaCha20-Poly1305 session cipher (session.rs advertises
+# `VIDEO_CAP_CHACHA20`; lifts the soft-AES decrypt ceiling on this armv7 target).
+# WIRE_VERSION 2 (verified unchanged across v0.16.0..v0.17.2 — the cipher rides a
+# new Welcome tail field, fail-closed, no protocol migration), and the C ABI in
+# `abi.rs` stays irrelevant to us (we link the Rust `client` API directly;
+# `NativeClient::connect`'s signature is unchanged across the bump).
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.17.2", features = [
     "quic",
 ] }
 serde = { version = "1", features = ["derive"] }
@@ -103,3 +105,15 @@ tiny-skia = { version = "0.12", default-features = false, features = ["std"] }
 # transitive dependency (punktfunk-core itself uses `libc::gettid` for its hot-thread
 # registry), pulled in directly since we call our own libc function against those ids.
 libc = "0.2"
+
+[profile.release]
+# The per-packet hot loops this client actually burns CPU in — AEAD decrypt, FEC
+# reassembly, QUIC/packet parsing — all live in punktfunk-core and its deps, not this
+# crate, so cargo's defaults (no cross-crate LTO, 16 codegen units) leave the
+# optimizer unable to inline across exactly the boundaries that matter on this
+# hardware. Fat LTO + one codegen unit costs build time (the deploy loop already runs
+# in Docker; drop to lto = "thin" if it ever gets painful) in exchange for the best
+# codegen the pinned toolchain can produce — this directly cheapens today's software
+# AES path and the ChaCha20-Poly1305 one planned to replace it.
+lto = "fat"
+codegen-units = 1

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -12,6 +12,24 @@ const SAMPLES_PER_FRAME: usize = 240;
 /// Max channels punktfunk ever negotiates (7.1) — sizes the scratch decode buffer.
 const MAX_CHANNELS: usize = 8;
 
+/// Requested SDL device buffer, in sample frames (~10.7ms at 48kHz). Left at
+/// `samples: None`, SDL2 picks "~46ms rounded up to a power of two"
+/// (`prepare_audiospec` in `SDL_audio.c`) — 4096 frames at 48kHz, ~85ms of built-in
+/// output latency before a single network/queue delay is even counted. 512 keeps a
+/// couple of 5ms audio frames of slack against main.rs's pump cadence while cutting
+/// that fixed latency by ~75ms. The obtained spec is logged at session start
+/// (main.rs), so what the driver actually granted is verifiable on-device.
+const DEVICE_BUFFER_FRAMES: u16 = 512;
+
+/// Hard bound on SDL-queued (pre-device) audio. With main.rs's few-ms pump cadence
+/// the queue normally holds well under a couple of frames; the only ways past this
+/// bound are a post-network-stall burst (punktfunk-core delivering its backlog at
+/// once) or slow host/TV sample-clock drift accumulating — both of which would
+/// otherwise become permanent added audio latency, since a realtime stream never
+/// drains a standing queue on its own. Clearing and resnapping to the freshest
+/// packet costs one audible blip but restores sync.
+pub const MAX_QUEUED_LAG_MS: u32 = 100;
+
 pub struct AudioPlayer {
     queue: sdl2::audio::AudioQueue<f32>,
     decoder: opus::MSDecoder,
@@ -29,7 +47,7 @@ impl AudioPlayer {
         let spec = sdl2::audio::AudioSpecDesired {
             freq: Some(SAMPLE_RATE as i32),
             channels: Some(layout.channels),
-            samples: None,
+            samples: Some(DEVICE_BUFFER_FRAMES),
         };
         let queue = sdl_audio
             .open_queue::<f32, _>(None, &spec)
@@ -50,8 +68,10 @@ impl AudioPlayer {
 
     /// Decodes one Opus packet and queues the resulting PCM for playback. Returns the
     /// decoded frame's peak absolute sample value — diagnostic for telling "silent
-    /// input" apart from "output path not reaching the speaker" (see session.rs).
-    pub fn play(&mut self, opus_payload: &[u8]) -> Result<f32> {
+    /// input" apart from "output path not reaching the speaker" (see session.rs) —
+    /// and whether the queue was cleared first because it had grown past
+    /// [`MAX_QUEUED_LAG_MS`] (the caller logs that; see the const's docs).
+    pub fn play(&mut self, opus_payload: &[u8]) -> Result<(f32, bool)> {
         let mut pcm = [0f32; SAMPLES_PER_FRAME * MAX_CHANNELS];
         let samples_per_channel = self
             .decoder
@@ -59,9 +79,15 @@ impl AudioPlayer {
             .map_err(|e| anyhow::anyhow!("opus decode_float: {e}"))?;
         let decoded = &pcm[..samples_per_channel * self.channels];
         let peak = decoded.iter().fold(0f32, |m, &s| m.max(s.abs()));
+        let max_queued_bytes =
+            SAMPLE_RATE / 1000 * MAX_QUEUED_LAG_MS * self.channels as u32 * std::mem::size_of::<f32>() as u32;
+        let resnapped = self.queue.size() > max_queued_bytes;
+        if resnapped {
+            self.queue.clear();
+        }
         self.queue
             .queue_audio(decoded)
             .map_err(|e| anyhow::anyhow!("SDL queue_audio: {e}"))?;
-        Ok(peak)
+        Ok((peak, resnapped))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -729,7 +729,13 @@ mod real {
                     break 'running StreamOutcome::ReturnToMenu;
                 }
 
-                std::thread::sleep(Duration::from_millis(8));
+                // This tick bounds how stale a forwarded input event or a queued audio
+                // packet can get (video has its own thread and never waits on this loop).
+                // 8ms here meant up to 8ms added to every remote/gamepad event and to the
+                // audio drain cadence; at 2ms an idle poll_iter + try-recv round is a few
+                // microseconds of work, so ~500 wakeups/s is noise even on this SoC while
+                // keeping the added input latency near zero.
+                std::thread::sleep(Duration::from_millis(2));
             };
 
             // `disconnect_quit()` was already called above for every deliberate-stop path;

--- a/src/session.rs
+++ b/src/session.rs
@@ -90,11 +90,21 @@ pub fn connect(
     display_h: i32,
     log: &mut std::fs::File,
 ) -> Result<Connected> {
-    let video_caps = if hdr_enabled {
-        quic::VIDEO_CAP_10BIT | quic::VIDEO_CAP_HDR
-    } else {
-        0
-    };
+    // `VIDEO_CAP_CHACHA20` is advertised unconditionally: this armv7 target has no
+    // hardware AES (RustCrypto aes-gcm resolves to fixsliced software AES + software
+    // GHASH here), and the bit is support-plus-request — a ≥0.17.2 host answers with a
+    // ChaCha20-Poly1305 session key in its Welcome (unless its PUNKTFUNK_CHACHA20
+    // kill-switch says no), while an older host simply ignores the unknown bit and the
+    // session runs AES exactly as before. Negotiation is fail-closed in punktfunk-core
+    // (no silent wrong-cipher fallback), and the *grant* isn't client-observable —
+    // `NativeClient` doesn't expose `Welcome::cipher` — so the host's session-start log
+    // is where the resolved cipher shows up.
+    let video_caps = quic::VIDEO_CAP_CHACHA20
+        | if hdr_enabled {
+            quic::VIDEO_CAP_10BIT | quic::VIDEO_CAP_HDR
+        } else {
+            0
+        };
     let display_hdr = hdr_enabled.then(cx_display_hdr);
     let client = NativeClient::connect(
         host,
@@ -122,7 +132,7 @@ pub fn connect(
     writeln!(
         log,
         "connected: codec={} compositor={:?} audio_channels={} color={:?} resolved_bitrate_kbps={} \
-         wants_decode_latency={} fingerprint={fp_hex}",
+         wants_decode_latency={} advertised_caps=0x{video_caps:02x} fingerprint={fp_hex}",
         client.codec,
         client.resolved_compositor,
         client.audio_channels,
@@ -444,7 +454,14 @@ pub fn pump_audio_once(client: &NativeClient, audio: &mut crate::audio::AudioPla
     static PACKET_COUNT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
     while let Ok(packet) = client.next_audio(Duration::ZERO) {
         match audio.play(&packet.data) {
-            Ok(peak) => {
+            Ok((peak, resnapped)) => {
+                if resnapped {
+                    let _ = writeln!(
+                        log,
+                        "audio queue over {}ms behind (post-stall burst or clock drift) — cleared to resnap",
+                        crate::audio::MAX_QUEUED_LAG_MS
+                    );
+                }
                 let n = PACKET_COUNT.fetch_add(1, Ordering::Relaxed);
                 if n % 200 == 0 {
                     let _ = writeln!(log, "audio decode peak amplitude: {peak:.4}");


### PR DESCRIPTION
## Streaming perf pass

- **`[profile.release]`: fat LTO + `codegen-units = 1`.** The per-packet hot loops (AEAD decrypt, FEC reassembly, QUIC parsing) all live in `punktfunk-core`, so the default no-cross-crate-LTO / 16-CGU build left the optimizer unable to inline across exactly the boundaries that matter on this CPU.
- **`target-cpu=cortex-a53`** (was `cortex-a9`): every webOS 5.x+ SoC is ARMv8-A running 32-bit userland; this unlocks A32 hardware integer divide — verified via disassembly: 143 inlined `udiv`/`sdiv`, `__aeabi_idiv` calls gone from our code (the ~31 remaining are from the prebuilt rustup `std`, same known limitation as its soft-float remnants) — plus VFPv4 FMA. ABI unchanged (still softfp). Revert this one value for any pre-ARMv8 device.
- **SDL audio device buffer 4096 → 512 frames (~75ms latency cut).** `samples: None` let SDL pick "~46ms rounded up to a power of two" = 4096 frames @ 48kHz ≈ 85ms of fixed output latency (confirmed in the webOS SDL fork's `prepare_audiospec`). The obtained spec is already logged at session start for on-device verification.
- **Streaming main-loop tick 8ms → 2ms**: bounds the staleness of forwarded remote/gamepad input and the audio drain cadence at negligible CPU cost (video has its own thread).
- **New 100ms bound on SDL-queued audio**: a post-stall burst or slow host/TV clock drift otherwise becomes *permanently* added audio latency (a realtime stream never drains a standing queue). Clear-and-resnap restores sync for one audible blip, logged.

## ChaCha20-Poly1305 (punktfunk `d36bec6e`'s "Phase 4")

- `punktfunk-core` pin bumped **v0.16.0 → v0.17.2**; `session.rs` advertises **`VIDEO_CAP_CHACHA20` unconditionally**. This armv7 target has no hardware AES, so `aes-gcm` resolves to fixsliced software AES + software GHASH (~50–100 cpb) while scalar ChaCha20-Poly1305 runs ~10–17 cpb — lifting the soft-AES decrypt ceiling.
- A ≥0.17.2 host answers with a ChaCha session key (`PUNKTFUNK_CHACHA20` kill-switch permitting); older hosts ignore the unknown bit and keep AES; negotiation is fail-closed in core.
- Verified across the bump: `WIRE_VERSION` still 2, `NativeClient::connect` signature unchanged, every client API this crate uses still present.
- The grant is host-log-observable only (`NativeClient` doesn't expose `Welcome::cipher`); the client's `connected:` line now logs the caps byte it advertised.

## Verification

- Cross-target release build (fat LTO link) and `clippy -D warnings` both green in the Docker toolchain.
- **Not yet soaked on a real TV** — needs a `task deploy` against a ≥0.17.2 host: check the TV log's `advertised_caps=0x4x` connected line and the smaller negotiated audio spec, the host log for the granted cipher, and whether the AES bitrate ceiling lifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)