### PR TITLE
Add full HID keyboard support and fix Magic Remote BACK handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,5 @@
 name: Build
 
-# Every push to main/PR builds and uploads a dev .ipk as a build artifact. A
-# published GitHub Release additionally re-runs the same build against the
-# release tag (`task native:package` detects it via GITHUB_REF_TYPE/GITHUB_REF_NAME —
-# see taskfiles/toolchain.yml) and attaches the .ipk + Homebrew Channel manifest
-# to the release page instead of just uploading an artifact.
 on:
   push:
     branches: [main]
@@ -21,8 +16,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
-          # Full history + tags: dev builds version themselves off the latest
-          # release tag (task native:package's LATEST_TAG, via `git describe`).
           fetch-depth: 0
 
       - name: Install Rust (stable, prebuilt) + cross target

--- a/README.md
+++ b/README.md
@@ -72,17 +72,6 @@ task deploy TV_HOST=root@<tv-ip>
 Only published [GitHub Releases](https://github.com/dyptan-io/pf-webos/releases) show up this way
 — dev/CI builds don't.
 
-## Known platform limitations
-
-Not fixable from application code — see `docs/NOTES.md` for the research trail:
-
-- **Frame rate paces the stream only; it can't change the TV panel's scan-out rate.** No webOS
-  system API exposes that to a native app.
-- **The Magic Remote's hardware Back button is intercepted by webOS's system launcher by
-  default** (a known upstream moonlight-tv issue too) — this client works around it (see
-  `docs/NOTES.md`), with the Red button kept as a fallback for firmware where the workaround isn't
-  honored.
-
 ## License
 
 Dual-licensed under [MIT](LICENSE-MIT) or [Apache 2.0](LICENSE-APACHE), matching upstream

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,6 +23,15 @@ vars:
   SYSROOT: '{{.NDK_DIR}}/arm-webos-linux-gnueabi/sysroot'
   TARGET: armv7-unknown-linux-gnueabi
   RUST_IMAGE: rust:bookworm
+  PKG_VERSION:
+    sh: |
+      if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+        echo "${GITHUB_REF_NAME#v}"
+      else
+        LATEST=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 0.0.1)
+        SHA=$(git rev-parse --short=8 HEAD 2>/dev/null || echo unknown)
+        echo "${LATEST}+git.${SHA}"
+      fi
 
 tasks:
   build:
@@ -42,11 +51,6 @@ tasks:
     cmds:
       - task: toolchain:docker-run
         vars: {TARGET_TASK: native:package}
-
-  shell:
-    desc: Interactive shell in the Docker build container (debugging)
-    cmds:
-      - task: toolchain:docker-shell
 
   lint:
     desc: Cross-target `cargo clippy` (the lint set in Cargo.toml's `[lints.clippy]`), inside Docker
@@ -97,18 +101,29 @@ tasks:
     deps: [native:build, toolchain:ares-package]
     cmds:
       - task: toolchain:stage-and-package
+        vars:
+          PKG_VERSION: '{{.PKG_VERSION}}'
 
   deploy:
     desc: >-
-      Build, package, install on a real TV over SSH, and launch it — useful for
-      iterating/debugging on real hardware. Usage: task deploy TV_HOST=root@<tv-ip>
-      (or set TV_HOST in .env, see .env.example)
+      Build, package, install on a real TV over SSH, and launch it. Usage:
+      task deploy TV_HOST=root@<tv-ip> (or set TV_HOST in .env)
     deps: [package]
     requires:
       vars: [TV_HOST]
+    vars:
+      IPK: dist/io.dyptan.punktfunk.webos_{{.PKG_VERSION}}_arm.ipk
     cmds:
-      - task: toolchain:deploy
-        vars: {TV_HOST: '{{.TV_HOST}}'}
+      - test -f "{{.IPK}}" || exit 1
+      - scp "{{.IPK}}" {{.TV_HOST}}:/tmp/
+      - >-
+        ssh -tt {{.TV_HOST}}
+        "luna-send -i -n 1 -f luna://com.webos.appInstallService/dev/install
+        '{\"id\":\"io.dyptan.punktfunk.webos\",\"ipkUrl\":\"/tmp/$(basename {{.IPK}})\",\"subscribe\":true}'"
+      - sleep 3
+      - >-
+        ssh -tt {{.TV_HOST}}
+        "luna-send -n 1 -f luna://com.webos.applicationManager/launch '{\"id\":\"io.dyptan.punktfunk.webos\"}'"
 
   deploy:log:
     desc: >-
@@ -120,13 +135,8 @@ tasks:
       - ssh {{.TV_HOST}} "tail -f /tmp/punktfunk-webos.log"
 
   clean:
-    desc: Remove local build output (dist/) — keeps the toolchain/cargo caches
-    cmds:
-      - rm -rf dist
-
-  clean:all:
     desc: Remove everything — dist/, .toolchains/, target/, and the Docker volumes
     cmds:
-      - task: clean
+      - rm -rf dist
       - rm -rf .toolchains target
-      - task: toolchain:docker-volumes-rm
+      - docker volume rm -f pf-webos-toolchains pf-webos-target pf-webos-cargo pf-webos-apt-cache pf-webos-apt-lists pf-webos-tools

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -22,7 +22,7 @@ moved the needle; the items here are real but each individually minor next to th
   swap) unconditionally every 16ms tick forever, even sitting on a completely untouched menu. Safe
   to skip when nothing changed *because* this UI has no time-based animation anywhere (no spinner/
   blink/marquee) — every pixel that can change does so only in reaction to an SDL event, a
-  Discovery/art background result, or the raw scancode Back/Red edge, all of which now set a
+  Discovery/art background result, or the raw scancode Red/color-button edge, all of which now set a
   `dirty` flag that gates the render call.
 - ~~**Cover-art GPU texture leak**: `app.art_pixels` (raw RGBA) gets cleared on every host switch,
   but `main.rs`'s separate GPU-texture cache built from it was never pruned to match.~~ Moot since
@@ -405,31 +405,11 @@ not a working refresh-rate switch. The panel's actual scan-out rate is fixed at 
 (HDMI timing negotiated once, or user-toggled TV settings like TruMotion/Game Optimizer) — outside
 any homebrew app's reach. Kodi's webOS port has the same limitation.
 
