### PR TITLE
Renice vendor decode-pipeline threads to fix resolution-dependent choppiness

### DIFF
--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -250,13 +250,58 @@ capability/version negotiation (every client and host must agree, so not a silen
 the key grows from 16 to 32 bytes. This is a `punktfunk-core`/`punktfunk-host` change — affects
 every client, not just this one.
 
-**Status (2026-07-21): the punktfunk maintainer has confirmed ChaCha20-Poly1305 is coming to
-the protocol.** Nothing to do in pf-webos yet — this client has no cipher-specific code of its
-own (it never touches `SessionCrypto`/`Aes128Gcm` directly; all of it is internal to
-`punktfunk-core`, invisible behind the `NativeClient` API this client consumes). Once
-punktfunk-core ships it and pf-webos bumps its pin, wire it in as the **sole** cipher — no
-client-side setting/toggle for encryption algorithm, same way codec/HDR/bitrate capability bits
-are just sent, not exposed as a user choice between wire-level options.
+**Status (2026-07-23): shipped and confirmed working.** `punktfunk-core` v0.17.2 negotiates
+ChaCha20-Poly1305 (`VIDEO_CAP_CHACHA20`, advertised unconditionally in `session.rs::connect` —
+no client-side setting/toggle, this is the one cipher this client speaks). Confirmed on-device:
+sustains meaningfully higher bitrate than AES-GCM did before it. The *grant* still isn't
+client-observable (`NativeClient` doesn't expose `Welcome::cipher`) — only the host's own log
+shows which cipher a given session actually resolved.
+
+## Resolution-dependent choppiness above 1080p (2026-07-22 – 2026-07-23)
+
+Symptom: both NDL and Starfish are butter-smooth at a *captured* (host-side) resolution of
+1080p, but choppy above it (1440p, 4K) — independent of bitrate or requested fps. aurora-tv is
+smooth above 1080p on the exact same TV/host, but over its GameStream-compatibility path, which
+is unencrypted and hits a different host code path — not a clean apples-to-apples reference for
+this symptom.
+
+**Tried, confirmed no measurable effect:**
+- **Starfish: reordering `SDL_webOSSetExportedWindow` to after `StarfishMediaAPIs_load()`**,
+  matching ss4s's `StarfishResourcePostLoad` timing — no change on its own, but kept: this is now
+  simply how `starfish.rs::load` binds the punch-through window (see the ordering there), not a
+  toggle.
+- **PTS smoothing/pacing** ported from aurora-tv's ss4s fork — anchor the host's PTS to a local
+  clock once, then either walk an idealized fixed-fps-interval grid, or just follow the host's
+  PTS deltas with a monotonic floor. The grid variant looked smoother on NDL but added real input
+  latency (holding frames back for a nominal cadence) and that improvement was never confirmed
+  reproducible; the non-grid variant removed the latency cost but fixed nothing. Neither helped
+  Starfish. Not committed — the actual reference `ss4s` (checked out locally) turns out not to
+  do any PTS smoothing at all (`SS4S_NDL_webOS5_GetPts` is plain wall-clock-since-load, same as
+  this client's own `ndl.rs`), so this was a custom design, not a direct port.
+- **Starfish `pauseAtDecodeTime: false`** — no change. Retested on a clean, correctly-isolated
+  build (an earlier attempt's negative result was suspect due to a mismatched build) — same
+  negative result confirmed. Not committed.
+
+**Fixed (2026-07-23), but NDL-only so far**: renicing the NDL/Starfish vendor `.so`'s internal
+decode-pipeline threads to -10 — **large, confirmed improvement on NDL**. These are
+`GStreamer`-element pad-task threads (`"<element>:<pad>"`, truncated to the kernel's 15-char
+`comm` limit) spawned *inside our own process* by the vendor library, invisible to
+punktfunk-core's hot-thread registry (that only covers threads this crate and punktfunk-core
+spawn themselves) and confirmed via live `/proc/<pid>/task` sampling to sit at default nice 0
+despite doing real decode work — a real contention cost on this SoC's **3 CPU cores**
+(`nproc`-confirmed on-device). `session.rs::spawn_vendor_decode_thread_renicer` matches by the
+`:src` pad-name suffix rather than the two exact names observed under NDL
+(`lxvideodec1:src`/`video-src:src`), on the theory that Starfish's own internal pipeline uses
+the same `GStreamer` pad-task convention with different element names — **not yet confirmed
+whether the broader match actually catches Starfish's threads; still choppy there as of this
+writing.** If Starfish remains unaffected after this generalization, the next step is live
+`/proc` sampling during an active Starfish session specifically, to find its actual thread names
+rather than assuming the `:src` suffix covers them.
+
+**Still open**: a prior data point (2560x1440@120fps/150Mbps, NDL) showed the host's own frame
+*arrival* rate cycling ~76-120fps with zero client-side drops/gaps ever flagged — suggesting the
+host itself wasn't always producing 120fps at that resolution, a separate, possibly-compounding
+host-side capture/encode throughput question, not yet re-examined after the thread-priority fix.
 
 ## Runtime/deploy gotchas (LG CX specifics)
 

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -282,21 +282,23 @@ this symptom.
   build (an earlier attempt's negative result was suspect due to a mismatched build) — same
   negative result confirmed. Not committed.
 
-**Fixed (2026-07-23), but NDL-only so far**: renicing the NDL/Starfish vendor `.so`'s internal
-decode-pipeline threads to -10 — **large, confirmed improvement on NDL**. These are
-`GStreamer`-element pad-task threads (`"<element>:<pad>"`, truncated to the kernel's 15-char
-`comm` limit) spawned *inside our own process* by the vendor library, invisible to
-punktfunk-core's hot-thread registry (that only covers threads this crate and punktfunk-core
-spawn themselves) and confirmed via live `/proc/<pid>/task` sampling to sit at default nice 0
-despite doing real decode work — a real contention cost on this SoC's **3 CPU cores**
-(`nproc`-confirmed on-device). `session.rs::spawn_vendor_decode_thread_renicer` matches by the
-`:src` pad-name suffix rather than the two exact names observed under NDL
-(`lxvideodec1:src`/`video-src:src`), on the theory that Starfish's own internal pipeline uses
-the same `GStreamer` pad-task convention with different element names — **not yet confirmed
-whether the broader match actually catches Starfish's threads; still choppy there as of this
-writing.** If Starfish remains unaffected after this generalization, the next step is live
-`/proc` sampling during an active Starfish session specifically, to find its actual thread names
-rather than assuming the `:src` suffix covers them.
+**Fixed (2026-07-23) for NDL — large, confirmed improvement. Starfish remains choppier despite an
+attempted generalization; parked, not pursued further for now.** Renicing the NDL/Starfish vendor
+`.so`'s internal decode-pipeline threads to -10 fixed NDL outright. These are `GStreamer`-element
+pad-task threads (`"<element>:<pad>"`, truncated to the kernel's 15-char `comm` limit) spawned
+*inside our own process* by the vendor library, invisible to punktfunk-core's hot-thread registry
+(that only covers threads this crate and punktfunk-core spawn themselves) and confirmed via live
+`/proc/<pid>/task` sampling to sit at default nice 0 despite doing real decode work — a real
+contention cost on this SoC's **3 CPU cores** (`nproc`-confirmed on-device).
+`session.rs::spawn_vendor_decode_thread_renicer` matches by the `:src` pad-name suffix rather than
+the two exact names observed under NDL (`lxvideodec1:src`/`video-src:src`), on the theory that
+Starfish's own internal pipeline uses the same `GStreamer` pad-task convention with different
+element names. **Retested after generalizing: no change for Starfish** — either its pipeline
+doesn't follow the `:src` naming convention, or thread priority isn't its bottleneck at all. Not
+investigated further this pass (would need live `/proc` sampling during an active Starfish
+session to find its actual thread names, or a different hypothesis entirely) — kept as a known,
+open gap rather than guessed at blindly. The suffix-based match and background-thread renicer
+are kept as shipped, confirmed-correct behavior for NDL regardless.
 
 **Still open**: a prior data point (2560x1440@120fps/150Mbps, NDL) showed the host's own frame
 *arrival* rate cycling ~76-120fps with zero client-side drops/gaps ever flagged — suggesting the

--- a/src/session.rs
+++ b/src/session.rs
@@ -337,34 +337,55 @@ const HOLD_GIVE_UP: Duration = Duration::from_secs(2);
 /// Feed calls slower than this suggest decoder backpressure rather than network loss.
 const FEED_BACKPRESSURE_WARN: Duration = Duration::from_millis(20);
 
-/// GStreamer-element-named threads the NDL/Starfish vendor `.so` spawns *inside our own
-/// process* for its internal decode pipeline — not part of punktfunk-core's hot-thread
-/// registry (that only covers threads this crate and punktfunk-core spawn themselves).
-/// Confirmed via live `/proc/<pid>/task` sampling during an active stream to be doing
-/// real CPU work while sitting at the default nice 0, unlike our own already-boosted
-/// video-pump/data-pump threads.
-const VENDOR_DECODE_THREAD_NAMES: [&str; 2] = ["lxvideodec1:src", "video-src:src"];
+/// Suffix identifying a `GStreamer` pad-task thread (`"<element-name>:<pad-name>"`,
+/// truncated to the kernel's 15-char `comm` limit) — both the NDL and Starfish vendor
+/// `.so`s build their internal decode pipeline out of `GStreamer` elements, each with its
+/// own pad-task thread spawned *inside our own process*. These are invisible to
+/// punktfunk-core's hot-thread registry (that only covers threads this crate and
+/// punktfunk-core spawn themselves) and sit at the default nice 0 despite doing real
+/// decode work — confirmed via live `/proc/<pid>/task` sampling during an active NDL
+/// stream (its `lxvideodec1:src`/`video-src:src` threads), a real contention cost
+/// against our own already-boosted video-pump/data-pump threads on this `SoC`'s 3 cores.
+/// Matched by suffix, not a fixed name list, so this also covers whichever
+/// differently-named elements the active backend's pipeline happens to use (e.g.
+/// Starfish's own, not just the ones observed under NDL).
+const VENDOR_DECODE_THREAD_SUFFIX: &str = ":src";
+/// How long a decode-thread scan may run with no new match before concluding the
+/// backend's pipeline has finished spawning threads (typically well under this in
+/// practice). Bounded separately by `VENDOR_DECODE_THREAD_SCAN_TIMEOUT` in case a
+/// backend never produces a matching thread at all.
+const VENDOR_DECODE_THREAD_QUIET_PERIOD: Duration = Duration::from_millis(500);
+const VENDOR_DECODE_THREAD_SCAN_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Test: renice the vendor `.so`'s internal decode-pipeline threads to -10, same as our
-/// own hot threads. These spawn asynchronously sometime after the decoder loads (not
-/// synchronously within the load call), so this polls `/proc/self/task` for up to a few
-/// seconds rather than scanning once. See docs/NOTES.md's resolution-choppiness entry —
-/// checking whether thread contention on this `SoC`'s 3 cores is what caps smoothness
-/// above 1080p.
-fn renice_vendor_decode_threads(log: &mut std::fs::File) {
-    let deadline = Instant::now() + Duration::from_secs(3);
-    let mut reniced = std::collections::HashSet::new();
-    while Instant::now() < deadline && reniced.len() < VENDOR_DECODE_THREAD_NAMES.len() {
-        if let Ok(entries) = std::fs::read_dir("/proc/self/task") {
-            for entry in entries.flatten() {
-                let Ok(tid) = entry.file_name().to_string_lossy().parse::<i32>() else {
-                    continue;
-                };
-                let Ok(comm) = std::fs::read_to_string(entry.path().join("comm")) else {
-                    continue;
-                };
-                let comm = comm.trim();
-                if VENDOR_DECODE_THREAD_NAMES.contains(&comm) && reniced.insert(comm.to_string()) {
+/// Renices the active backend's vendor-spawned `GStreamer` pad-task threads to -10, same
+/// as this crate's own hot threads (see [`VENDOR_DECODE_THREAD_SUFFIX`]). Runs on its
+/// own thread — these threads spawn asynchronously sometime after the decoder loads,
+/// not synchronously within the load call, so this polls `/proc/self/task` rather than
+/// scanning once, and must not block `video_pump` from starting to feed frames while it
+/// does.
+fn spawn_vendor_decode_thread_renicer(mut log: std::fs::File) {
+    std::thread::spawn(move || {
+        let start = Instant::now();
+        let mut last_found = start;
+        let mut reniced: std::collections::HashSet<i32> = std::collections::HashSet::new();
+        loop {
+            if let Ok(entries) = std::fs::read_dir("/proc/self/task") {
+                for entry in entries.flatten() {
+                    let Ok(tid) = entry.file_name().to_string_lossy().parse::<i32>() else {
+                        continue;
+                    };
+                    if reniced.contains(&tid) {
+                        continue;
+                    }
+                    let Ok(comm) = std::fs::read_to_string(entry.path().join("comm")) else {
+                        continue;
+                    };
+                    let comm = comm.trim();
+                    if !comm.ends_with(VENDOR_DECODE_THREAD_SUFFIX) {
+                        continue;
+                    }
+                    reniced.insert(tid);
+                    last_found = Instant::now();
                     // SAFETY: plain syscall — tid and priority value only, no pointers.
                     if unsafe { libc::setpriority(libc::PRIO_PROCESS, tid as libc::id_t, -10) } != 0 {
                         let _ = writeln!(
@@ -377,11 +398,14 @@ fn renice_vendor_decode_threads(log: &mut std::fs::File) {
                     }
                 }
             }
-        }
-        if reniced.len() < VENDOR_DECODE_THREAD_NAMES.len() {
+            let now = Instant::now();
+            let quiet = !reniced.is_empty() && now.duration_since(last_found) >= VENDOR_DECODE_THREAD_QUIET_PERIOD;
+            if quiet || now.duration_since(start) >= VENDOR_DECODE_THREAD_SCAN_TIMEOUT {
+                break;
+            }
             std::thread::sleep(Duration::from_millis(100));
         }
-    }
+    });
 }
 
 fn video_pump(
@@ -403,7 +427,12 @@ fn video_pump(
             );
         }
     }
-    renice_vendor_decode_threads(log);
+    match log.try_clone() {
+        Ok(renicer_log) => spawn_vendor_decode_thread_renicer(renicer_log),
+        Err(e) => {
+            let _ = writeln!(log, "clone log for decode-thread renicer failed: {e:#}");
+        }
+    }
 
     let wants_decode_latency = client.wants_decode_latency();
     let mut last_dropped_seen = client.frames_dropped();

--- a/src/session.rs
+++ b/src/session.rs
@@ -337,6 +337,53 @@ const HOLD_GIVE_UP: Duration = Duration::from_secs(2);
 /// Feed calls slower than this suggest decoder backpressure rather than network loss.
 const FEED_BACKPRESSURE_WARN: Duration = Duration::from_millis(20);
 
+/// GStreamer-element-named threads the NDL/Starfish vendor `.so` spawns *inside our own
+/// process* for its internal decode pipeline — not part of punktfunk-core's hot-thread
+/// registry (that only covers threads this crate and punktfunk-core spawn themselves).
+/// Confirmed via live `/proc/<pid>/task` sampling during an active stream to be doing
+/// real CPU work while sitting at the default nice 0, unlike our own already-boosted
+/// video-pump/data-pump threads.
+const VENDOR_DECODE_THREAD_NAMES: [&str; 2] = ["lxvideodec1:src", "video-src:src"];
+
+/// Test: renice the vendor `.so`'s internal decode-pipeline threads to -10, same as our
+/// own hot threads. These spawn asynchronously sometime after the decoder loads (not
+/// synchronously within the load call), so this polls `/proc/self/task` for up to a few
+/// seconds rather than scanning once. See docs/NOTES.md's resolution-choppiness entry —
+/// checking whether thread contention on this `SoC`'s 3 cores is what caps smoothness
+/// above 1080p.
+fn renice_vendor_decode_threads(log: &mut std::fs::File) {
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let mut reniced = std::collections::HashSet::new();
+    while Instant::now() < deadline && reniced.len() < VENDOR_DECODE_THREAD_NAMES.len() {
+        if let Ok(entries) = std::fs::read_dir("/proc/self/task") {
+            for entry in entries.flatten() {
+                let Ok(tid) = entry.file_name().to_string_lossy().parse::<i32>() else {
+                    continue;
+                };
+                let Ok(comm) = std::fs::read_to_string(entry.path().join("comm")) else {
+                    continue;
+                };
+                let comm = comm.trim();
+                if VENDOR_DECODE_THREAD_NAMES.contains(&comm) && reniced.insert(comm.to_string()) {
+                    // SAFETY: plain syscall — tid and priority value only, no pointers.
+                    if unsafe { libc::setpriority(libc::PRIO_PROCESS, tid as libc::id_t, -10) } != 0 {
+                        let _ = writeln!(
+                            log,
+                            "setpriority(vendor thread {comm}, tid={tid}) failed: {}",
+                            std::io::Error::last_os_error()
+                        );
+                    } else {
+                        let _ = writeln!(log, "reniced vendor decode thread {comm} (tid={tid}) to -10");
+                    }
+                }
+            }
+        }
+        if reniced.len() < VENDOR_DECODE_THREAD_NAMES.len() {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+}
+
 fn video_pump(
     client: Arc<NativeClient>,
     player: VideoPlayer,
@@ -356,6 +403,7 @@ fn video_pump(
             );
         }
     }
+    renice_vendor_decode_threads(log);
 
     let wants_decode_latency = client.wants_decode_latency();
     let mut last_dropped_seen = client.frames_dropped();


### PR DESCRIPTION
## Summary
- Both NDL and Starfish were smooth at 1080p but choppy above it (1440p, 4K), independent of bitrate/fps. Root cause: the NDL/Starfish vendor `.so` spawns its own internal decode-pipeline threads (GStreamer pad-task threads, e.g. `lxvideodec1:src`/`video-src:src` under NDL) inside our process at the default nice 0, invisible to punktfunk-core's own hot-thread registry — real contention on this TV's 3-core SoC.
- Adds `session.rs::spawn_vendor_decode_thread_renicer`: renices any thread matching GStreamer's `:src` pad-task naming convention to -10, on its own background thread so it never blocks `video_pump` startup.
- Matches by suffix rather than a fixed name list so it isn't tied to the specific names observed under NDL.

## Result
- **NDL**: confirmed on-device, large improvement — smooth well above 1080p now.
- **Starfish**: retested after generalizing the match — still choppier than NDL, no change. Parked as a known, open gap rather than pursued further this pass (see `docs/NOTES.md`'s resolution-choppiness entry for the full trail of what's been tried).

## Test plan
- [x] `task check` / `task lint` clean
- [x] Deployed to LG CX, confirmed NDL smooth above 1080p (previously choppy)
- [x] Confirmed Starfish unaffected by the generalized match

🤖 Generated with [Claude Code](https://claude.com/claude-code)