### PR TITLE
Show packaged version in UI + bump punktfunk-core to v0.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
 ]
@@ -501,7 +501,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.17.2#87e7c82cbc453551c201843f863c3b81ab9c827f"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.19.1#ebddffa4c8d76301b43c5c6be5355a62e2f8b102"
 
 [[package]]
 name = "fiat-crypto"
@@ -833,9 +833,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -1076,8 +1076,8 @@ dependencies = [
 
 [[package]]
 name = "punktfunk-core"
-version = "0.17.2"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.17.2#87e7c82cbc453551c201843f863c3b81ab9c827f"
+version = "0.19.1"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.19.1#ebddffa4c8d76301b43c5c6be5355a62e2f8b102"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -1377,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1533,7 +1533,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1697,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1736,7 +1736,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1809,9 +1809,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "libc",
  "mio",
@@ -2248,18 +2248,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,12 @@ tracing-subscriber = "0.3"
 # pf-client-core's session::start() (see session.rs docs for why we don't use that).
 # Pinned to a tagged punktfunk release (not a branch tip) this client was
 # developed/tested against — bump deliberately, not automatically, since
-# punktfunk-core's wire/ABI surface can move. Currently v0.17.2 — bumped from
-# v0.16.0 for the ChaCha20-Poly1305 session cipher (session.rs advertises
-# `VIDEO_CAP_CHACHA20`; lifts the soft-AES decrypt ceiling on this armv7 target).
-# WIRE_VERSION 2 (verified unchanged across v0.16.0..v0.17.2 — the cipher rides a
-# new Welcome tail field, fail-closed, no protocol migration), and the C ABI in
-# `abi.rs` stays irrelevant to us (we link the Rust `client` API directly;
-# `NativeClient::connect`'s signature is unchanged across the bump).
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.17.2", features = [
+# punktfunk-core's wire/ABI surface can move. Currently v0.19.1 — bumped from
+# v0.17.2 to track the latest release; the ChaCha20-Poly1305 session cipher
+# (session.rs advertises `VIDEO_CAP_CHACHA20`) lifts the soft-AES decrypt ceiling
+# on this armv7 target. The C ABI in `abi.rs` stays irrelevant to us (we link the
+# Rust `client` API directly), so upstream's ABI_VERSION bumps don't reach us.
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.19.1", features = [
     "quic",
 ] }
 serde = { version = "1", features = ["derive"] }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -77,6 +77,10 @@ tasks:
       # Modern CMake refuses vendored libopus's old cmake_minimum_required
       # (audiopus_sys, pulled in transitively by punktfunk-core's `quic` feature).
       CMAKE_POLICY_VERSION_MINIMUM: '3.5'
+      # Thread the packaged version into the binary so the UI's build marker matches
+      # the .ipk (Cargo.toml stays a fixed 0.0.1; recomputed inside Docker from the
+      # mounted repo's git, so both `build` and CI's `native:build` pick it up).
+      PKG_VERSION: '{{.PKG_VERSION}}'
     cmds:
       - rustup target add {{.TARGET}}
       - cargo build --release --target {{.TARGET}}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1383,12 +1383,20 @@ pub fn draw_sidebar(
     // alpha color here barely dims them, where a literally darker color reads
     // as dim against `SIDEBAR_BG` the same way `MUTED` text does everywhere
     // else in this UI.
-    let version = concat!("v", env!("CARGO_PKG_VERSION"));
+    // The packaged version (e.g. `0.0.1+git.abc12345`) is threaded in at compile
+    // time via `PKG_VERSION` by the Taskfile's build step; `Cargo.toml` stays a
+    // fixed `0.0.1` (see CLAUDE.md), so a bare native `cargo build` falls back to
+    // `CARGO_PKG_VERSION` rather than showing an empty marker.
+    const VERSION: &str = match option_env!("PKG_VERSION") {
+        Some(v) => v,
+        None => env!("CARGO_PKG_VERSION"),
+    };
+    let version = format!("v{VERSION}");
     draw_text(
         painter,
         text_cache,
         fonts.value,
-        version,
+        &version,
         settings_rect.x(),
         settings_rect.y() - 14 - 10 - fonts.value.height(),
         lerp_color(SIDEBAR_BG, MUTED, 0.35),


### PR DESCRIPTION
## Summary
- **Version marker fix**: the pre-stream UI sidebar showed `v0.0.1` unconditionally because it read `env!("CARGO_PKG_VERSION")`, which stays pinned at `0.0.1` by design (`Cargo.toml`/`appinfo.json`). The real packaged version (`0.0.1+git.<sha>`, or a clean `x.y.z` on a release tag) only ever reached `appinfo.json`, never the binary. Now `PKG_VERSION` is threaded into the compile via the Taskfile's `native:build` env and read with `option_env!`, falling back to `CARGO_PKG_VERSION` for a bare native `cargo build`.
- **Dependency update**: `punktfunk-core` bumped `v0.17.2` → `v0.19.1` (latest release) plus a `cargo update` refresh of the lockfile.

## Verification
- Version marker: rendered by the `#[cfg(target_os = "linux")]`-gated `ui` module, so it needs an on-target build — confirm via `task build`/`deploy` (a native macOS `cargo check` compiles only the stub `main`).
- punktfunk-core bump: not verified against the cross target yet. Recommend `task check` (Docker) before merge, since the client links the Rust `client`/`quic`/`config`/`audio` API directly and the pin jumped two minor versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)