-**`SDL_WEBOS_ACCESS_POLICY_KEYS_BACK` stops the launcher from opening, but the Magic
-Remote's Back/Red buttons still never reach the app as a usable scancode.** `webosbrew/
-SDL-webOS`'s `src/video/wayland/SDL_waylandwebos.c` sets a Wayland shell-surface property,
-`_WEBOS_ACCESS_POLICY_KEYS_BACK`, gated behind this SDL hint — setting it to `"true"` before
-window creation (`run_inner`, via `sdl2::hint::set`) is kept because it's confirmed on-device to
-do what it's documented to do: the system launcher no longer opens/kills the app when Back is
-pressed (a real, working improvement over the old default). But that's as far as it goes: polling
-`SDL_GetKeyboardState`'s raw byte array (the only place `SDL_SCANCODE_WEBOS_BACK = 482` would be
-visible at all, since `sdl2`'s vendored `Scancode`/`Keycode` bindings only name scancodes up to
-290) shows every other key's scancode changing normally, but Back and Red specifically never flip
-— confirmed twice on-device, once via a single-scancode check and once via a full-array scan
-logging every changed index. Likely cause (unconfirmed): `Wayland_get_scancode_from_key` in
-`SDL_waylandevents.c` only calls the webOS scancode fallback (`SDL_GetWebOSScancode`, the thing
-that actually maps the LG remote's raw IR keycodes to `SDL_SCANCODE_WEBOS_*`) from one specific
-branch, gated on `!input->keyboard_is_virtual`; if this compositor's remote input reports as a
-virtual keyboard, that branch — and the webOS fallback with it — is skipped entirely, and these
-two LG-specific keycodes have no xkb keysym either, so SDL drops the whole key event before it's
-visible in any form (no scancode, no `Event::KeyDown`, nothing — confirmed via a catch-all logger
-on every otherwise-unhandled SDL event too, which also logged nothing for these two keys).
-Whatever the exact mechanism, don't re-attempt reading Back/Red via `SDL_GetKeyboardState`,
-`Keycode`, or `Scancode` without new evidence — the on-screen close (X) button, keyboard/gamepad
-Back mapping (`Escape`/`Backspace`/`AcBack`, or a controller's B button), and the in-stream
-long-press-to-disconnect are the only working Back paths. The access-policy hint itself is safe
-to leave set (confirmed harmless, and it does genuinely stop the launcher takeover) even though
-nothing currently consumes the scancode it was meant to unlock.
+**Magic Remote Back button requires `SDL_WEBOS_ACCESS_POLICY_KEYS_BACK`.** Set before window
+creation — without it webOS's system launcher intercepts the key before SDL sees it. With the
+hint active, Back arrives as `keycode = 2097155` (`WEBOS_BACK_KEYCODE` in `ui.rs`; SDL's webOS
+extension, not a named sdl2 `Keycode` variant), and `menu_event_for_key` catches it via a raw
+`i32` comparison and maps it to `MenuEvent::Back` alongside `Escape`/`AcBack`.
 
 **A hidden/unmapped window doesn't receive pointer input.** The stream-time window was `.hide()`n
 (since `set_opacity` isn't supported on this Wayland backend) so it wouldn't visually cover the NDL

--- a/src/app.rs
+++ b/src/app.rs
@@ -605,9 +605,9 @@ impl App {
     /// Applies a `Back` to whichever screen is current — the single shared
     /// definition of "what Back means here" for every caller that needs it
     /// pre-emptively rather than through the normal per-screen `MenuEvent`
-    /// dispatch: `main.rs`'s keyboard/gamepad Back shortcut on Home (straight
-    /// to Settings) and a modal's close (X) button click
-    /// (`handle_mouse_click`'s `hover_close` branch below).
+    /// dispatch: `main.rs`'s Back handling on Home (a no-op there, but routed
+    /// through here so the policy lives in one place) and a modal's close (X)
+    /// button click (`handle_mouse_click`'s `hover_close` branch below).
     pub fn back(&mut self, log: &mut std::fs::File) -> Option<ConnectTarget> {
         match self.screen {
             // Home has nothing to "back out" of (it's the root screen) — Back is a
@@ -1804,7 +1804,7 @@ impl App {
             Tile::NoHost => self.nohost_tile.as_ref(),
             // Stream-side only (uploaded directly by `run_inner`'s overlay
             // refresh) — never one of App's menu tiles.
-            Tile::StatsOverlay => None,
+            Tile::StatsOverlay | Tile::DisconnectDialog => None,
         }
     }
 

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -35,6 +35,8 @@ pub enum Tile {
     NoHost,
     /// The in-stream stats overlay panel (`ui::render_stats_overlay_tile`).
     StatsOverlay,
+    /// The in-stream disconnect-confirmation dialog (`ui::render_disconnect_dialog_tile`).
+    DisconnectDialog,
 }
 
 /// One step of a frame's composition, in paint order.

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -2,28 +2,147 @@
 //! Remote's 5-way pad surfaces as plain SDL2 `Keycode::Up/Down/Left/Right` (same as
 //! any desktop arrow key), forwarded to the host as real key presses during a stream
 //! so directional navigation drives the host UI instead of only the local menu (see
-//! `ui::menu_event_for_key`, used pre-stream for the same keycodes).
+//! `ui::menu_event_for_key`, used pre-stream for the same keycodes). USB keyboards
+//! connected to the TV are handled the same way via SDL2 scancodes (physical key
+//! positions) so the host receives QWERTY-positional VKs regardless of layout.
 use punktfunk_core::input::{InputEvent, InputKind};
-use sdl2::keyboard::Keycode;
+use sdl2::keyboard::Scancode;
 
-/// Windows VK code `punktfunk-host`'s injector expects in a `KeyDown`/`KeyUp`'s `code`
-/// (confirmed via `vk_to_evdev` in `punktfunk-host/pf-inject/src/inject/keymap.rs`).
-/// `None` for any key not yet forwarded during streaming.
-fn vk_code(keycode: Keycode) -> Option<u32> {
-    match keycode {
-        Keycode::Left => Some(0x25),
-        Keycode::Up => Some(0x26),
-        Keycode::Right => Some(0x27),
-        Keycode::Down => Some(0x28),
-        _ => None,
-    }
+/// SDL2 scancode → Windows VK code (`vk_to_evdev` on the host side).
+/// `None` for keys not in that table.
+fn vk_code(sc: Scancode) -> Option<u32> {
+    Some(match sc {
+        // ── Navigation / editing / whitespace ────────────────────────────────
+        Scancode::Backspace   => 0x08, // VK_BACK
+        Scancode::Tab         => 0x09, // VK_TAB
+        Scancode::Return | Scancode::KpEnter => 0x0D, // VK_RETURN (numpad enter too)
+        Scancode::Pause       => 0x13, // VK_PAUSE
+        Scancode::CapsLock    => 0x14, // VK_CAPITAL
+        Scancode::Escape      => 0x1B, // VK_ESCAPE
+        Scancode::Space       => 0x20, // VK_SPACE
+        Scancode::PageUp      => 0x21, // VK_PRIOR
+        Scancode::PageDown    => 0x22, // VK_NEXT
+        Scancode::End         => 0x23, // VK_END
+        Scancode::Home        => 0x24, // VK_HOME
+        Scancode::Left        => 0x25, // VK_LEFT
+        Scancode::Up          => 0x26, // VK_UP
+        Scancode::Right       => 0x27, // VK_RIGHT
+        Scancode::Down        => 0x28, // VK_DOWN
+        Scancode::PrintScreen => 0x2C, // VK_SNAPSHOT
+        Scancode::Insert      => 0x2D, // VK_INSERT
+        Scancode::Delete      => 0x2E, // VK_DELETE
+
+        // ── Digit row ─────────────────────────────────────────────────────────
+        Scancode::Num0 => 0x30, // VK_0
+        Scancode::Num1 => 0x31, // VK_1
+        Scancode::Num2 => 0x32, // VK_2
+        Scancode::Num3 => 0x33, // VK_3
+        Scancode::Num4 => 0x34, // VK_4
+        Scancode::Num5 => 0x35, // VK_5
+        Scancode::Num6 => 0x36, // VK_6
+        Scancode::Num7 => 0x37, // VK_7
+        Scancode::Num8 => 0x38, // VK_8
+        Scancode::Num9 => 0x39, // VK_9
+
+        // ── Letters A–Z (QWERTY positional) ──────────────────────────────────
+        Scancode::A => 0x41,
+        Scancode::B => 0x42,
+        Scancode::C => 0x43,
+        Scancode::D => 0x44,
+        Scancode::E => 0x45,
+        Scancode::F => 0x46,
+        Scancode::G => 0x47,
+        Scancode::H => 0x48,
+        Scancode::I => 0x49,
+        Scancode::J => 0x4A,
+        Scancode::K => 0x4B,
+        Scancode::L => 0x4C,
+        Scancode::M => 0x4D,
+        Scancode::N => 0x4E,
+        Scancode::O => 0x4F,
+        Scancode::P => 0x50,
+        Scancode::Q => 0x51,
+        Scancode::R => 0x52,
+        Scancode::S => 0x53,
+        Scancode::T => 0x54,
+        Scancode::U => 0x55,
+        Scancode::V => 0x56,
+        Scancode::W => 0x57,
+        Scancode::X => 0x58,
+        Scancode::Y => 0x59,
+        Scancode::Z => 0x5A,
+
+        // ── Meta / context-menu ───────────────────────────────────────────────
+        Scancode::LGui       => 0x5B, // VK_LWIN
+        Scancode::RGui       => 0x5C, // VK_RWIN
+        Scancode::Application => 0x5D, // VK_APPS
+
+        // ── Numpad ────────────────────────────────────────────────────────────
+        Scancode::Kp0        => 0x60, // VK_NUMPAD0
+        Scancode::Kp1        => 0x61, // VK_NUMPAD1
+        Scancode::Kp2        => 0x62, // VK_NUMPAD2
+        Scancode::Kp3        => 0x63, // VK_NUMPAD3
+        Scancode::Kp4        => 0x64, // VK_NUMPAD4
+        Scancode::Kp5        => 0x65, // VK_NUMPAD5
+        Scancode::Kp6        => 0x66, // VK_NUMPAD6
+        Scancode::Kp7        => 0x67, // VK_NUMPAD7
+        Scancode::Kp8        => 0x68, // VK_NUMPAD8
+        Scancode::Kp9        => 0x69, // VK_NUMPAD9
+        Scancode::KpMultiply => 0x6A, // VK_MULTIPLY
+        Scancode::KpPlus     => 0x6B, // VK_ADD
+        Scancode::KpMinus    => 0x6D, // VK_SUBTRACT
+        Scancode::KpPeriod   => 0x6E, // VK_DECIMAL
+        Scancode::KpDivide   => 0x6F, // VK_DIVIDE
+
+        // ── Function keys ─────────────────────────────────────────────────────
+        Scancode::F1  => 0x70,
+        Scancode::F2  => 0x71,
+        Scancode::F3  => 0x72,
+        Scancode::F4  => 0x73,
+        Scancode::F5  => 0x74,
+        Scancode::F6  => 0x75,
+        Scancode::F7  => 0x76,
+        Scancode::F8  => 0x77,
+        Scancode::F9  => 0x78,
+        Scancode::F10 => 0x79,
+        Scancode::F11 => 0x7A,
+        Scancode::F12 => 0x7B,
+
+        // ── Lock keys ─────────────────────────────────────────────────────────
+        Scancode::NumLockClear => 0x90, // VK_NUMLOCK
+        Scancode::ScrollLock   => 0x91, // VK_SCROLL
+
+        // ── Sided modifiers ───────────────────────────────────────────────────
+        Scancode::LShift => 0xA0, // VK_LSHIFT
+        Scancode::RShift => 0xA1, // VK_RSHIFT
+        Scancode::LCtrl  => 0xA2, // VK_LCONTROL
+        Scancode::RCtrl  => 0xA3, // VK_RCONTROL
+        Scancode::LAlt   => 0xA4, // VK_LMENU
+        Scancode::RAlt   => 0xA5, // VK_RMENU
+
+        // ── OEM punctuation (US layout positions) ─────────────────────────────
+        Scancode::Semicolon        => 0xBA, // VK_OEM_1      ;:
+        Scancode::Equals           => 0xBB, // VK_OEM_PLUS   =+
+        Scancode::Comma            => 0xBC, // VK_OEM_COMMA  ,<
+        Scancode::Minus            => 0xBD, // VK_OEM_MINUS  -_
+        Scancode::Period           => 0xBE, // VK_OEM_PERIOD .>
+        Scancode::Slash            => 0xBF, // VK_OEM_2      /?
+        Scancode::Grave            => 0xC0, // VK_OEM_3      `~
+        Scancode::LeftBracket      => 0xDB, // VK_OEM_4      [{
+        Scancode::Backslash        => 0xDC, // VK_OEM_5      \|
+        Scancode::RightBracket     => 0xDD, // VK_OEM_6      ]}
+        Scancode::Apostrophe       => 0xDE, // VK_OEM_7      '"
+        Scancode::NonUsBackslash   => 0xE2, // VK_OEM_102    ISO extra key
+
+        _ => return None,
+    })
 }
 
