### PR TITLE
Faster cover-art loading, reveal-all grid spinner, center-cropped art

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,14 @@ jobs:
         with:
           targets: armv7-unknown-linux-gnueabi
 
+      - name: Cache clippy target
+        uses: actions/cache@v5
+        with:
+          path: target-clippy
+          key: armv7-unknown-linux-gnueabi-clippy-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            armv7-unknown-linux-gnueabi-clippy-
+
       - name: Cache cargo registry/git/target
         uses: Swatinem/rust-cache@v2
         with:
@@ -41,12 +49,10 @@ jobs:
         with:
           version: 3
 
-      # Runs BEFORE the build: the crate carries a curated `[lints.clippy]` set
-      # (see Cargo.toml) that nothing enforced until now — which is exactly how an
-      # `items_after_statements` violation reached main unnoticed. Cheap here, since
-      # the build step below reuses the same cached target dir.
       - name: Lint
         run: task native:lint
+        env:
+          CARGO_TARGET_DIR: target-clippy
 
       - name: Build and package
         run: task native:package

--- a/src/app/home.rs
+++ b/src/app/home.rs
@@ -127,6 +127,8 @@ impl App {
                     self.screen = Screen::Settings;
                     self.dropdown = None;
                     self.settings_focused = 0;
+                    self.settings_scroll = 0;
+                    self.settings_scroll_shown_at = None;
                 }
                 HomeFocus::SidebarMenu(i) => self.open_host_menu(i),
                 HomeFocus::Grid(i) => self.confirm_grid_card(i),
