### PR TITLE
Stream logs to a dev machine instead of writing to /tmp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
 # Copy to .env (gitignored) to set local defaults for Task — lets you run
-# `task deploy` / `task deploy:log` without typing TV_HOST every time.
+# `task deploy` without typing TV_HOST every time.
 TV_HOST=root@192.168.1.100
+
+# Optional: task deploy TELEMETRY=... streams the app's logs live to this machine
+# instead of writing a file on-device (see `task deploy --list`/Taskfile.yml for
+# details). Leave unset for the default (on-device file, info-and-above only).
+#
+# TELEMETRY=auto              # this machine's own LAN IP, random port (printed on start)
+# TELEMETRY=192.168.1.50:9234 # an explicit host:port
+# TELEMETRY_LEVEL=debug       # debug|info|warn|error (default debug) — min level sent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,15 @@ cross-toolchain is Linux-aarch64-only, so `build`/`check`/`package`/`lint` run i
 - `task build` / `task check` — compile only / `cargo check` only
 - `task lint` / `task fmt` — clippy (Docker) / rustfmt (native)
 - `task deploy TV_HOST=root@<tv-ip>` — build, package, install, launch over SSH
-- `task deploy:log TV_HOST=root@<tv-ip>` — tail `/tmp/punktfunk-webos.log` on the TV
+- `task deploy TV_HOST=... TELEMETRY=auto` (or `TELEMETRY=<dev-host>:<port>`) — same, but the app
+  streams its logs (via `tracing`, see `src/logger.rs`) live to this machine over TCP instead of
+  writing a file on-device — passed at launch via SAM's `params` (argv[1] JSON), no rebuild needed.
+  The task listens locally first and prints lines as they arrive instead of returning.
+  `TELEMETRY_LEVEL=debug|info|warn|error` (default `debug`) sets the minimum level sent.
 
 Set `TV_HOST` in a local `.env` (copy `.env.example`). Run tasks with `task -s` to skip the command
-echo. No test suite — verify via `task deploy` + `deploy:log` on real hardware, or a native
-`cargo check`/`build` (macOS/Windows stay green via a stub `main()`).
+echo. No test suite — verify via `task deploy` (with `TELEMETRY=auto` for live logs) on real
+hardware, or a native `cargo check`/`build` (macOS/Windows stay green via a stub `main()`).
 
 
 ## Architecture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1136,7 @@ dependencies = [
  "serde_json",
  "tiny-skia",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "ureq",
 ]
@@ -1685,6 +1701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +1781,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1766,6 +1789,16 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-skia"
@@ -1881,6 +1914,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ anyhow = "1"
 # for this whole client until this was added.
 tracing = "0.1"
 tracing-subscriber = "0.3"
+tracing-appender = "0.2"
 # Pure Rust + libc (unix), portable — no FFmpeg/PipeWire/SDL3 baggage, unlike
 # pf-client-core's session::start() (see session.rs docs for why we don't use that).
 # Pinned to a tagged punktfunk release (not a branch tip) this client was

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ QEMU). Run `task --list` for everything.
 | `task build` / `task check` | Faster inner loop: compile only, or `cargo check` only |
 | `task lint` / `task fmt` | `cargo clippy` / `cargo fmt` |
 | `task deploy TV_HOST=root@<tv-ip>` | Build, package, install, and launch on a real TV over SSH |
-| `task deploy:log TV_HOST=root@<tv-ip>` | Tail the app's log on the TV |
+| `task deploy TV_HOST=... TELEMETRY=auto` | Same, but streams the app's logs live to this machine instead of a file on-device |
 | `task clean` | Remove build output and caches |
 
 Set `TV_HOST` once in a local `.env` (copy `.env.example`) to skip typing it each time. Architecture

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,7 +9,7 @@ version: '3'
 # to just the command's own output (less noise, fewer tokens when read back).
 silent: true
 
-# TV_HOST (used by deploy/deploy:log below) can live in a local, gitignored .env
+# TV_HOST (used by deploy below) can live in a local, gitignored .env
 # instead of being typed on every invocation — see .env.example.
 dotenv: ['.env']
 
@@ -115,12 +115,20 @@ tasks:
   deploy:
     desc: >-
       Build, package, install on a real TV over SSH, and launch it. Usage:
-      task deploy TV_HOST=root@<tv-ip> (or set TV_HOST in .env)
+      task deploy TV_HOST=root@<tv-ip> (or set TV_HOST in .env). Without TELEMETRY,
+      the app just writes a versioned file in its data dir (info-and-above only) —
+      the same as always. Pass TELEMETRY=<host:port> to stream logs live to that
+      address instead (SAM hands launch `params` to a native app as argv[1] JSON on
+      initial launch — see src/logger.rs — no rebuild needed), or TELEMETRY=auto to
+      use this machine's own LAN IP on a random port (printed once the listener is
+      up, in case you need to connect to it manually). TELEMETRY_LEVEL
+      (debug/info/warn/error, default debug) sets the minimum level sent.
     deps: [package]
     requires:
       vars: [TV_HOST]
     vars:
       IPK: dist/io.dyptan.punktfunk.webos_{{.PKG_VERSION}}_arm.ipk
+      TELEMETRY_LEVEL: '{{.TELEMETRY_LEVEL | default "debug"}}'
     cmds:
       - test -f "{{.IPK}}" || exit 1
       - scp "{{.IPK}}" {{.TV_HOST}}:/tmp/
@@ -129,18 +137,30 @@ tasks:
         "luna-send -i -n 1 -f luna://com.webos.appInstallService/dev/install
         '{\"id\":\"io.dyptan.punktfunk.webos\",\"ipkUrl\":\"/tmp/$(basename {{.IPK}})\",\"subscribe\":true}'"
       - sleep 3
-      - >-
-        ssh -tt {{.TV_HOST}}
-        "luna-send -n 1 -f luna://com.webos.applicationManager/launch '{\"id\":\"io.dyptan.punktfunk.webos\"}'"
+      - |
+        set -eu
+        TELEMETRY="{{.TELEMETRY}}"
+        if [ "$TELEMETRY" = "auto" ]; then
+          IP="$(ipconfig getifaddr en0 2>/dev/null || hostname -I 2>/dev/null | awk '{print $1}')"
+          PORT="$(awk 'BEGIN { srand(); print int(20000 + rand() * 20000) }')"
+          TELEMETRY="${IP}:${PORT}"
+        fi
 
-  deploy:log:
-    desc: >-
-      Tail the app's log file on the TV over SSH. Usage:
-      task deploy:log TV_HOST=root@<tv-ip>
-    requires:
-      vars: [TV_HOST]
-    cmds:
-      - ssh {{.TV_HOST}} "tail -f /tmp/punktfunk-webos.log"
+        PARAMS=""
+        NC_PID=""
+        if [ -n "$TELEMETRY" ]; then
+          PORT="${TELEMETRY##*:}"
+          ( while true; do nc -l "$PORT"; done ) &
+          NC_PID=$!
+          trap 'kill "$NC_PID" 2>/dev/null || true' EXIT
+          sleep 0.5
+          echo "listening on :${PORT} (destination sent to device: $TELEMETRY)" >&2
+          PARAMS=",\"params\":{\"telemetry\":\"$TELEMETRY\",\"telemetry_level\":\"{{.TELEMETRY_LEVEL}}\"}"
+        fi
+        ssh -tt {{.TV_HOST}} "luna-send -n 1 -f luna://com.webos.applicationManager/launch '{\"id\":\"io.dyptan.punktfunk.webos\"${PARAMS}}'"
+        if [ -n "$NC_PID" ]; then
+          wait "$NC_PID"
+        fi
 
   clean:
     desc: Remove everything — dist/, .toolchains/, target/, and the Docker volumes

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -127,16 +127,20 @@ a host-side capture/encode throughput question, not this client. See
 
 ## Runtime/deploy gotchas (LG CX)
 
