### PR TITLE
Fix build broken by v0.19.1 bump: NativeClient::connect client_caps arg

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -165,6 +165,7 @@ pub fn connect(
         quic::CODEC_HEVC | quic::CODEC_H264,
         0, // let the host choose
         display_hdr,
+        0, // client_caps: this client composites the host cursor into the video, not locally
         launch,
         pin,
         Some(identity),
@@ -316,6 +317,7 @@ pub fn request_access(
         quic::CODEC_H264,
         0,
         None, // no HDR display metadata
+        0,    // client_caps: no local cursor rendering
         None, // no launch
         None, // pin = None → trust-on-first-use, host parks until operator approval
         Some(identity),


### PR DESCRIPTION
## Summary
PR #24 bumped `punktfunk-core` v0.17.2 → v0.19.1 but merged without the call-site fix, leaving **`main` un-buildable** on the cross target. v0.19.1's `NativeClient::connect` inserts a new `client_caps: u8` argument (`Hello::client_caps`, e.g. `CLIENT_CAP_CURSOR`) between `display_hdr` and `launch`.

This passes `0` at both call sites (`session::connect` and `session::request_access`): this client composites the host cursor into the video stream and never renders it locally, so it must **not** advertise `CLIENT_CAP_CURSOR` — doing so would make the host stop compositing the pointer and the stream would show no cursor at all.

## Verification
`task check` (Docker, cross target `armv7-unknown-linux-gnueabi`) now compiles clean — only the pre-existing `target-feature` (neon/vfp3/soft-float) warnings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)