### PR TITLE
Remove controller rumble — it breaks Bluetooth input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -521,13 +521,6 @@ mod real {
         // before the window is created — `SDL_waylandwebos.c` only applies it at
         // window-creation time (plus a runtime hint-watcher for later changes).
         sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_BACK", "true");
-        // SDL2 disables "extended" HID reports for PS4/PS5 pads over Bluetooth by
-        // default — and rumble is only carried in the extended report, so a
-        // Bluetooth DualSense/DualShock4 otherwise never vibrates no matter what
-        // `GameController::set_rumble` is called with. Must be set before the game
-        // controller subsystem opens the pad (SDL reads these at HIDAPI driver init).
-        sdl2::hint::set("SDL_JOYSTICK_HIDAPI_PS5_RUMBLE", "1");
-        sdl2::hint::set("SDL_JOYSTICK_HIDAPI_PS4_RUMBLE", "1");
         let sdl = sdl2::init().map_err(|e| anyhow::anyhow!("SDL_Init: {e}"))?;
         let ttf = sdl2::ttf::init().map_err(|e| anyhow::anyhow!("SDL_ttf init: {e}"))?;
         let video = sdl.video().map_err(|e| anyhow::anyhow!("SDL video subsystem: {e}"))?;
@@ -813,7 +806,6 @@ mod real {
                     ok_promoted = true;
                 }
                 session::pump_audio_once(&connected.client, &mut audio_player, log);
-                session::pump_rumble_once(&connected.client, &mut controller, log);
                 if connected.client.is_session_ended() {
                     writeln!(log, "host ended the session")?;
                     break 'running StreamOutcome::ReturnToMenu;

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,7 +23,6 @@ use punktfunk_core::config::{CompositorPref, Mode};
 use punktfunk_core::input::InputEvent;
 use punktfunk_core::packet::{FLAG_SOF, USER_FLAG_RECOVERY_ANCHOR};
 use punktfunk_core::quic;
-use sdl2::controller::GameController;
 
 use crate::ndl::{NdlCodec, NdlVideo};
 
@@ -430,21 +429,6 @@ pub fn pump_audio_once(client: &NativeClient, audio: &mut crate::audio::AudioPla
             }
             Err(e) => {
                 let _ = writeln!(log, "audio play error (seq {}): {e:#}", packet.seq);
-            }
-        }
-    }
-}
-
-/// Drains every pending rumble command from the shared policy engine (non-blocking,
-/// like `pump_audio_once`) and applies it to the currently open controller. A single
-/// pad is all this client tracks (see `gamepad.rs`), so `cmd.pad` is ignored rather
-/// than matched against one; a command that arrives with no controller open is just
-/// dropped.
-pub fn pump_rumble_once(client: &NativeClient, controller: &mut Option<GameController>, log: &mut std::fs::File) {
-    while let Ok(cmd) = client.next_rumble_command(Duration::ZERO) {
-        if let Some(c) = controller {
-            if let Err(e) = c.set_rumble(cmd.low, cmd.high, cmd.backstop_ms) {
-                let _ = writeln!(log, "controller rumble failed: {e}");
             }
         }
     }


### PR DESCRIPTION
## Summary
A prior PR (#15) added controller rumble support, requiring `SDL_JOYSTICK_HIDAPI_PS5_RUMBLE`/`PS4_RUMBLE` hints to enable Bluetooth rumble (SDL disables it by default). On-device testing showed this broke input entirely: the DualSense would connect (`attached: true`) but deliver zero button/axis events, with the Bluetooth connection repeatedly flapping (connect/disconnect).

Traced into SDL2's vendored `SDL_hidapi_ps5.c`/`ps4.c`: `HIDAPI_DriverPS5_SetEnhancedMode()` is called unconditionally from inside the rumble path itself, not just gated by the startup hint — so simply calling `set_rumble()`/`Haptic::rumble_play()` at all re-enables the same "enhanced mode" that destabilizes the Bluetooth link on this webOS/SDL2 build, regardless of hint state. There's no rumble entry point in this SDL2 version that avoids it.

Removes rumble entirely (hints, `pump_rumble_once`, its wiring, and the now-unused `GameController` import in `session.rs`) rather than leave dead/hazardous plumbing that can only re-trigger the same instability if touched. Wired (USB) rumble was not affected by this bug (the instability is specific to the Bluetooth link) but isn't being reintroduced given how easy it'd be to reintroduce the whole class of bug — a future USB-only attempt should gate carefully on connection type at minimum.

## Test plan
- [x] `cargo clippy --target armv7-unknown-linux-gnueabi --all-targets -- -D warnings` clean
- [x] On-device: DualSense over Bluetooth navigates the menu and streams gameplay input reliably (button + stick), confirmed via log after removing the hints and power-cycling the controller