-pub fn key_event(keycode: Keycode, pressed: bool) -> Option<InputEvent> {
+pub fn key_event(scancode: Scancode, pressed: bool) -> Option<InputEvent> {
     Some(InputEvent {
         kind: if pressed { InputKind::KeyDown } else { InputKind::KeyUp },
         _pad: [0; 3],
-        code: vk_code(keycode)?,
+        code: vk_code(scancode)?,
         x: 0,
         y: 0,
         flags: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,6 @@ mod real {
     use anyhow::{Context, Result};
     use punktfunk_core::config::Mode;
     use sdl2::controller::GameController;
-    use sdl2::mouse::MouseButton;
 
     use crate::app::{App, Screen};
     use crate::compositor::{Compositor, DrawCmd, Tile};
@@ -136,16 +135,6 @@ mod real {
         }
     }
 
-    /// How long the keyboard/gamepad Back-equivalent must be held during a
-    /// stream before it disconnects and returns to the menu — long enough that a
-    /// normal game-input tap of the same physical button (many games use
-    /// B/Back-ish buttons) never triggers it.
-    const LONG_PRESS_BACK: Duration = Duration::from_millis(1500);
-    /// How long the Magic Remote's OK button (the pointer's left click) must be held
-    /// before it's promoted to a right click — long enough that a normal click never
-    /// trips it, short enough to feel deliberate rather than sluggish.
-    const LONG_PRESS_OK: Duration = Duration::from_millis(500);
-
     /// How long OK must be held on a sidebar host row before it opens
     /// `Screen::ForgetHost` instead of that row's normal short-press action
     /// (connect/pair) — see `run_ui_flow`'s `confirm_held_since`. Short enough
@@ -168,20 +157,6 @@ mod real {
         } else {
             *held = true;
             ev
-        }
-    }
-
-    /// Starts/clears the streaming loop's Back long-press timer (see
-    /// `LONG_PRESS_BACK`) — shared by the keyboard and controller arms, which
-    /// otherwise repeat this identically.
-    fn track_back_hold(is_back: bool, pressed: bool, held_since: &mut Option<Instant>) {
-        if !is_back {
-            return;
-        }
-        if pressed {
-            held_since.get_or_insert_with(Instant::now);
-        } else {
-            *held_since = None;
         }
     }
 
@@ -545,12 +520,8 @@ mod real {
     }
 
     fn run_inner(log: &mut std::fs::File) -> Result<()> {
-        // Without this, webOS's system launcher intercepts the Magic Remote's Back
-        // key before the app ever sees it (confirmed on-device — see
-        // docs/NOTES.md's "Tried and abandoned" note on this exact hint, previously
-        // removed after it appeared not to help; re-trying it here). Must be set
-        // before the window is created — `SDL_waylandwebos.c` only applies it at
-        // window-creation time (plus a runtime hint-watcher for later changes).
+        // Prevents webOS's system launcher from intercepting the Magic Remote's Back
+        // key. Must be set before window creation.
         sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_BACK", "true");
         // Linear texture filtering (SDL defaults to nearest) — the focus pop
         // scales card textures slightly, which shimmers without it.
@@ -729,9 +700,6 @@ mod real {
                 audio_player.spec()
             )?;
 
-            let mut back_held_since: Option<Instant> = None;
-            let mut ok_held_since: Option<Instant> = None;
-            let mut ok_promoted = false;
             let mut scroll_acc = mouse::ScrollAccumulator::default();
             // In-stream stats overlay (Settings toggle): refreshed at ~2Hz onto the
             // otherwise-transparent stream window. Drawing composites OVER the
@@ -743,6 +711,10 @@ mod real {
             let mut overlay_last: Option<Instant> = None;
             let mut overlay_prev_frames: u64 = 0;
             let mut overlay_prev_at = Instant::now();
+            // None = dialog not shown; Some(0) = shown, "Disconnect" focused;
+            // Some(1) = shown, "Cancel" focused (default on open — safer).
+            let mut disconnect_dialog: Option<usize> = None;
+            let mut dialog_dirty = false;
             let outcome = 'running: loop {
                 if QUIT_REQUESTED.load(Ordering::Relaxed) {
                     writeln!(log, "SIGTERM/SIGINT received — disconnecting before exit")?;
@@ -770,29 +742,73 @@ mod real {
                         Event::ControllerDeviceRemoved { .. } => {
                             controller = None;
                         }
-                        Event::KeyDown { keycode: Some(k), .. } => {
-                            let is_back = crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back);
-                            track_back_hold(is_back, true, &mut back_held_since);
-                            if let Some(ev) = keyboard::key_event(k, true) {
+                        // Dialog open: navigate it only, don't forward input to the
+                        // host. Non-repeat keys/fresh controller presses only, so the
+                        // held Back that opened it doesn't also dismiss it.
+                        _ if disconnect_dialog.is_some() => {
+                            let focus = disconnect_dialog.expect("guarded by is_some above");
+                            let nav = match &event {
+                                Event::KeyDown { keycode: Some(k), repeat: false, .. } => {
+                                    crate::ui::menu_event_for_key(*k)
+                                }
+                                Event::ControllerButtonDown { button, .. } => {
+                                    crate::ui::menu_event_for_button(*button)
+                                }
+                                _ => None,
+                            };
+                            match nav {
+                                Some(MenuEvent::Left) | Some(MenuEvent::Right) => {
+                                    disconnect_dialog = Some(1 - focus);
+                                    dialog_dirty = true;
+                                }
+                                Some(MenuEvent::Confirm) if focus == 0 => {
+                                    writeln!(log, "back — disconnecting to menu")?;
+                                    connected.client.disconnect_quit();
+                                    break 'running StreamOutcome::ReturnToMenu;
+                                }
+                                Some(MenuEvent::Confirm) | Some(MenuEvent::Back) => {
+                                    disconnect_dialog = None;
+                                    // Clear both double-buffer frames back to transparent
+                                    // (also wipes the stats overlay — force a redraw).
+                                    canvas.set_draw_color(sdl2::pixels::Color::RGBA(0, 0, 0, 0));
+                                    canvas.clear();
+                                    canvas.present();
+                                    canvas.clear();
+                                    canvas.present();
+                                    overlay_last = None;
+                                }
+                                _ => {}
+                            }
+                        }
+                        // Scancode keys are real game input (Backspace/Escape/etc.
+                        // included) — forward only, never open the dialog.
+                        Event::KeyDown { scancode: Some(sc), .. } => {
+                            if let Some(ev) = keyboard::key_event(sc, true) {
                                 let _ = session::send_input(&connected.client, &ev);
                             }
                         }
-                        Event::KeyUp { keycode: Some(k), .. } => {
-                            let is_back = crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back);
-                            track_back_hold(is_back, false, &mut back_held_since);
-                            if let Some(ev) = keyboard::key_event(k, false) {
+                        // Magic Remote Back (0x200003): no scancode, never
+                        // forwarded to the host — open the disconnect dialog.
+                        Event::KeyDown { keycode: Some(k), scancode: None, repeat: false, .. }
+                            if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back) =>
+                        {
+                            disconnect_dialog = Some(1);
+                            dialog_dirty = true;
+                        }
+                        Event::KeyUp { scancode: Some(sc), .. } => {
+                            if let Some(ev) = keyboard::key_event(sc, false) {
                                 let _ = session::send_input(&connected.client, &ev);
                             }
                         }
                         Event::ControllerButtonDown { button, .. } => {
-                            let is_back = crate::ui::menu_event_for_button(button) == Some(MenuEvent::Back);
-                            track_back_hold(is_back, true, &mut back_held_since);
+                            if crate::ui::menu_event_for_button(button) == Some(MenuEvent::Back) {
+                                disconnect_dialog = Some(1);
+                                dialog_dirty = true;
+                            }
                             let ev = gamepad::button_event(button, true, 0);
                             let _ = session::send_input(&connected.client, &ev);
                         }
                         Event::ControllerButtonUp { button, .. } => {
-                            let is_back = crate::ui::menu_event_for_button(button) == Some(MenuEvent::Back);
-                            track_back_hold(is_back, false, &mut back_held_since);
                             let ev = gamepad::button_event(button, false, 0);
                             let _ = session::send_input(&connected.client, &ev);
                         }
@@ -809,25 +825,12 @@ mod real {
                             let _ = session::send_input(&connected.client, &ev);
                         }
                         Event::MouseButtonDown { mouse_btn, .. } => {
-                            if mouse_btn == MouseButton::Left {
-                                ok_held_since = Some(Instant::now());
-                                ok_promoted = false;
-                            }
                             if let Some(ev) = mouse::button_event(mouse_btn, true) {
                                 let _ = session::send_input(&connected.client, &ev);
                             }
                         }
                         Event::MouseButtonUp { mouse_btn, .. } => {
-                            let released = if mouse_btn == MouseButton::Left && ok_promoted {
-                                MouseButton::Right
-                            } else {
-                                mouse_btn
-                            };
-                            if mouse_btn == MouseButton::Left {
-                                ok_held_since = None;
-                                ok_promoted = false;
-                            }
-                            if let Some(ev) = mouse::button_event(released, false) {
+                            if let Some(ev) = mouse::button_event(mouse_btn, false) {
                                 let _ = session::send_input(&connected.client, &ev);
                             }
                         }
@@ -846,29 +849,42 @@ mod real {
                         _ => {}
                     }
                 }
-                if back_held_since.is_some_and(|t| t.elapsed() >= LONG_PRESS_BACK) {
-                    writeln!(log, "back — disconnecting to menu")?;
-                    // A deliberate user stop (not a network drop/backgrounding) — the
-                    // host tears the virtual display down immediately instead of
-                    // lingering for a reconnect that isn't coming (see the embedding
-                    // guide's teardown section). Every other exit path (host ended
-                    // the session, app quit) leaves this alone and just drops the
-                    // client, which closes with the "may reconnect" code instead.
-                    connected.client.disconnect_quit();
-                    break 'running StreamOutcome::ReturnToMenu;
-                }
-                if !ok_promoted && ok_held_since.is_some_and(|t| t.elapsed() >= LONG_PRESS_OK) {
-                    // Release left before pressing right so the host never sees both held.
-                    if let Some(ev) = mouse::button_event(MouseButton::Left, false) {
-                        let _ = session::send_input(&connected.client, &ev);
+                // Render the disconnect dialog when open. The card floats over
+                // the live video (transparent surroundings); tile re-rasterizes only
+                // on focus change, but scrim + card recomposite every tick (double
+                // buffered — a single present would leave the other buffer stale).
+                if let Some(focus) = disconnect_dialog {
+                    let full = sdl2::rect::Rect::new(0, 0, display_mode.w as u32, display_mode.h as u32);
+                    if dialog_dirty {
+                        dialog_dirty = false;
+                        let tile = crate::ui::render_disconnect_dialog_tile(
+                            full.width(),
+                            full.height(),
+                            &font_label,
+                            &icon_font,
+                            focus,
+                        )?;
+                        compositor.upload(&texture_creator, Tile::DisconnectDialog, &tile)?;
                     }
-                    if let Some(ev) = mouse::button_event(MouseButton::Right, true) {
-                        let _ = session::send_input(&connected.client, &ev);
-                    }
-                    ok_promoted = true;
+                    canvas.set_blend_mode(sdl2::render::BlendMode::None);
+                    canvas.set_draw_color(sdl2::pixels::Color::RGBA(0, 0, 0, 0));
+                    canvas.clear();
+                    compositor.execute(
+                        &mut canvas,
+                        &[
+                            DrawCmd::Fill { rect: full, color: sdl2::pixels::Color::RGBA(0, 0, 0, crate::ui::MODAL_SCRIM.a) },
+                            DrawCmd::Tex { tile: Tile::DisconnectDialog, dst: full, alpha: 0xff },
+                        ],
+                    )?;
+                    canvas.present();
                 }
                 session::pump_audio_once(&connected.client, &mut audio_player, log);
-                if stats_enabled && overlay_last.is_none_or(|t| t.elapsed() >= Duration::from_millis(500)) {
+                // Skipped while the dialog is open — its own redraw above already
+                // owns the canvas this tick.
+                if stats_enabled
+                    && disconnect_dialog.is_none()
+                    && overlay_last.is_none_or(|t| t.elapsed() >= Duration::from_millis(500))
+                {
                     overlay_last = Some(Instant::now());
                     let frames = connected.stats.frames.load(Ordering::Relaxed);
                     let dt = overlay_prev_at.elapsed().as_secs_f32().max(0.001);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1108,6 +1108,46 @@ pub fn render_stats_overlay_tile(font: &Font, lines: &[String]) -> Result<Painte
     Ok(p)
 }
 
+/// The in-stream disconnect-confirmation dialog: card, title, and confirm
+/// buttons, full-screen sized like `App`'s `Tile::Modal` so `main.rs` can
+/// place it at `(0, 0)`. No backdrop dim baked in — `main.rs` draws that as
+/// its own compositor `Fill`, same as `App::draw_list` scrims `Tile::Modal`.
+pub fn render_disconnect_dialog_tile(
+    screen_w: u32,
+    screen_h: u32,
+    font_label: &Font,
+    icon_font: &Font,
+    focused: usize,
+) -> Result<Painter> {
+    let mut p = Painter::new(screen_w, screen_h);
+    let mut tc = TextCache::new();
+    let card = modal_card_rect(screen_w, screen_h, 0.34, 200);
+    draw_modal_card(&mut p, card);
+    let title = "Stop streaming?";
+    let (title_w, _) = font_label.size_of(title).unwrap_or((0, 0));
+    let title_x = card.x() + (card.width() as i32 - title_w as i32) / 2;
+    draw_text(&mut p, &mut tc, font_label, title, title_x, card.y() + 36, WHITE)?;
+    let btn_rect = Rect::new(
+        card.x() + 32,
+        card.y() + 36 + font_label.height() + 28,
+        card.width().saturating_sub(64),
+        72,
+    );
+    draw_confirm_buttons(
+        &mut p,
+        &mut tc,
+        font_label,
+        icon_font,
+        btn_rect,
+        &[
+            ConfirmButton { icon: Some(ICON_CLOSE), label: "Disconnect", color: ERROR_RED },
+            ConfirmButton { icon: None, label: "Cancel", color: WHITE },
+        ],
+        focused,
+    )?;
+    Ok(p)
+}
+
 // ---------------------------------------------------------------------- sidebar --
 
 // Sized for a 10-foot TV viewing distance, not a desktop/phone screen.

--- a/taskfiles/toolchain.yml
+++ b/taskfiles/toolchain.yml
@@ -1,58 +1,35 @@
-# webOS-specific plumbing: cross-toolchain fetch, staging/packaging the .ipk, and
-# the Docker wrapper. Kept out of the root Taskfile.yml so that one stays short.
-# Vars are passed in explicitly from the root Taskfile's `includes:` block — Task
-# doesn't share `vars:` between a parent and an included Taskfile by default.
 version: '3'
 
 vars:
   SDL2_BACKPORT_RELEASE: release-2.30.12-webos.5
   SDL2_BACKPORT_VERSION: 2.30.12
   SDL2_BACKPORT_SONAME: libSDL2-2.0.so.0.3000.12
-  GIT_SHA:
-    sh: git rev-parse --short=8 HEAD 2>/dev/null || echo unknown
-  # Non-empty only on a tagged release build (GITHUB_REF_TYPE/GITHUB_REF_NAME are
-  # set by GitHub Actions on every job).
-  RELEASE_TAG:
-    sh: |
-      if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
-        echo "${GITHUB_REF_NAME#v}"
-      fi
-  # Most recent published release, for dev builds to version themselves off of
-  # (see stage-and-package below). Needs the repo's tags fetched — CI's checkout
-  # step uses fetch-depth: 0 for this.
-  LATEST_TAG:
-    sh: git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 0.0.1
-  # Named volumes, never `/usr/local/cargo`/`/usr/local/rustup` themselves — a
-  # mount over either would blow away the base image's own Rust install.
   DOCKER_MOUNTS: >-
     -v {{.ROOT_DIR}}:/workspace
     -v pf-webos-toolchains:/workspace/.toolchains
     -v pf-webos-target:/workspace/target
-    -v pf-webos-cargo-registry:/usr/local/cargo/registry
-    -v pf-webos-cargo-git:/usr/local/cargo/git
+    -v pf-webos-cargo:/opt/pf-webos-cargo
     -v pf-webos-apt-cache:/var/cache/apt/archives
+    -v pf-webos-apt-lists:/var/lib/apt/lists
     -v pf-webos-tools:/opt/pf-webos-tools
     -w /workspace
-    -e PATH=/opt/pf-webos-tools/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    -e CARGO_HOME=/opt/pf-webos-cargo
+    -e PATH=/opt/pf-webos-tools/bin:/opt/pf-webos-cargo/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 tasks:
   # ---------------------------------------------------------------- toolchain --
 
   ndk:
-    desc: Fetch the webosbrew/native-toolchain cross-compiler (idempotent)
+    desc: Fetch the webosbrew/native-toolchain cross-compiler
     status:
       - test -x {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-gcc
     cmds:
       - |
         set -eu
-        # Only a Linux aarch64 build exists (confirmed via the GitHub releases
-        # API back to 2023 — no linux-x86_64 ever shipped). This always runs
-        # inside the Docker container (forced to --platform linux/arm64) or on
-        # an aarch64 CI runner, so that's the only case handled.
         case "$(uname -s)-$(uname -m)" in
             Linux-aarch64|Linux-arm64) PLATFORM=linux-aarch64 ;;
             *)
-                echo "no webosbrew/native-toolchain release for $(uname -s)-$(uname -m) — this must run on Linux/aarch64 (inside the Docker container, or an aarch64 CI runner)" >&2
+                echo "no webosbrew/native-toolchain release for $(uname -s)-$(uname -m) — must run on Linux/aarch64" >&2
                 exit 1
                 ;;
         esac
@@ -61,33 +38,24 @@ tasks:
         mkdir -p "$(dirname {{.NDK_DIR}})"
         TMP="$(mktemp -d)"
         trap 'rm -rf "$TMP"' EXIT
-        echo "downloading $URL"
         curl -sL -o "$TMP/$ASSET" "$URL"
         tar xjf "$TMP/$ASSET" -C "$(dirname {{.NDK_DIR}})"
         sh {{.NDK_DIR}}/relocate-sdk.sh
-        # Baked-in default --sysroot is stale post-relocate (cc-shim.sh/
-        # cxx-shim.sh pass it explicitly) — this is just a link sanity check.
         echo 'int main(void) { return 0; }' | {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-gcc \
             --sysroot={{.SYSROOT}} -x c -o "$TMP/probe" -
-        echo "webOS NDK ready at {{.NDK_DIR}}"
 
   sdl2:
-    desc: Overlay webosbrew/SDL-webOS's webOS-patched SDL2 onto the NDK sysroot (idempotent)
+    desc: Overlay webosbrew/SDL-webOS onto the NDK sysroot
     deps: [ndk]
     status:
       - test "$(readlink {{.SYSROOT}}/usr/lib/libSDL2-2.0.so.0)" = "{{.SDL2_BACKPORT_SONAME}}"
     cmds:
       - |
         set -eu
-        # The NDK's own bundled SDL2 lacks webOS's Wayland shell-integration
-        # protocol, so its driver can't get a surface from the TV's compositor
-        # (confirmed live on an LG CX) — every other native webOS SDL2 app
-        # bundles this same fork for the same reason.
         TMP="$(mktemp -d)"
         trap 'rm -rf "$TMP"' EXIT
         ASSET="SDL2-{{.SDL2_BACKPORT_VERSION}}-webos.tar.gz"
         URL="https://github.com/webosbrew/SDL-webOS/releases/download/{{.SDL2_BACKPORT_RELEASE}}/${ASSET}"
-        echo "downloading $URL"
         curl -sL -o "$TMP/$ASSET" "$URL"
         mkdir -p "$TMP/extracted"
         tar xzf "$TMP/$ASSET" -C "$TMP/extracted"
@@ -97,10 +65,9 @@ tasks:
         ln -sf {{.SDL2_BACKPORT_SONAME}} {{.SYSROOT}}/usr/lib/libSDL2.so
         sed -i.bak "s/^Version:.*/Version: {{.SDL2_BACKPORT_VERSION}}/" {{.SYSROOT}}/usr/lib/pkgconfig/sdl2.pc
         rm -f {{.SYSROOT}}/usr/lib/pkgconfig/sdl2.pc.bak
-        echo "webOS SDL2 backport overlaid onto {{.SYSROOT}}"
 
   all:
-    desc: Fetch the full webOS cross-toolchain (NDK + SDL2 overlay) — idempotent
+    desc: Fetch the full webOS cross-toolchain
     deps: [ndk, sdl2]
 
   ares-package:
@@ -108,41 +75,14 @@ tasks:
     status:
       - command -v ares-package
     cmds:
-      # Needs a fairly recent stable Rust (its source uses let-chains).
       - cargo install --git https://github.com/webosbrew/ares-cli-rs ares-package
-
-  deploy:
-    internal: true
-    requires:
-      vars: [TV_HOST]
-    vars:
-      IPK_PATH:
-        sh: ls -t dist/*.ipk | head -1
-      IPK_NAME:
-        sh: basename {{.IPK_PATH}}
-    cmds:
-      - echo "installing {{.IPK_NAME}} on {{.TV_HOST}}"
-      - scp {{.IPK_PATH}} {{.TV_HOST}}:/tmp/
-      # -tt: luna-send needs a real PTY over non-interactive SSH or it silently
-      # swallows output (see docs/NOTES.md). install is async — `-n 1` only
-      # acks that it started, so launching too soon races it into "app is
-      # locked"; the sleep is the same margin the hand-verified recipe used.
-      - >-
-        ssh -tt {{.TV_HOST}}
-        "luna-send -i -n 1 -f luna://com.webos.appInstallService/dev/install
-        '{\"id\":\"io.dyptan.punktfunk.webos\",\"ipkUrl\":\"/tmp/{{.IPK_NAME}}\",\"subscribe\":true}'"
-      - sleep 3
-      - ssh {{.TV_HOST}} "rm -f /tmp/punktfunk-webos.log"
-      - >-
-        ssh -tt {{.TV_HOST}}
-        "luna-send -n 1 -f luna://com.webos.applicationManager/launch '{\"id\":\"io.dyptan.punktfunk.webos\"}'"
-      - 'echo "launched — tail the log with: task deploy:log TV_HOST={{.TV_HOST}}"'
 
   # ------------------------------------------------------------------ package --
 
   stage-and-package:
     internal: true
-    desc: Stage the stripped binary + bundled SDL2 + assets, then invoke ares-package
+    requires:
+      vars: [PKG_VERSION, TARGET, NDK_DIR, SYSROOT]
     cmds:
       - |
         set -eu
@@ -151,57 +91,30 @@ tasks:
         mkdir -p "$STAGE_DIR/bin" "$STAGE_DIR/lib"
         cp target/{{.TARGET}}/release/punktfunk-webos "$STAGE_DIR/bin/"
         {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-strip "$STAGE_DIR/bin/punktfunk-webos"
-        # On-device libSDL2 (2.0.10) is missing ABI symbols this binary needs —
-        # bundle the exact .so it linked against under the SONAME the dynamic
-        # linker looks for, loaded via the $ORIGIN/../lib rpath build.rs sets.
         cp -L {{.SYSROOT}}/usr/lib/libSDL2-2.0.so.0 "$STAGE_DIR/lib/libSDL2-2.0.so.0"
         {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-strip "$STAGE_DIR/lib/libSDL2-2.0.so.0"
-        # libplayerAPIs_C.so: C wrapper for the C++ StarfishMediaAPIs class.
-        # build.rs compiles this from src/starfish_c_shim.cpp; it is not on the
-        # TV, so we bundle it here (same pattern as libSDL2-2.0.so.0 above).
         cp target/{{.TARGET}}/release/libplayerAPIs_C.so "$STAGE_DIR/lib/libplayerAPIs_C.so"
         {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-strip "$STAGE_DIR/lib/libplayerAPIs_C.so"
         cp packaging/appinfo.json packaging/icon.png packaging/icon_large.png packaging/splash.png "$STAGE_DIR/"
 
-        # webOS/Homebrew Channel reads the *installed* app's own appinfo.json
-        # version (not just the manifest below) to decide if an update is
-        # available — so it must be patched to a real version before
-        # packaging, not left at the checked-in 0.0.1, or every install looks
-        # perpetually outdated. Release builds get the release tag; dev builds
-        # get the latest published release instead, with the HEAD commit's
-        # short sha (`{{.GIT_SHA}}`) appended to the *filename* for traceability
-        # (the version field itself must stay a plain x.x.x).
-        {{if .RELEASE_TAG}}
-        sed -i.bak 's/"version": "0.0.1"/"version": "{{.RELEASE_TAG}}"/' "$STAGE_DIR/appinfo.json"
-        {{else}}
-        sed -i.bak 's/"version": "0.0.1"/"version": "{{.LATEST_TAG}}"/' "$STAGE_DIR/appinfo.json"
-        {{end}}
+        PKG_VERSION="{{.PKG_VERSION}}"
+        APP_VERSION="${PKG_VERSION%%+git.*}"
+        case "$APP_VERSION" in
+          *+*|*[^0-9.]*) echo "error: APP_VERSION '${APP_VERSION}' is not x.x.x" >&2; exit 1 ;;
+        esac
+        sed -i.bak "s/\"version\": \"0.0.1\"/\"version\": \"${APP_VERSION}\"/" "$STAGE_DIR/appinfo.json"
         rm -f "$STAGE_DIR/appinfo.json.bak"
         mkdir -p dist
         ares-package "$STAGE_DIR" -o dist --force-arch arm
 
-        {{if .RELEASE_TAG}}
-        # Nothing to rename — ares-package already names the .ipk after the
-        # patched appinfo.json version above.
-        {{else}}
-        for f in dist/*_arm.ipk; do
-          [ -e "$f" ] || continue
-          case "$f" in *"+git.{{.GIT_SHA}}"*) continue ;; esac
-          mv "$f" "${f%_arm.ipk}+git.{{.GIT_SHA}}_arm.ipk"
-        done
-        {{end}}
-
-        {{if .RELEASE_TAG}}
-        # Homebrew Channel manifest (schema: webosbrew/docs/schemas/
-        # HomebrewPackageManifest.schema.json) — repo.json's manifestUrl
-        # resolves to this. Only generated on a tagged release build.
-        IPK_FILE="$(ls dist/*_{{.RELEASE_TAG}}_arm.ipk)"
-        IPK_SHA256="$(sha256sum "$IPK_FILE" | cut -d' ' -f1)"
-        REPO="${GITHUB_REPOSITORY:-dyptan-io/pf-webos}"
-        cat > dist/io.dyptan.punktfunk.webos.manifest.json <<EOF
+        if [ "$PKG_VERSION" = "$APP_VERSION" ]; then
+          IPK_FILE="dist/io.dyptan.punktfunk.webos_${PKG_VERSION}_arm.ipk"
+          IPK_SHA256="$(sha256sum "$IPK_FILE" | cut -d' ' -f1)"
+          REPO="${GITHUB_REPOSITORY:-dyptan-io/pf-webos}"
+          cat > dist/io.dyptan.punktfunk.webos.manifest.json <<EOF
         {
           "id": "io.dyptan.punktfunk.webos",
-          "version": "{{.RELEASE_TAG}}",
+          "version": "${APP_VERSION}",
           "type": "native",
           "title": "punktfunk",
           "appDescription": "punktfunk — low-latency desktop/game streaming client",
@@ -212,18 +125,12 @@ tasks:
           "ipkHash": { "sha256": "$IPK_SHA256" }
         }
         EOF
-        echo "manifest: dist/io.dyptan.punktfunk.webos.manifest.json"
-        {{end}}
-
-        echo "packaged:"
-        ls -lh dist/*.ipk
+        else
+          mv "dist/io.dyptan.punktfunk.webos_${APP_VERSION}_arm.ipk" \
+             "dist/io.dyptan.punktfunk.webos_${PKG_VERSION}_arm.ipk"
+        fi
 
   # ------------------------------------------------------------------- docker --
-  # Ephemeral `docker run --rm` against the stock `rust` image, re-invoking the
-  # root `native:*` tasks inside via a nested `task` install — no build logic
-  # duplicated between CI's native path and this one. Forced to
-  # --platform linux/arm64 regardless of host arch: the webOS NDK has no
-  # linux-x86_64 build, so an amd64 host runs it under QEMU instead of failing.
 
   docker-run:
     internal: true
@@ -239,12 +146,3 @@ tasks:
           task {{.TARGET_TASK}}
         '
 
-  docker-shell:
-    internal: true
-    cmds:
-      - "docker run --rm -it --platform linux/arm64 {{.DOCKER_MOUNTS}} {{.RUST_IMAGE}} bash"
-
-  docker-volumes-rm:
-    internal: true
-    cmds:
-      - docker volume rm -f pf-webos-toolchains pf-webos-target pf-webos-cargo-registry pf-webos-cargo-git pf-webos-apt-cache pf-webos-tools


### PR DESCRIPTION
## Summary
- Full HID keyboard support: maps SDL2 scancodes to Windows VK codes matching the host's `vk_to_evdev` table, so a USB keyboard plugged into the TV sends QWERTY-positional keys during a stream regardless of the TV's layout.
- Fixes the Magic Remote's BACK button: it arrives as a raw webOS SDL keycode (`2097155`) with no scancode and no named `sdl2::Keycode` variant, so `menu_event_for_key` now matches it directly.
- In a stream, BACK now opens a "Stop streaming?" confirmation dialog instead of disconnecting immediately — reimplemented on top of `main`'s new GPU tile compositor (`Tile::DisconnectDialog` + `ui::render_disconnect_dialog_tile`) rather than the pre-overhaul single-`Painter`/`frame_texture` pipeline.
- Fixes a bug (found in review) where the dialog blinked twice a second while open: the stats overlay's ~2Hz refresh unconditionally cleared the whole canvas and redrew only its own tile, wiping the dialog out until the next tick redrew it.
- Reverts an earlier long-press-OK-promotes-to-right-click experiment that felt unreliable in practice.

## Test plan
- [x] `task check` / `task lint` clean on the rebased branch
- [ ] `task deploy` to a real LG CX and verify: USB keyboard input during a stream, Magic Remote BACK opens the disconnect dialog without blinking, Disconnect/Cancel both work, stats overlay (if enabled) still refreshes normally outside the dialog
