### PR TITLE
Fix settings dropdown overlay bleed-through and refresh library on host re-click

### DIFF
--- a/src/app/home.rs
+++ b/src/app/home.rs
@@ -201,15 +201,10 @@ impl App {
         match entry {
             HostEntry::Known(h) if h.fingerprint.is_some() => {
                 let (host, port, mgmt_port) = (h.host, h.port, h.mgmt_port);
-                // Re-confirming the already-active host must not refetch — `select_host`
-                // unconditionally clears art/games and re-hits the library API, blinking
-                // every card back to a placeholder for nothing. Just jump focus into the
-                // grid instead. Assumes `mgmt_port`/cert can't change without `(host, port)`.
-                if self.selected_host.as_ref() == Some(&(host.clone(), port)) {
-                    self.home_focus = HomeFocus::Grid(0);
-                } else {
-                    self.select_host(host, port, mgmt_port);
-                }
+                // Re-confirming the already-active host refreshes its library too — a
+                // user clicking it is asking to see the current game list, e.g. after
+                // installing something new on the host.
+                self.select_host(host, port, mgmt_port);
             }
             _ => self.open_pairing(idx),
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -440,9 +440,13 @@ pub struct App {
     /// The single focused, zoom-animated widget of whichever modal is open —
     /// see `ModalFocusKey`'s docs on why one tile/key suffices for all of them.
     pub(crate) modal_focus_tile: Option<(ModalFocusKey, Painter)>,
+    /// The open dropdown's panel + unfocused option list, keyed by its row (the
+    /// options list depends only on which row opened it). Composited *after*
+    /// `settings_rows_tile` — see `Tile::DropdownOverlay`'s docs.
+    pub(crate) dropdown_overlay_tile: Option<(usize, Painter)>,
     /// The open dropdown's focused option, as its own small tile — keyed by
-    /// (dropdown row, focused option index). Composited over `modal_tile`'s
-    /// shell (which draws the overlay's option list unfocused); moving the
+    /// (dropdown row, focused option index). Composited over `dropdown_overlay_tile`
+    /// (which draws the overlay's option list unfocused); moving the
     /// dropdown's own focus rebuilds only this.
     pub(crate) dropdown_focus_tile: Option<((usize, usize), Painter)>,
     /// The Settings scrollbar, keyed by `(total rows, visible rows, scroll)` — rebuilt
@@ -585,6 +589,7 @@ impl App {
             modal_tile: None,
             modal_shell_key: None,
             modal_focus_tile: None,
+            dropdown_overlay_tile: None,
             dropdown_focus_tile: None,
             settings_scrollbar_tile: None,
             settings_rows_tile: None,
@@ -1544,17 +1549,29 @@ impl App {
         }
 
         if let Some(dd) = &self.dropdown {
+            let (_, content) = Self::settings_layout(screen_w, screen_h);
+            let options = ui::dropdown_options(&self.settings, dd.row);
+
+            let overlay_stale = !matches!(&self.dropdown_overlay_tile, Some((k, _)) if *k == dd.row);
+            if overlay_stale {
+                let overlay_h = options.len() as u32 * ui::DROPDOWN_OPTION_H;
+                let mut p = Painter::new(content.width(), overlay_h.max(1));
+                let rect = Rect::new(0, 0, content.width(), overlay_h);
+                ui::draw_dropdown_overlay(&mut p, text_cache, fonts.value, &options, usize::MAX, rect)?;
+                self.dropdown_overlay_tile = Some((dd.row, p));
+                updated.push(Tile::DropdownOverlay);
+            }
+
             let key = (dd.row, dd.focused);
             let stale = !matches!(&self.dropdown_focus_tile, Some((k, _)) if *k == key);
             if stale {
-                let (_, content) = Self::settings_layout(screen_w, screen_h);
-                let options = ui::dropdown_options(&self.settings, dd.row);
                 let option = options.get(dd.focused).map_or("", String::as_str);
                 let tile = ui::render_dropdown_option_tile(text_cache, fonts.value, option, content.width())?;
                 self.dropdown_focus_tile = Some((key, tile));
                 updated.push(Tile::DropdownFocusOption);
             }
         } else {
+            self.dropdown_overlay_tile = None;
             self.dropdown_focus_tile = None;
         }
 
@@ -1598,6 +1615,7 @@ impl App {
             Tile::Ring => self.ring_tile.as_ref(),
             Tile::Modal => self.modal_tile.as_ref(),
             Tile::ModalFocusElement => self.modal_focus_tile.as_ref().map(|(_, p)| p),
+            Tile::DropdownOverlay => self.dropdown_overlay_tile.as_ref().map(|(_, p)| p),
             Tile::DropdownFocusOption => self.dropdown_focus_tile.as_ref().map(|(_, p)| p),
             Tile::SettingsScrollbar => self.settings_scrollbar_tile.as_ref().map(|(_, p)| p),
             Tile::SettingsRows => self.settings_rows_tile.as_ref().map(|(_, p)| p),
@@ -1774,6 +1792,25 @@ impl App {
                     dst: Rect::new(content.x(), content.y() + dy, content.width(), content.height()),
                     alpha: (255.0 * m) as u8,
                 });
+            }
+            // The open dropdown's panel + unfocused option list — its own tile so it
+            // composites *after* `Tile::SettingsRows` (which would otherwise redraw the
+            // rows the overlay extends over, on top of it).
+            if let Some(((_, content), scroll)) = settings_geom {
+                if let Some(dd) = &self.dropdown {
+                    let overlay_rect = Self::dropdown_overlay_rect(content, dd.row - scroll);
+                    let options_len = ui::dropdown_options(&self.settings, dd.row).len();
+                    cmds.push(DrawCmd::Tex {
+                        tile: Tile::DropdownOverlay,
+                        dst: Rect::new(
+                            overlay_rect.x(),
+                            overlay_rect.y() + dy,
+                            overlay_rect.width(),
+                            options_len as u32 * ui::DROPDOWN_OPTION_H,
+                        ),
+                        alpha: (255.0 * m) as u8,
+                    });
+                }
             }
             // Whichever modal is open, its one focused widget — a settings/Wake
             // row, a pairing digit/button, or a Forget-host button (see

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -179,6 +179,8 @@ impl App {
 
         // The row list itself is drawn separately — see `Tile::SettingsRows` — so
         // scrolling never re-rasterizes this shell; only a value/dropdown change does.
+        // The open dropdown's panel is drawn separately too — see `Tile::DropdownOverlay`
+        // — so it composites *after* `Tile::SettingsRows` instead of being covered by it.
 
         if self.settings.bitrate_kbps > ui::BITRATE_WARN_KBPS {
             ui::draw_text(
@@ -190,17 +192,6 @@ impl App {
                 content.y() + content.height() as i32 + 16,
                 ui::WARNING,
             )?;
-        }
-
-        if let Some(dd) = &self.dropdown {
-            let options = ui::dropdown_options(&self.settings, dd.row);
-            // Scroll is always frozen while a dropdown is open (`handle_settings_event`
-            // routes Up/Down to the dropdown itself, not `settings_scroll`), so this
-            // stays correct for the dropdown's whole lifetime.
-            let overlay_rect = Self::dropdown_overlay_rect(content, dd.row - self.clamped_settings_scroll(screen_h));
-            // `usize::MAX` = no option focused; the focused one is a separate
-            // `Tile::DropdownFocusOption` (see `prepare_tiles`).
-            ui::draw_dropdown_overlay(painter, text_cache, fonts.value, &options, usize::MAX, overlay_rect)?;
         }
         Ok(())
     }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -37,8 +37,13 @@ pub enum Tile {
     /// whole modal. Only one modal is ever open at a time, so one tile
     /// suffices for all of them.
     ModalFocusElement,
+    /// An open dropdown's panel + unfocused option list, positioned over the
+    /// row that opened it. Its own tile — rather than being baked into
+    /// `Modal`'s shell — so it composites *after* `SettingsRows`, which would
+    /// otherwise redraw the rows the panel overlaps on top of it.
+    DropdownOverlay,
     /// An open dropdown's focused option, as its own small tile — composited
-    /// over `Modal`'s shell (which draws the dropdown's option list
+    /// over `DropdownOverlay` (which draws the dropdown's option list
     /// unfocused) so moving the dropdown's own focus recomposites this
     /// instead of re-rasterizing the whole modal.
     DropdownFocusOption,


### PR DESCRIPTION
## Summary
- The Settings dropdown's option panel was baked into the `Modal` tile, which composites *before* `Tile::SettingsRows` — so rows below the open dropdown got redrawn on top of it, showing text bleeding through the panel. It's now its own `Tile::DropdownOverlay`, composited after `SettingsRows` (and before `DropdownFocusOption`), so nothing draws over it.
- Clicking the already-connected host in the sidebar now always refetches its game library (with the loading spinner), instead of just jumping focus into the grid — so newly-installed games on the host show up without needing to switch away and back.

## Test plan
- [ ] `task deploy TV_HOST=...` and open Settings → open a dropdown (Resolution/Frame rate/etc.) → confirm rows below it no longer show through the panel, scrolling/focus still behave.
- [ ] With a host already selected, click it again in the sidebar → confirm the grid shows the loading spinner and the library refetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)