-- Apps install to `/media/developer/apps/usr/palm/applications/<appid>/`; jail root
-  `/var/palm/jail/<appid>/`. **`/tmp` is shared between jail and host** — a log written to `/tmp/` is
-  readable from the plain host SSH shell (`/tmp/punktfunk-webos.log`).
+- Apps install to `/media/developer/apps/usr/palm/applications/<appid>/`, which is also `$HOME` —
+  the app's own writable directory (`store::app_dir`), where the versioned log file
+  (`punktfunk-webos-<version>.log`) and `connect.conf` live.
 - `luna-send` **needs `ssh -tt`** (a real PTY) or its output is silently swallowed even on success.
 - **Black screen despite correct decode**: launch through the real app lifecycle
   (`luna-send .../launch`, jailed uid under SAM), never a raw SSH exec — NDL's punch-through plane
   only composites for the real SAM-managed foreground app. (Install/launch luna-send invocations are
   in `Taskfile.yml`'s `deploy` task.)
-- No documented way to pass CLI args through a SAM launch — worked around with a `$HOME/connect.conf`
-  dev-override file read on startup if present.
+- No env vars through a SAM launch, but `params` given to `applicationManager/launch` DOES reach a
+  native app — SAM JSON-encodes it as `argv[1]` on initial launch (confirmed against the webOS OSE
+  native-app docs, contradicting an earlier assumption here). `src/logger.rs` reads a `telemetry`/
+  `telemetry_level` key from it this way (see `task deploy TELEMETRY=...`); the older
+  `$HOME/connect.conf` dev-override file predates this finding and could likely become a launch
+  param too, but hasn't been converted.
 - SDL2/Wayland may report `refresh_rate=0` in some launch contexts; clamp to a real default.
 
 ## Confirmed platform limitations (don't try to "fix" these again)

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,15 +3,14 @@
 //! centered modals on top of it — modeled on moonlight-tv's actual layout (see
 //! `ui.rs`'s module docs). `ui.rs` owns drawing/input-mapping primitives,
 //! `store.rs` owns persistence, `discovery.rs` owns mDNS.
-use std::io::Write as _;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use sdl2::rect::Rect;
 use tiny_skia::Pixmap;
 
-use crate::library::GameEntry;
 use crate::compositor::{DrawCmd, Tile};
+use crate::library::GameEntry;
 use crate::store::{self, KnownHost, Settings};
 use crate::ui::{self, AddHostState, HostEntry, MenuEvent, Painter};
 
@@ -366,14 +365,10 @@ impl Drop for App {
 }
 
 impl App {
-    pub fn new(identity: (String, String), log: &mut std::fs::File) -> Self {
+    pub fn new(identity: (String, String)) -> Self {
         let known_hosts = store::load_known_hosts();
         let entries = known_hosts.iter().cloned().map(HostEntry::Known).collect();
-        // A second handle onto the same log file (both just append — see
-        // `main.rs::log_path`) for the mdns background thread to log through, since
-        // it can't share this `&mut File` across threads.
-        let discovery_log = log.try_clone().expect("clone log file handle for mdns thread");
-        let (discovered, discovery_daemon) = match crate::discovery::browse(discovery_log) {
+        let (discovered, discovery_daemon) = match crate::discovery::browse() {
             Some((rx, daemon)) => (rx, Some(daemon)),
             None => (std::sync::mpsc::channel().1, None),
         };
@@ -439,7 +434,7 @@ impl App {
                 .find(|h| h.host == host && h.port == port && h.fingerprint.is_some())
             {
                 let (host, port, mgmt_port) = (h.host.clone(), h.port, h.mgmt_port);
-                app.select_host(host, port, mgmt_port, log);
+                app.select_host(host, port, mgmt_port);
             }
         }
         app
@@ -452,7 +447,7 @@ impl App {
     /// waking host reappears on mDNS and reconnects. Returns whether the sidebar
     /// actually changed — `main.rs`'s render loop uses this to skip a redraw when a
     /// discovery tick found nothing new (see its dirty-flag docs).
-    pub fn drain_discovery(&mut self, log: &mut std::fs::File) -> bool {
+    pub fn drain_discovery(&mut self) -> bool {
         let mut changed = false;
         let mut mac_learned = false;
         let mut woke = None;
@@ -496,7 +491,7 @@ impl App {
             let _ = store::save_known_hosts(&self.known_hosts);
         }
         if let Some((host, port, mgmt_port)) = woke {
-            self.wake_succeeded(host, port, mgmt_port, "mDNS", log);
+            self.wake_succeeded(host, port, mgmt_port, "mDNS");
             changed = true;
         }
         if changed {
@@ -508,11 +503,11 @@ impl App {
     /// Ends an in-flight wake because the host is actually back — whether that was
     /// noticed passively (`drain_discovery` seeing a fresh mDNS resolve) or actively
     /// (`tick_wake`'s reachability probe succeeding). `source` is just for the log line.
-    fn wake_succeeded(&mut self, host: String, port: u16, mgmt_port: Option<u16>, source: &str, log: &mut std::fs::File) {
-        let _ = writeln!(log, "wake succeeded: {host}:{port} back ({source})");
+    fn wake_succeeded(&mut self, host: String, port: u16, mgmt_port: Option<u16>, source: &str) {
+        tracing::info!("wake succeeded: {host}:{port} back ({source})");
         self.wake = None;
         self.screen = Screen::Home;
-        self.select_host(host, port, mgmt_port, log);
+        self.select_host(host, port, mgmt_port);
     }
 
     /// Drains any cover art that's finished decoding since the last tick — called
@@ -626,13 +621,7 @@ impl App {
 
     /// Handles one menu event on the Home screen (sidebar + grid). Returns a
     /// `ConnectTarget` when a grid card is confirmed.
-    pub fn handle_home_event(
-        &mut self,
-        ev: MenuEvent,
-        screen_w: u32,
-        screen_h: u32,
-        log: &mut std::fs::File,
-    ) -> Option<ConnectTarget> {
+    pub fn handle_home_event(&mut self, ev: MenuEvent, screen_w: u32, screen_h: u32) -> Option<ConnectTarget> {
         let sidebar_len = self.sidebar_len();
         let grid_len = self.grid_len();
         let available_w = screen_w.saturating_sub(ui::SIDEBAR_W);
@@ -685,7 +674,7 @@ impl App {
             },
             MenuEvent::Confirm => match self.home_focus {
                 HomeFocus::Sidebar(i) if i < self.entries.len() => {
-                    self.confirm_sidebar_host(i, log);
+                    self.confirm_sidebar_host(i);
                 }
                 HomeFocus::Sidebar(i) if i == self.entries.len() => {
                     self.add_host = AddHostState::default();
@@ -696,7 +685,7 @@ impl App {
                     self.dropdown = None;
                     self.settings_focused = 0;
                 }
-                HomeFocus::Grid(i) => self.confirm_grid_card(i, log),
+                HomeFocus::Grid(i) => self.confirm_grid_card(i),
             },
             // Forgets the focused host (removes its persisted entry/fingerprint —
             // it'll reappear as "not paired" if still discoverable on the LAN).
@@ -718,7 +707,7 @@ impl App {
     /// dispatch: `main.rs`'s Back handling on Home (a no-op there, but routed
     /// through here so the policy lives in one place) and a modal's close (X)
     /// button click (`handle_mouse_click`'s `hover_close` branch below).
-    pub fn back(&mut self, log: &mut std::fs::File) -> Option<ConnectTarget> {
+    pub fn back(&mut self) -> Option<ConnectTarget> {
         match self.screen {
             // Home has nothing to "back out" of (it's the root screen) — Back is a
             // no-op. (It used to be a shortcut straight to Settings, but that made
@@ -726,7 +715,7 @@ impl App {
             // Settings popped right back up.)
             Screen::Home => None,
             Screen::Pairing => {
-                self.handle_pairing_event(MenuEvent::Back, log);
+                self.handle_pairing_event(MenuEvent::Back);
                 None
             }
             Screen::Settings => {
@@ -738,7 +727,7 @@ impl App {
                 None
             }
             Screen::Wake => {
-                self.handle_wake_event(MenuEvent::Back, log);
+                self.handle_wake_event(MenuEvent::Back);
                 None
             }
             Screen::ForgetHost => {
@@ -752,9 +741,7 @@ impl App {
     /// everything already fits on screen.
     fn max_grid_scroll(&self, columns: usize, available_w: u32, screen_h: u32) -> i32 {
         let viewport_h = screen_h as i32 - ui::GRID_PAD - ui::GRID_TOP_Y;
-        (ui::grid_layer_height(self.grid_len(), columns, available_w) as i32
-            - 2 * ui::GRID_LAYER_PAD
-            - viewport_h)
+        (ui::grid_layer_height(self.grid_len(), columns, available_w) as i32 - 2 * ui::GRID_LAYER_PAD - viewport_h)
             .max(0)
     }
 
@@ -851,12 +838,12 @@ impl App {
         animating
     }
 
-    fn confirm_sidebar_host(&mut self, idx: usize, log: &mut std::fs::File) {
+    fn confirm_sidebar_host(&mut self, idx: usize) {
         let entry = self.entries[idx].clone();
         match entry {
             HostEntry::Known(h) if h.fingerprint.is_some() => {
                 let (host, port, mgmt_port) = (h.host, h.port, h.mgmt_port);
-                self.select_host(host, port, mgmt_port, log);
+                self.select_host(host, port, mgmt_port);
             }
             _ => {
                 self.pairing_entry = idx;
@@ -879,7 +866,7 @@ impl App {
     /// time out. `App::new` calls this synchronously-in-spirit-only at startup
     /// too (restoring the last-selected host), so that froze every launch just
     /// the same.
-    fn select_host(&mut self, host: String, port: u16, mgmt_port: Option<u16>, log: &mut std::fs::File) {
+    fn select_host(&mut self, host: String, port: u16, mgmt_port: Option<u16>) {
         let _ = store::save_selected_host(&host, port);
         self.selected_host = Some((host.clone(), port));
         self.home_status = Some("Loading library…".into());
@@ -899,7 +886,7 @@ impl App {
             .find(|h| h.host == host && h.port == port)
             .and_then(|h| h.fingerprint);
         let mgmt_port = mgmt_port.unwrap_or(crate::library::DEFAULT_MGMT_PORT);
-        let _ = writeln!(log, "library: fetching from {host}:{mgmt_port}…");
+        tracing::debug!("library: fetching from {host}:{mgmt_port}…");
         self.games_rx = Some(crate::library::load_games_async(
             host,
             port,
@@ -914,7 +901,7 @@ impl App {
     /// Switching hosts again before a fetch finishes discards its result safely:
     /// `select_host` already replaced `games_rx` with a fresh channel by the time
     /// this could run, so there's nothing here to receive from for the stale one.
-    pub fn drain_games(&mut self, log: &mut std::fs::File) -> bool {
+    pub fn drain_games(&mut self) -> bool {
         let Some(rx) = &self.games_rx else { return false };
         let Ok(loaded) = rx.try_recv() else { return false };
         self.games_rx = None;
@@ -926,7 +913,7 @@ impl App {
         } = loaded;
         match result {
             Ok(games) => {
-                let _ = writeln!(log, "library: {} games from {host}:{mgmt_port}", games.len());
+                tracing::info!("library: {} games from {host}:{mgmt_port}", games.len());
                 let identity = (self.identity.0.clone(), self.identity.1.clone());
                 let fingerprint = self
                     .known_hosts
@@ -944,8 +931,8 @@ impl App {
                 self.home_status = None;
             }
             Err(e) => {
-                let _ = writeln!(log, "library fetch failed ({host}:{mgmt_port}): {e}");
-                self.handle_library_error(host, port, e, log);
+                tracing::warn!("library fetch failed ({host}:{mgmt_port}): {e}");
+                self.handle_library_error(host, port, e);
             }
         }
         self.grid_dirty = true;
@@ -957,7 +944,7 @@ impl App {
     /// (even with no MAC on record — `start_wake`/`render_wake` just hide the send
     /// controls then); `NotPaired`/`PinMismatch`/`Http` mean the host answered, so
     /// Wake-on-LAN wouldn't help — those stay a plain status line.
-    fn handle_library_error(&mut self, host: String, port: u16, e: crate::library::LibraryError, log: &mut std::fs::File) {
+    fn handle_library_error(&mut self, host: String, port: u16, e: crate::library::LibraryError) {
         let reason = format!("{e} (Desktop is still available.)");
         if matches!(e, crate::library::LibraryError::Unreachable(_)) {
             let mac = self
@@ -966,7 +953,7 @@ impl App {
                 .find(|h| h.host == host && h.port == port)
                 .map(|h| h.mac.clone())
                 .unwrap_or_default();
-            self.start_wake(host, port, mac, reason, log);
+            self.start_wake(host, port, mac, reason);
         } else {
             self.home_status = Some(reason);
         }
@@ -978,7 +965,7 @@ impl App {
     /// silently — the prompt only appears if the host still hasn't come back a minute
     /// later (`tick_wake`), which is also the one place that setting can be turned back
     /// off (no separate settings row for it — see `Settings::wol_auto_send`).
-    fn start_wake(&mut self, host: String, port: u16, mac: Vec<String>, reason: String, log: &mut std::fs::File) {
+    fn start_wake(&mut self, host: String, port: u16, mac: Vec<String>, reason: String) {
         let name = self
             .known_hosts
             .iter()
@@ -1008,7 +995,7 @@ impl App {
             probe_rx: None,
         };
         if auto {
-            Self::send_wake(&mut wake, log);
+            Self::send_wake(&mut wake);
         } else {
             self.screen = Screen::Wake;
         }
@@ -1018,12 +1005,12 @@ impl App {
     /// Fires (or re-fires) the magic packet for an in-flight wake, bumping its resend
     /// timer — shared by the modal's explicit "Send" action and `tick_wake`'s periodic
     /// resend.
-    fn send_wake(wake: &mut WakeState, log: &mut std::fs::File) {
+    fn send_wake(wake: &mut WakeState) {
         // Only claim "sent" if a magic packet actually went out — `wake_and_log`
         // returns false on an unparseable MAC / no usable interface, and showing
         // "Sent a wake signal… waiting" for a packet that never left would leave
         // the user waiting on nothing.
-        let sent = crate::wol::wake_and_log(&wake.mac, wake.host.parse().ok(), &wake.name, log);
+        let sent = crate::wol::wake_and_log(&wake.mac, wake.host.parse().ok(), &wake.name);
         let now = Instant::now();
         if sent {
             wake.sent = true;
@@ -1044,7 +1031,7 @@ impl App {
     /// check can also end a wake independently, whichever notices first. Called every UI
     /// tick; returns whether anything visibly changed (same contract as
     /// `drain_discovery`/`drain_art`).
-    pub fn tick_wake(&mut self, log: &mut std::fs::File) -> bool {
+    pub fn tick_wake(&mut self) -> bool {
         let Some(wake) = &mut self.wake else { return false };
         let now = Instant::now();
         let mut changed = false;
@@ -1060,7 +1047,7 @@ impl App {
                         .iter()
                         .find(|h| h.host == host && h.port == port)
                         .and_then(|h| h.mgmt_port);
-                    self.wake_succeeded(host, port, mgmt_port, "reachability probe", log);
+                    self.wake_succeeded(host, port, mgmt_port, "reachability probe");
                     return true;
                 }
                 wake.last_probe = Some(now);
@@ -1074,9 +1061,12 @@ impl App {
         // send is either `start_wake`'s own immediate call (auto-send on) or the user's
         // explicit Confirm on "Send" (`handle_wake_event`).
         if !wake.mac.is_empty() {
-            let due = wake.sent && wake.last_attempt.is_some_and(|t| now.duration_since(t) >= WAKE_RESEND_INTERVAL);
+            let due = wake.sent
+                && wake
+                    .last_attempt
+                    .is_some_and(|t| now.duration_since(t) >= WAKE_RESEND_INTERVAL);
             if due {
-                Self::send_wake(wake, log);
+                Self::send_wake(wake);
                 changed = true;
             }
         }
@@ -1088,7 +1078,11 @@ impl App {
             changed = true;
         }
 
-        if wake.probe_rx.is_none() && wake.last_probe.is_some_and(|t| now.duration_since(t) >= WAKE_PROBE_INTERVAL) {
+        if wake.probe_rx.is_none()
+            && wake
+                .last_probe
+                .is_some_and(|t| now.duration_since(t) >= WAKE_PROBE_INTERVAL)
+        {
             let (host, port) = (wake.host.clone(), wake.port);
             wake.probe_rx = Some(Self::wake_probe(&self.known_hosts, &self.identity, &host, port));
             wake.last_probe = Some(now);
@@ -1107,7 +1101,9 @@ impl App {
         port: u16,
     ) -> std::sync::mpsc::Receiver<crate::library::GamesLoaded> {
         let known = known_hosts.iter().find(|h| h.host == host && h.port == port);
-        let mgmt_port = known.and_then(|h| h.mgmt_port).unwrap_or(crate::library::DEFAULT_MGMT_PORT);
+        let mgmt_port = known
+            .and_then(|h| h.mgmt_port)
+            .unwrap_or(crate::library::DEFAULT_MGMT_PORT);
         let fingerprint = known.and_then(|h| h.fingerprint);
         crate::library::load_games_async(host.to_string(), port, mgmt_port, identity.clone(), fingerprint)
     }
@@ -1120,7 +1116,7 @@ impl App {
     /// Confirm flips the toggle, sends, or cancels depending on which is
     /// focused. Back always dismisses back to the plain error text
     /// `WakeState::reason` carries, same as Cancel.
-    pub fn handle_wake_event(&mut self, ev: MenuEvent, log: &mut std::fs::File) {
+    pub fn handle_wake_event(&mut self, ev: MenuEvent) {
         let Some(wake) = self.wake.as_mut() else { return };
         // No MAC on record for this host yet — there's nothing to send or automate
         // (see `render_wake`, which hides the toggle/buttons in this case too), so
@@ -1151,7 +1147,7 @@ impl App {
                 wake.focused = if wake.focused == 1 { 2 } else { 1 };
                 self.modal_focus_anim = Some(Instant::now());
             }
-            MenuEvent::Confirm if wake.focused == 1 => Self::send_wake(wake, log),
+            MenuEvent::Confirm if wake.focused == 1 => Self::send_wake(wake),
             MenuEvent::Confirm => {
                 // focused == 2 ("Cancel") — same as Back.
                 self.home_status = self.wake.take().map(|w| w.reason);
@@ -1168,11 +1164,13 @@ impl App {
     /// failure currently propagates uncaught, taking the whole process down — see
     /// `main.rs`'s docs). `main.rs`'s tick loop drains the result via
     /// `drain_launch_check`/`take_ready_launch`. No-ops if a check is already in flight.
-    fn confirm_grid_card(&mut self, idx: usize, log: &mut std::fs::File) {
+    fn confirm_grid_card(&mut self, idx: usize) {
         if self.pending_launch.is_some() {
             return;
         }
-        let Some((host, port)) = self.selected_host.clone() else { return };
+        let Some((host, port)) = self.selected_host.clone() else {
+            return;
+        };
         let Some(known) = self.known_hosts.iter().find(|h| h.host == host && h.port == port) else {
             return;
         };
@@ -1185,7 +1183,7 @@ impl App {
         };
         let mgmt_port = known.mgmt_port.unwrap_or(crate::library::DEFAULT_MGMT_PORT);
         let identity = (self.identity.0.clone(), self.identity.1.clone());
-        let _ = writeln!(log, "launch: checking {host}:{port} is still reachable before connecting…");
+        tracing::debug!("launch: checking {host}:{port} is still reachable before connecting…");
         self.home_status = Some("Checking connection…".into());
         let rx = crate::library::load_games_async(host.clone(), port, mgmt_port, identity, Some(fingerprint));
         self.pending_launch = Some(PendingLaunch {
@@ -1201,9 +1199,13 @@ impl App {
     /// success, stashes the result in `launch_ready` for `main.rs` to pick up via
     /// `take_ready_launch` (dropped instead if the selection has since moved to a
     /// different host). On failure, defers to `handle_library_error`.
-    pub fn drain_launch_check(&mut self, log: &mut std::fs::File) -> bool {
-        let Some(pending) = &self.pending_launch else { return false };
-        let Ok(loaded) = pending.rx.try_recv() else { return false };
+    pub fn drain_launch_check(&mut self) -> bool {
+        let Some(pending) = &self.pending_launch else {
+            return false;
+        };
+        let Ok(loaded) = pending.rx.try_recv() else {
+            return false;
+        };
         let PendingLaunch {
             host,
             port,
@@ -1213,7 +1215,11 @@ impl App {
         } = self.pending_launch.take().expect("just matched Some above");
         match loaded.result {
             Ok(_) => {
-                if self.selected_host.as_ref().is_some_and(|(h, p)| *h == host && *p == port) {
+                if self
+                    .selected_host
+                    .as_ref()
+                    .is_some_and(|(h, p)| *h == host && *p == port)
+                {
                     self.home_status = None;
                     self.launch_ready = Some(ConnectTarget {
                         host,
@@ -1224,8 +1230,8 @@ impl App {
                 }
             }
             Err(e) => {
-                let _ = writeln!(log, "launch check failed ({host}:{port}): {e}");
-                self.handle_library_error(host, port, e, log);
+                tracing::warn!("launch check failed ({host}:{port}): {e}");
+                self.handle_library_error(host, port, e);
             }
         }
         self.sidebar_dirty = true;
@@ -1267,7 +1273,7 @@ impl App {
     /// Handles one menu event on the pairing modal. Two focus zones (`PairingFocus`):
     /// the PIN digit row (blocking SPAKE2 ceremony on `Confirm`) and the "Request
     /// access" button (blocking no-PIN, park-until-approved connect on `Confirm`).
-    pub fn handle_pairing_event(&mut self, ev: MenuEvent, log: &mut std::fs::File) {
+    pub fn handle_pairing_event(&mut self, ev: MenuEvent) {
         if self.pairing_busy {
             // Mid-ceremony, Back cancels (dropping the receiver orphans the
             // worker — its send fails and it exits); everything else is ignored.
@@ -1322,7 +1328,7 @@ impl App {
                     }
                     self.modal_focus_anim = Some(Instant::now());
                 }
-                MenuEvent::Confirm => self.try_pair(log),
+                MenuEvent::Confirm => self.try_pair(),
                 MenuEvent::Back | MenuEvent::Secondary => {} // handled above
             },
             // Left tabs back onto the PIN row; Confirm sends the access request.
@@ -1331,7 +1337,7 @@ impl App {
                     self.pairing_focus = PairingFocus::Pin;
                     self.modal_focus_anim = Some(Instant::now());
                 }
-                MenuEvent::Confirm => self.try_request_access(log),
+                MenuEvent::Confirm => self.try_request_access(),
                 // Up/Down/Right are no-ops here; Back/Secondary were handled above.
                 MenuEvent::Up | MenuEvent::Down | MenuEvent::Right | MenuEvent::Back | MenuEvent::Secondary => {}
             },
@@ -1345,7 +1351,7 @@ impl App {
     /// background thread (this one can block for MINUTES waiting on the approval, so
     /// freezing the UI for it is not an option). The 185s budget matches `run_inner`'s
     /// pending-approval wait, long enough for a human to notice and click.
-    fn try_request_access(&mut self, log: &mut std::fs::File) {
+    fn try_request_access(&mut self) {
         let entry = &self.entries[self.pairing_entry];
         let host = entry.host().to_string();
         let port = entry.port();
@@ -1354,15 +1360,14 @@ impl App {
         let mac = entry.mac().to_vec();
         self.pairing_busy = true;
         self.pairing_status = Some("Requesting access… approve this device on the host".into());
-        let _ = writeln!(log, "requesting access to {host}:{port}");
+        tracing::info!("requesting access to {host}:{port}");
 
         let identity = (self.identity.0.clone(), self.identity.1.clone());
         let (tx, rx) = std::sync::mpsc::channel();
         self.pairing_rx = Some(rx);
         std::thread::spawn(move || {
-            let result =
-                crate::session::request_access(&host, port, identity, std::time::Duration::from_secs(185))
-                    .map_err(|e| format!("Request failed: {e}"));
+            let result = crate::session::request_access(&host, port, identity, std::time::Duration::from_secs(185))
+                .map_err(|e| format!("Request failed: {e}"));
             let _ = tx.send(PairingOutcome {
                 host,
                 port,
@@ -1378,14 +1383,14 @@ impl App {
     /// called each tick from `run_ui_flow` like the other `drain_*`s. Success
     /// persists the host and lands on its game grid; failure re-arms the pairing
     /// modal with the error text.
-    pub fn drain_pairing(&mut self, log: &mut std::fs::File) -> bool {
+    pub fn drain_pairing(&mut self) -> bool {
         let Some(rx) = &self.pairing_rx else { return false };
         let Ok(outcome) = rx.try_recv() else { return false };
         self.pairing_rx = None;
         self.pairing_busy = false;
         match outcome.result {
             Ok(fingerprint) => {
-                let _ = writeln!(log, "paired ok ({}:{}), fingerprint set", outcome.host, outcome.port);
+                tracing::info!("paired ok ({}:{}), fingerprint set", outcome.host, outcome.port);
                 store::upsert_known_host(
                     &mut self.known_hosts,
                     KnownHost {
@@ -1401,10 +1406,10 @@ impl App {
                 self.entries = self.known_hosts.iter().cloned().map(HostEntry::Known).collect();
                 self.sidebar_dirty = true;
                 self.screen = Screen::Home;
-                self.select_host(outcome.host, outcome.port, outcome.mgmt_port, log);
+                self.select_host(outcome.host, outcome.port, outcome.mgmt_port);
             }
             Err(e) => {
-                let _ = writeln!(log, "pairing/request failed: {e}");
+                tracing::warn!("pairing/request failed: {e}");
                 self.pairing_status = Some(e);
             }
         }
@@ -1414,7 +1419,7 @@ impl App {
     /// Direct digit entry (the Magic Remote's number buttons) — types `digit` into
     /// the current PIN slot and auto-advances, like a phone lock-screen PIN pad,
     /// instead of requiring left/right cycling through 0-9 per digit.
-    pub fn enter_pin_digit(&mut self, digit: u8, log: &mut std::fs::File) {
+    pub fn enter_pin_digit(&mut self, digit: u8) {
         if self.pairing_busy {
             return;
         }
@@ -1426,13 +1431,13 @@ impl App {
         if self.pin_digit_index + 1 < self.pin_digits.len() {
             self.pin_digit_index += 1;
         } else {
-            self.try_pair(log);
+            self.try_pair();
         }
     }
 
     /// Starts the PIN pairing ceremony on a background thread (see
     /// `pairing_rx`'s docs — the ceremony blocks, the UI must not).
-    fn try_pair(&mut self, log: &mut std::fs::File) {
+    fn try_pair(&mut self) {
         let entry = &self.entries[self.pairing_entry];
         let host = entry.host().to_string();
         let port = entry.port();
@@ -1442,7 +1447,7 @@ impl App {
         let pin: String = self.pin_digits.iter().map(std::string::ToString::to_string).collect();
         self.pairing_busy = true;
         self.pairing_status = Some("Pairing… confirm the PIN on the host".into());
-        let _ = writeln!(log, "pairing with {host}:{port} (pin len {})", pin.len());
+        tracing::info!("pairing with {host}:{port} (pin len {})", pin.len());
 
         let identity = (self.identity.0.clone(), self.identity.1.clone());
         let (tx, rx) = std::sync::mpsc::channel();
@@ -1708,14 +1713,7 @@ impl App {
     /// the pointer drifting across the screen. Only keyboard/remote navigation or a
     /// click (`handle_mouse_click` below) moves it now. Hover still drives the
     /// close (X) button's highlight, a conventional affordance this excludes.
-    pub fn handle_mouse_motion(
-        &mut self,
-        x: i32,
-        y: i32,
-        screen_w: u32,
-        screen_h: u32,
-        fonts: &ui::Fonts,
-    ) -> bool {
+    pub fn handle_mouse_motion(&mut self, x: i32, y: i32, screen_w: u32, screen_h: u32, fonts: &ui::Fonts) -> bool {
         match self.screen {
             Screen::Home => {
                 // Home has no close button, but `hover_close` is only ever set by
@@ -1753,7 +1751,11 @@ impl App {
                 self.set_hover_close(ui::modal_close_rect(card).contains_point((x, y)))
             }
             Screen::ForgetHost => {
-                let name = self.host_menu_index.and_then(|i| self.entries.get(i)).map(HostEntry::name).unwrap_or_default();
+                let name = self
+                    .host_menu_index
+                    .and_then(|i| self.entries.get(i))
+                    .map(HostEntry::name)
+                    .unwrap_or_default();
                 let card = Self::forget_host_card_rect(screen_w, screen_h, name, fonts);
                 self.set_hover_close(ui::modal_close_rect(card).contains_point((x, y)))
             }
@@ -1778,7 +1780,6 @@ impl App {
         screen_w: u32,
         screen_h: u32,
         fonts: &ui::Fonts,
-        log: &mut std::fs::File,
     ) -> Option<ConnectTarget> {
         // Re-sync the close-button hover to the click's own position first — a
         // MouseButtonDown can carry a slightly different (x, y) than the last
@@ -1786,7 +1787,7 @@ impl App {
         self.handle_mouse_motion(x, y, screen_w, screen_h, fonts);
         if self.hover_close {
             // Same "what Back means here" as everywhere else — see `back`'s docs.
-            return self.back(log);
+            return self.back();
         }
         // Unlike hover, a click DOES move `home_focus`/`settings_focused` — fresh at
         // the click's own position, so it confirms what was actually clicked rather
@@ -1810,7 +1811,7 @@ impl App {
                     )?;
                     self.home_focus = HomeFocus::Grid(idx);
                 }
-                self.handle_home_event(MenuEvent::Confirm, screen_w, screen_h, log)
+                self.handle_home_event(MenuEvent::Confirm, screen_w, screen_h)
             }
             Screen::Settings => {
                 // An open dropdown has no row grid of its own here — Confirm picks
@@ -1835,13 +1836,13 @@ impl App {
                 let card = Self::pairing_card_rect(screen_w, screen_h, fonts.label);
                 if Self::pairing_request_button_rect(card).contains_point((x, y)) {
                     self.pairing_focus = PairingFocus::RequestAccess;
-                    self.handle_pairing_event(MenuEvent::Confirm, log);
+                    self.handle_pairing_event(MenuEvent::Confirm);
                 }
                 None
             }
             Screen::AddHost => None,
             Screen::Wake => {
-                self.handle_wake_event(MenuEvent::Confirm, log);
+                self.handle_wake_event(MenuEvent::Confirm);
                 None
             }
             Screen::ForgetHost => {
@@ -1872,7 +1873,11 @@ impl App {
         match self.switch_anim {
             Some((t, from_on)) if from_on != target_on => {
                 let f = ui::anim_frac(Some(t), ui::FOCUS_POP);
-                if target_on { f } else { 1.0 - f }
+                if target_on {
+                    f
+                } else {
+                    1.0 - f
+                }
             }
             _ => f32::from(target_on),
         }
@@ -1913,14 +1918,7 @@ impl App {
                 Some(l) => l,
                 None => Painter::new(ui::SIDEBAR_W, screen_h),
             };
-            ui::draw_sidebar(
-                &mut layer,
-                text_cache,
-                fonts,
-                &self.entries,
-                None,
-                screen_h,
-            )?;
+            ui::draw_sidebar(&mut layer, text_cache, fonts, &self.entries, None, screen_h)?;
             self.sidebar_layer = Some(layer);
             self.sidebar_dirty = false;
             self.focused_row_tile = None; // row content may have changed under it
@@ -2011,7 +2009,10 @@ impl App {
                 hover_close: self.hover_close,
             }),
             Screen::ForgetHost => Some(ModalShellKey::ForgetHost {
-                name: self.host_menu_index.and_then(|i| self.entries.get(i)).map(|e| e.name().to_string()),
+                name: self
+                    .host_menu_index
+                    .and_then(|i| self.entries.get(i))
+                    .map(|e| e.name().to_string()),
                 hover_close: self.hover_close,
             }),
             Screen::Home | Screen::AddHost => None,
@@ -2092,7 +2093,10 @@ impl App {
                         )?
                     }
                     Screen::Wake => {
-                        let wake = self.wake.as_ref().expect("focus_key only Some for a Wake with a focusable widget");
+                        let wake = self
+                            .wake
+                            .as_ref()
+                            .expect("focus_key only Some for a Wake with a focusable widget");
                         let card = Self::wake_card_rect(screen_w, screen_h, wake, fonts);
                         if wake.focused == 0 {
                             let rows = ui::wake_rows(self.settings.wol_auto_send);
@@ -2120,9 +2124,11 @@ impl App {
                         }
                     }
                     Screen::Pairing => match self.pairing_focus {
-                        PairingFocus::Pin => {
-                            ui::render_pairing_digit_tile(text_cache, fonts.title, self.pin_digits[self.pin_digit_index])?
-                        }
+                        PairingFocus::Pin => ui::render_pairing_digit_tile(
+                            text_cache,
+                            fonts.title,
+                            self.pin_digits[self.pin_digit_index],
+                        )?,
                         PairingFocus::RequestAccess => {
                             let card = Self::pairing_card_rect(screen_w, screen_h, fonts.label);
                             let btn = Self::pairing_request_button_rect(card);
@@ -2130,7 +2136,11 @@ impl App {
                         }
                     },
                     Screen::ForgetHost => {
-                        let name = self.host_menu_index.and_then(|i| self.entries.get(i)).map(HostEntry::name).unwrap_or_default();
+                        let name = self
+                            .host_menu_index
+                            .and_then(|i| self.entries.get(i))
+                            .map(HostEntry::name)
+                            .unwrap_or_default();
                         let card = Self::forget_host_card_rect(screen_w, screen_h, name, fonts);
                         let content = Self::forget_host_content_rect(card, name, fonts);
                         let rect = ui::confirm_button_rect(content, self.host_menu_focused);
@@ -2192,12 +2202,7 @@ impl App {
     /// params are only for pure geometry — `ui::modal_header_end_y` and
     /// friends — needed to position a modal's focused-widget tile without
     /// re-rendering its header). The GPU executes it (`Compositor::execute`).
-    pub fn draw_list(
-        &self,
-        screen_w: u32,
-        screen_h: u32,
-        fonts: &ui::Fonts,
-    ) -> Vec<DrawCmd> {
+    pub fn draw_list(&self, screen_w: u32, screen_h: u32, fonts: &ui::Fonts) -> Vec<DrawCmd> {
         let mut cmds = Vec::new();
         let grid_x = ui::SIDEBAR_W as i32;
         let available_w = screen_w.saturating_sub(ui::SIDEBAR_W);
@@ -2235,7 +2240,12 @@ impl App {
                 }
                 cmds.push(DrawCmd::Tex {
                     tile: Tile::Card(idx),
-                    dst: Rect::new(r.x() - pad, y - pad, r.width() + 2 * pad as u32, r.height() + 2 * pad as u32),
+                    dst: Rect::new(
+                        r.x() - pad,
+                        y - pad,
+                        r.width() + 2 * pad as u32,
+                        r.height() + 2 * pad as u32,
+                    ),
                     alpha: 0xff,
                 });
             }
@@ -2246,16 +2256,24 @@ impl App {
                 let f = ui::anim_frac(self.focus_anim, ui::FOCUS_POP);
                 let r = ui::grid_card_rect(idx, columns, grid_x, available_w);
                 let y = r.y() - self.grid_scroll;
-                let card_base =
-                    Rect::new(r.x() - pad, y - pad, r.width() + 2 * pad as u32, r.height() + 2 * pad as u32);
+                let card_base = Rect::new(
+                    r.x() - pad,
+                    y - pad,
+                    r.width() + 2 * pad as u32,
+                    r.height() + 2 * pad as u32,
+                );
                 cmds.push(DrawCmd::Tex {
                     tile: Tile::Card(idx),
                     dst: ui::zoom_rect(card_base, f, CARD_GROWTH),
                     alpha: 0xff,
                 });
                 let rp = ui::FOCUS_RING_PAD;
-                let ring_base =
-                    Rect::new(r.x() - rp, y - rp, r.width() + 2 * rp as u32, r.height() + 2 * rp as u32);
+                let ring_base = Rect::new(
+                    r.x() - rp,
+                    y - rp,
+                    r.width() + 2 * rp as u32,
+                    r.height() + 2 * rp as u32,
+                );
                 cmds.push(DrawCmd::Tex {
                     tile: Tile::Ring,
                     dst: ui::zoom_rect(ring_base, f, CARD_GROWTH),
@@ -2283,7 +2301,12 @@ impl App {
             let pad = ui::ROW_TILE_PAD;
             cmds.push(DrawCmd::Tex {
                 tile: Tile::FocusRow,
-                dst: Rect::new(rect.x() - pad, rect.y() - pad, rect.width() + 2 * pad as u32, rect.height() + 2 * pad as u32),
+                dst: Rect::new(
+                    rect.x() - pad,
+                    rect.y() - pad,
+                    rect.width() + 2 * pad as u32,
+                    rect.height() + 2 * pad as u32,
+                ),
                 alpha: 0xff,
             });
         }
@@ -2334,7 +2357,11 @@ impl App {
                     })
                 }
                 Screen::ForgetHost => {
-                    let name = self.host_menu_index.and_then(|i| self.entries.get(i)).map(HostEntry::name).unwrap_or_default();
+                    let name = self
+                        .host_menu_index
+                        .and_then(|i| self.entries.get(i))
+                        .map(HostEntry::name)
+                        .unwrap_or_default();
                     let card = Self::forget_host_card_rect(screen_w, screen_h, name, fonts);
                     let content = Self::forget_host_content_rect(card, name, fonts);
                     Some(ui::confirm_button_rect(content, self.host_menu_focused))
@@ -2343,8 +2370,12 @@ impl App {
             };
             if let Some(rect) = focus_rect {
                 let pad = ui::ROW_TILE_PAD;
-                let base =
-                    Rect::new(rect.x() - pad, rect.y() - pad + dy, rect.width() + 2 * pad as u32, rect.height() + 2 * pad as u32);
+                let base = Rect::new(
+                    rect.x() - pad,
+                    rect.y() - pad + dy,
+                    rect.width() + 2 * pad as u32,
+                    rect.height() + 2 * pad as u32,
+                );
                 // The zoom-in: same GPU-scale-around-center technique as the
                 // grid's card focus pop (see above) — `modal_focus_tile` is
                 // rasterized once at its literal size, never re-rendered for
@@ -2368,7 +2399,12 @@ impl App {
                     let option_rect = ui::dropdown_option_rect(overlay_rect, dd.focused);
                     cmds.push(DrawCmd::Tex {
                         tile: Tile::DropdownFocusOption,
-                        dst: Rect::new(option_rect.x(), option_rect.y() + dy, option_rect.width(), option_rect.height()),
+                        dst: Rect::new(
+                            option_rect.x(),
+                            option_rect.y() + dy,
+                            option_rect.width(),
+                            option_rect.height(),
+                        ),
                         alpha: (255.0 * m) as u8,
                     });
                 }
@@ -2620,7 +2656,15 @@ impl App {
 
         let status = Self::wake_status_text(wake);
         ui::draw_modal_header(
-            painter, text_cache, fonts.title, fonts.label, card, "Host unreachable", ui::WHITE, &status, ui::MUTED,
+            painter,
+            text_cache,
+            fonts.title,
+            fonts.label,
+            card,
+            "Host unreachable",
+            ui::WHITE,
+            &status,
+            ui::MUTED,
         )?;
 
         // No MAC on record — nothing to send or automate, so there's nothing
@@ -2687,7 +2731,12 @@ impl App {
     /// without re-rendering the header.
     fn wake_toggle_rect(card: Rect, wake: &WakeState, fonts: &ui::Fonts) -> Rect {
         let after_status_y = ui::modal_header_end_y(fonts.title, fonts.label, card, &Self::wake_status_text(wake));
-        Rect::new(card.x() + 32, after_status_y + 28, card.width().saturating_sub(64), ui::SETTINGS_ROW_H)
+        Rect::new(
+            card.x() + 32,
+            after_status_y + 28,
+            card.width().saturating_sub(64),
+            ui::SETTINGS_ROW_H,
+        )
     }
 
     /// The Wake/Cancel button row's rect, stacked below the toggle row —
@@ -2760,7 +2809,13 @@ impl App {
     /// without drawing so `prepare_tiles`/`draw_list` can position the
     /// focused-button tile without re-rendering the header.
     fn forget_host_content_rect(card: Rect, name: &str, fonts: &ui::Fonts) -> Rect {
-        let after_subtitle_y = ui::modal_header_end_y(fonts.label, fonts.value, card, &Self::forget_host_subtitle(name));
-        Rect::new(card.x() + 32, after_subtitle_y + 32, card.width().saturating_sub(64), 72)
+        let after_subtitle_y =
+            ui::modal_header_end_y(fonts.label, fonts.value, card, &Self::forget_host_subtitle(name));
+        Rect::new(
+            card.x() + 32,
+            after_subtitle_y + 32,
+            card.width().saturating_sub(64),
+            72,
+        )
     }
 }

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -2,8 +2,6 @@
 //! (`_punktfunk._udp` advert, same TXT keys) but as our own direct `mdns-sd`
 //! dependency rather than depending on `pf-client-core` itself (see `session.rs`
 //! docs for why: its Cargo.toml would drag in FFmpeg/PipeWire for our target too).
-use std::io::Write as _;
-
 use mdns_sd::{ServiceDaemon, ServiceEvent};
 
 #[derive(Clone, Debug)]
@@ -31,17 +29,16 @@ pub struct DiscoveredHost {
 /// returned `ServiceDaemon` handle is `Clone` and lets a caller call `shutdown()`
 /// explicitly once discovery is no longer needed (see `App`'s `Drop` impl) — that
 /// unblocks the thread's `receiver.recv()` promptly instead of waiting on a lucky
-/// future resolution event. `log` is a second handle onto the app's own log file
-/// (see `main.rs::log_path`) — every failure/event point here is logged, since this
-/// previously failed completely silently: a `ServiceDaemon::new()`/`browse()` error,
-/// or every non-`ServiceResolved` event, was just dropped with no trace, making "no
-/// hosts showed up" undiagnosable from the log alone (was it a permissions/socket
-/// failure, wrong interface, or genuinely nothing advertising?).
-pub fn browse(mut log: std::fs::File) -> Option<(std::sync::mpsc::Receiver<DiscoveredHost>, ServiceDaemon)> {
+/// future resolution event. Every failure/event point here is logged via `tracing`,
+/// since this previously failed completely silently: a `ServiceDaemon::new()`/
+/// `browse()` error, or every non-`ServiceResolved` event, was just dropped with no
+/// trace, making "no hosts showed up" undiagnosable from the log alone (was it a
+/// permissions/socket failure, wrong interface, or genuinely nothing advertising?).
+pub fn browse() -> Option<(std::sync::mpsc::Receiver<DiscoveredHost>, ServiceDaemon)> {
     let (tx, rx) = std::sync::mpsc::channel();
     let daemon = ServiceDaemon::new()
         .inspect_err(|e| {
-            let _ = writeln!(log, "mdns: ServiceDaemon::new failed: {e}");
+            tracing::error!("mdns: ServiceDaemon::new failed: {e}");
         })
         .ok()?;
     let daemon_handle = daemon.clone();
@@ -51,16 +48,16 @@ pub fn browse(mut log: std::fs::File) -> Option<(std::sync::mpsc::Receiver<Disco
             let receiver = match daemon.browse("_punktfunk._udp.local.") {
                 Ok(r) => r,
                 Err(e) => {
-                    let _ = writeln!(log, "mdns: browse(_punktfunk._udp.local.) failed: {e}");
+                    tracing::error!("mdns: browse(_punktfunk._udp.local.) failed: {e}");
                     return;
                 }
             };
-            let _ = writeln!(log, "mdns: browsing _punktfunk._udp.local.");
+            tracing::debug!("mdns: browsing _punktfunk._udp.local.");
             while let Ok(event) = receiver.recv() {
                 let info = match event {
                     ServiceEvent::ServiceResolved(info) => info,
                     other => {
-                        let _ = writeln!(log, "mdns: {other:?}");
+                        tracing::debug!("mdns: {other:?}");
                         continue;
                     }
                 };
@@ -72,11 +69,7 @@ pub fn browse(mut log: std::fs::File) -> Option<(std::sync::mpsc::Receiver<Disco
                     .next()
                     .map(std::string::ToString::to_string)
                 else {
-                    let _ = writeln!(
-                        log,
-                        "mdns: resolved {} with no IPv4 address, skipping",
-                        info.get_fullname()
-                    );
+                    tracing::warn!("mdns: resolved {} with no IPv4 address, skipping", info.get_fullname());
                     continue;
                 };
                 let props = info.get_properties();
@@ -93,12 +86,12 @@ pub fn browse(mut log: std::fs::File) -> Option<(std::sync::mpsc::Receiver<Disco
                         .filter(|s| !s.is_empty())
                         .collect(),
                 };
-                let _ = writeln!(log, "mdns: resolved {} at {}:{}", host.name, host.addr, host.port);
+                tracing::info!("mdns: resolved {} at {}:{}", host.name, host.addr, host.port);
                 if tx.send(host).is_err() {
                     break; // receiver gone — stop browsing
                 }
             }
-            let _ = writeln!(log, "mdns: receiver loop ended, shutting down");
+            tracing::debug!("mdns: receiver loop ended, shutting down");
             let _ = daemon.shutdown();
         })
         .expect("spawn mdns thread");

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,146 @@
+//! Picks where `tracing` writes: a TCP stream to a dev machine when `task deploy`
+//! passed a `telemetry` destination at launch, otherwise a versioned file under the
+//! app's own writable directory (see `store.rs`'s module docs on that directory).
+//! Call sites everywhere else just use plain `tracing::info!`/`warn!`/`debug!`/
+//! `error!` — no handle to thread through; see `main.rs::run` for the one-time
+//! subscriber setup this feeds.
+//!
+//! The destination is read from `argv[1]` at runtime, not baked in at compile time:
+//! webOS's SAM launch passes the `params` object given to
+//! `luna://com.webos.applicationManager/launch` to a native app as a JSON-encoded
+//! first command-line argument on initial launch (confirmed in the webOS OSE native
+//! app docs) — so `task deploy TELEMETRY=<host:port>` just threads it through that
+//! `luna-send` call instead of requiring a rebuild per destination.
+use std::io::Write;
+use std::net::TcpStream;
+use std::path::Path;
+use std::sync::OnceLock;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+/// Matches `ui.rs`'s version marker: `PKG_VERSION` is threaded in at Docker build
+/// time by the Taskfile (`Cargo.toml` itself stays a fixed `0.0.1`); falls back to
+/// `CARGO_PKG_VERSION` for a plain native `cargo build`.
+const VERSION: &str = match option_env!("PKG_VERSION") {
+    Some(v) => v,
+    None => env!("CARGO_PKG_VERSION"),
+};
+
+/// `argv[1]`'s shape, as SAM hands it to a native app on initial launch — see this
+/// module's docs. Both fields optional: a plain launch (no `params`, or a `params`
+/// with neither key — e.g. a future unrelated use of `params`) just means "no
+/// telemetry", not a parse error.
+#[derive(Deserialize, Default)]
+struct LaunchParams {
+    /// `host:port` of the dev machine's listener.
+    telemetry: Option<String>,
+    /// `debug`/`info`/`warn`/`error` — parsed via `tracing::Level`'s own `FromStr`.
+    telemetry_level: Option<String>,
+}
+
+/// Parsed once (argv doesn't change over the process lifetime) and cached — every
+/// caller below reads through this instead of re-parsing.
+fn launch_params() -> &'static LaunchParams {
+    static PARAMS: OnceLock<LaunchParams> = OnceLock::new();
+    PARAMS.get_or_init(|| {
+        std::env::args()
+            .nth(1)
+            .and_then(|raw| serde_json::from_str(&raw).ok())
+            .unwrap_or_default()
+    })
+}
+
+fn telemetry_addr() -> Option<&'static str> {
+    launch_params().telemetry.as_deref().filter(|s| !s.is_empty())
+}
+
+/// Defaults to `debug` — a configured TCP sink is an explicit opt-in for a dev
+/// session, so send everything unless told otherwise.
+fn telemetry_level() -> tracing::Level {
+    launch_params()
+        .telemetry_level
+        .as_deref()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(tracing::Level::DEBUG)
+}
+
+/// Where log lines actually go — a plain `Write` impl handed to
+/// `tracing_appender::non_blocking`, which owns the buffering/background-thread
+/// dispatch (see `main.rs::run`) so a slow disk or a dev machine not draining its
+/// listener fast enough never blocks the caller, in particular the video-pump
+/// thread.
+enum Sink {
+    File(std::fs::File),
+    Tcp(TcpStream),
+}
+
+impl Write for Sink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::File(f) => f.write(buf),
+            Self::Tcp(s) => s.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::File(f) => f.flush(),
+            Self::Tcp(s) => s.flush(),
+        }
+    }
+}
+
+/// Truncate (not append) — this file previously grew unbounded across every launch
+/// for the life of the install; each run's log now starts fresh. Info-and-above
+/// only (no debug) so on-device disk usage stays bounded across ordinary
+/// sideloaded runs with no telemetry destination configured.
+fn open_file(app_dir: &Path) -> Result<Sink> {
+    let path = app_dir.join(format!("punktfunk-webos-{VERSION}.log"));
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&path)
+        .with_context(|| format!("open log file {}", path.display()))?;
+    Ok(Sink::File(file))
+}
+
+/// `app_dir` is the app's own writable directory (`store::app_dir()`).
+///
+/// A configured address that's unreachable (dev machine off the network, `task
+/// deploy` exited before this launch) falls back to the file sink rather than
+/// failing the whole app over what's meant to be a dev convenience.
+fn open_sink(app_dir: &Path) -> Result<Sink> {
+    if let Some(addr) = telemetry_addr() {
+        if let Ok(stream) = TcpStream::connect(addr) {
+            return Ok(Sink::Tcp(stream));
+        }
+    }
+    open_file(app_dir)
+}
+
+/// The level the installed subscriber should filter at — `debug` (or whatever
+/// `telemetry_level` was given) when a telemetry address was configured, `info`
+/// for the plain on-device file (see `open_file`'s docs on why).
+pub fn resolved_level() -> tracing::Level {
+    if telemetry_addr().is_some() {
+        telemetry_level()
+    } else {
+        tracing::Level::INFO
+    }
+}
+
+/// Builds the writer `main.rs::run` installs into `tracing_subscriber::fmt()`.
+/// Returns the `non_blocking` writer plus its `WorkerGuard` — the guard must be
+/// kept alive for the process lifetime (dropping it stops the background writer
+/// thread and flushes whatever's queued).
+pub fn init(
+    app_dir: &Path,
+) -> Result<(
+    tracing_appender::non_blocking::NonBlocking,
+    tracing_appender::non_blocking::WorkerGuard,
+)> {
+    let sink = open_sink(app_dir).context("open log sink")?;
+    Ok(tracing_appender::non_blocking(sink))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod gamepad;
 mod keyboard;
 #[cfg(target_os = "linux")]
 mod library;
+mod logger;
 #[cfg(target_os = "linux")]
 mod mouse;
 #[cfg(target_os = "linux")]
@@ -36,8 +37,6 @@ mod wol;
 
 #[cfg(target_os = "linux")]
 mod real {
-    use std::io::Write as _;
-    use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::{Duration, Instant};
 
@@ -84,52 +83,32 @@ mod real {
         }
     }
 
-    /// webOS native apps run with no attached terminal; `dev-manager-desktop`'s log
-    /// viewer reads this file. `/media/developer/apps/usr/palm/applications/<appid>/`
-    /// is the app's own writable directory (falls back to `/tmp` off-device, e.g. when
-    /// smoke-testing this binary on a Linux dev box before packaging).
-    fn log_path() -> PathBuf {
-        std::env::var_os("PUNKTFUNK_WEBOS_LOG_DIR")
-            .map_or_else(|| PathBuf::from("/tmp"), PathBuf::from)
-            .join("punktfunk-webos.log")
-    }
-
     pub fn run() -> Result<()> {
         install_signal_handlers();
-        let log_path = log_path();
-        // Truncate (not append) — this file previously grew unbounded across every
-        // launch for the life of the install; each run's log now starts fresh, and
-        // `task deploy:log` tails it live anyway.
-        let mut log = std::fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&log_path)
-            .with_context(|| format!("open log file {}", log_path.display()))?;
-        writeln!(log, "punktfunk-webos starting")?;
-
-        // Without this, punktfunk-core's own `tracing::info!`/`warn!` calls — including the
-        // startup link-capacity probe's measured throughput and the ABR ceiling it derives from
-        // it — are silent no-ops (nothing installs a subscriber by default). A fresh handle to
-        // the same file, not `log.try_clone()`, since this subscriber outlives `run_inner`'s
-        // `&mut log` borrow for the whole process.
-        let tracing_log = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&log_path)
-            .with_context(|| format!("open log file {} for tracing", log_path.display()))?;
+        // Streams to a dev machine when `task deploy TELEMETRY=...` passed a
+        // destination as a launch param; otherwise a versioned file under the app's
+        // own writable directory (falls back to `/tmp` off-device, e.g. when
+        // smoke-testing this binary on a Linux dev box before packaging). `_guard`
+        // owns the background writer thread `non_blocking` spawns — held for the
+        // whole process so logging never blocks a caller (in particular the
+        // video-pump thread) on a slow disk or a dev machine not draining its
+        // telemetry listener fast enough.
+        let app_dir = store::app_dir();
+        let (writer, _guard) = crate::logger::init(&app_dir).context("init logger")?;
         tracing_subscriber::fmt()
-            .with_writer(std::sync::Mutex::new(tracing_log))
+            .with_writer(writer)
             .with_ansi(false)
             .with_target(false)
+            .with_max_level(crate::logger::resolved_level())
             .init();
+        tracing::info!("punktfunk-webos starting");
 
         // Errors from here on only ever reached stderr, which is invisible for a
         // webOS native app with no attached terminal.
-        match run_inner(&mut log) {
+        match run_inner() {
             Ok(()) => Ok(()),
             Err(e) => {
-                let _ = writeln!(log, "error: {e:#}");
+                tracing::error!("error: {e:#}");
                 Err(e)
             }
         }
@@ -185,18 +164,17 @@ mod real {
         display_mode: sdl2::video::DisplayMode,
         fonts: &crate::ui::Fonts,
         initial_status: Option<String>,
-        log: &mut std::fs::File,
     ) -> Result<Option<ConnectOutcome>> {
         // Test/dev override: skip the UI entirely if a connect.conf was dropped
         // alongside sideloading (see store.rs docs) — the UI flow is the normal path.
         // Bypasses the library screen too (`launch: None`, a plain desktop session).
         if let Some((host, port)) = store::dev_override_connect() {
-            writeln!(log, "dev override: connecting to {host}:{port}")?;
+            tracing::info!("dev override: connecting to {host}:{port}");
             return Ok(Some((host, port, None, None)));
         }
 
         canvas.window_mut().show();
-        let mut app = App::new(identity.clone(), log);
+        let mut app = App::new(identity.clone());
         // E.g. "the last connect attempt failed, and here's why" — shown on the
         // Home screen the user just got dropped back onto (see `run_inner`'s
         // connect-error path).
@@ -235,22 +213,22 @@ mod real {
         let mut dirty = true;
         let target = 'ui: loop {
             if QUIT_REQUESTED.load(Ordering::Relaxed) {
-                writeln!(log, "SIGTERM/SIGINT received during UI")?;
+                tracing::warn!("SIGTERM/SIGINT received during UI");
                 return Ok(None);
             }
-            dirty |= app.drain_discovery(log);
+            dirty |= app.drain_discovery();
             dirty |= app.drain_art();
-            dirty |= app.drain_games(log);
-            dirty |= app.drain_pairing(log);
-            dirty |= app.tick_wake(log);
-            dirty |= app.drain_launch_check(log);
+            dirty |= app.drain_games();
+            dirty |= app.drain_pairing();
+            dirty |= app.tick_wake();
+            dirty |= app.drain_launch_check();
             if let Some(target) = app.take_ready_launch() {
                 break 'ui target;
             }
             for event in events.poll_iter() {
                 use sdl2::event::Event;
                 if let Event::Quit { .. } = event {
-                    writeln!(log, "quit during UI")?;
+                    tracing::info!("quit during UI");
                     return Ok(None);
                 }
                 // The Magic Remote's pointer mode surfaces as a plain SDL2
@@ -259,13 +237,7 @@ mod real {
                 // if the motion actually changed the focused/hovered element,
                 // not on every no-op tick.
                 if let Event::MouseMotion { x, y, .. } = event {
-                    dirty |= app.handle_mouse_motion(
-                        x,
-                        y,
-                        display_mode.w as u32,
-                        display_mode.h as u32,
-                        fonts,
-                    );
+                    dirty |= app.handle_mouse_motion(x, y, display_mode.w as u32, display_mode.h as u32, fonts);
                     continue;
                 }
                 // The Magic Remote's scroll wheel — scrolls the game grid on Home
@@ -277,11 +249,8 @@ mod real {
                         /// Grid px scrolled per wheel detent — about a third of a
                         /// card row, so a few ticks walk one row.
                         const WHEEL_STEP: i32 = 120;
-                        dirty |= app.scroll_grid_by(
-                            -wheel_y * WHEEL_STEP,
-                            display_mode.w as u32,
-                            display_mode.h as u32,
-                        );
+                        dirty |=
+                            app.scroll_grid_by(-wheel_y * WHEEL_STEP, display_mode.w as u32, display_mode.h as u32);
                     }
                     continue;
                 }
@@ -308,7 +277,7 @@ mod real {
                             continue;
                         }
                         if let Some(target) =
-                            app.handle_mouse_click(x, y, display_mode.w as u32, display_mode.h as u32, fonts, log)
+                            app.handle_mouse_click(x, y, display_mode.w as u32, display_mode.h as u32, fonts)
                         {
                             break 'ui target;
                         }
@@ -323,7 +292,7 @@ mod real {
                         let held = confirm_held_since.take().is_some();
                         if held && !confirm_long_fired {
                             if let Some(target) =
-                                app.handle_mouse_click(x, y, display_mode.w as u32, display_mode.h as u32, fonts, log)
+                                app.handle_mouse_click(x, y, display_mode.w as u32, display_mode.h as u32, fonts)
                             {
                                 break 'ui target;
                             }
@@ -373,7 +342,8 @@ mod real {
                         // library fetch failing into the Wake prompt) could in
                         // principle have changed screens while OK was down.
                         if held && !confirm_long_fired && matches!(app.screen, Screen::Home) {
-                            if let Some(target) = app.handle_home_event(MenuEvent::Confirm, display_mode.w as u32, display_mode.h as u32, log)
+                            if let Some(target) =
+                                app.handle_home_event(MenuEvent::Confirm, display_mode.w as u32, display_mode.h as u32)
                             {
                                 break 'ui target;
                             }
@@ -386,7 +356,8 @@ mod real {
                     {
                         let held = confirm_held_since.take().is_some();
                         if held && !confirm_long_fired && matches!(app.screen, Screen::Home) {
-                            if let Some(target) = app.handle_home_event(MenuEvent::Confirm, display_mode.w as u32, display_mode.h as u32, log)
+                            if let Some(target) =
+                                app.handle_home_event(MenuEvent::Confirm, display_mode.w as u32, display_mode.h as u32)
                             {
                                 break 'ui target;
                             }
@@ -401,7 +372,7 @@ mod real {
                     {
                         if let Some(digit) = crate::ui::digit_key_value(k) {
                             match app.screen {
-                                Screen::Pairing => app.enter_pin_digit(digit, log),
+                                Screen::Pairing => app.enter_pin_digit(digit),
                                 Screen::AddHost => app.enter_add_host_digit(digit),
                                 _ => unreachable!(),
                             }
@@ -432,10 +403,10 @@ mod real {
                     Event::ControllerDeviceAdded { which, .. } if controller.is_none() => {
                         match game_controller.open(which) {
                             Ok(c) => {
-                                writeln!(log, "controller connected: {}", c.name())?;
+                                tracing::info!("controller connected: {}", c.name());
                                 *controller = Some(c);
                             }
-                            Err(e) => writeln!(log, "controller open failed: {e}")?,
+                            Err(e) => tracing::warn!("controller open failed: {e}"),
                         }
                         None
                     }
@@ -452,17 +423,19 @@ mod real {
                     // routed through `back` anyway so the policy lives in one place.
                     Screen::Home => {
                         if menu_ev == MenuEvent::Back {
-                            if let Some(target) = app.back(log) {
+                            if let Some(target) = app.back() {
                                 break 'ui target;
                             }
-                        } else if let Some(target) = app.handle_home_event(menu_ev, display_mode.w as u32, display_mode.h as u32, log) {
+                        } else if let Some(target) =
+                            app.handle_home_event(menu_ev, display_mode.w as u32, display_mode.h as u32)
+                        {
                             break 'ui target;
                         }
                     }
-                    Screen::Pairing => app.handle_pairing_event(menu_ev, log),
+                    Screen::Pairing => app.handle_pairing_event(menu_ev),
                     Screen::Settings => app.handle_settings_event(menu_ev),
                     Screen::AddHost => app.handle_add_host_event(menu_ev),
-                    Screen::Wake => app.handle_wake_event(menu_ev, log),
+                    Screen::Wake => app.handle_wake_event(menu_ev),
                     Screen::ForgetHost => app.handle_forget_host_event(menu_ev),
                 }
             }
@@ -519,7 +492,7 @@ mod real {
         )))
     }
 
-    fn run_inner(log: &mut std::fs::File) -> Result<()> {
+    fn run_inner() -> Result<()> {
         // Prevents webOS's system launcher from intercepting the Magic Remote's Back
         // key. Must be set before window creation.
         sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_BACK", "true");
@@ -533,16 +506,17 @@ mod real {
             .game_controller()
             .map_err(|e| anyhow::anyhow!("SDL game controller subsystem: {e}"))?;
         let sdl_audio = sdl.audio().map_err(|e| anyhow::anyhow!("SDL audio subsystem: {e}"))?;
-        writeln!(log, "SDL video subsystem up (driver: {})", video.current_video_driver())?;
+        tracing::info!("SDL video subsystem up (driver: {})", video.current_video_driver());
 
         let display_mode = video
             .current_display_mode(0)
             .map_err(|e| anyhow::anyhow!("current_display_mode: {e}"))?;
-        writeln!(
-            log,
+        tracing::info!(
             "display mode: {}x{}@{}",
-            display_mode.w, display_mode.h, display_mode.refresh_rate
-        )?;
+            display_mode.w,
+            display_mode.h,
+            display_mode.refresh_rate
+        );
 
         let window = video
             .window("punktfunk", display_mode.w as u32, display_mode.h as u32)
@@ -554,7 +528,7 @@ mod real {
             .build()
             .map_err(|e| anyhow::anyhow!("create canvas: {e}"))?;
         let texture_creator = canvas.texture_creator();
-        writeln!(log, "window + canvas created (renderer: {})", canvas.info().name)?;
+        tracing::info!("window + canvas created (renderer: {})", canvas.info().name);
 
         // The pre-stream UI's rendering backend: tiny-skia rasterizes cached
         // widget tiles (see `ui.rs`'s `render_*_tile` helpers), and the GPU
@@ -601,15 +575,14 @@ mod real {
                 display_mode,
                 &fonts,
                 menu_status.take(),
-                log,
             )?
             else {
-                writeln!(log, "punktfunk-webos exiting cleanly")?;
+                tracing::info!("punktfunk-webos exiting cleanly");
                 return Ok(());
             };
 
             let settings = store::load_settings();
-            writeln!(log, "settings: {settings:?}")?;
+            tracing::debug!("settings: {settings:?}");
 
             // `hide()` (the previous approach here, when `set_opacity` fails — confirmed
             // unsupported on this Wayland backend) unmaps the surface entirely, which
@@ -638,11 +611,12 @@ mod real {
             // the host's virtual-display driver rejected a literal "0 Hz" mode request
             // with "the parameter is incorrect") — the settings' own nominal rate (never
             // 0; see store::Settings::default) is what drives the wire value directly.
-            writeln!(
-                log,
+            tracing::info!(
                 "requesting {}x{}@{}",
-                settings.width, settings.height, settings.refresh_hz
-            )?;
+                settings.width,
+                settings.height,
+                settings.refresh_hz
+            );
             let mode = Mode {
                 width: settings.width,
                 height: settings.height,
@@ -664,7 +638,6 @@ mod real {
                 display_mode.w,
                 display_mode.h,
                 settings.video_backend,
-                log,
             ) {
                 Ok(c) => c,
                 Err(e) => {
@@ -672,22 +645,21 @@ mod real {
                     // rejection, handshake error) used to `?` out of `run_inner`
                     // and take the whole app down — return to the menu with the
                     // reason on screen instead.
-                    writeln!(log, "session connect failed: {e:#}")?;
+                    tracing::error!("session connect failed: {e:#}");
                     sdl.mouse().show_cursor(true);
                     menu_status = Some(format!("Couldn't connect: {e:#}"));
                     continue;
                 }
             };
-            writeln!(log, "session connected, entering event loop")?;
+            tracing::info!("session connected, entering event loop");
 
-            let mut audio_player = match crate::audio::AudioPlayer::new(&sdl_audio, connected.client.audio_channels)
-            {
+            let mut audio_player = match crate::audio::AudioPlayer::new(&sdl_audio, connected.client.audio_channels) {
                 Ok(p) => p,
                 Err(e) => {
                     // Same no-crash policy as the connect above — including the
                     // video-side teardown the normal stream exit does, since the
                     // connect succeeded and loaded a decoder.
-                    writeln!(log, "audio player init failed: {e:#}")?;
+                    tracing::error!("audio player init failed: {e:#}");
                     connected.client.disconnect_quit();
                     connected.shutdown();
                     crate::ndl::quit();
@@ -696,12 +668,11 @@ mod real {
                     continue;
                 }
             };
-            writeln!(
-                log,
+            tracing::info!(
                 "SDL audio driver: {}, spec: {:?}",
                 sdl_audio.current_audio_driver(),
                 audio_player.spec()
-            )?;
+            );
 
             let mut scroll_acc = mouse::ScrollAccumulator::default();
             // In-stream stats overlay (Settings toggle): refreshed at ~2Hz onto the
@@ -733,7 +704,7 @@ mod real {
             let mut guide_held_since: Option<Instant> = None;
             let outcome = 'running: loop {
                 if QUIT_REQUESTED.load(Ordering::Relaxed) {
-                    writeln!(log, "SIGTERM/SIGINT received — disconnecting before exit")?;
+                    tracing::warn!("SIGTERM/SIGINT received — disconnecting before exit");
                     connected.client.disconnect_quit();
                     break 'running StreamOutcome::Quit;
                 }
@@ -749,10 +720,10 @@ mod real {
                         Event::ControllerDeviceAdded { which, .. } if controller.is_none() => {
                             match game_controller.open(which) {
                                 Ok(c) => {
-                                    writeln!(log, "controller connected: {}", c.name())?;
+                                    tracing::info!("controller connected: {}", c.name());
                                     controller = Some(c);
                                 }
-                                Err(e) => writeln!(log, "controller open failed: {e}")?,
+                                Err(e) => tracing::warn!("controller open failed: {e}"),
                             }
                         }
                         Event::ControllerDeviceRemoved { .. } => {
@@ -764,12 +735,12 @@ mod real {
                         _ if disconnect_dialog.is_some() => {
                             let focus = disconnect_dialog.expect("guarded by is_some above");
                             let nav = match &event {
-                                Event::KeyDown { keycode: Some(k), repeat: false, .. } => {
-                                    crate::ui::menu_event_for_key(*k)
-                                }
-                                Event::ControllerButtonDown { button, .. } => {
-                                    crate::ui::menu_event_for_button(*button)
-                                }
+                                Event::KeyDown {
+                                    keycode: Some(k),
+                                    repeat: false,
+                                    ..
+                                } => crate::ui::menu_event_for_key(*k),
+                                Event::ControllerButtonDown { button, .. } => crate::ui::menu_event_for_button(*button),
                                 _ => None,
                             };
                             match nav {
@@ -779,7 +750,7 @@ mod real {
                                     disconnect_focus_anim = Some(Instant::now());
                                 }
                                 Some(MenuEvent::Confirm) if focus == 0 => {
-                                    writeln!(log, "back — disconnecting to menu")?;
+                                    tracing::info!("back — disconnecting to menu");
                                     connected.client.disconnect_quit();
                                     break 'running StreamOutcome::ReturnToMenu;
                                 }
@@ -806,9 +777,12 @@ mod real {
                         }
                         // Magic Remote Back (0x200003): no scancode, never
                         // forwarded to the host — open the disconnect dialog.
-                        Event::KeyDown { keycode: Some(k), scancode: None, repeat: false, .. }
-                            if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back) =>
-                        {
+                        Event::KeyDown {
+                            keycode: Some(k),
+                            scancode: None,
+                            repeat: false,
+                            ..
+                        } if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back) => {
                             disconnect_dialog = Some(1);
                             disconnect_shell_dirty = true;
                             disconnect_focus_dirty = true;
@@ -929,8 +903,15 @@ mod real {
                     compositor.execute(
                         &mut canvas,
                         &[
-                            DrawCmd::Fill { rect: full, color: sdl2::pixels::Color::RGBA(0, 0, 0, crate::ui::MODAL_SCRIM.a) },
-                            DrawCmd::Tex { tile: Tile::DisconnectDialog, dst: full, alpha: 0xff },
+                            DrawCmd::Fill {
+                                rect: full,
+                                color: sdl2::pixels::Color::RGBA(0, 0, 0, crate::ui::MODAL_SCRIM.a),
+                            },
+                            DrawCmd::Tex {
+                                tile: Tile::DisconnectDialog,
+                                dst: full,
+                                alpha: 0xff,
+                            },
                             DrawCmd::Tex {
                                 tile: Tile::DisconnectFocusButton,
                                 dst: crate::ui::zoom_rect(base, f, 0.02),
@@ -940,7 +921,7 @@ mod real {
                     )?;
                     canvas.present();
                 }
-                session::pump_audio_once(&connected.client, &mut audio_player, log);
+                session::pump_audio_once(&connected.client, &mut audio_player);
                 // Skipped while the dialog is open — its own redraw above already
                 // owns the canvas this tick.
                 if stats_enabled
@@ -954,8 +935,7 @@ mod real {
                     overlay_prev_frames = frames;
                     overlay_prev_at = Instant::now();
                     let mode = connected.client.mode();
-                    let feed_ms =
-                        connected.stats.feed_us.load(Ordering::Relaxed) as f32 / 1000.0;
+                    let feed_ms = connected.stats.feed_us.load(Ordering::Relaxed) as f32 / 1000.0;
                     let holding = connected.stats.holding.load(Ordering::Relaxed);
                     let lines = vec![
                         format!(
@@ -994,11 +974,11 @@ mod real {
                             )?;
                             canvas.present();
                         }
-                        Err(e) => writeln!(log, "stats overlay render failed: {e:#}")?,
+                        Err(e) => tracing::warn!("stats overlay render failed: {e:#}"),
                     }
                 }
                 if connected.client.is_session_ended() {
-                    writeln!(log, "host ended the session")?;
+                    tracing::info!("host ended the session");
                     break 'running StreamOutcome::ReturnToMenu;
                 }
 
@@ -1019,7 +999,7 @@ mod real {
             sdl.mouse().show_cursor(true);
             match outcome {
                 StreamOutcome::Quit => {
-                    writeln!(log, "punktfunk-webos exiting cleanly")?;
+                    tracing::info!("punktfunk-webos exiting cleanly");
                     return Ok(());
                 }
                 StreamOutcome::ReturnToMenu => continue,

--- a/src/session.rs
+++ b/src/session.rs
@@ -6,7 +6,6 @@
 //! Audio is drained from the main thread ([`pump_audio_once`]) because
 //! `sdl2::audio::AudioQueue` is `!Send`.
 use std::fmt::Write as _;
-use std::io::Write as _;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -145,12 +144,15 @@ pub fn connect(
     display_w: i32,
     display_h: i32,
     video_backend: VideoBackend,
-    log: &mut std::fs::File,
 ) -> Result<Connected> {
     // VIDEO_CAP_CHACHA20: unconditional — armv7 has no hardware AES, so ChaCha20 is
     // faster. A ≥0.17.2 host picks it up; older hosts ignore the unknown bit.
     let video_caps = quic::VIDEO_CAP_CHACHA20
-        | if hdr_enabled { quic::VIDEO_CAP_10BIT | quic::VIDEO_CAP_HDR } else { 0 };
+        | if hdr_enabled {
+            quic::VIDEO_CAP_10BIT | quic::VIDEO_CAP_HDR
+        } else {
+            0
+        };
     let display_hdr = hdr_enabled.then(cx_display_hdr);
 
     let client = NativeClient::connect(
@@ -174,12 +176,11 @@ pub fn connect(
     .context("connect")?;
     let client = Arc::new(client);
 
-    let fp_hex = client
-        .host_fingerprint
-        .iter()
-        .fold(String::new(), |mut s, b| { let _ = write!(s, "{b:02x}"); s });
-    writeln!(
-        log,
+    let fp_hex = client.host_fingerprint.iter().fold(String::new(), |mut s, b| {
+        let _ = write!(s, "{b:02x}");
+        s
+    });
+    tracing::info!(
         "connected: codec={} compositor={:?} audio_ch={} color={:?} bitrate_kbps={} \
          decode_latency={} caps=0x{video_caps:02x} fp={fp_hex}",
         client.codec,
@@ -188,12 +189,12 @@ pub fn connect(
         client.color,
         client.resolved_bitrate_kbps,
         client.wants_decode_latency(),
-    )?;
+    );
 
     let resolved_mode = client.mode();
     let fps = resolved_mode.refresh_hz.max(1);
-    let codec = NdlCodec::from_wire(client.codec)
-        .with_context(|| format!("unsupported codec 0x{:02x}", client.codec))?;
+    let codec =
+        NdlCodec::from_wire(client.codec).with_context(|| format!("unsupported codec 0x{:02x}", client.codec))?;
     let app_id = std::env::var("APPID").unwrap_or_else(|_| "io.dyptan.punktfunk.webos".into());
 
     let player = match video_backend {
@@ -210,47 +211,36 @@ pub fn connect(
                 codec,
                 display_w,
                 display_h,
-                log,
             ) {
                 Ok(sf) => {
-                    writeln!(
-                        log,
+                    tracing::info!(
                         "Starfish loaded ({codec:?} {}x{}@{fps}fps, display {display_w}x{display_h})",
-                        resolved_mode.width, resolved_mode.height,
-                    )?;
+                        resolved_mode.width,
+                        resolved_mode.height,
+                    );
                     VideoPlayer::Starfish(sf)
                 }
                 Err(e) => {
-                    writeln!(log, "Starfish load failed ({e:#}) — falling back to NDL")?;
-                    let ndl = NdlVideo::load(
-                        &app_id,
-                        resolved_mode.width as i32,
-                        resolved_mode.height as i32,
-                        codec,
-                    )
-                    .context("NDL load (Starfish fallback)")?;
-                    writeln!(
-                        log,
+                    tracing::warn!("Starfish load failed ({e:#}) — falling back to NDL");
+                    let ndl = NdlVideo::load(&app_id, resolved_mode.width as i32, resolved_mode.height as i32, codec)
+                        .context("NDL load (Starfish fallback)")?;
+                    tracing::info!(
                         "NDL loaded ({codec:?} {}x{}@{fps}fps)",
-                        resolved_mode.width, resolved_mode.height,
-                    )?;
+                        resolved_mode.width,
+                        resolved_mode.height,
+                    );
                     VideoPlayer::Ndl(ndl)
                 }
             }
         }
         VideoBackend::Ndl => {
-            let ndl = NdlVideo::load(
-                &app_id,
-                resolved_mode.width as i32,
-                resolved_mode.height as i32,
-                codec,
-            )
-            .context("NDL load")?;
-            writeln!(
-                log,
+            let ndl = NdlVideo::load(&app_id, resolved_mode.width as i32, resolved_mode.height as i32, codec)
+                .context("NDL load")?;
+            tracing::info!(
                 "NDL loaded ({codec:?} {}x{}@{fps}fps)",
-                resolved_mode.width, resolved_mode.height,
-            )?;
+                resolved_mode.width,
+                resolved_mode.height,
+            );
             VideoPlayer::Ndl(ndl)
         }
     };
@@ -265,26 +255,32 @@ pub fn connect(
     let is_hdr = client.color.is_hdr();
     let initial_meta = is_hdr.then(cx_display_hdr);
     if let Err(e) = player.set_color_info(initial_meta.as_ref(), client.color) {
-        writeln!(log, "{} colour metadata failed: {e:#}", player.backend_name())?;
+        tracing::warn!("{} colour metadata failed: {e:#}", player.backend_name());
     }
-    writeln!(
-        log,
+    tracing::debug!(
         "colour metadata sent: hdr={is_hdr} transfer={} primaries={} matrix={} full_range={}",
-        client.color.transfer, client.color.primaries, client.color.matrix, client.color.full_range,
-    )?;
+        client.color.transfer,
+        client.color.primaries,
+        client.color.matrix,
+        client.color.full_range,
+    );
 
     let stop = Arc::new(AtomicBool::new(false));
     let stats = Arc::new(StreamStats::default());
     let video_client = client.clone();
     let video_stop = stop.clone();
     let video_stats = stats.clone();
-    let mut video_log = log.try_clone().context("clone log")?;
     let video_thread = std::thread::Builder::new()
         .name("punktfunk-webos-video".into())
-        .spawn(move || video_pump(video_client, player, video_stop, video_stats, is_hdr, &mut video_log))
+        .spawn(move || video_pump(video_client, player, video_stop, video_stats, is_hdr))
         .context("spawn video thread")?;
 
-    Ok(Connected { client, stop, stats, video_thread })
+    Ok(Connected {
+        client,
+        stop,
+        stats,
+        video_thread,
+    })
 }
 
 /// The no-PIN "request access" trust step: open a trust-on-first-use connection
@@ -298,13 +294,12 @@ pub fn connect(
 /// negotiated `mode`/codec are irrelevant here (immediately dropped); a small 720p H.264
 /// request keeps the host from doing needless 4K/HEVC setup for a connection we close at
 /// once. Blocks up to `timeout` (the operator-approval window).
-pub fn request_access(
-    host: &str,
-    port: u16,
-    identity: (String, String),
-    timeout: Duration,
-) -> Result<[u8; 32]> {
-    let mode = Mode { width: 1280, height: 720, refresh_hz: 60 };
+pub fn request_access(host: &str, port: u16, identity: (String, String), timeout: Duration) -> Result<[u8; 32]> {
+    let mode = Mode {
+        width: 1280,
+        height: 720,
+        refresh_hz: 60,
+    };
     let client = NativeClient::connect(
         host,
         port,
@@ -365,7 +360,7 @@ const VENDOR_DECODE_THREAD_SCAN_TIMEOUT: Duration = Duration::from_secs(5);
 /// not synchronously within the load call, so this polls `/proc/self/task` rather than
 /// scanning once, and must not block `video_pump` from starting to feed frames while it
 /// does.
-fn spawn_vendor_decode_thread_renicer(mut log: std::fs::File) {
+fn spawn_vendor_decode_thread_renicer() {
     std::thread::spawn(move || {
         let start = Instant::now();
         let mut last_found = start;
@@ -390,13 +385,12 @@ fn spawn_vendor_decode_thread_renicer(mut log: std::fs::File) {
                     last_found = Instant::now();
                     // SAFETY: plain syscall — tid and priority value only, no pointers.
                     if unsafe { libc::setpriority(libc::PRIO_PROCESS, tid as libc::id_t, -10) } != 0 {
-                        let _ = writeln!(
-                            log,
+                        tracing::warn!(
                             "setpriority(vendor thread {comm}, tid={tid}) failed: {}",
                             std::io::Error::last_os_error()
                         );
                     } else {
-                        let _ = writeln!(log, "reniced vendor decode thread {comm} (tid={tid}) to -10");
+                        tracing::debug!("reniced vendor decode thread {comm} (tid={tid}) to -10");
                     }
                 }
             }
@@ -416,25 +410,18 @@ fn video_pump(
     stop: Arc<AtomicBool>,
     stats: Arc<StreamStats>,
     is_hdr: bool,
-    log: &mut std::fs::File,
 ) {
     client.register_hot_thread();
     for tid in client.hot_thread_ids() {
         // SAFETY: plain syscall — tid and priority value only, no pointers.
         if unsafe { libc::setpriority(libc::PRIO_PROCESS, tid as libc::id_t, -10) } != 0 {
-            let _ = writeln!(
-                log,
+            tracing::debug!(
                 "setpriority(tid={tid}) failed (expected without CAP_SYS_NICE): {}",
                 std::io::Error::last_os_error()
             );
         }
     }
-    match log.try_clone() {
-        Ok(renicer_log) => spawn_vendor_decode_thread_renicer(renicer_log),
-        Err(e) => {
-            let _ = writeln!(log, "clone log for decode-thread renicer failed: {e:#}");
-        }
-    }
+    spawn_vendor_decode_thread_renicer();
 
     let wants_decode_latency = client.wants_decode_latency();
     let mut last_dropped_seen = client.frames_dropped();
@@ -455,8 +442,7 @@ fn video_pump(
                 stats.frames.store(frames_received, Ordering::Relaxed);
                 if last_heartbeat.elapsed() >= Duration::from_secs(2) {
                     last_heartbeat = Instant::now();
-                    let _ = writeln!(
-                        log,
+                    tracing::debug!(
                         "video: {frames_received} frames, holding={holding}, dropped={}",
                         client.frames_dropped()
                     );
@@ -472,33 +458,28 @@ fn video_pump(
                     holding = true;
                     stats.holding.store(true, Ordering::Relaxed);
                     hold_started = Some(Instant::now());
-                    let _ = writeln!(
-                        log,
+                    tracing::warn!(
                         "loss (gap={gap} dropped={dropped}, frame {}) — freezing",
                         frame.frame_index
                     );
                     let _ = player.flush();
                 }
-                if holding
-                    && last_keyframe_request
-                        .is_none_or(|t| t.elapsed() >= KEYFRAME_REQUEST_MIN_INTERVAL)
-                {
+                if holding && last_keyframe_request.is_none_or(|t| t.elapsed() >= KEYFRAME_REQUEST_MIN_INTERVAL) {
                     if let Err(e) = client.request_keyframe() {
-                        let _ = writeln!(log, "request_keyframe: {e:#}");
+                        tracing::warn!("request_keyframe: {e:#}");
                     }
                     last_keyframe_request = Some(Instant::now());
                 }
 
-                let is_reanchor = frame.flags & u32::from(FLAG_SOF) != 0
-                    || frame.flags & USER_FLAG_RECOVERY_ANCHOR != 0;
+                let is_reanchor =
+                    frame.flags & u32::from(FLAG_SOF) != 0 || frame.flags & USER_FLAG_RECOVERY_ANCHOR != 0;
                 let gave_up = hold_started.is_some_and(|t| t.elapsed() >= HOLD_GIVE_UP);
                 if holding && !is_reanchor && !gave_up {
                     // Still frozen — drop this concealed frame, but fall through to the
                     // HDR poll below instead of `continue`ing past it.
                 } else {
                     if holding {
-                        let _ = writeln!(
-                            log,
+                        tracing::info!(
                             "resuming after {:.0}ms (frame {}, flags=0x{:x}, reanchor={is_reanchor}, gave_up={gave_up})",
                             hold_started.map_or(0.0, |t| t.elapsed().as_secs_f32() * 1000.0),
                             frame.frame_index,
@@ -511,13 +492,13 @@ fn video_pump(
 
                     let pts_ns = frame.pts_ns;
                     let (play_result, feed_elapsed) = player.play(&frame.data, pts_ns);
-                    stats
-                        .feed_us
-                        .store(u32::try_from(feed_elapsed.as_micros()).unwrap_or(u32::MAX), Ordering::Relaxed);
+                    stats.feed_us.store(
+                        u32::try_from(feed_elapsed.as_micros()).unwrap_or(u32::MAX),
+                        Ordering::Relaxed,
+                    );
 
                     if feed_elapsed >= FEED_BACKPRESSURE_WARN {
-                        let _ = writeln!(
-                            log,
+                        tracing::warn!(
                             "{} slow: {:.1}ms (frame {}, pts {:.2}ms)",
                             player.backend_name(),
                             feed_elapsed.as_secs_f32() * 1000.0,
@@ -526,21 +507,16 @@ fn video_pump(
                         );
                     }
                     if wants_decode_latency && play_result.is_ok() {
-                        client.report_decode_us(
-                            u32::try_from(feed_elapsed.as_micros()).unwrap_or(u32::MAX),
-                        );
+                        client.report_decode_us(u32::try_from(feed_elapsed.as_micros()).unwrap_or(u32::MAX));
                     }
                     if let Err(e) = play_result {
-                        let _ = writeln!(
-                            log,
+                        tracing::warn!(
                             "{} error (frame {}, pts {:.2}ms): {e:#}",
                             player.backend_name(),
                             frame.frame_index,
                             pts_ns as f64 / 1_000_000.0,
                         );
-                        if last_keyframe_request
-                            .is_none_or(|t| t.elapsed() >= KEYFRAME_REQUEST_MIN_INTERVAL)
-                        {
+                        if last_keyframe_request.is_none_or(|t| t.elapsed() >= KEYFRAME_REQUEST_MIN_INTERVAL) {
                             let _ = client.request_keyframe();
                             let _ = player.flush();
                             last_keyframe_request = Some(Instant::now());
@@ -553,11 +529,11 @@ fn video_pump(
             Err(punktfunk_core::PunktfunkError::NoFrame) => {
                 if last_heartbeat.elapsed() >= Duration::from_secs(2) {
                     last_heartbeat = Instant::now();
-                    let _ = writeln!(log, "video: {frames_received} frames (idle)");
+                    tracing::debug!("video: {frames_received} frames (idle)");
                 }
             }
             Err(e) => {
-                let _ = writeln!(log, "video pump: {e:#}");
+                tracing::error!("video pump: {e:#}");
                 break;
             }
         }
@@ -565,7 +541,7 @@ fn video_pump(
         if is_hdr {
             if let Ok(meta) = client.next_hdr_meta(Duration::ZERO) {
                 if let Err(e) = player.set_color_info(Some(&meta), client.color) {
-                    let _ = writeln!(log, "{} set_color_info: {e:#}", player.backend_name());
+                    tracing::warn!("{} set_color_info: {e:#}", player.backend_name());
                 }
             }
         }
@@ -574,30 +550,25 @@ fn video_pump(
 
 /// Drains and plays all pending audio packets (non-blocking). Call once per main-loop
 /// tick; runs on the main thread because `sdl2::audio::AudioQueue` is `!Send`.
-pub fn pump_audio_once(
-    client: &NativeClient,
-    audio: &mut crate::audio::AudioPlayer,
-    log: &mut std::fs::File,
-) {
+pub fn pump_audio_once(client: &NativeClient, audio: &mut crate::audio::AudioPlayer) {
     // Logged roughly once/sec (200 packets @ 5ms/frame).
     static PACKET_COUNT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
     while let Ok(packet) = client.next_audio(Duration::ZERO) {
         match audio.play(&packet.data) {
             Ok((peak, resnapped)) => {
                 if resnapped {
-                    let _ = writeln!(
-                        log,
+                    tracing::debug!(
                         "audio resnapped (queue was >{}ms behind)",
                         crate::audio::MAX_QUEUED_LAG_MS
                     );
                 }
                 let n = PACKET_COUNT.fetch_add(1, Ordering::Relaxed);
                 if n % 200 == 0 {
-                    let _ = writeln!(log, "audio peak: {peak:.4}");
+                    tracing::debug!("audio peak: {peak:.4}");
                 }
             }
             Err(e) => {
-                let _ = writeln!(log, "audio error (seq {}): {e:#}", packet.seq);
+                tracing::warn!("audio error (seq {}): {e:#}", packet.seq);
             }
         }
     }

--- a/src/starfish.rs
+++ b/src/starfish.rs
@@ -41,25 +41,15 @@ struct SdlRect {
 #[link(name = "SDL2")]
 extern "C" {
     fn SDL_webOSCreateExportedWindow(hint: c_int) -> *const c_char;
-    fn SDL_webOSSetExportedWindow(
-        window_id: *const c_char,
-        src: *const SdlRect,
-        dst: *const SdlRect,
-    ) -> c_int;
+    fn SDL_webOSSetExportedWindow(window_id: *const c_char, src: *const SdlRect, dst: *const SdlRect) -> c_int;
     fn SDL_webOSDestroyExportedWindow(window_id: *const c_char);
 }
 
 // StarfishMediaAPIs_C function types — mirrored from StarfishMediaAPIs_C.h, resolved via dlsym.
 
 type FnCreate = unsafe extern "C" fn(*const c_char) -> *mut c_void;
-type FnLoad = unsafe extern "C" fn(
-    *mut c_void,
-    *const c_char,
-    Option<LoadCb>,
-    *mut c_void,
-) -> bool;
-type FnFeed =
-    unsafe extern "C" fn(*mut c_void, *const c_char, *mut c_char, usize) -> bool;
+type FnLoad = unsafe extern "C" fn(*mut c_void, *const c_char, Option<LoadCb>, *mut c_void) -> bool;
+type FnFeed = unsafe extern "C" fn(*mut c_void, *const c_char, *mut c_char, usize) -> bool;
 type FnPlay = unsafe extern "C" fn(*mut c_void) -> bool;
 type FnPushEos = unsafe extern "C" fn(*mut c_void) -> bool;
 type FnUnload = unsafe extern "C" fn(*mut c_void) -> bool;
@@ -94,12 +84,7 @@ struct StarfishFns {
 
 impl StarfishFns {
     fn load_library() -> Result<Self> {
-        let lib = unsafe {
-            libc::dlopen(
-                c"libplayerAPIs_C.so".as_ptr(),
-                libc::RTLD_LAZY | libc::RTLD_GLOBAL,
-            )
-        };
+        let lib = unsafe { libc::dlopen(c"libplayerAPIs_C.so".as_ptr(), libc::RTLD_LAZY | libc::RTLD_GLOBAL) };
         if lib.is_null() {
             bail!("dlopen(libplayerAPIs_C.so) failed — Starfish/SMP not available");
         }
@@ -108,10 +93,7 @@ impl StarfishFns {
             ($sym:literal, $ty:ty) => {
                 match unsafe { sym::<$ty>(lib, concat!($sym, "\0").as_bytes()) } {
                     Some(f) => f,
-                    None => bail!(concat!(
-                        "StarfishMediaAPIs_C.so missing symbol: ",
-                        $sym
-                    )),
+                    None => bail!(concat!("StarfishMediaAPIs_C.so missing symbol: ", $sym)),
                 }
             };
         }
@@ -146,12 +128,7 @@ unsafe impl Sync for LoadState {}
 
 /// `StarfishMediaAPIs_load` callback. On LOADCOMPLETED, calls `play` (required by
 /// the SMP API) and signals the spin-wait in [`StarfishVideo::load`].
-unsafe extern "C" fn on_load_event(
-    event_type: c_int,
-    _num_value: i64,
-    _str_value: *const c_char,
-    data: *mut c_void,
-) {
+unsafe extern "C" fn on_load_event(event_type: c_int, _num_value: i64, _str_value: *const c_char, data: *mut c_void) {
     if data.is_null() {
         return;
     }
@@ -190,10 +167,7 @@ impl StarfishVideo {
         codec: NdlCodec,
         display_w: i32,
         display_h: i32,
-        log: &mut std::fs::File,
     ) -> Result<Self> {
-        use std::io::Write as _;
-
         let fns = StarfishFns::load_library()?;
 
         let api = unsafe { (fns.create)(std::ptr::null()) };
@@ -210,9 +184,7 @@ impl StarfishVideo {
         }
 
         let window_id_cstr = unsafe { CStr::from_ptr(raw_window_id) }.to_owned();
-        let window_id_str = unsafe { CStr::from_ptr(raw_window_id) }
-            .to_str()
-            .unwrap_or("");
+        let window_id_str = unsafe { CStr::from_ptr(raw_window_id) }.to_str().unwrap_or("");
 
         let codec_str = match codec {
             NdlCodec::H264 => "H264",
@@ -268,11 +240,7 @@ impl StarfishVideo {
         })
         .to_string();
 
-        writeln!(
-            log,
-            "Starfish load payload: {}",
-            &payload[..payload.len().min(512)]
-        )?;
+        tracing::debug!("Starfish load payload: {}", &payload[..payload.len().min(512)]);
 
         let payload_cstr = CString::new(payload)?;
 
@@ -285,8 +253,7 @@ impl StarfishVideo {
 
         // SAFETY: `payload_cstr` and `state_ptr` outlive this call; `state_ptr`
         // remains valid for the session (owned by `load_state` in `Self`).
-        let load_ok =
-            unsafe { (fns.load)(api, payload_cstr.as_ptr(), Some(on_load_event), state_ptr) };
+        let load_ok = unsafe { (fns.load)(api, payload_cstr.as_ptr(), Some(on_load_event), state_ptr) };
         if !load_ok {
             unsafe {
                 (fns.destroy)(api);
@@ -311,8 +278,18 @@ impl StarfishVideo {
         // Bind source (stream rect) and destination (full display) punch-through area
         // only after load completes — matches ss4s's `StarfishResourcePostLoad` timing,
         // rather than binding it before the pipeline exists.
-        let src = SdlRect { x: 0, y: 0, w: width, h: height };
-        let dst = SdlRect { x: 0, y: 0, w: display_w, h: display_h };
+        let src = SdlRect {
+            x: 0,
+            y: 0,
+            w: width,
+            h: height,
+        };
+        let dst = SdlRect {
+            x: 0,
+            y: 0,
+            w: display_w,
+            h: display_h,
+        };
         unsafe { SDL_webOSSetExportedWindow(raw_window_id, &src, &dst) };
 
         Ok(Self {
@@ -344,10 +321,7 @@ impl StarfishVideo {
             )
         };
 
-        let result_str = std::str::from_utf8(&result)
-            .unwrap_or("")
-            .trim_end_matches('\0')
-            .trim();
+        let result_str = std::str::from_utf8(&result).unwrap_or("").trim_end_matches('\0').trim();
         // Feed's result is JSON, e.g. `{"returnValue":"Ok"}` — not a bare string.
         let return_value = serde_json::from_str::<serde_json::Value>(result_str)
             .ok()

--- a/src/store.rs
+++ b/src/store.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-fn app_dir() -> PathBuf {
+pub(crate) fn app_dir() -> PathBuf {
     std::env::var("HOME").map_or_else(|_| PathBuf::from("/tmp"), PathBuf::from)
 }
 
@@ -245,9 +245,10 @@ impl SettingsWriter {
 }
 
 /// Test/dev override: a config file dropped alongside sideloading skips straight to
-/// a connect target — see `punktfunk-webos-client` memory notes for why this exists
-/// (no documented way to pass CLI args through a normal SAM launch). Still supported
-/// for quick bring-up testing; the UI flow below is the normal path.
+/// a connect target — predates the finding (see `docs/NOTES.md`) that SAM launch
+/// `params` reach a native app as `argv[1]` JSON on initial launch, which
+/// `logger.rs` uses instead for telemetry. Still supported for quick bring-up
+/// testing; the UI flow below is the normal path.
 pub fn dev_override_connect() -> Option<(String, u16)> {
     let path = Path::new(&app_dir()).join("connect.conf");
     let content = std::fs::read_to_string(path).ok()?;

--- a/src/wol.rs
+++ b/src/wol.rs
@@ -5,7 +5,6 @@
 //! A sleeping host has no ARP entry, so the broadcast the core builds (each NIC's
 //! subnet-directed broadcast, plus the limited broadcast) is what actually reaches it;
 //! `last_ip`, when known, is additionally unicast.
-use std::io::Write as _;
 use std::net::Ipv4Addr;
 
 /// Sends a magic packet to every parseable MAC in `macs`. Returns whether at least one
@@ -24,8 +23,8 @@ pub fn wake(macs: &[String], last_ip: Option<Ipv4Addr>) -> bool {
 /// action and its periodic resend while a wake is in flight, so neither has to spell out
 /// the log message itself. `name` is just for a readable log line (the host's display
 /// name), not part of the wake mechanics.
-pub fn wake_and_log(macs: &[String], last_ip: Option<Ipv4Addr>, name: &str, log: &mut std::fs::File) -> bool {
+pub fn wake_and_log(macs: &[String], last_ip: Option<Ipv4Addr>, name: &str) -> bool {
     let ok = wake(macs, last_ip);
-    let _ = writeln!(log, "wake-on-lan: sent to {name} ({} mac(s)), ok={ok}", macs.len());
+    tracing::info!("wake-on-lan: sent to {name} ({} mac(s)), ok={ok}", macs.len());
     ok
 }

--- a/taskfiles/toolchain.yml
+++ b/taskfiles/toolchain.yml
@@ -141,7 +141,8 @@ tasks:
       vars: [TARGET_TASK]
     cmds:
       - >-
-        docker run --rm --platform linux/arm64 -e DEBIAN_FRONTEND=noninteractive {{.DOCKER_MOUNTS}} {{.RUST_IMAGE}}
+        docker run --rm --platform linux/arm64 -e DEBIAN_FRONTEND=noninteractive
+        {{.DOCKER_MOUNTS}} {{.RUST_IMAGE}}
         sh -c '
           apt-get update -qq &&
           apt-get install -y -qq --no-install-recommends apt-utils cmake curl ca-certificates git pkg-config build-essential xz-utils > /dev/null &&


### PR DESCRIPTION
## Summary
- Replaces the ad-hoc `writeln!(log, ...)`/`&mut std::fs::File` threading (~40 call sites across `main.rs`, `app.rs`, `session.rs`, `discovery.rs`, `wol.rs`, `starfish.rs`) with plain `tracing::{debug,info,warn,error}!` macros — no handle to pass around, one subscriber installed once in `main.rs::run`.
- New `src/logger.rs` picks the `tracing` sink: a versioned on-device file (`punktfunk-webos-<version>.log`, info-and-above, unchanged default behavior) or a TCP stream to a dev machine, via `tracing-appender`'s `non_blocking()` writer — so a slow disk or an undrained dev-machine listener never blocks a caller, in particular the reniced video-pump thread.
- The telemetry destination is read from `argv[1]` at **runtime**, not baked in at compile time: SAM's `applicationManager/launch` `params` are delivered to a native app as JSON-encoded `argv[1]` on initial launch (confirmed against the webOS OSE native-app docs — an assumption in this repo that no CLI args/env vars reach a native app turned out to be only half-true). An unreachable/misconfigured address falls back to the file sink rather than failing the app.
- `task deploy` gains `TELEMETRY=<host:port>` (explicit) or `TELEMETRY=auto` (this machine's own LAN IP, random port, printed once the listener is up) — opt-in only; omitting it keeps the exact previous behavior (on-device file, info-and-above). The task now listens locally *before* the `luna-send launch` call, then streams lines until Ctrl-C instead of returning. `deploy:log` is removed (superseded).
- `TELEMETRY_LEVEL` (debug/info/warn/error, default debug) sets the minimum level sent to a TCP sink.

## Test plan
- [x] `task check` (dockerized cross-compile) — clean, no new warnings
- [x] `task lint` — no new clippy findings (2 pre-existing, unrelated `items_after_statements` failures in `ui.rs`/`main.rs` confirmed present on `main` before this branch, via `git stash` + re-run)
- [x] `cargo fmt`
- [x] Dry-ran the `deploy` task's shell logic standalone for all TELEMETRY input cases (unset, `auto`, explicit `host:port`) — resolves and escapes the `luna-send` JSON correctly
- [x] Code-reviewed (not test-covered, per request) that telemetry-enabled connects never fall through to `open_file`, and that the no-telemetry path always resolves to `Level::INFO`
- [ ] Not yet verified on real hardware (`task deploy TELEMETRY=auto`) — recommend a live smoke test before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)