@@ -199,7 +201,15 @@ impl App {
         match entry {
             HostEntry::Known(h) if h.fingerprint.is_some() => {
                 let (host, port, mgmt_port) = (h.host, h.port, h.mgmt_port);
-                self.select_host(host, port, mgmt_port);
+                // Re-confirming the already-active host must not refetch — `select_host`
+                // unconditionally clears art/games and re-hits the library API, blinking
+                // every card back to a placeholder for nothing. Just jump focus into the
+                // grid instead. Assumes `mgmt_port`/cert can't change without `(host, port)`.
+                if self.selected_host.as_ref() == Some(&(host.clone(), port)) {
+                    self.home_focus = HomeFocus::Grid(0);
+                } else {
+                    self.select_host(host, port, mgmt_port);
+                }
             }
             _ => self.open_pairing(idx),
         }
@@ -279,7 +289,13 @@ impl App {
                     .and_then(|h| h.fingerprint);
                 // Covers are requested per card as the grid window reaches them (see
                 // `App::prepare_tiles`), not fetched for the whole library up front.
-                self.art_loader = Some(crate::art::ArtLoader::spawn(host, mgmt_port, identity, fingerprint));
+                self.art_loader = Some(crate::art::ArtLoader::spawn(
+                    host,
+                    port,
+                    mgmt_port,
+                    identity,
+                    fingerprint,
+                ));
                 self.games = games;
                 self.home_status = None;
             }
@@ -404,6 +420,7 @@ impl App {
             return;
         };
         let (host, port) = (h.host.clone(), h.port);
+        crate::art::clear_host_cache(&host, port);
         self.known_hosts.retain(|k| !(k.host == host && k.port == port));
         let _ = store::save_known_hosts(&self.known_hosts);
         self.entries = self.known_hosts.iter().cloned().map(HostEntry::Known).collect();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -83,13 +83,31 @@ const CARD_KEEP_ROWS: i32 = 5;
 /// on a TV with under 2 GB usable. Spreading the work keeps every frame bounded; cards
 /// outside the window are simply not drawn (`Compositor::execute` skips a tile with no
 /// texture), so they appear as they are built rather than blocking the UI.
-const CARD_BUILD_BUDGET: usize = 3;
+///
+/// Only bounds the visible+prefetch window (a few dozen tiles), not the whole library, so
+/// it can be much higher than the original whole-library concern without reintroducing
+/// the freeze. Raised from 3, which took 7-10 frames to fill a 20-30 card window.
+const CARD_BUILD_BUDGET: usize = 10;
+
+/// How long the loading spinner waits for the whole window to become art-ready before
+/// revealing anyway — a fetch that fails (rather than being merely slow) never becomes
+/// ready, so this is what stops `grid_reveal_ready` from blocking forever.
+const SPINNER_MAX_WAIT: Duration = Duration::from_millis(900);
 
 /// How much the grid's focused card (and its ring) grows during
 /// `ui::FOCUS_POP` — see `ui::zoom_rect`.
 pub(crate) const CARD_GROWTH: f32 = 0.028;
 /// How long a modal's fade/slide-in runs.
 pub(crate) const MODAL_FADE: Duration = Duration::from_millis(170);
+/// How long the Settings scrollbar stays at full opacity after a scroll before fading out.
+pub(crate) const SETTINGS_SCROLLBAR_HOLD: Duration = Duration::from_millis(700);
+/// How long the scrollbar's fade-out takes once `SETTINGS_SCROLLBAR_HOLD` elapses.
+pub(crate) const SETTINGS_SCROLLBAR_FADE: Duration = Duration::from_millis(350);
+/// Total lifetime of one scrollbar appearance — hold, then fade to gone.
+pub(crate) const SETTINGS_SCROLL_INDICATOR: Duration =
+    Duration::from_millis(SETTINGS_SCROLLBAR_HOLD.as_millis() as u64 + SETTINGS_SCROLLBAR_FADE.as_millis() as u64);
+/// A few px wider than the scrollbar track so its rounded caps aren't clipped.
+const SETTINGS_SCROLLBAR_TILE_W: u32 = 10;
 
 /// The pairing modal's subtitle — pulled out to a constant since both
 /// `render_pairing` (drawing it) and `Self::pairing_pin_row_y` (measuring its
@@ -213,7 +231,11 @@ pub struct DropdownState {
 /// focus there is `modal_focus_tile`'s job, not this one's.
 #[derive(PartialEq)]
 pub(crate) enum ModalShellKey {
-    Settings(Settings, Option<usize>, bool),
+    Settings {
+        settings: Settings,
+        open_dropdown_row: Option<usize>,
+        hover_close: bool,
+    },
     Wake {
         name: String,
         mac_empty: bool,
@@ -315,6 +337,10 @@ pub struct App {
     /// `store::save_settings` on every adjustment read as input lag.
     pub(crate) settings_writer: store::SettingsWriter,
     pub settings_focused: usize,
+    /// Index of the topmost visible row in the Settings list (see `settings_visible_rows`).
+    pub(crate) settings_scroll: usize,
+    /// When `settings_scroll` last changed — the scrollbar shows briefly after this.
+    pub(crate) settings_scroll_shown_at: Option<Instant>,
     pub dropdown: Option<DropdownState>,
     /// The sidebar row `Screen::ForgetHost` is confirming forgetting — set
     /// alongside `screen = Screen::ForgetHost` (see `App::open_forget_host`),
@@ -419,10 +445,26 @@ pub struct App {
     /// shell (which draws the overlay's option list unfocused); moving the
     /// dropdown's own focus rebuilds only this.
     pub(crate) dropdown_focus_tile: Option<((usize, usize), Painter)>,
+    /// The Settings scrollbar, keyed by `(total rows, visible rows, scroll)` — rebuilt
+    /// only when those change; the fade is a per-frame alpha, not baked into the tile.
+    pub(crate) settings_scrollbar_tile: Option<((usize, usize, usize), Painter)>,
+    /// Every Settings row, unfocused, at full (unscrolled) height — keyed by
+    /// `(settings, open dropdown row)`. Scrolling never invalidates this; see
+    /// `Tile::SettingsRows`'s docs.
+    pub(crate) settings_rows_tile: Option<((Settings, Option<usize>), Painter)>,
     /// Home's status line block, keyed by its text.
     pub(crate) status_tile: Option<(String, Painter)>,
     /// The static "No host selected" hint line.
     pub(crate) nohost_tile: Option<Painter>,
+    /// Whether the grid's initial build for the current library has finished — while
+    /// `false`, the grid shows [`Tile::Spinner`] instead of popping cards in one by one.
+    /// One-shot per library: only `prepare_tiles`'s full-reset branch sets it `false`
+    /// again; later scrolling into a fresh row does not.
+    pub(crate) grid_reveal_ready: bool,
+    /// The rasterized spinner tile, rebuilt every tick it's shown.
+    pub(crate) spinner_tile: Option<Painter>,
+    /// When the grid last became not-ready — feeds the spinner's rotation phase.
+    pub(crate) spinner_since: Option<Instant>,
     // ------------------------------------------------------------ animations --
     /// Grid scroll offset actually rendered this frame (px; 0 = row 0 at
     /// `GRID_TOP_Y`) — eases toward `grid_scroll_target` each tick.
@@ -504,6 +546,8 @@ impl App {
             settings: store::load_settings(),
             settings_writer: store::SettingsWriter::spawn(),
             settings_focused: 0,
+            settings_scroll: 0,
+            settings_scroll_shown_at: None,
             dropdown: None,
             host_menu_index: None,
             host_menu_focused: 1,
@@ -542,8 +586,13 @@ impl App {
             modal_shell_key: None,
             modal_focus_tile: None,
             dropdown_focus_tile: None,
+            settings_scrollbar_tile: None,
+            settings_rows_tile: None,
             status_tile: None,
             nohost_tile: None,
+            grid_reveal_ready: true,
+            spinner_tile: None,
+            spinner_since: None,
             grid_scroll: 0,
             grid_scroll_target: 0,
             focus_anim: None,
@@ -675,7 +724,8 @@ impl App {
                 None
             }
             Screen::Settings => {
-                self.handle_settings_event(MenuEvent::Back);
+                // `Back` never consults `screen_h` (only `Up`/`Down` scroll) — 0 is fine.
+                self.handle_settings_event(MenuEvent::Back, 0);
                 None
             }
             Screen::AddHost => {
@@ -754,6 +804,12 @@ impl App {
         if let Some((t, _)) = self.switch_anim {
             if t.elapsed() >= ui::FOCUS_POP {
                 self.switch_anim = None;
+            }
+            animating = true;
+        }
+        if let Some(t) = self.settings_scroll_shown_at {
+            if t.elapsed() >= SETTINGS_SCROLL_INDICATOR {
+                self.settings_scroll_shown_at = None;
             }
             animating = true;
         }
@@ -932,15 +988,16 @@ impl App {
                 // as everywhere else) already points at; unaffected by this change.
                 if self.dropdown.is_none() {
                     let (_, content) = Self::settings_layout(screen_w, screen_h);
-                    // Clicked empty space within the card (`?`'s early `None`) — nothing to
-                    // focus or confirm.
-                    let i = (0..ui::SETTINGS_ROW_COUNT).find(|&i| {
+                    let visible = Self::settings_visible_rows(screen_h);
+                    // `local` is relative to the visible window; `?` bails if the click
+                    // hit empty space within the card — nothing to focus or confirm.
+                    let local = (0..visible).find(|&i| {
                         let row_y = content.y() + i as i32 * (ui::SETTINGS_ROW_H as i32 + ui::SETTINGS_ROW_GAP);
                         Rect::new(content.x(), row_y, content.width(), ui::SETTINGS_ROW_H).contains_point((x, y))
                     })?;
-                    self.settings_focused = i;
+                    self.settings_focused = self.settings_scroll + local;
                 }
-                self.handle_settings_event(MenuEvent::Confirm);
+                self.handle_settings_event(MenuEvent::Confirm, screen_h);
                 None
             }
             Screen::Pairing => {
@@ -1093,6 +1150,10 @@ impl App {
                 self.card_tiles = std::iter::repeat_with(|| None).take(count).collect();
                 self.grid_dirty = false;
                 self.grid_cards_dirty.clear();
+                // Only a full reset re-arms the spinner — ordinary scrolling into the
+                // prefetch window must not hide the grid again.
+                self.grid_reveal_ready = false;
+                self.spinner_since = None;
             } else {
                 for idx in std::mem::take(&mut self.grid_cards_dirty) {
                     if idx < count {
@@ -1129,8 +1190,18 @@ impl App {
                 }
             }
 
-            let mut built = 0usize;
-            let mut pending = false;
+            // Ready once nothing more can arrive: cover already in `self.art`, or the game
+            // never had one to fetch (no `self.art` entry either way). `idx == 0` (Desktop)
+            // has no `games` entry and is always ready.
+            let art_ready = |idx: usize| {
+                self.games.get(idx.wrapping_sub(1)).is_none_or(|game| {
+                    self.art.contains_key(&game.id) || (game.art.portrait.is_none() && game.art.header.is_none())
+                })
+            };
+
+            // Art-ready cards build first — building one before its cover arrives just
+            // burns a second budget slot re-dirtying it once the cover shows up.
+            let mut to_build = Vec::new();
             for idx in 0..count {
                 let row = row_of(idx);
                 if row < build_lo || row > build_hi {
@@ -1144,6 +1215,12 @@ impl App {
                 if self.card_tiles[idx].is_some() {
                     continue;
                 }
+                to_build.push((idx, art_ready(idx)));
+            }
+            to_build.sort_by_key(|(_, ready)| !ready);
+
+            let mut pending = false;
+            for (built, (idx, _)) in to_build.into_iter().enumerate() {
                 if built >= CARD_BUILD_BUDGET {
                     pending = true;
                     break;
@@ -1154,9 +1231,29 @@ impl App {
                 };
                 self.card_tiles[idx] = Some(tile);
                 updated.push(Tile::Card(idx));
-                built += 1;
             }
             self.tiles_pending = pending;
+
+            // Rechecks the whole window rather than trusting `!pending`, since a card
+            // built earlier can still be waiting behind a re-dirtied sibling; requires
+            // `art_ready` too so a placeholder built this tick can't count as revealed.
+            if !self.grid_reveal_ready {
+                let window_ready = (0..count)
+                    .filter(|&idx| {
+                        let row = row_of(idx);
+                        row >= build_lo && row <= build_hi
+                    })
+                    .all(|idx| self.card_tiles[idx].is_some() && art_ready(idx));
+                let since = *self.spinner_since.get_or_insert_with(Instant::now);
+                self.grid_reveal_ready = window_ready || since.elapsed() >= SPINNER_MAX_WAIT;
+                if self.grid_reveal_ready {
+                    self.spinner_since = None;
+                } else {
+                    self.spinner_tile = Some(ui::render_spinner_tile(since.elapsed().as_secs_f32()));
+                    updated.push(Tile::Spinner);
+                }
+            }
+
             let ring_w = card_w + 2 * ui::FOCUS_RING_PAD as u32;
             if !matches!(&self.ring_tile, Some(p) if p.width() == ring_w) {
                 self.ring_tile = Some(ui::render_focus_ring_tile(card_w, card_h));
@@ -1174,14 +1271,18 @@ impl App {
                 }
                 None => self.status_tile = None,
             }
-        } else if self.nohost_tile.is_none() {
-            self.nohost_tile = Some(ui::render_text_tile(
-                text_cache,
-                fonts.label,
-                "No host selected — pick one from the list, or add one.",
-                ui::MUTED,
-            )?);
-            updated.push(Tile::NoHost);
+        } else {
+            self.grid_reveal_ready = true;
+            self.spinner_since = None;
+            if self.nohost_tile.is_none() {
+                self.nohost_tile = Some(ui::render_text_tile(
+                    text_cache,
+                    fonts.label,
+                    "No host selected — pick one from the list, or add one.",
+                    ui::MUTED,
+                )?);
+                updated.push(Tile::NoHost);
+            }
         }
 
         let modal_open = !matches!(self.screen, Screen::Home);
@@ -1191,11 +1292,11 @@ impl App {
         // (no split focus tile to protect) and just redraws on any
         // `content_dirty` tick, same as every modal did before this split.
         let modal_shell_key = match self.screen {
-            Screen::Settings => Some(ModalShellKey::Settings(
-                self.settings,
-                self.dropdown.as_ref().map(|dd| dd.row),
-                self.hover_close,
-            )),
+            Screen::Settings => Some(ModalShellKey::Settings {
+                settings: self.settings,
+                open_dropdown_row: self.dropdown.as_ref().map(|dd| dd.row),
+                hover_close: self.hover_close,
+            }),
             Screen::Wake => self.wake.as_ref().map(|w| ModalShellKey::Wake {
                 name: w.name.clone(),
                 mac_empty: w.mac.is_empty(),
@@ -1456,6 +1557,35 @@ impl App {
         } else {
             self.dropdown_focus_tile = None;
         }
+
+        if matches!(self.screen, Screen::Settings) {
+            let (_, content) = Self::settings_layout(screen_w, screen_h);
+            let visible = Self::settings_visible_rows(screen_h);
+            let scroll = self.clamped_settings_scroll(screen_h);
+            let key = (ui::SETTINGS_ROW_COUNT, visible, scroll);
+            let stale = !matches!(&self.settings_scrollbar_tile, Some((k, _)) if *k == key);
+            if stale {
+                let tile = ui::render_list_scrollbar_tile(
+                    SETTINGS_SCROLLBAR_TILE_W,
+                    content.height(),
+                    ui::SETTINGS_ROW_COUNT,
+                    visible,
+                    scroll,
+                );
+                self.settings_scrollbar_tile = Some((key, tile));
+                updated.push(Tile::SettingsScrollbar);
+            }
+
+            let dropdown_row = self.dropdown.as_ref().map(|dd| dd.row);
+            let rows_key = (self.settings, dropdown_row);
+            let rows_stale = !matches!(&self.settings_rows_tile, Some((k, _)) if *k == rows_key);
+            if rows_stale {
+                let rows = ui::settings_rows(&self.settings);
+                let tile = ui::render_focus_rows_tile(text_cache, fonts, &rows, content.width(), dropdown_row)?;
+                self.settings_rows_tile = Some((rows_key, tile));
+                updated.push(Tile::SettingsRows);
+            }
+        }
         Ok(updated)
     }
 
@@ -1469,8 +1599,11 @@ impl App {
             Tile::Modal => self.modal_tile.as_ref(),
             Tile::ModalFocusElement => self.modal_focus_tile.as_ref().map(|(_, p)| p),
             Tile::DropdownFocusOption => self.dropdown_focus_tile.as_ref().map(|(_, p)| p),
+            Tile::SettingsScrollbar => self.settings_scrollbar_tile.as_ref().map(|(_, p)| p),
+            Tile::SettingsRows => self.settings_rows_tile.as_ref().map(|(_, p)| p),
             Tile::Status => self.status_tile.as_ref().map(|(_, p)| p),
             Tile::NoHost => self.nohost_tile.as_ref(),
+            Tile::Spinner => self.spinner_tile.as_ref(),
             // Stream-side only (uploaded directly by `run_inner`'s overlay
             // refresh) — never one of App's menu tiles.
             Tile::StatsOverlay | Tile::DisconnectDialog | Tile::DisconnectFocusButton => None,
@@ -1499,6 +1632,18 @@ impl App {
                 cmds.push(DrawCmd::Tex {
                     tile: Tile::NoHost,
                     dst: Rect::new(grid_x + ui::GRID_PAD, ui::GRID_TOP_Y, p.width(), p.height()),
+                    alpha: 0xff,
+                });
+            }
+        } else if !self.grid_reveal_ready {
+            if let Some(p) = &self.spinner_tile {
+                let x = grid_x + (available_w as i32 - p.width() as i32) / 2;
+                // 40% down rather than dead-center, which reads as slightly low on a TV.
+                let area_h = screen_h as i32 - ui::GRID_TOP_Y;
+                let y = ui::GRID_TOP_Y + (area_h - p.height() as i32) * 2 / 5;
+                cmds.push(DrawCmd::Tex {
+                    tile: Tile::Spinner,
+                    dst: Rect::new(x, y, p.width(), p.height()),
                     alpha: 0xff,
                 });
             }
@@ -1560,15 +1705,15 @@ impl App {
                     alpha: (255.0 * f) as u8,
                 });
             }
-            if self.home_status.is_some() {
-                if let Some((_, p)) = &self.status_tile {
-                    let y = screen_h as i32 - ui::GRID_PAD - p.height() as i32;
-                    cmds.push(DrawCmd::Tex {
-                        tile: Tile::Status,
-                        dst: Rect::new(grid_x + ui::GRID_PAD, y, p.width(), p.height()),
-                        alpha: 0xff,
-                    });
-                }
+        }
+        if self.selected_host.is_some() && self.home_status.is_some() {
+            if let Some((_, p)) = &self.status_tile {
+                let y = screen_h as i32 - ui::GRID_PAD - p.height() as i32;
+                cmds.push(DrawCmd::Tex {
+                    tile: Tile::Status,
+                    dst: Rect::new(grid_x + ui::GRID_PAD, y, p.width(), p.height()),
+                    alpha: 0xff,
+                });
             }
         }
 
@@ -1609,6 +1754,27 @@ impl App {
                 dst: Rect::new(0, dy, screen_w, screen_h),
                 alpha: (255.0 * m) as u8,
             });
+            // Settings' card/content/scroll, computed once and reused by every block
+            // below instead of each re-deriving it (they're all pure geometry, but no
+            // reason to repeat the call four times in one frame).
+            let settings_geom = matches!(self.screen, Screen::Settings).then(|| {
+                (
+                    Self::settings_layout(screen_w, screen_h),
+                    self.clamped_settings_scroll(screen_h),
+                )
+            });
+            // The Settings row list: cropped/repositioned straight off its full
+            // (unscrolled) tile — a GPU op, so scrolling never re-rasterizes anything
+            // (see `Tile::SettingsRows`'s docs).
+            if let Some(((_, content), scroll)) = settings_geom {
+                let stride = ui::SETTINGS_ROW_H as i32 + ui::SETTINGS_ROW_GAP;
+                cmds.push(DrawCmd::TexCropped {
+                    tile: Tile::SettingsRows,
+                    src: Rect::new(0, scroll as i32 * stride, content.width(), content.height()),
+                    dst: Rect::new(content.x(), content.y() + dy, content.width(), content.height()),
+                    alpha: (255.0 * m) as u8,
+                });
+            }
             // Whichever modal is open, its one focused widget — a settings/Wake
             // row, a pairing digit/button, or a Forget-host button (see
             // `ModalFocusKey`'s docs) — composites on top of the shell (which
@@ -1618,8 +1784,10 @@ impl App {
             // modal-open animation.
             let focus_rect = match self.screen {
                 Screen::Settings => {
-                    let (_, content) = Self::settings_layout(screen_w, screen_h);
-                    Some(ui::focus_row_rect(content, self.settings_focused))
+                    let ((_, content), scroll) = settings_geom.expect("screen is Screen::Settings");
+                    // `content`'s rows are the scrolled-to-visible window — translate
+                    // the focused row's global index back to a local one.
+                    Some(ui::focus_row_rect(content, self.settings_focused - scroll))
                 }
                 Screen::Wake => self.wake.as_ref().filter(|w| !w.mac.is_empty()).map(|w| {
                     let card = Self::wake_card_rect(screen_w, screen_h, w, fonts);
@@ -1691,10 +1859,9 @@ impl App {
             // top of the shell's unfocused option list at its actual
             // position, so navigating dropdown options needs no modal
             // re-rasterize either.
-            if matches!(self.screen, Screen::Settings) {
+            if let Some(((card, content), scroll)) = settings_geom {
                 if let Some(dd) = &self.dropdown {
-                    let (_, content) = Self::settings_layout(screen_w, screen_h);
-                    let overlay_rect = Self::dropdown_overlay_rect(content, dd.row);
+                    let overlay_rect = Self::dropdown_overlay_rect(content, dd.row - scroll);
                     let option_rect = ui::dropdown_option_rect(overlay_rect, dd.focused);
                     cmds.push(DrawCmd::Tex {
                         tile: Tile::DropdownFocusOption,
@@ -1705,6 +1872,34 @@ impl App {
                             option_rect.height(),
                         ),
                         alpha: (255.0 * m) as u8,
+                    });
+                }
+                // Full opacity for `SETTINGS_SCROLLBAR_HOLD`, then a linear fade over
+                // `SETTINGS_SCROLLBAR_FADE`.
+                let scroll_alpha = self.settings_scroll_shown_at.map_or(0.0, |t| {
+                    let elapsed = t.elapsed();
+                    if elapsed < SETTINGS_SCROLLBAR_HOLD {
+                        1.0
+                    } else {
+                        let fading = (elapsed - SETTINGS_SCROLLBAR_HOLD).as_secs_f32();
+                        1.0 - (fading / SETTINGS_SCROLLBAR_FADE.as_secs_f32()).clamp(0.0, 1.0)
+                    }
+                });
+                if scroll_alpha > 0.0 {
+                    // Sits nearer the card's edge than the row content's, so it doesn't
+                    // overlap a row's dropdown pill/slider/switch. The `26` offset isn't
+                    // derived from `settings_layout`'s 0.62 card-width fraction — re-check
+                    // both if either changes.
+                    let dst = Rect::new(
+                        card.x() + card.width() as i32 - 26,
+                        content.y() + dy,
+                        SETTINGS_SCROLLBAR_TILE_W,
+                        content.height(),
+                    );
+                    cmds.push(DrawCmd::Tex {
+                        tile: Tile::SettingsScrollbar,
+                        dst,
+                        alpha: (255.0 * m * scroll_alpha) as u8,
                     });
                 }
             }

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -2,14 +2,15 @@
 //!
 //! Split out of the former single-file `app.rs`; see `super`'s module docs.
 use super::*;
-use std::time::Instant;
+use crate::ui::{self, MenuEvent, Painter};
 use anyhow::Result;
 use sdl2::rect::Rect;
-use crate::ui::{self, MenuEvent, Painter};
+use std::time::Instant;
 
 impl App {
-    /// Handles one menu event on the settings modal.
-    pub fn handle_settings_event(&mut self, ev: MenuEvent) {
+    /// Handles one menu event on the settings modal. `screen_h` is only used by
+    /// `Up`/`Down` to keep `settings_scroll` following `settings_focused`.
+    pub fn handle_settings_event(&mut self, ev: MenuEvent, screen_h: u32) {
         // An open Resolution/Frame rate dropdown intercepts all input until it's
         // closed (by picking an option or backing out) — it's a modal overlay on
         // top of the settings row list.
@@ -34,17 +35,21 @@ impl App {
         }
         let total = ui::SETTINGS_ROW_COUNT;
         match ev {
+            // No wraparound here (unlike most other row lists) — wrapping a scrolled
+            // list would silently jump the scroll position across the whole card.
             MenuEvent::Up => {
-                self.settings_focused = if self.settings_focused == 0 {
-                    total - 1
-                } else {
-                    self.settings_focused - 1
-                };
-                self.modal_focus_anim = Some(Instant::now());
+                if self.settings_focused > 0 {
+                    self.settings_focused -= 1;
+                    self.modal_focus_anim = Some(Instant::now());
+                    self.scroll_settings_into_view(screen_h);
+                }
             }
             MenuEvent::Down => {
-                self.settings_focused = (self.settings_focused + 1) % total;
-                self.modal_focus_anim = Some(Instant::now());
+                if self.settings_focused + 1 < total {
+                    self.settings_focused += 1;
+                    self.modal_focus_anim = Some(Instant::now());
+                    self.scroll_settings_into_view(screen_h);
+                }
             }
             MenuEvent::Left => self.apply_setting_adjust(self.settings_focused, false),
             MenuEvent::Right => self.apply_setting_adjust(self.settings_focused, true),
@@ -98,13 +103,48 @@ impl App {
             }
         }
     }
+    /// How many settings rows fit on screen at once, so the card scrolls instead of
+    /// overflowing a 1080p-class panel. Clamped to `[1, SETTINGS_ROW_COUNT]`.
+    pub(crate) fn settings_visible_rows(screen_h: u32) -> usize {
+        let stride = ui::SETTINGS_ROW_H + ui::SETTINGS_ROW_GAP as u32;
+        // 200 header/footer padding (mirrors `settings_layout`) + 160 edge margin.
+        let available = screen_h.saturating_sub(200 + 160);
+        ((available / stride) as usize).clamp(1, ui::SETTINGS_ROW_COUNT)
+    }
+
+    /// `settings_scroll` is only re-clamped on `Up`/`Down`, so it can be stale after a
+    /// resize; use this instead of the raw field wherever it's subtracted from a row
+    /// index, to avoid underflow.
+    pub(crate) fn clamped_settings_scroll(&self, screen_h: u32) -> usize {
+        let visible = Self::settings_visible_rows(screen_h);
+        self.settings_scroll.min(ui::SETTINGS_ROW_COUNT.saturating_sub(visible))
+    }
+
+    /// Moves `settings_scroll` just enough to keep `settings_focused` in view, and marks
+    /// the scrollbar to show briefly if the position actually moved.
+    pub(crate) fn scroll_settings_into_view(&mut self, screen_h: u32) {
+        let visible = Self::settings_visible_rows(screen_h);
+        let before = self.settings_scroll;
+        if self.settings_focused < self.settings_scroll {
+            self.settings_scroll = self.settings_focused;
+        } else if self.settings_focused >= self.settings_scroll + visible {
+            self.settings_scroll = self.settings_focused + 1 - visible;
+        }
+        if self.settings_scroll != before {
+            self.settings_scroll_shown_at = Some(Instant::now());
+        }
+    }
+
     /// The settings modal's card/content rects — shared by `render` and mouse
-    /// hit-testing so they can never disagree.
+    /// hit-testing so they can never disagree. `content`'s height spans only the
+    /// visible row window (`settings_visible_rows`), not the full row list.
     pub(crate) fn settings_layout(screen_w: u32, screen_h: u32) -> (Rect, Rect) {
-        let content_h = ui::SETTINGS_ROW_COUNT as u32 * (ui::SETTINGS_ROW_H + ui::SETTINGS_ROW_GAP as u32);
+        let visible = Self::settings_visible_rows(screen_h);
+        let content_h = visible as u32 * (ui::SETTINGS_ROW_H + ui::SETTINGS_ROW_GAP as u32);
         // Room for the title/divider above and the high-bitrate caution below.
         let card_h = content_h + 200;
-        let card = ui::modal_card_rect(screen_w, screen_h, 0.56, card_h);
+        // Widened from 0.56 to fit the scroll indicator on the right edge.
+        let card = ui::modal_card_rect(screen_w, screen_h, 0.62, card_h);
         let content = Rect::new(
             card.x() + 40,
             card.y() + 120,
@@ -137,20 +177,8 @@ impl App {
             sdl2::pixels::Color::RGBA(0xff, 0xff, 0xff, 0x1e),
         );
 
-        let rows = ui::settings_rows(&self.settings);
-        // `usize::MAX` = no row focused: this shell draws every row unfocused,
-        // the focused one is a separate `Tile::ModalFocusElement` (see
-        // `prepare_tiles`), so moving focus never re-rasterizes the modal.
-        let open_dropdown_row = self.dropdown.as_ref().map(|dd| dd.row);
-        ui::draw_focus_rows(
-            painter,
-            text_cache,
-            fonts,
-            &rows,
-            usize::MAX,
-            open_dropdown_row,
-            content,
-        )?;
+        // The row list itself is drawn separately — see `Tile::SettingsRows` — so
+        // scrolling never re-rasterizes this shell; only a value/dropdown change does.
 
         if self.settings.bitrate_kbps > ui::BITRATE_WARN_KBPS {
             ui::draw_text(
@@ -166,7 +194,10 @@ impl App {
 
         if let Some(dd) = &self.dropdown {
             let options = ui::dropdown_options(&self.settings, dd.row);
-            let overlay_rect = Self::dropdown_overlay_rect(content, dd.row);
+            // Scroll is always frozen while a dropdown is open (`handle_settings_event`
+            // routes Up/Down to the dropdown itself, not `settings_scroll`), so this
+            // stays correct for the dropdown's whole lifetime.
+            let overlay_rect = Self::dropdown_overlay_rect(content, dd.row - self.clamped_settings_scroll(screen_h));
             // `usize::MAX` = no option focused; the focused one is a separate
             // `Tile::DropdownFocusOption` (see `prepare_tiles`).
             ui::draw_dropdown_overlay(painter, text_cache, fonts.value, &options, usize::MAX, overlay_rect)?;

--- a/src/art.rs
+++ b/src/art.rs
@@ -44,18 +44,96 @@ struct ArtRequest {
 /// the panel cannot show.
 const MAX_ART_DIMENSION: u32 = 480;
 
-/// Where cached encoded art lives, under the app's own writable directory.
-fn cache_dir() -> PathBuf {
+/// The grid card's fixed portrait aspect (see `ui::grid_card_size`). A card's art is
+/// stretched to exactly fill its rect (`Painter::draw_pixmap_scaled`), so source art at a
+/// different aspect ratio — a lot of it, in the wild (Steam capsules, custom box art) —
+/// would otherwise look visibly squashed or stretched. Center-cropping to this aspect once
+/// at decode time avoids that without ever distorting the image.
+const TARGET_ART_ASPECT: f32 = 3.0 / 4.0;
+
+/// Center-crops `img` to `aspect` (width/height), trimming whichever axis is oversized.
+/// A no-op if `img` is already close enough to `aspect`.
+fn crop_to_aspect(img: image::DynamicImage, aspect: f32) -> image::DynamicImage {
+    let (w, h) = (img.width(), img.height());
+    if w == 0 || h == 0 {
+        return img;
+    }
+    let current = w as f32 / h as f32;
+    if (current - aspect).abs() < 0.01 {
+        return img;
+    }
+    if current > aspect {
+        let new_w = ((h as f32 * aspect).round() as u32).clamp(1, w);
+        img.crop_imm((w - new_w) / 2, 0, new_w, h)
+    } else {
+        let new_h = ((w as f32 / aspect).round() as u32).clamp(1, h);
+        img.crop_imm(0, (h - new_h) / 2, w, new_h)
+    }
+}
+
+/// Bump when the raw-cache layout or `MAX_ART_DIMENSION` changes, to invalidate stale caches.
+const RAW_CACHE_MAGIC: u32 = 0x50465232; // "PFR2" — bumped for center-cropped art
+
+/// Root of all cached art, under the app's own writable directory.
+fn cache_root() -> PathBuf {
     let home = std::env::var("HOME").map_or_else(|_| PathBuf::from("/tmp"), PathBuf::from);
     home.join("art-cache")
 }
 
-/// A filesystem-safe name for a store-qualified id (`steam:570`, `custom:12`).
-fn cache_name(game_id: &str) -> String {
-    game_id
-        .chars()
+/// A filesystem-safe name for a store-qualified id (`steam:570`, `custom:12`) or a
+/// `host:port` key. Not collision-proof (e.g. `"a:1"` and `"a_1"` sanitize the same).
+fn cache_name(id: &str) -> String {
+    id.chars()
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
         .collect()
+}
+
+/// One subdirectory per host (keyed by `(host, port)`, same as `store::KnownHost`'s dedup
+/// key) — keeps game-id collisions across hosts from leaking art, and lets a forgotten
+/// host's cache be dropped in one `remove_dir_all`.
+fn cache_dir(host: &str, port: u16) -> PathBuf {
+    cache_root().join(cache_name(&format!("{host}_{port}")))
+}
+
+/// Deletes a forgotten host's cached art. Best-effort: a missing or unremovable directory
+/// is not an error the caller needs to react to.
+pub fn clear_host_cache(host: &str, port: u16) {
+    let _ = std::fs::remove_dir_all(cache_dir(host, port));
+}
+
+/// Decoded/resized/premultiplied pixels, keyed like the encoded cache. A hit here skips
+/// `image::load_from_memory`, `resize`, and `premultiply_rgba` entirely.
+fn raw_cache_path(dir: &std::path::Path, game_id: &str) -> PathBuf {
+    dir.join(format!("{}.raw", cache_name(game_id)))
+}
+
+/// Layout: `[magic: u32 LE][width: u32 LE][height: u32 LE][premultiplied RGBA bytes]`.
+fn write_raw_cache(path: &std::path::Path, pixmap: &Pixmap) {
+    let mut buf = Vec::with_capacity(12 + pixmap.data().len());
+    buf.extend_from_slice(&RAW_CACHE_MAGIC.to_le_bytes());
+    buf.extend_from_slice(&pixmap.width().to_le_bytes());
+    buf.extend_from_slice(&pixmap.height().to_le_bytes());
+    buf.extend_from_slice(pixmap.data());
+    // Write-then-rename so a kill mid-write can't leave a truncated file that parses as
+    // garbage forever (same discipline as the encoded cache below).
+    let tmp = path.with_extension("raw.tmp");
+    if std::fs::write(&tmp, &buf).is_ok() {
+        let _ = std::fs::rename(&tmp, path);
+    }
+}
+
+/// Reads back a raw cache entry written by [`write_raw_cache`], if present and well-formed.
+fn read_raw_cache(path: &std::path::Path) -> Option<Pixmap> {
+    let buf = std::fs::read(path).ok()?;
+    let magic = u32::from_le_bytes(buf.get(0..4)?.try_into().ok()?);
+    if magic != RAW_CACHE_MAGIC {
+        return None;
+    }
+    let width = u32::from_le_bytes(buf.get(4..8)?.try_into().ok()?);
+    let height = u32::from_le_bytes(buf.get(8..12)?.try_into().ok()?);
+    let size = IntSize::from_wh(width, height)?;
+    let pixels = buf.get(12..)?.to_vec();
+    Pixmap::from_vec(pixels, size)
 }
 
 /// Background fetcher/decoder. Requests go in, decoded covers come out; both ends are
@@ -69,17 +147,21 @@ pub struct ArtLoader {
 }
 
 impl ArtLoader {
+    /// `port` is the host's identity port (matches `store::KnownHost::port`); `mgmt_port`
+    /// is what's actually dialed to fetch art.
     pub fn spawn(
         host: String,
+        port: u16,
         mgmt_port: u16,
         identity: (String, String),
         fingerprint: Option<[u8; 32]>,
     ) -> Self {
         let (tx_req, rx_req) = std::sync::mpsc::channel::<ArtRequest>();
         let (tx_done, rx_done) = std::sync::mpsc::channel::<ArtLoaded>();
+        let dir = cache_dir(&host, port);
         std::thread::Builder::new()
             .name("punktfunk-webos-art".into())
-            .spawn(move || worker(&host, mgmt_port, &identity, fingerprint, &rx_req, &tx_done))
+            .spawn(move || worker(&host, mgmt_port, &identity, fingerprint, &dir, &rx_req, &tx_done))
             .expect("spawn art-loader thread");
         Self {
             tx: tx_req,
@@ -130,18 +212,29 @@ fn worker(
     mgmt_port: u16,
     identity: &(String, String),
     fingerprint: Option<[u8; 32]>,
+    dir: &std::path::Path,
     rx: &Receiver<ArtRequest>,
     tx: &Sender<ArtLoaded>,
 ) {
-    let dir = cache_dir();
-    let _ = std::fs::create_dir_all(&dir);
+    let _ = std::fs::create_dir_all(dir);
     // One mTLS agent reused for every fetch — a fresh `ureq::Agent` per cover means a
     // fresh TCP+TLS handshake including client-cert auth, real avoidable cost that scales
     // with library size (see `library::agent`). Built lazily, so a fully cached library
     // never opens a connection at all.
     let mut agent = None;
 
+    // A closed channel means the host was switched away from; the caller stops draining.
+    let deliver = |tx: &Sender<ArtLoaded>, game_id: String, pixmap: Pixmap| tx.send(ArtLoaded { game_id, pixmap });
+
     while let Ok(req) = rx.recv() {
+        let raw_cached = raw_cache_path(dir, &req.game_id);
+        if let Some(pixmap) = read_raw_cache(&raw_cached) {
+            if deliver(tx, req.game_id, pixmap).is_err() {
+                return;
+            }
+            continue;
+        }
+
         let cached = dir.join(cache_name(&req.game_id));
         let bytes = match std::fs::read(&cached) {
             Ok(b) if !b.is_empty() => b,
@@ -173,6 +266,7 @@ fn worker(
             let _ = std::fs::remove_file(&cached);
             continue;
         };
+        let decoded = crop_to_aspect(decoded, TARGET_ART_ASPECT);
         let longer_side = decoded.width().max(decoded.height());
         let decoded = if longer_side > MAX_ART_DIMENSION {
             decoded.resize(
@@ -193,14 +287,8 @@ fn worker(
         let Some(pixmap) = Pixmap::from_vec(buf, size) else {
             continue;
         };
-        // A receiver drop (host switched) ends the thread — nothing left to deliver to.
-        if tx
-            .send(ArtLoaded {
-                game_id: req.game_id,
-                pixmap,
-            })
-            .is_err()
-        {
+        write_raw_cache(&raw_cached, &pixmap);
+        if deliver(tx, req.game_id, pixmap).is_err() {
             return;
         }
     }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -46,6 +46,15 @@ pub enum Tile {
     Status,
     /// The "No host selected" hint line.
     NoHost,
+    /// The Settings modal's scroll indicator (`ui::render_list_scrollbar_tile`).
+    SettingsScrollbar,
+    /// Every Settings row, unfocused, at its *unscrolled* position — full row-list
+    /// height, not just the visible window. Scrolling crops/repositions this via
+    /// `DrawCmd::TexCropped` (a GPU op), so it only needs rebuilding when a value or
+    /// the open dropdown changes, never when the list merely scrolls.
+    SettingsRows,
+    /// The loading spinner shown over the grid while it fills in (`ui::render_spinner_tile`).
+    Spinner,
     /// The in-stream stats overlay panel (`ui::render_stats_overlay_tile`).
     StatsOverlay,
     /// The in-stream disconnect-confirmation dialog's shell — card, title,
@@ -63,6 +72,15 @@ pub enum DrawCmd {
     /// Copy `tile`'s texture to `dst` (scaled by the GPU if sizes differ),
     /// modulated by `alpha`.
     Tex { tile: Tile, dst: Rect, alpha: u8 },
+    /// Same as `Tex`, but samples only `src` (in the tile's own pixel space) —
+    /// how the Settings row list scrolls: cropping/repositioning a fixed texture
+    /// is a GPU op, so scrolling never needs the tile re-rasterized.
+    TexCropped {
+        tile: Tile,
+        src: Rect,
+        dst: Rect,
+        alpha: u8,
+    },
     /// A blended solid fill — the modal scrim.
     Fill { rect: Rect, color: sdl2::pixels::Color },
 }
@@ -162,10 +180,21 @@ impl Compositor {
                         .copy(tex, None, Some(*dst))
                         .map_err(|e| anyhow::anyhow!("copy {tile:?}: {e}"))?;
                 }
+                DrawCmd::TexCropped { tile, src, dst, alpha } => {
+                    let Some(tex) = self.textures.get_mut(tile) else {
+                        continue; // not uploaded yet — skip
+                    };
+                    tex.set_alpha_mod(*alpha);
+                    canvas
+                        .copy(tex, Some(*src), Some(*dst))
+                        .map_err(|e| anyhow::anyhow!("copy cropped {tile:?}: {e}"))?;
+                }
                 DrawCmd::Fill { rect, color } => {
                     canvas.set_blend_mode(BlendMode::Blend);
                     canvas.set_draw_color(*color);
-                    canvas.fill_rect(Some(*rect)).map_err(|e| anyhow::anyhow!("fill: {e}"))?;
+                    canvas
+                        .fill_rect(Some(*rect))
+                        .map_err(|e| anyhow::anyhow!("fill: {e}"))?;
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,7 +410,7 @@ mod real {
                         }
                     }
                     Screen::Pairing => app.handle_pairing_event(menu_ev),
-                    Screen::Settings => app.handle_settings_event(menu_ev),
+                    Screen::Settings => app.handle_settings_event(menu_ev, display_mode.h as u32),
                     Screen::AddHost => app.handle_add_host_event(menu_ev),
                     Screen::Wake => app.handle_wake_event(menu_ev),
                     Screen::ForgetHost => app.handle_forget_host_event(menu_ev),
@@ -461,8 +461,9 @@ mod real {
             // `tiles_pending` keeps frames flowing while the card window is still being
             // filled a few tiles at a time (see `CARD_BUILD_BUDGET`) — the
             // redraw-on-change loop would otherwise go idle mid-build and leave the rest
-            // of the visible cards blank until the next input.
-            let animating = app.tick_animations() || app.tiles_pending;
+            // of the visible cards blank until the next input. `!grid_reveal_ready` keeps
+            // it flowing the same way while waiting on art still in flight.
+            let animating = app.tick_animations() || app.tiles_pending || !app.grid_reveal_ready;
             if !dirty && !animating {
                 std::thread::sleep(Duration::from_millis(16));
                 continue;

--- a/src/ui/painter.rs
+++ b/src/ui/painter.rs
@@ -205,14 +205,13 @@ impl Painter {
             .draw_pixmap(x, y, src.as_ref(), &PixmapPaint::default(), Transform::identity(), None);
     }
 
-    /// Composites `src` scaled to exactly fill `dst` — `image`-decoded cover art
-    /// (see `art.rs`) is already downscaled close to display size, so this is just
-    /// a small final-fit correction, not doing the heavy lifting of the downscale.
-    /// `FilterQuality::Nearest`, not `Bilinear`: tiny-skia's bilinear `Pattern`
-    /// pushes extra interpolation stages into its raster pipeline whenever the
-    /// transform scales (see `Pattern::push_stages`), which measured as a real
-    /// (if modest) per-call cost on real webOS hardware — see docs/NOTES.md's "UI
-    /// performance, round 2" entry.
+    /// Composites `src` scaled to exactly fill `dst` — the one caller is game-art
+    /// rendering (`ui::draw_poster_card`), and only at tile-build time (see
+    /// `App::prepare_tiles`), not per frame: the result is cached into the card's tile
+    /// and only re-scaled when the art or card size actually changes. `Bilinear`
+    /// (rather than `Nearest`) is worth its modest per-call cost here since it's paid
+    /// once per card build, not every frame — plain `Nearest` scaling left visible
+    /// jaggies on art whose source resolution didn't cleanly divide into the card size.
     pub fn draw_pixmap_scaled(&mut self, dst: Rect, src: &Pixmap) {
         let (dw, dh) = (dst.width() as f32, dst.height() as f32);
         let (sw, sh) = (src.width() as f32, src.height() as f32);
@@ -221,7 +220,7 @@ impl Painter {
         }
         let transform = Transform::from_scale(dw / sw, dh / sh).post_translate(dst.x() as f32, dst.y() as f32);
         let paint = PixmapPaint {
-            quality: FilterQuality::Nearest,
+            quality: FilterQuality::Bilinear,
             ..PixmapPaint::default()
         };
         self.pixmap.draw_pixmap(0, 0, src.as_ref(), &paint, transform, None);

--- a/src/ui/rows.rs
+++ b/src/ui/rows.rs
@@ -148,6 +148,31 @@ pub fn render_focus_row_tile(
     Ok(p)
 }
 
+/// Every row unfocused, as one tile at its own full (unscrolled) height — the
+/// Settings modal's `Tile::SettingsRows`. Scrolling crops/repositions this via a
+/// GPU-side `DrawCmd::TexCropped` instead of re-rasterizing, so this only needs
+/// rebuilding when a value or the open dropdown changes, never on scroll.
+pub fn render_focus_rows_tile(
+    text_cache: &mut TextCache,
+    fonts: &Fonts,
+    rows: &[FocusRow],
+    width: u32,
+    open_dropdown_row: Option<usize>,
+) -> Result<Painter> {
+    let height = rows.len() as u32 * (SETTINGS_ROW_H + SETTINGS_ROW_GAP as u32);
+    let mut p = Painter::new(width, height.max(1));
+    draw_focus_rows(
+        &mut p,
+        text_cache,
+        fonts,
+        rows,
+        usize::MAX,
+        open_dropdown_row,
+        Rect::new(0, 0, width, height),
+    )?;
+    Ok(p)
+}
+
 /// Draws one focus row (icon + label + dropdown pill / slider / modern switch
 /// / nothing, per `RowKind`) into `row_rect`, focused or not — shared by
 /// `draw_focus_rows` (the static, always-unfocused shell) and
@@ -277,7 +302,11 @@ pub fn draw_dropdown_pill(
     painter.stroke_rounded_rect(
         rect,
         radius,
-        if open { ACCENT_BRIGHT } else { Color::RGBA(0xff, 0xff, 0xff, 0x30) },
+        if open {
+            ACCENT_BRIGHT
+        } else {
+            Color::RGBA(0xff, 0xff, 0xff, 0x30)
+        },
         1.5,
     );
     let chevron_size = 20u32;
@@ -325,7 +354,12 @@ pub fn draw_slider_with_thumb(painter: &mut Painter, rect: Rect, fraction: f32, 
 pub fn lerp_color(from: Color, to: Color, frac: f32) -> Color {
     let f = frac.clamp(0.0, 1.0);
     let lerp = |a: u8, b: u8| (f32::from(a) + (f32::from(b) - f32::from(a)) * f) as u8;
-    Color::RGBA(lerp(from.r, to.r), lerp(from.g, to.g), lerp(from.b, to.b), lerp(from.a, to.a))
+    Color::RGBA(
+        lerp(from.r, to.r),
+        lerp(from.g, to.g),
+        lerp(from.b, to.b),
+        lerp(from.a, to.a),
+    )
 }
 
 pub const SWITCH_OFF_TRACK: Color = Color::RGBA(0xff, 0xff, 0xff, 0x22);
@@ -351,6 +385,30 @@ pub fn draw_switch(painter: &mut Painter, rect: Rect, frac: f32) {
 /// Row height of one dropdown option — also `render_dropdown_option_tile`'s tile size.
 pub const DROPDOWN_OPTION_H: u32 = 56;
 
+/// A track+thumb along a scrollable list's right edge. `total`/`visible`/`scroll` are row
+/// counts (`visible` <= `total`, `scroll` <= `total - visible`). Rendered into its own
+/// tile so the fade-in/out is a per-frame alpha composite, not a re-rasterize.
+const SCROLLBAR_TRACK_W: u32 = 6;
+
+pub fn render_list_scrollbar_tile(tile_w: u32, tile_h: u32, total: usize, visible: usize, scroll: usize) -> Painter {
+    let mut painter = Painter::new(tile_w, tile_h.max(1));
+    if total <= visible {
+        return painter;
+    }
+    let track_w = SCROLLBAR_TRACK_W.min(tile_w);
+    let track = Rect::new(tile_w as i32 - track_w as i32, 0, track_w, tile_h);
+    painter.fill_rounded_rect(track, track_w as i32 / 2, Color::RGBA(0xff, 0xff, 0xff, 0x14));
+
+    let thumb_h = ((visible as f32 / total as f32) * track.height() as f32).round() as u32;
+    let thumb_h = thumb_h.clamp(24, track.height());
+    let max_thumb_y = track.height().saturating_sub(thumb_h) as f32;
+    let max_scroll = (total - visible).max(1) as f32;
+    let thumb_y = track.y() + ((scroll as f32 / max_scroll) * max_thumb_y).round() as i32;
+    let thumb = Rect::new(track.x(), thumb_y, track_w, thumb_h);
+    painter.fill_rounded_rect(thumb, track_w as i32 / 2, Color::RGBA(0xff, 0xff, 0xff, 0x50));
+    painter
+}
+
 /// Renders a dropdown's options as an overlay list anchored just below the row that
 /// opened it, inside the settings modal card. One shadow/background for the whole
 /// panel and contiguous, same-height rows — like a typical dropdown/picker list —
@@ -365,7 +423,12 @@ pub fn draw_dropdown_overlay(
     focused_index: usize,
     rect: Rect,
 ) -> Result<()> {
-    let bg_rect = Rect::new(rect.x(), rect.y(), rect.width(), options.len() as u32 * DROPDOWN_OPTION_H);
+    let bg_rect = Rect::new(
+        rect.x(),
+        rect.y(),
+        rect.width(),
+        options.len() as u32 * DROPDOWN_OPTION_H,
+    );
     draw_popup_panel(painter, bg_rect, Color::RGBA(0xff, 0xff, 0xff, 0x20));
     for (i, opt) in options.iter().enumerate() {
         let row_rect = dropdown_option_rect(rect, i);
@@ -379,7 +442,12 @@ pub fn draw_dropdown_overlay(
 /// `app.rs`'s `draw_list` (which needs it to position the composited
 /// focused-option tile).
 pub fn dropdown_option_rect(rect: Rect, index: usize) -> Rect {
-    Rect::new(rect.x(), rect.y() + index as i32 * DROPDOWN_OPTION_H as i32, rect.width(), DROPDOWN_OPTION_H)
+    Rect::new(
+        rect.x(),
+        rect.y() + index as i32 * DROPDOWN_OPTION_H as i32,
+        rect.width(),
+        DROPDOWN_OPTION_H,
+    )
 }
 
 /// One dropdown option, focused, as its own tile (no padding needed — unlike
@@ -387,7 +455,12 @@ pub fn dropdown_option_rect(rect: Rect, index: usize) -> Rect {
 /// its row rect) — composited by the GPU over the overlay's unfocused option
 /// list. Moving the dropdown's own focus recomposites just this small tile
 /// instead of re-rasterizing the whole modal.
-pub fn render_dropdown_option_tile(text_cache: &mut TextCache, font_value: &Font, option: &str, width: u32) -> Result<Painter> {
+pub fn render_dropdown_option_tile(
+    text_cache: &mut TextCache,
+    font_value: &Font,
+    option: &str,
+    width: u32,
+) -> Result<Painter> {
     let mut p = Painter::new(width, DROPDOWN_OPTION_H);
     let rect = Rect::new(0, 0, width, DROPDOWN_OPTION_H);
     draw_dropdown_option(&mut p, text_cache, font_value, option, true, rect)?;
@@ -473,7 +546,11 @@ pub fn confirm_row_min_width(font: &Font, buttons: &[ConfirmButton; 2]) -> u32 {
         .iter()
         .map(|b| {
             let label_w = font.size_of(b.label).map_or(0, |(w, _)| w);
-            let leading = if b.icon.is_some() { icon_size + icon_gap as u32 } else { 0 };
+            let leading = if b.icon.is_some() {
+                icon_size + icon_gap as u32
+            } else {
+                0
+            };
             label_w + leading + 2 * side_pad as u32
         })
         .max()
@@ -488,7 +565,12 @@ pub fn confirm_row_min_width(font: &Font, buttons: &[ConfirmButton; 2]) -> u32 {
 pub fn confirm_button_rect(content: Rect, index: usize) -> Rect {
     let gap = CONFIRM_BUTTON_GAP;
     let btn_w = content.width().saturating_sub(gap as u32) / 2;
-    Rect::new(content.x() + index as i32 * (btn_w as i32 + gap), content.y(), btn_w, content.height())
+    Rect::new(
+        content.x() + index as i32 * (btn_w as i32 + gap),
+        content.y(),
+        btn_w,
+        content.height(),
+    )
 }
 
 /// A row of side-by-side buttons for a Yes/No-style confirmation (currently
@@ -587,4 +669,3 @@ pub fn draw_confirm_button(
     )?;
     Ok(())
 }
-

--- a/src/ui/tiles.rs
+++ b/src/ui/tiles.rs
@@ -43,6 +43,37 @@ pub fn render_card_tile(
     Ok(p)
 }
 
+/// Fixed size of the loading spinner drawn over the grid — see `App::grid_reveal_ready`.
+pub const SPINNER_SIZE: u32 = 64;
+
+/// A 12-dot activity indicator. `phase` is seconds elapsed since the spinner started
+/// (`App::spinner_since`) — the lead dot advances continuously, trailing dots fading out.
+pub fn render_spinner_tile(phase: f32) -> Painter {
+    const DOTS: usize = 12;
+    const REVOLUTION_SECS: f32 = 1.4;
+    let size = SPINNER_SIZE;
+    let mut p = Painter::new(size, size);
+    let (cx, cy) = (size as f32 / 2.0, size as f32 / 2.0);
+    let orbit = size as f32 / 2.0 - 6.0;
+    let dot_r = size as f32 / 16.0;
+    let lead = (phase / REVOLUTION_SECS).rem_euclid(1.0);
+    for i in 0..DOTS {
+        let t = i as f32 / DOTS as f32;
+        let angle = t * std::f32::consts::TAU - std::f32::consts::FRAC_PI_2;
+        let (x, y) = (cx + orbit * angle.cos(), cy + orbit * angle.sin());
+        // Distance behind the lead dot, wrapped — farther behind fades more.
+        let behind = (t - lead).rem_euclid(1.0);
+        let alpha = (255.0 * (1.0 - behind)).clamp(40.0, 255.0) as u8;
+        p.fill_circle(
+            x,
+            y,
+            dot_r,
+            Color::RGBA(ACCENT_BRIGHT.r, ACCENT_BRIGHT.g, ACCENT_BRIGHT.b, alpha),
+        );
+    }
+    p
+}
+
 /// Transparent padding around the focus-ring tile (the ring's outer glow pass
 /// sits 6px out + stroke width).
 pub const FOCUS_RING_PAD: i32 = 12;
@@ -105,12 +136,7 @@ pub fn render_focused_row_tile(
 }
 
 /// A single line of text as its own tight transparent tile.
-pub fn render_text_tile(
-    text_cache: &mut TextCache,
-    font: &Font,
-    text: &str,
-    color: Color,
-) -> Result<Painter> {
+pub fn render_text_tile(text_cache: &mut TextCache, font: &Font, text: &str, color: Color) -> Result<Painter> {
     let (w, h) = font.size_of(text).unwrap_or((1, 1));
     let mut p = Painter::new(w.max(1), h.max(1));
     draw_text(&mut p, text_cache, font, text, 0, 0, color)?;
@@ -158,11 +184,7 @@ pub fn render_stats_overlay_tile(font: &Font, lines: &[String]) -> Result<Painte
     let h = (lines.len() as i32 * line_h + 2 * pad) as u32;
     let mut p = Painter::new(w.max(1), h.max(1));
     let mut tc = TextCache::new();
-    p.fill_rounded_rect(
-        Rect::new(0, 0, w, h),
-        14,
-        Color::RGBA(0x14, 0x10, 0x1f, 0xd2),
-    );
+    p.fill_rounded_rect(Rect::new(0, 0, w, h), 14, Color::RGBA(0x14, 0x10, 0x1f, 0xd2));
     for (i, line) in lines.iter().enumerate() {
         // First line (mode/codec header) pops; the measurements below are muted.
         let color = if i == 0 { WHITE } else { MUTED };
@@ -179,8 +201,16 @@ pub fn disconnect_dialog_buttons() -> [ConfirmButton<'static>; 2] {
     [
         // Echoes the question's own verb ("Stop streaming?"), the same way the Forget
         // confirmation's button echoes its title.
-        ConfirmButton { icon: Some(ICON_CLOSE), label: "Stop streaming", color: ERROR_RED },
-        ConfirmButton { icon: None, label: "Cancel", color: WHITE },
+        ConfirmButton {
+            icon: Some(ICON_CLOSE),
+            label: "Stop streaming",
+            color: ERROR_RED,
+        },
+        ConfirmButton {
+            icon: None,
+            label: "Cancel",
+            color: WHITE,
+        },
     ]
 }
 
@@ -224,7 +254,13 @@ pub fn render_disconnect_dialog_shell(screen_w: u32, screen_h: u32, fonts: &Font
     let (title_w, _) = fonts.label.size_of(title).unwrap_or((0, 0));
     let title_x = card.x() + (card.width() as i32 - title_w as i32) / 2;
     draw_text(&mut p, &mut tc, fonts.label, title, title_x, card.y() + 36, WHITE)?;
-    draw_confirm_buttons(&mut p, &mut tc, fonts, content, &disconnect_dialog_buttons(), usize::MAX)?;
+    draw_confirm_buttons(
+        &mut p,
+        &mut tc,
+        fonts,
+        content,
+        &disconnect_dialog_buttons(),
+        usize::MAX,
+    )?;
     Ok(p)
 }
-


### PR DESCRIPTION
## Summary
- Two-tier art disk cache (raw decoded pixels + existing encoded bytes), scoped per host — a hit skips decode/resize/premultiply entirely, and forgetting a host drops its cache.
- `CARD_BUILD_BUDGET` raised 3 → 10 with art-ready cards built first, since the budget only ever bounds the small visible+prefetch window.
- Same-host reconnect (re-confirming the sidebar row / "Connect" from ⋯) no longer refetches and blinks the grid back to placeholders.
- Loading spinner reveals the whole visible+prefetch window at once instead of cards popping in individually.
- Cover art is now center-cropped to the card's 3:4 aspect at decode time instead of being non-uniformly stretched, which was visibly distorting art with unusual aspect ratios.

## Test plan
- [ ] `task check`/`task lint` (Docker cross-toolchain)
- [ ] `task deploy TV_HOST=... TELEMETRY=auto` on real hardware — confirm raw-cache decode savings, `CARD_BUILD_BUDGET` frame cost, spinner timing/feel, and that oddly-shaped art now crops instead of stretching

🤖 Generated with [Claude Code](https://claude.com/claude-code)