### PR TITLE
Hardware-accelerated scroll for About, shared with Settings

### DIFF
--- a/src/app/about.rs
+++ b/src/app/about.rs
@@ -1,37 +1,47 @@
-//! The About & licenses screen's state: which line the document is scrolled to.
+//! The About & licenses screen's state: which visual line the document is
+//! scrolled to.
 //!
 //! Split out of the former single-file `app.rs`; see `super`'s module docs.
-//! Layout and drawing live in `ui::about` — including why only the visible window is
-//! ever rasterized.
+//! Layout and drawing live in `ui::about` — including the wrapped-line/windowed-tile
+//! scheme that makes this screen scroll like Settings' row list (see its module docs).
 use super::*;
 use sdl2::rect::Rect;
 
 use crate::ui::{self, MenuEvent, Painter};
 
 impl App {
-    /// Enters `Screen::About`, building the document on first open (see
-    /// `ui::about_lines`).
+    /// Enters `Screen::About`, building the document's source lines on first open
+    /// (see `ui::about_lines`) — wrapping them to visual lines happens lazily in
+    /// `ensure_about_wrapped`, once a body width is known.
     pub(crate) fn open_about(&mut self) {
         if self.about_lines.is_empty() {
             self.about_lines = ui::about_lines();
         }
-        self.about_scroll = 0;
+        self.scroll = ui::ScrollWindow::new();
+        self.content_window = ui::ContentWindow::new();
         self.screen = Screen::About;
     }
 
-    /// Up/Down scroll by a line, Left/Right by a page. There is nothing focusable on
-    /// this screen, so every event is either scrolling or leaving.
+    /// Up/Down scroll by a visual line, Left/Right by a page. There is nothing
+    /// focusable on this screen, so every event is either scrolling or leaving.
     pub(crate) fn handle_about_event(&mut self, ev: MenuEvent, screen_w: u32, screen_h: u32, fonts: &ui::Fonts) {
-        let page = self.about_page_lines(screen_w, screen_h, fonts);
+        let (total, visible) = self.about_scroll_geometry(screen_w, screen_h, fonts);
         // Keep a couple of lines of the previous screenful visible when paging, so the
         // reader has an anchor rather than a hard cut.
-        let page_step = page.saturating_sub(2).max(1);
-        let max = self.about_lines.len().saturating_sub(1);
+        let page_step = visible.saturating_sub(2).max(1);
         match ev {
-            MenuEvent::Up => self.about_scroll = self.about_scroll.saturating_sub(1),
-            MenuEvent::Down => self.about_scroll = (self.about_scroll + 1).min(max),
-            MenuEvent::Left => self.about_scroll = self.about_scroll.saturating_sub(page_step),
-            MenuEvent::Right => self.about_scroll = (self.about_scroll + page_step).min(max),
+            MenuEvent::Up => {
+                self.scroll.scroll_by(-1, total, visible);
+            }
+            MenuEvent::Down => {
+                self.scroll.scroll_by(1, total, visible);
+            }
+            MenuEvent::Left => {
+                self.scroll.page(page_step, false, total, visible);
+            }
+            MenuEvent::Right => {
+                self.scroll.page(page_step, true, total, visible);
+            }
             // Back returns to Settings, where this screen was opened from — not Home,
             // which would throw away the settings context the user was in.
             MenuEvent::Back | MenuEvent::Confirm => self.screen = Screen::Settings,
@@ -41,30 +51,45 @@ impl App {
 
     /// Scrolls by `dy_px` worth of lines — the Magic Remote's wheel. Returns whether
     /// the position actually moved (drives the redraw).
-    pub(crate) fn scroll_about_by(&mut self, dy_px: i32, fonts: &ui::Fonts) -> bool {
-        let step = (fonts.value.height() + 4).max(1);
+    pub(crate) fn scroll_about_by(&mut self, dy_px: i32, screen_w: u32, screen_h: u32, fonts: &ui::Fonts) -> bool {
+        let (total, visible) = self.about_scroll_geometry(screen_w, screen_h, fonts);
+        let step = ui::about_line_stride(fonts.value).max(1);
         let lines = dy_px / step;
         if lines == 0 {
             return false;
         }
-        let max = self.about_lines.len().saturating_sub(1);
-        let next = (self.about_scroll as i64 + i64::from(lines)).clamp(0, max as i64) as usize;
-        let changed = next != self.about_scroll;
-        self.about_scroll = next;
-        changed
+        self.scroll.scroll_by(i64::from(lines), total, visible)
     }
 
-    /// How many source lines one screenful holds at the current geometry.
-    pub(crate) fn about_page_lines(&self, screen_w: u32, screen_h: u32, fonts: &ui::Fonts) -> usize {
+    /// `(total wrapped lines, visible lines)` for the current geometry, ensuring the
+    /// wrapped-line cache (`about_wrapped`) is fresh for this body width first — the
+    /// mutating half of what `App::scroll_geometry` reads back out (`&self`) later in
+    /// the same frame, once `prepare_tiles` has already called this.
+    pub(crate) fn about_scroll_geometry(&mut self, screen_w: u32, screen_h: u32, fonts: &ui::Fonts) -> (usize, usize) {
         let card = ui::about_card_rect(screen_w, screen_h);
         let body = ui::about_body_rect(card, fonts);
-        ui::about_visible_lines(body, fonts.value)
+        self.ensure_about_wrapped(fonts, body.width());
+        let total = self.about_wrapped.as_ref().map_or(0, |(_, v)| v.len());
+        let visible = ui::about_visible_lines(body, fonts.value);
+        (total, visible)
+    }
+
+    /// Wraps the whole document once per body width (see `ui::wrap_document`) — this
+    /// can't happen at `open_about` time since no screen geometry is known yet.
+    pub(crate) fn ensure_about_wrapped(&mut self, fonts: &ui::Fonts, width: u32) {
+        let stale = !matches!(&self.about_wrapped, Some((w, _)) if *w == width);
+        if stale {
+            self.about_wrapped = Some((width, ui::wrap_document(fonts.value, &self.about_lines, width)));
+        }
     }
 
     pub(crate) fn about_card_rect(screen_w: u32, screen_h: u32) -> Rect {
         ui::about_card_rect(screen_w, screen_h)
     }
 
+    /// The shell only — header and card chrome. The document body is its own
+    /// `Tile::ScrollContent(Screen::About)` tile, composited separately (see the
+    /// module docs), so this no longer depends on scroll position at all.
     pub(crate) fn render_about(
         &self,
         painter: &mut Painter,
@@ -86,7 +111,6 @@ impl App {
             &format!("Version {}", ui::VERSION),
             ui::MUTED,
         )?;
-        let body = ui::about_body_rect(card, fonts);
-        ui::draw_about_body(painter, fonts.value, &self.about_lines, self.about_scroll, body)
+        Ok(())
     }
 }

--- a/src/app/addhost.rs
+++ b/src/app/addhost.rs
@@ -2,10 +2,10 @@
 //!
 //! Split out of the former single-file `app.rs`; see `super`'s module docs.
 use super::*;
-use anyhow::Result;
-use sdl2::rect::Rect;
 use crate::store::{self, KnownHost};
 use crate::ui::{self, HostEntry, MenuEvent, Painter};
+use anyhow::Result;
+use sdl2::rect::Rect;
 
 /// The add-host screen's subtitle. `Screen::EditHost` builds its own — see
 /// `App::address_subtitle`.
@@ -96,7 +96,12 @@ impl App {
         let subtitle = self.address_subtitle();
         let card = self.address_card_rect(screen_w, screen_h, fonts);
         let after_subtitle_y = ui::modal_header_end_y(fonts.label, fonts.value, card, &subtitle);
-        Rect::new(card.x() + 32, after_subtitle_y + 20, card.width().saturating_sub(64), 80)
+        Rect::new(
+            card.x() + 32,
+            after_subtitle_y + 20,
+            card.width().saturating_sub(64),
+            80,
+        )
     }
 
     /// The address form's card rect — shared by the renderer and mouse hit-testing.

--- a/src/app/edithost.rs
+++ b/src/app/edithost.rs
@@ -19,7 +19,9 @@ impl App {
     /// current address. No-ops for a discovered-but-unsaved entry (there is nothing
     /// persisted to edit).
     pub(crate) fn open_edit_host(&mut self, idx: usize) {
-        let Some(HostEntry::Known(h)) = self.entries.get(idx) else { return };
+        let Some(HostEntry::Known(h)) = self.entries.get(idx) else {
+            return;
+        };
         self.add_host = AddHostState::from_ip(&h.host);
         self.edit_host_index = Some(idx);
         self.host_menu_index = None;
@@ -49,7 +51,9 @@ impl App {
             return;
         }
         let Some(idx) = self.edit_host_index else { return };
-        let Some(HostEntry::Known(old)) = self.entries.get(idx).cloned() else { return };
+        let Some(HostEntry::Known(old)) = self.entries.get(idx).cloned() else {
+            return;
+        };
         let (host, port) = self.add_host.host_and_port();
         if host == old.host && port == old.port {
             self.edit_host_index = None;

--- a/src/app/forget.rs
+++ b/src/app/forget.rs
@@ -2,10 +2,10 @@
 //!
 //! Split out of the former single-file `app.rs`; see `super`'s module docs.
 use super::*;
-use std::time::Instant;
+use crate::ui::{self, HostEntry, MenuEvent, Painter};
 use anyhow::Result;
 use sdl2::rect::Rect;
-use crate::ui::{self, HostEntry, MenuEvent, Painter};
+use std::time::Instant;
 
 impl App {
     /// Enters `Screen::ForgetHost` for the sidebar row at `idx` — called from
@@ -129,7 +129,13 @@ impl App {
     /// without drawing so `prepare_tiles`/`draw_list` can position the
     /// focused-button tile without re-rendering the header.
     pub(crate) fn forget_host_content_rect(card: Rect, name: &str, fonts: &ui::Fonts) -> Rect {
-        let after_subtitle_y = ui::modal_header_end_y(fonts.label, fonts.value, card, &Self::forget_host_subtitle(name));
-        Rect::new(card.x() + 32, after_subtitle_y + 32, card.width().saturating_sub(64), 72)
+        let after_subtitle_y =
+            ui::modal_header_end_y(fonts.label, fonts.value, card, &Self::forget_host_subtitle(name));
+        Rect::new(
+            card.x() + 32,
+            after_subtitle_y + 32,
+            card.width().saturating_sub(64),
+            72,
+        )
     }
 }

--- a/src/app/home.rs
+++ b/src/app/home.rs
@@ -13,11 +13,12 @@ impl App {
         self.entries.len() + 2
     }
 
-    /// Total grid nav positions: "Desktop" + fetched games. `0` (no cards at all)
-    /// only when no host is selected yet.
+    /// Total grid nav positions: "Desktop" (only once `games_loaded`) + fetched
+    /// games. `0` (no cards at all) only when no host is selected yet, or one's
+    /// selected but hasn't answered a library fetch yet.
     pub(crate) fn grid_len(&self) -> usize {
         if self.selected_host.is_some() {
-            1 + self.games.len()
+            self.card_offset() + self.games.len()
         } else {
             0
         }
@@ -127,8 +128,8 @@ impl App {
                     self.screen = Screen::Settings;
                     self.dropdown = None;
                     self.settings_focused = 0;
-                    self.settings_scroll = 0;
-                    self.settings_scroll_shown_at = None;
+                    self.scroll = ui::ScrollWindow::new();
+                    self.content_window = ui::ContentWindow::new();
                 }
                 HomeFocus::SidebarMenu(i) => self.open_host_menu(i),
                 HomeFocus::Grid(i) => self.confirm_grid_card(i),
@@ -225,6 +226,7 @@ impl App {
         self.selected_host = Some((host.clone(), port));
         self.home_status = Some("Loading library…".into());
         self.games = Vec::new();
+        self.games_loaded = false;
         self.art.clear();
         // Dropping the loader stops its worker (its request channel closes), so a host
         // switch abandons in-flight fetches for the previous library.
@@ -292,6 +294,7 @@ impl App {
                     fingerprint,
                 ));
                 self.games = games;
+                self.games_loaded = true;
                 self.home_status = None;
             }
             Err(e) => {
@@ -309,7 +312,7 @@ impl App {
     /// controls then); `NotPaired`/`PinMismatch`/`Http` mean the host answered, so
     /// Wake-on-LAN wouldn't help — those stay a plain status line.
     pub(crate) fn handle_library_error(&mut self, host: String, port: u16, e: crate::library::LibraryError) {
-        let reason = format!("{e} (Desktop is still available.)");
+        let reason = e.to_string();
         if matches!(e, crate::library::LibraryError::Unreachable(_)) {
             let mac = self
                 .known_hosts
@@ -319,6 +322,9 @@ impl App {
                 .unwrap_or_default();
             self.start_wake(host, port, mac, reason);
         } else {
+            // The host answered — just not with a usable library — so Desktop is a
+            // legitimate fallback here, unlike the `Unreachable` branch above.
+            self.games_loaded = true;
             self.home_status = Some(reason);
         }
     }
@@ -340,10 +346,12 @@ impl App {
             return;
         };
         let Some(fingerprint) = known.fingerprint else { return };
-        let launch = if idx == 0 {
+        let launch = if self.games_loaded && idx == 0 {
             None
         } else {
-            let Some(game) = self.games.get(idx - 1) else { return };
+            let Some(game) = self.games.get(idx - self.card_offset()) else {
+                return;
+            };
             Some(game.id.clone())
         };
         let mgmt_port = known.mgmt_port.unwrap_or(crate::library::DEFAULT_MGMT_PORT);
@@ -422,6 +430,7 @@ impl App {
         if self.selected_host.as_ref() == Some(&(host, port)) {
             self.selected_host = None;
             self.games = Vec::new();
+            self.games_loaded = false;
             self.home_status = None;
             self.home_focus = HomeFocus::Sidebar(0);
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -26,7 +26,7 @@ mod settings;
 mod speedtest;
 mod wake;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Screen {
     Home,
     Pairing,
@@ -99,15 +99,30 @@ const SPINNER_MAX_WAIT: Duration = Duration::from_millis(900);
 pub(crate) const CARD_GROWTH: f32 = 0.028;
 /// How long a modal's fade/slide-in runs.
 pub(crate) const MODAL_FADE: Duration = Duration::from_millis(170);
-/// How long the Settings scrollbar stays at full opacity after a scroll before fading out.
-pub(crate) const SETTINGS_SCROLLBAR_HOLD: Duration = Duration::from_millis(700);
-/// How long the scrollbar's fade-out takes once `SETTINGS_SCROLLBAR_HOLD` elapses.
-pub(crate) const SETTINGS_SCROLLBAR_FADE: Duration = Duration::from_millis(350);
-/// Total lifetime of one scrollbar appearance — hold, then fade to gone.
-pub(crate) const SETTINGS_SCROLL_INDICATOR: Duration =
-    Duration::from_millis(SETTINGS_SCROLLBAR_HOLD.as_millis() as u64 + SETTINGS_SCROLLBAR_FADE.as_millis() as u64);
-/// A few px wider than the scrollbar track so its rounded caps aren't clipped.
-const SETTINGS_SCROLLBAR_TILE_W: u32 = 10;
+/// How long a scroll indicator (Settings' row list, About's document, ...) stays
+/// at full opacity after a scroll before fading out.
+pub(crate) const SCROLL_INDICATOR_HOLD: Duration = Duration::from_millis(700);
+/// How long the indicator's fade-out takes once `SCROLL_INDICATOR_HOLD` elapses.
+pub(crate) const SCROLL_INDICATOR_FADE: Duration = Duration::from_millis(350);
+/// Total lifetime of one scroll indicator appearance — hold, then fade to gone.
+pub(crate) const SCROLL_INDICATOR_LIFETIME: Duration =
+    Duration::from_millis(SCROLL_INDICATOR_HOLD.as_millis() as u64 + SCROLL_INDICATOR_FADE.as_millis() as u64);
+/// A few px wider than the indicator's track so its rounded caps aren't clipped.
+const SCROLL_INDICATOR_TILE_W: u32 = 10;
+
+/// Wrapped-visual-lines worth of the About document baked into one content
+/// tile at a time (see `ui::ContentWindow`) — comfortably more than one
+/// screenful in each direction so ordinary scrolling almost never triggers a
+/// rebuild, while staying well under any plausible GLES2 max-texture-height
+/// for this content's pixel width. Each rebuild renders every line in the
+/// window uncached (`ui::draw_about_window` — see its docs on why), so this
+/// is also a direct knob on how long one rebuild's hitch runs; kept smaller
+/// than a "whole screen of slack" budget would otherwise be, so a rebuild
+/// stays a brief blip rather than a rasterize-120-lines stall.
+const ABOUT_WINDOW_BUDGET: usize = 80;
+/// How close to the baked window's edge (in visual lines) the scroll position
+/// must get before the window re-centers around it.
+const ABOUT_WINDOW_MARGIN: usize = 16;
 
 /// The pairing modal's subtitle — pulled out to a constant since both
 /// `render_pairing` (drawing it) and `Self::pairing_pin_row_y` (measuring its
@@ -262,10 +277,12 @@ pub(crate) enum ModalShellKey {
         rows: usize,
         hover_close: bool,
     },
-    /// Only the scroll position changes what this shell draws (the body is a static
-    /// document) — but it changes ALL of it, so it is the whole key.
+    /// The document itself never changes, and its scroll position no longer lives
+    /// in this shell at all — the body is its own `Tile::ScrollContent(Screen::About)`
+    /// tile, cropped/positioned by the GPU same as Settings' row list. So this shell
+    /// is invalidated only by the same thing every other shell already excludes
+    /// focus/scroll for: nothing screen-specific here at all.
     About {
-        scroll: usize,
         hover_close: bool,
     },
     SpeedTest {
@@ -301,6 +318,23 @@ pub(crate) enum ModalFocusKey {
     MenuRow(usize, String),
 }
 
+/// What invalidates whichever modal's `Tile::ScrollContent(Screen)` is currently
+/// baked (see `App::scroll_content_tile`) — one variant per screen that has
+/// overflowing content. Paired with its `Screen` in the tile's staleness key, so
+/// switching between two scrollable modals always rebuilds (there's only ever
+/// one baked content tile, same "one modal open at a time" rationale as
+/// `ModalFocusKey`).
+#[derive(Clone, PartialEq)]
+pub(crate) enum ScrollContentKey {
+    /// Settings' row list — the whole `Settings` snapshot plus which row's
+    /// dropdown (if any) is open, mirroring `ModalFocusKey::SettingsRow`.
+    Settings(Settings, Option<usize>),
+    /// About's document window — the wrapped-line index its content tile
+    /// currently starts at (see `ui::ContentWindow`). The document itself
+    /// never changes, so this is the only thing that invalidates it.
+    About(usize),
+}
+
 pub struct App {
     pub screen: Screen,
     pub known_hosts: Vec<KnownHost>,
@@ -318,6 +352,11 @@ pub struct App {
     /// selected (or restored from `store::load_selected_host` at startup).
     pub selected_host: Option<(String, u16)>,
     pub games: Vec<GameEntry>,
+    /// Whether the current host has actually answered a library fetch — gates the
+    /// fixed "Desktop" grid card (see `card_offset`), which has no reason to show
+    /// before the host is confirmed reachable. Reset to `false` on every
+    /// `select_host`; set once `drain_games`/`handle_library_error` hears back.
+    pub(crate) games_loaded: bool,
     /// In-flight `library::fetch_games` call, if any — see `select_host`/`drain_games`.
     pub(crate) games_rx: Option<std::sync::mpsc::Receiver<crate::library::GamesLoaded>>,
     /// Library loading/error message shown in the grid area in place of cards.
@@ -337,10 +376,17 @@ pub struct App {
     /// `store::save_settings` on every adjustment read as input lag.
     pub(crate) settings_writer: store::SettingsWriter,
     pub settings_focused: usize,
-    /// Index of the topmost visible row in the Settings list (see `settings_visible_rows`).
-    pub(crate) settings_scroll: usize,
-    /// When `settings_scroll` last changed — the scrollbar shows briefly after this.
-    pub(crate) settings_scroll_shown_at: Option<Instant>,
+    /// Offset/fade-in bookkeeping for whichever modal's content currently
+    /// overflows its viewport (Settings' row list, About's document) — shared
+    /// across screens since only one modal is ever open at a time, same
+    /// rationale as `modal_focus_tile`. Reset whenever a scrollable modal is
+    /// (re)opened (see `open_about`, `Screen::Settings`'s entry in `home.rs`).
+    pub(crate) scroll: ui::ScrollWindow,
+    /// Which slice of a too-long-for-one-texture document (About's) is
+    /// currently baked into `scroll_content_tile` — see `ui::ContentWindow`.
+    /// Settings never windows (its whole row list always fits one tile), so
+    /// this is only ever meaningfully non-trivial for `Screen::About`.
+    pub(crate) content_window: ui::ContentWindow,
     pub dropdown: Option<DropdownState>,
     /// The sidebar row `Screen::ForgetHost` is confirming forgetting — set
     /// alongside `screen = Screen::ForgetHost` (see `App::open_forget_host`),
@@ -373,12 +419,15 @@ pub struct App {
     /// `SDL_IsScreenKeyboardShown` each tick by `main.rs` — it moves the address form out
     /// from under the panel (see `App::keyboard_modal_card`).
     pub keyboard_shown: bool,
-    /// First visible source line of `Screen::About`'s document (see
-    /// `ui::draw_about_body` — scrolling is by line, not pixel).
-    pub about_scroll: usize,
-    /// The About document, built once on first open. ~10,000 static string slices;
-    /// cheap to hold, wasteful to rebuild per frame.
+    /// The About document's source lines, built once on first open. ~10,000
+    /// static string slices; cheap to hold, wasteful to rebuild per frame.
     pub about_lines: Vec<&'static str>,
+    /// `about_lines` wrapped to a body width, flattened into one list of visual
+    /// lines (see `ui::wrap_document`) — the unit `scroll`/`content_window`
+    /// actually scroll over, since a source line's wrapped length varies and
+    /// only the flattened list has a uniform per-unit stride. Keyed by the
+    /// body width it was wrapped for, rebuilt if that width changes.
+    pub(crate) about_wrapped: Option<(u32, Vec<String>)>,
     pub add_host: AddHostState,
     /// The active "host unreachable — wake it?" prompt/wait, if any — see `WakeState`.
     pub wake: Option<WakeState>,
@@ -442,20 +491,22 @@ pub struct App {
     pub(crate) modal_focus_tile: Option<(ModalFocusKey, Painter)>,
     /// The open dropdown's panel + unfocused option list, keyed by its row (the
     /// options list depends only on which row opened it). Composited *after*
-    /// `settings_rows_tile` — see `Tile::DropdownOverlay`'s docs.
+    /// `scroll_content_tile` — see `Tile::DropdownOverlay`'s docs.
     pub(crate) dropdown_overlay_tile: Option<(usize, Painter)>,
     /// The open dropdown's focused option, as its own small tile — keyed by
     /// (dropdown row, focused option index). Composited over `dropdown_overlay_tile`
     /// (which draws the overlay's option list unfocused); moving the
     /// dropdown's own focus rebuilds only this.
     pub(crate) dropdown_focus_tile: Option<((usize, usize), Painter)>,
-    /// The Settings scrollbar, keyed by `(total rows, visible rows, scroll)` — rebuilt
-    /// only when those change; the fade is a per-frame alpha, not baked into the tile.
-    pub(crate) settings_scrollbar_tile: Option<((usize, usize, usize), Painter)>,
-    /// Every Settings row, unfocused, at full (unscrolled) height — keyed by
-    /// `(settings, open dropdown row)`. Scrolling never invalidates this; see
-    /// `Tile::SettingsRows`'s docs.
-    pub(crate) settings_rows_tile: Option<((Settings, Option<usize>), Painter)>,
+    /// Whichever scrollable modal's indicator is baked, keyed by `(total units,
+    /// visible units, scroll offset)` — rebuilt only when those change; the
+    /// fade is a per-frame alpha, not baked into the tile. One slot for all of
+    /// them (see `Tile::ScrollIndicator`'s docs — only one modal open at once).
+    pub(crate) scroll_indicator_tile: Option<((usize, usize, usize), Painter)>,
+    /// Whichever scrollable modal's content is baked, at full (unscrolled)
+    /// height — keyed by `(Screen, ScrollContentKey)`. Scrolling within the
+    /// baked window never invalidates this; see `Tile::ScrollContent`'s docs.
+    pub(crate) scroll_content_tile: Option<((Screen, ScrollContentKey), Painter)>,
     /// Home's status line block, keyed by its text.
     pub(crate) status_tile: Option<(String, Painter)>,
     /// The static "No host selected" hint line.
@@ -541,6 +592,7 @@ impl App {
             home_focus: HomeFocus::Sidebar(0),
             selected_host: None,
             games: Vec::new(),
+            games_loaded: false,
             games_rx: None,
             home_status: None,
             art: std::collections::HashMap::new(),
@@ -550,8 +602,8 @@ impl App {
             settings: store::load_settings(),
             settings_writer: store::SettingsWriter::spawn(),
             settings_focused: 0,
-            settings_scroll: 0,
-            settings_scroll_shown_at: None,
+            scroll: ui::ScrollWindow::new(),
+            content_window: ui::ContentWindow::new(),
             dropdown: None,
             host_menu_index: None,
             host_menu_focused: 1,
@@ -565,8 +617,8 @@ impl App {
             reach_rx: None,
             reach_last: None,
             keyboard_shown: false,
-            about_scroll: 0,
             about_lines: Vec::new(),
+            about_wrapped: None,
             add_host: AddHostState::default(),
             wake: None,
             pin_digits: [0; 4],
@@ -591,8 +643,8 @@ impl App {
             modal_focus_tile: None,
             dropdown_overlay_tile: None,
             dropdown_focus_tile: None,
-            settings_scrollbar_tile: None,
-            settings_rows_tile: None,
+            scroll_indicator_tile: None,
+            scroll_content_tile: None,
             status_tile: None,
             nohost_tile: None,
             grid_reveal_ready: true,
@@ -705,7 +757,7 @@ impl App {
             // Layout is unchanged by art arriving — queue a repaint of just that
             // card's tile (see `grid_cards_dirty`) rather than a full layer rebuild.
             if let Some(i) = self.games.iter().position(|g| g.id == item.game_id) {
-                self.grid_cards_dirty.push(i + 1); // +1: card 0 is Desktop
+                self.grid_cards_dirty.push(i + self.card_offset());
             }
             self.art.insert(item.game_id, item.pixmap);
         }
@@ -812,9 +864,9 @@ impl App {
             }
             animating = true;
         }
-        if let Some(t) = self.settings_scroll_shown_at {
-            if t.elapsed() >= SETTINGS_SCROLL_INDICATOR {
-                self.settings_scroll_shown_at = None;
+        if let Some(t) = self.scroll.shown_at {
+            if t.elapsed() >= SCROLL_INDICATOR_LIFETIME {
+                self.scroll.shown_at = None;
             }
             animating = true;
         }
@@ -1000,7 +1052,7 @@ impl App {
                         let row_y = content.y() + i as i32 * (ui::SETTINGS_ROW_H as i32 + ui::SETTINGS_ROW_GAP);
                         Rect::new(content.x(), row_y, content.width(), ui::SETTINGS_ROW_H).contains_point((x, y))
                     })?;
-                    self.settings_focused = self.settings_scroll + local;
+                    self.settings_focused = self.scroll.clamped(ui::SETTINGS_ROW_COUNT, visible) + local;
                 }
                 self.handle_settings_event(MenuEvent::Confirm, screen_h);
                 None
@@ -1045,13 +1097,21 @@ impl App {
     }
     // --------------------------------------------------------------- render --
 
-    /// The title of grid card `idx` (0 = the fixed "Desktop" card) and its cover
-    /// art, if fetched.
+    /// `1` when the fixed "Desktop" card occupies grid index `0` — only once
+    /// `games_loaded`, i.e. the host has actually answered a library fetch — `0`
+    /// otherwise, so index `0` is the first game directly. Subtract this from a
+    /// grid index before indexing into `games`.
+    pub(crate) fn card_offset(&self) -> usize {
+        usize::from(self.games_loaded)
+    }
+
+    /// The title of grid card `idx` (0 = the fixed "Desktop" card, when shown — see
+    /// `card_offset`) and its cover art, if fetched.
     pub(crate) fn grid_card_content(&self, idx: usize) -> (&str, Option<&Pixmap>) {
-        if idx == 0 {
+        if self.games_loaded && idx == 0 {
             ("Desktop", None)
         } else {
-            let game = &self.games[idx - 1];
+            let game = &self.games[idx - self.card_offset()];
             (game.title.as_str(), self.art.get(&game.id))
         }
     }
@@ -1184,7 +1244,7 @@ impl App {
                 if (row < keep_lo || row > keep_hi) && self.card_tiles[idx].is_some() {
                     self.card_tiles[idx] = None;
                     self.evicted_tiles.push(Tile::Card(idx));
-                    if let Some(game) = self.games.get(idx.wrapping_sub(1)) {
+                    if let Some(game) = self.games.get(idx.wrapping_sub(self.card_offset())) {
                         // Drop the decoded cover too — it is several times the size of the
                         // tile it feeds. Re-requested from the disk cache on scroll back.
                         self.art.remove(&game.id);
@@ -1196,10 +1256,11 @@ impl App {
             }
 
             // Ready once nothing more can arrive: cover already in `self.art`, or the game
-            // never had one to fetch (no `self.art` entry either way). `idx == 0` (Desktop)
-            // has no `games` entry and is always ready.
+            // never had one to fetch (no `self.art` entry either way). `idx == 0` (Desktop,
+            // when shown) has no `games` entry and is always ready.
+            let card_offset = self.card_offset();
             let art_ready = |idx: usize| {
-                self.games.get(idx.wrapping_sub(1)).is_none_or(|game| {
+                self.games.get(idx.wrapping_sub(card_offset)).is_none_or(|game| {
                     self.art.contains_key(&game.id) || (game.art.portrait.is_none() && game.art.header.is_none())
                 })
             };
@@ -1214,7 +1275,9 @@ impl App {
                 }
                 // Ask for this card's cover as it enters the window, not for the whole
                 // library at once (see `art::ArtLoader`).
-                if let (Some(loader), Some(game)) = (&mut self.art_loader, self.games.get(idx.wrapping_sub(1))) {
+                if let (Some(loader), Some(game)) =
+                    (&mut self.art_loader, self.games.get(idx.wrapping_sub(card_offset)))
+                {
                     loader.request(game);
                 }
                 if self.card_tiles[idx].is_some() {
@@ -1329,7 +1392,6 @@ impl App {
                 hover_close: self.hover_close,
             }),
             Screen::About => Some(ModalShellKey::About {
-                scroll: self.about_scroll,
                 hover_close: self.hover_close,
             }),
             // The whole shell is derived from the status sentence, which already encodes
@@ -1575,35 +1637,112 @@ impl App {
             self.dropdown_focus_tile = None;
         }
 
-        if matches!(self.screen, Screen::Settings) {
-            let (_, content) = Self::settings_layout(screen_w, screen_h);
-            let visible = Self::settings_visible_rows(screen_h);
-            let scroll = self.clamped_settings_scroll(screen_h);
-            let key = (ui::SETTINGS_ROW_COUNT, visible, scroll);
-            let stale = !matches!(&self.settings_scrollbar_tile, Some((k, _)) if *k == key);
-            if stale {
-                let tile = ui::render_list_scrollbar_tile(
-                    SETTINGS_SCROLLBAR_TILE_W,
-                    content.height(),
-                    ui::SETTINGS_ROW_COUNT,
-                    visible,
-                    scroll,
-                );
-                self.settings_scrollbar_tile = Some((key, tile));
-                updated.push(Tile::SettingsScrollbar);
+        // Whichever modal's content overflows its viewport (Settings' rows, About's
+        // document) gets its scroll indicator and content tile refreshed here — see
+        // `scroll_geometry`'s docs for why this one block covers every such modal
+        // instead of being hand-copied per screen.
+        if matches!(self.screen, Screen::About) {
+            // Mutates `about_wrapped` only — must happen before `scroll_geometry`
+            // (a `&self` read) can report a non-zero total for this frame.
+            let card = ui::about_card_rect(screen_w, screen_h);
+            let body = ui::about_body_rect(card, fonts);
+            self.ensure_about_wrapped(fonts, body.width());
+        }
+        if let Some((total, visible, _, content)) = self.scroll_geometry(screen_w, screen_h, fonts) {
+            let scroll = self.scroll.clamped(total, visible);
+            let ind_key = (total, visible, scroll);
+            let ind_stale = !matches!(&self.scroll_indicator_tile, Some((k, _)) if *k == ind_key);
+            if ind_stale {
+                let tile =
+                    ui::render_list_scrollbar_tile(SCROLL_INDICATOR_TILE_W, content.height(), total, visible, scroll);
+                self.scroll_indicator_tile = Some((ind_key, tile));
+                updated.push(Tile::ScrollIndicator(self.screen));
             }
 
-            let dropdown_row = self.dropdown.as_ref().map(|dd| dd.row);
-            let rows_key = (self.settings, dropdown_row);
-            let rows_stale = !matches!(&self.settings_rows_tile, Some((k, _)) if *k == rows_key);
-            if rows_stale {
-                let rows = ui::settings_rows(&self.settings);
-                let tile = ui::render_focus_rows_tile(text_cache, fonts, &rows, content.width(), dropdown_row)?;
-                self.settings_rows_tile = Some((rows_key, tile));
-                updated.push(Tile::SettingsRows);
+            match self.screen {
+                Screen::Settings => {
+                    let dropdown_row = self.dropdown.as_ref().map(|dd| dd.row);
+                    let key = (
+                        Screen::Settings,
+                        ScrollContentKey::Settings(self.settings, dropdown_row),
+                    );
+                    let stale = !matches!(&self.scroll_content_tile, Some((k, _)) if *k == key);
+                    if stale {
+                        let rows = ui::settings_rows(&self.settings);
+                        let tile = ui::render_focus_rows_tile(text_cache, fonts, &rows, content.width(), dropdown_row)?;
+                        self.scroll_content_tile = Some((key, tile));
+                        // Settings' whole row list always fits one tile — no windowing.
+                        self.content_window = ui::ContentWindow {
+                            start: 0,
+                            len: ui::SETTINGS_ROW_COUNT,
+                        };
+                        updated.push(Tile::ScrollContent(Screen::Settings));
+                    }
+                }
+                Screen::About => {
+                    if let Some(new_start) = self.content_window.recenter_if_needed(
+                        scroll,
+                        visible,
+                        total,
+                        ABOUT_WINDOW_BUDGET,
+                        ABOUT_WINDOW_MARGIN,
+                    ) {
+                        let len = ABOUT_WINDOW_BUDGET.min(total.saturating_sub(new_start));
+                        if let Some((_, wrapped)) = &self.about_wrapped {
+                            let stride = self.scroll_stride(fonts) as u32;
+                            let mut p = Painter::new(content.width().max(1), (len as u32 * stride).max(1));
+                            ui::draw_about_window(&mut p, fonts.value, wrapped, new_start, len)?;
+                            self.content_window = ui::ContentWindow { start: new_start, len };
+                            self.scroll_content_tile = Some(((Screen::About, ScrollContentKey::About(new_start)), p));
+                            updated.push(Tile::ScrollContent(Screen::About));
+                        }
+                    }
+                }
+                _ => {}
             }
         }
         Ok(updated)
+    }
+
+    /// `(total units, visible units, card rect, content/viewport rect)` for whichever
+    /// scrollable modal is open — `None` if `self.screen` has no overflowing content.
+    /// The one place this per-modal geometry lives, shared by `prepare_tiles`'s
+    /// staleness checks and `draw_list`'s GPU-crop math so the two can't disagree.
+    /// `About`'s `total` depends on `about_wrapped` already being fresh for this
+    /// frame's body width — `prepare_tiles` ensures that before calling this;
+    /// `draw_list` runs after `prepare_tiles` in the same frame, so it's already set.
+    pub(crate) fn scroll_geometry(
+        &self,
+        screen_w: u32,
+        screen_h: u32,
+        fonts: &ui::Fonts,
+    ) -> Option<(usize, usize, Rect, Rect)> {
+        match self.screen {
+            Screen::Settings => {
+                let (card, content) = Self::settings_layout(screen_w, screen_h);
+                let visible = Self::settings_visible_rows(screen_h);
+                Some((ui::SETTINGS_ROW_COUNT, visible, card, content))
+            }
+            Screen::About => {
+                let card = ui::about_card_rect(screen_w, screen_h);
+                let body = ui::about_body_rect(card, fonts);
+                let total = self.about_wrapped.as_ref().map_or(0, |(_, v)| v.len());
+                let visible = ui::about_visible_lines(body, fonts.value);
+                Some((total, visible, card, body))
+            }
+            _ => None,
+        }
+    }
+
+    /// Pixel stride between two consecutive units of whichever modal is scrolling —
+    /// Settings' fixed row height, or About's wrapped-line height. Only meaningful
+    /// when `scroll_geometry` returns `Some`.
+    fn scroll_stride(&self, fonts: &ui::Fonts) -> i32 {
+        match self.screen {
+            Screen::Settings => ui::SETTINGS_ROW_H as i32 + ui::SETTINGS_ROW_GAP,
+            Screen::About => ui::about_line_stride(fonts.value),
+            _ => 1,
+        }
     }
 
     /// The pixmap behind `tile`, for the compositor to upload.
@@ -1617,8 +1756,8 @@ impl App {
             Tile::ModalFocusElement => self.modal_focus_tile.as_ref().map(|(_, p)| p),
             Tile::DropdownOverlay => self.dropdown_overlay_tile.as_ref().map(|(_, p)| p),
             Tile::DropdownFocusOption => self.dropdown_focus_tile.as_ref().map(|(_, p)| p),
-            Tile::SettingsScrollbar => self.settings_scrollbar_tile.as_ref().map(|(_, p)| p),
-            Tile::SettingsRows => self.settings_rows_tile.as_ref().map(|(_, p)| p),
+            Tile::ScrollIndicator(_) => self.scroll_indicator_tile.as_ref().map(|(_, p)| p),
+            Tile::ScrollContent(_) => self.scroll_content_tile.as_ref().map(|(_, p)| p),
             Tile::Status => self.status_tile.as_ref().map(|(_, p)| p),
             Tile::NoHost => self.nohost_tile.as_ref(),
             Tile::Spinner => self.spinner_tile.as_ref(),
@@ -1726,7 +1865,17 @@ impl App {
         }
         if self.selected_host.is_some() && self.home_status.is_some() {
             if let Some((_, p)) = &self.status_tile {
-                let y = screen_h as i32 - ui::GRID_PAD - p.height() as i32;
+                // Fixed at two text rows regardless of how many the current message
+                // actually wraps to, so the bar doesn't resize as status text changes.
+                const STATUS_BG_PAD: i32 = 12;
+                let line_h = fonts.label.height() + 6;
+                let box_h = 2 * line_h as u32 + 2 * STATUS_BG_PAD as u32;
+                let box_y = screen_h as i32 - box_h as i32;
+                cmds.push(DrawCmd::Fill {
+                    rect: Rect::new(grid_x, box_y, available_w, box_h),
+                    color: ui::MODAL_SCRIM,
+                });
+                let y = box_y + (box_h as i32 - p.height() as i32) / 2;
                 cmds.push(DrawCmd::Tex {
                     tile: Tile::Status,
                     dst: Rect::new(grid_x + ui::GRID_PAD, y, p.width(), p.height()),
@@ -1772,44 +1921,55 @@ impl App {
                 dst: Rect::new(0, dy, screen_w, screen_h),
                 alpha: (255.0 * m) as u8,
             });
-            // Settings' card/content/scroll, computed once and reused by every block
-            // below instead of each re-deriving it (they're all pure geometry, but no
-            // reason to repeat the call four times in one frame).
-            let settings_geom = matches!(self.screen, Screen::Settings).then(|| {
-                (
-                    Self::settings_layout(screen_w, screen_h),
-                    self.clamped_settings_scroll(screen_h),
-                )
-            });
-            // The Settings row list: cropped/repositioned straight off its full
-            // (unscrolled) tile — a GPU op, so scrolling never re-rasterizes anything
-            // (see `Tile::SettingsRows`'s docs).
-            if let Some(((_, content), scroll)) = settings_geom {
-                let stride = ui::SETTINGS_ROW_H as i32 + ui::SETTINGS_ROW_GAP;
+            // Whichever modal's content overflows (Settings' rows, About's document),
+            // computed once and reused by every block below instead of each
+            // re-deriving it — see `scroll_geometry`'s docs.
+            let scroll_geom = self.scroll_geometry(screen_w, screen_h, fonts);
+            // Its content: cropped/repositioned straight off its own full (unscrolled)
+            // tile — a GPU op, so scrolling never re-rasterizes anything (see
+            // `Tile::ScrollContent`'s docs). About's tile only ever holds a bounded
+            // window of the document, not the whole thing — `window_start` is where
+            // that window begins, so the crop offset is relative to it, not to 0.
+            if let Some((total, visible, _, content)) = scroll_geom {
+                let scroll = self.scroll.clamped(total, visible);
+                let window_start = match self.screen {
+                    Screen::About => self.content_window.start,
+                    _ => 0,
+                };
+                let stride = self.scroll_stride(fonts);
                 cmds.push(DrawCmd::TexCropped {
-                    tile: Tile::SettingsRows,
-                    src: Rect::new(0, scroll as i32 * stride, content.width(), content.height()),
+                    tile: Tile::ScrollContent(self.screen),
+                    src: Rect::new(
+                        0,
+                        (scroll - window_start) as i32 * stride,
+                        content.width(),
+                        content.height(),
+                    ),
                     dst: Rect::new(content.x(), content.y() + dy, content.width(), content.height()),
                     alpha: (255.0 * m) as u8,
                 });
             }
-            // The open dropdown's panel + unfocused option list — its own tile so it
-            // composites *after* `Tile::SettingsRows` (which would otherwise redraw the
-            // rows the overlay extends over, on top of it).
-            if let Some(((_, content), scroll)) = settings_geom {
-                if let Some(dd) = &self.dropdown {
-                    let overlay_rect = Self::dropdown_overlay_rect(content, dd.row - scroll);
-                    let options_len = ui::dropdown_options(&self.settings, dd.row).len();
-                    cmds.push(DrawCmd::Tex {
-                        tile: Tile::DropdownOverlay,
-                        dst: Rect::new(
-                            overlay_rect.x(),
-                            overlay_rect.y() + dy,
-                            overlay_rect.width(),
-                            options_len as u32 * ui::DROPDOWN_OPTION_H,
-                        ),
-                        alpha: (255.0 * m) as u8,
-                    });
+            // The open dropdown's panel + unfocused option list — Settings-only (no
+            // other modal has one) — its own tile so it composites *after*
+            // `Tile::ScrollContent` (which would otherwise redraw the rows the overlay
+            // extends over, on top of it).
+            if matches!(self.screen, Screen::Settings) {
+                if let Some((total, visible, _, content)) = scroll_geom {
+                    let scroll = self.scroll.clamped(total, visible);
+                    if let Some(dd) = &self.dropdown {
+                        let overlay_rect = Self::dropdown_overlay_rect(content, dd.row - scroll);
+                        let options_len = ui::dropdown_options(&self.settings, dd.row).len();
+                        cmds.push(DrawCmd::Tex {
+                            tile: Tile::DropdownOverlay,
+                            dst: Rect::new(
+                                overlay_rect.x(),
+                                overlay_rect.y() + dy,
+                                overlay_rect.width(),
+                                options_len as u32 * ui::DROPDOWN_OPTION_H,
+                            ),
+                            alpha: (255.0 * m) as u8,
+                        });
+                    }
                 }
             }
             // Whichever modal is open, its one focused widget — a settings/Wake
@@ -1821,7 +1981,8 @@ impl App {
             // modal-open animation.
             let focus_rect = match self.screen {
                 Screen::Settings => {
-                    let ((_, content), scroll) = settings_geom.expect("screen is Screen::Settings");
+                    let (total, visible, _, content) = scroll_geom.expect("screen is Screen::Settings");
+                    let scroll = self.scroll.clamped(total, visible);
                     // `content`'s rows are the scrolled-to-visible window — translate
                     // the focused row's global index back to a local one.
                     Some(ui::focus_row_rect(content, self.settings_focused - scroll))
@@ -1895,49 +2056,59 @@ impl App {
             // The open dropdown's focused option — same idea, composited on
             // top of the shell's unfocused option list at its actual
             // position, so navigating dropdown options needs no modal
-            // re-rasterize either.
-            if let Some(((card, content), scroll)) = settings_geom {
-                if let Some(dd) = &self.dropdown {
-                    let overlay_rect = Self::dropdown_overlay_rect(content, dd.row - scroll);
-                    let option_rect = ui::dropdown_option_rect(overlay_rect, dd.focused);
-                    cmds.push(DrawCmd::Tex {
-                        tile: Tile::DropdownFocusOption,
-                        dst: Rect::new(
-                            option_rect.x(),
-                            option_rect.y() + dy,
-                            option_rect.width(),
-                            option_rect.height(),
-                        ),
-                        alpha: (255.0 * m) as u8,
-                    });
-                }
-                // Full opacity for `SETTINGS_SCROLLBAR_HOLD`, then a linear fade over
-                // `SETTINGS_SCROLLBAR_FADE`.
-                let scroll_alpha = self.settings_scroll_shown_at.map_or(0.0, |t| {
-                    let elapsed = t.elapsed();
-                    if elapsed < SETTINGS_SCROLLBAR_HOLD {
-                        1.0
-                    } else {
-                        let fading = (elapsed - SETTINGS_SCROLLBAR_HOLD).as_secs_f32();
-                        1.0 - (fading / SETTINGS_SCROLLBAR_FADE.as_secs_f32()).clamp(0.0, 1.0)
+            // re-rasterize either. Settings-only.
+            if matches!(self.screen, Screen::Settings) {
+                if let Some((total, visible, _, content)) = scroll_geom {
+                    let scroll = self.scroll.clamped(total, visible);
+                    if let Some(dd) = &self.dropdown {
+                        let overlay_rect = Self::dropdown_overlay_rect(content, dd.row - scroll);
+                        let option_rect = ui::dropdown_option_rect(overlay_rect, dd.focused);
+                        cmds.push(DrawCmd::Tex {
+                            tile: Tile::DropdownFocusOption,
+                            dst: Rect::new(
+                                option_rect.x(),
+                                option_rect.y() + dy,
+                                option_rect.width(),
+                                option_rect.height(),
+                            ),
+                            alpha: (255.0 * m) as u8,
+                        });
                     }
-                });
-                if scroll_alpha > 0.0 {
-                    // Sits nearer the card's edge than the row content's, so it doesn't
-                    // overlap a row's dropdown pill/slider/switch. The `26` offset isn't
-                    // derived from `settings_layout`'s 0.62 card-width fraction — re-check
-                    // both if either changes.
-                    let dst = Rect::new(
-                        card.x() + card.width() as i32 - 26,
-                        content.y() + dy,
-                        SETTINGS_SCROLLBAR_TILE_W,
-                        content.height(),
-                    );
-                    cmds.push(DrawCmd::Tex {
-                        tile: Tile::SettingsScrollbar,
-                        dst,
-                        alpha: (255.0 * m * scroll_alpha) as u8,
+                }
+            }
+            // Whichever modal is scrollable, its indicator — full opacity for
+            // `SCROLL_INDICATOR_HOLD`, then a linear fade over `SCROLL_INDICATOR_FADE`
+            // (names kept from when only Settings had one; every scrollable modal now
+            // shares the same timing and the same `self.scroll.shown_at` clock, since
+            // only one is ever open at a time).
+            if let Some((total, visible, card, content)) = scroll_geom {
+                if total > visible {
+                    let scroll_alpha = self.scroll.shown_at.map_or(0.0, |t| {
+                        let elapsed = t.elapsed();
+                        if elapsed < SCROLL_INDICATOR_HOLD {
+                            1.0
+                        } else {
+                            let fading = (elapsed - SCROLL_INDICATOR_HOLD).as_secs_f32();
+                            1.0 - (fading / SCROLL_INDICATOR_FADE.as_secs_f32()).clamp(0.0, 1.0)
+                        }
                     });
+                    if scroll_alpha > 0.0 {
+                        // Sits nearer the card's edge than the content's, so it doesn't
+                        // overlap a Settings row's dropdown pill/slider/switch. The `26`
+                        // offset isn't derived from either modal's own width fraction —
+                        // re-check both if either changes.
+                        let dst = Rect::new(
+                            card.x() + card.width() as i32 - 26,
+                            content.y() + dy,
+                            SCROLL_INDICATOR_TILE_W,
+                            content.height(),
+                        );
+                        cmds.push(DrawCmd::Tex {
+                            tile: Tile::ScrollIndicator(self.screen),
+                            dst,
+                            alpha: (255.0 * m * scroll_alpha) as u8,
+                        });
+                    }
                 }
             }
         }

--- a/src/app/reach.rs
+++ b/src/app/reach.rs
@@ -41,11 +41,7 @@ impl App {
             return;
         }
         self.reach_last = Some(Instant::now());
-        let targets: Vec<(String, u16)> = self
-            .entries
-            .iter()
-            .map(|e| (e.host().to_string(), e.port()))
-            .collect();
+        let targets: Vec<(String, u16)> = self.entries.iter().map(|e| (e.host().to_string(), e.port())).collect();
         if targets.is_empty() {
             return;
         }
@@ -99,9 +95,7 @@ impl App {
     /// This entry's last known reachability — `None` until it has been probed once, which
     /// the sidebar draws as "no dot" rather than guessing.
     pub(crate) fn entry_online(&self, entry: &crate::ui::HostEntry) -> Option<bool> {
-        self.reachable
-            .get(&(entry.host().to_string(), entry.port()))
-            .copied()
+        self.reachable.get(&(entry.host().to_string(), entry.port())).copied()
     }
 
     /// Every entry's state, index-aligned with `entries` — what the sidebar renderer takes.

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 
 impl App {
     /// Handles one menu event on the settings modal. `screen_h` is only used by
-    /// `Up`/`Down` to keep `settings_scroll` following `settings_focused`.
+    /// `Up`/`Down` to keep `self.scroll` following `settings_focused`.
     pub fn handle_settings_event(&mut self, ev: MenuEvent, screen_h: u32) {
         // An open Resolution/Frame rate dropdown intercepts all input until it's
         // closed (by picking an option or backing out) — it's a modal overlay on
@@ -112,27 +112,12 @@ impl App {
         ((available / stride) as usize).clamp(1, ui::SETTINGS_ROW_COUNT)
     }
 
-    /// `settings_scroll` is only re-clamped on `Up`/`Down`, so it can be stale after a
-    /// resize; use this instead of the raw field wherever it's subtracted from a row
-    /// index, to avoid underflow.
-    pub(crate) fn clamped_settings_scroll(&self, screen_h: u32) -> usize {
-        let visible = Self::settings_visible_rows(screen_h);
-        self.settings_scroll.min(ui::SETTINGS_ROW_COUNT.saturating_sub(visible))
-    }
-
-    /// Moves `settings_scroll` just enough to keep `settings_focused` in view, and marks
-    /// the scrollbar to show briefly if the position actually moved.
+    /// Moves the scroll offset just enough to keep `settings_focused` in view, and
+    /// marks the scroll indicator to show briefly if the position actually moved.
     pub(crate) fn scroll_settings_into_view(&mut self, screen_h: u32) {
         let visible = Self::settings_visible_rows(screen_h);
-        let before = self.settings_scroll;
-        if self.settings_focused < self.settings_scroll {
-            self.settings_scroll = self.settings_focused;
-        } else if self.settings_focused >= self.settings_scroll + visible {
-            self.settings_scroll = self.settings_focused + 1 - visible;
-        }
-        if self.settings_scroll != before {
-            self.settings_scroll_shown_at = Some(Instant::now());
-        }
+        self.scroll
+            .scroll_into_view(self.settings_focused, ui::SETTINGS_ROW_COUNT, visible);
     }
 
     /// The settings modal's card/content rects — shared by `render` and mouse
@@ -177,10 +162,10 @@ impl App {
             sdl2::pixels::Color::RGBA(0xff, 0xff, 0xff, 0x1e),
         );
 
-        // The row list itself is drawn separately — see `Tile::SettingsRows` — so
+        // The row list itself is drawn separately — see `Tile::ScrollContent` — so
         // scrolling never re-rasterizes this shell; only a value/dropdown change does.
         // The open dropdown's panel is drawn separately too — see `Tile::DropdownOverlay`
-        // — so it composites *after* `Tile::SettingsRows` instead of being covered by it.
+        // — so it composites *after* `Tile::ScrollContent` instead of being covered by it.
 
         if self.settings.bitrate_kbps > ui::BITRATE_WARN_KBPS {
             ui::draw_text(

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -149,7 +149,14 @@ impl AudioPlayer {
         }
 
         let peak = self.queue_packet(opus_payload)?;
-        Ok((peak, if underrun { AudioEvent::Underrun } else { AudioEvent::Queued }))
+        Ok((
+            peak,
+            if underrun {
+                AudioEvent::Underrun
+            } else {
+                AudioEvent::Queued
+            },
+        ))
     }
 
     /// Decodes one real packet into the device queue, returning its peak sample.

--- a/src/bin/pfprobe.rs
+++ b/src/bin/pfprobe.rs
@@ -40,8 +40,7 @@ mod real {
         anyhow::ensure!(hex.len() == 64, "pin must be 64 hex chars");
         let mut pin = [0u8; 32];
         for (i, byte) in pin.iter_mut().enumerate() {
-            *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16)
-                .with_context(|| format!("bad hex at byte {i}"))?;
+            *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).with_context(|| format!("bad hex at byte {i}"))?;
         }
         Ok(pin)
     }
@@ -66,7 +65,11 @@ mod real {
         let target_kbps: u32 = args.get(6).map_or(Ok(320_000), |s| s.parse()).context("target_kbps")?;
         let duration_ms: u32 = args.get(7).map_or(Ok(3_000), |s| s.parse()).context("duration_ms")?;
 
-        let mode = Mode { width: 1280, height: 720, refresh_hz: 60 };
+        let mode = Mode {
+            width: 1280,
+            height: 720,
+            refresh_hz: 60,
+        };
         let client = NativeClient::connect(
             host,
             port,
@@ -108,7 +111,9 @@ mod real {
             warm_start.elapsed().as_millis()
         );
 
-        client.request_probe(target_kbps, duration_ms).context("request_probe")?;
+        client
+            .request_probe(target_kbps, duration_ms)
+            .context("request_probe")?;
         let started = Instant::now();
         let deadline = started + Duration::from_millis(u64::from(duration_ms)) + PROBE_REPORT_GRACE;
         loop {

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -14,6 +14,7 @@ use sdl2::rect::Rect;
 use sdl2::render::{BlendMode, Canvas, Texture, TextureCreator};
 use sdl2::video::{Window, WindowContext};
 
+use crate::app::Screen;
 use crate::ui::Painter;
 
 /// Identity of one cached tile/texture. `Card` is keyed by grid index.
@@ -39,7 +40,7 @@ pub enum Tile {
     ModalFocusElement,
     /// An open dropdown's panel + unfocused option list, positioned over the
     /// row that opened it. Its own tile — rather than being baked into
-    /// `Modal`'s shell — so it composites *after* `SettingsRows`, which would
+    /// `Modal`'s shell — so it composites *after* `ScrollContent`, which would
     /// otherwise redraw the rows the panel overlaps on top of it.
     DropdownOverlay,
     /// An open dropdown's focused option, as its own small tile — composited
@@ -51,13 +52,21 @@ pub enum Tile {
     Status,
     /// The "No host selected" hint line.
     NoHost,
-    /// The Settings modal's scroll indicator (`ui::render_list_scrollbar_tile`).
-    SettingsScrollbar,
-    /// Every Settings row, unfocused, at its *unscrolled* position — full row-list
-    /// height, not just the visible window. Scrolling crops/repositions this via
-    /// `DrawCmd::TexCropped` (a GPU op), so it only needs rebuilding when a value or
-    /// the open dropdown changes, never when the list merely scrolls.
-    SettingsRows,
+    /// Whichever modal's scroll position indicator is currently baked
+    /// (`ui::render_list_scrollbar_tile`) — keyed by `Screen` since only one
+    /// modal is ever open at a time, so one keyed pair of variants covers
+    /// every scrollable modal (Settings' row list, About's document, ...)
+    /// instead of two new `Tile` variants per modal. See `App::scroll_geometry`.
+    ScrollIndicator(Screen),
+    /// Whichever modal's scrollable content is currently baked, at its
+    /// *unscrolled* position — for Settings, every row at full row-list
+    /// height; for About, a bounded window of the wrapped document (see
+    /// `ui::ContentWindow` — the whole ~12k-line document is far too tall for
+    /// one GPU texture). Scrolling crops/repositions this via
+    /// `DrawCmd::TexCropped` (a GPU op), so it only needs rebuilding when the
+    /// content itself changes (a value/dropdown, or About's window
+    /// recentering), never when the list merely scrolls within it.
+    ScrollContent(Screen),
     /// The loading spinner shown over the grid while it fills in (`ui::render_spinner_tile`).
     Spinner,
     /// The in-stream stats overlay panel (`ui::render_stats_overlay_tile`).

--- a/src/device.rs
+++ b/src/device.rs
@@ -62,8 +62,7 @@ pub fn supports_av1() -> bool {
     static SUPPORTED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *SUPPORTED.get_or_init(|| {
         let needle = b"video/x-av1";
-        let found = std::fs::read(LX_VIDEODEC_PLUGIN)
-            .is_ok_and(|data| data.windows(needle.len()).any(|w| w == needle));
+        let found = std::fs::read(LX_VIDEODEC_PLUGIN).is_ok_and(|data| data.windows(needle.len()).any(|w| w == needle));
         tracing::info!(
             "device: platform decoder {} AV1 ({LX_VIDEODEC_PLUGIN})",
             if found { "declares" } else { "does not declare" },

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -68,9 +68,7 @@ pub fn connect_message(err: &PunktfunkError) -> String {
 /// verify, i.e. the wrong PIN, which must not be reported as a network problem.
 pub fn pair_message(err: &PunktfunkError) -> String {
     match err {
-        PunktfunkError::Crypto => {
-            "Wrong PIN — check the PIN on the host's Pairing page and try again.".into()
-        }
+        PunktfunkError::Crypto => "Wrong PIN — check the PIN on the host's Pairing page and try again.".into(),
         other => connect_message(other),
     }
 }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -13,24 +13,24 @@ use sdl2::keyboard::Scancode;
 fn vk_code(sc: Scancode) -> Option<u32> {
     Some(match sc {
         // ── Navigation / editing / whitespace ────────────────────────────────
-        Scancode::Backspace   => 0x08, // VK_BACK
-        Scancode::Tab         => 0x09, // VK_TAB
+        Scancode::Backspace => 0x08,                  // VK_BACK
+        Scancode::Tab => 0x09,                        // VK_TAB
         Scancode::Return | Scancode::KpEnter => 0x0D, // VK_RETURN (numpad enter too)
-        Scancode::Pause       => 0x13, // VK_PAUSE
-        Scancode::CapsLock    => 0x14, // VK_CAPITAL
-        Scancode::Escape      => 0x1B, // VK_ESCAPE
-        Scancode::Space       => 0x20, // VK_SPACE
-        Scancode::PageUp      => 0x21, // VK_PRIOR
-        Scancode::PageDown    => 0x22, // VK_NEXT
-        Scancode::End         => 0x23, // VK_END
-        Scancode::Home        => 0x24, // VK_HOME
-        Scancode::Left        => 0x25, // VK_LEFT
-        Scancode::Up          => 0x26, // VK_UP
-        Scancode::Right       => 0x27, // VK_RIGHT
-        Scancode::Down        => 0x28, // VK_DOWN
-        Scancode::PrintScreen => 0x2C, // VK_SNAPSHOT
-        Scancode::Insert      => 0x2D, // VK_INSERT
-        Scancode::Delete      => 0x2E, // VK_DELETE
+        Scancode::Pause => 0x13,                      // VK_PAUSE
+        Scancode::CapsLock => 0x14,                   // VK_CAPITAL
+        Scancode::Escape => 0x1B,                     // VK_ESCAPE
+        Scancode::Space => 0x20,                      // VK_SPACE
+        Scancode::PageUp => 0x21,                     // VK_PRIOR
+        Scancode::PageDown => 0x22,                   // VK_NEXT
+        Scancode::End => 0x23,                        // VK_END
+        Scancode::Home => 0x24,                       // VK_HOME
+        Scancode::Left => 0x25,                       // VK_LEFT
+        Scancode::Up => 0x26,                         // VK_UP
+        Scancode::Right => 0x27,                      // VK_RIGHT
+        Scancode::Down => 0x28,                       // VK_DOWN
+        Scancode::PrintScreen => 0x2C,                // VK_SNAPSHOT
+        Scancode::Insert => 0x2D,                     // VK_INSERT
+        Scancode::Delete => 0x2E,                     // VK_DELETE
 
         // ── Digit row ─────────────────────────────────────────────────────────
         Scancode::Num0 => 0x30, // VK_0
@@ -73,66 +73,66 @@ fn vk_code(sc: Scancode) -> Option<u32> {
         Scancode::Z => 0x5A,
 
         // ── Meta / context-menu ───────────────────────────────────────────────
-        Scancode::LGui       => 0x5B, // VK_LWIN
-        Scancode::RGui       => 0x5C, // VK_RWIN
+        Scancode::LGui => 0x5B,        // VK_LWIN
+        Scancode::RGui => 0x5C,        // VK_RWIN
         Scancode::Application => 0x5D, // VK_APPS
 
         // ── Numpad ────────────────────────────────────────────────────────────
-        Scancode::Kp0        => 0x60, // VK_NUMPAD0
-        Scancode::Kp1        => 0x61, // VK_NUMPAD1
-        Scancode::Kp2        => 0x62, // VK_NUMPAD2
-        Scancode::Kp3        => 0x63, // VK_NUMPAD3
-        Scancode::Kp4        => 0x64, // VK_NUMPAD4
-        Scancode::Kp5        => 0x65, // VK_NUMPAD5
-        Scancode::Kp6        => 0x66, // VK_NUMPAD6
-        Scancode::Kp7        => 0x67, // VK_NUMPAD7
-        Scancode::Kp8        => 0x68, // VK_NUMPAD8
-        Scancode::Kp9        => 0x69, // VK_NUMPAD9
+        Scancode::Kp0 => 0x60,        // VK_NUMPAD0
+        Scancode::Kp1 => 0x61,        // VK_NUMPAD1
+        Scancode::Kp2 => 0x62,        // VK_NUMPAD2
+        Scancode::Kp3 => 0x63,        // VK_NUMPAD3
+        Scancode::Kp4 => 0x64,        // VK_NUMPAD4
+        Scancode::Kp5 => 0x65,        // VK_NUMPAD5
+        Scancode::Kp6 => 0x66,        // VK_NUMPAD6
+        Scancode::Kp7 => 0x67,        // VK_NUMPAD7
+        Scancode::Kp8 => 0x68,        // VK_NUMPAD8
+        Scancode::Kp9 => 0x69,        // VK_NUMPAD9
         Scancode::KpMultiply => 0x6A, // VK_MULTIPLY
-        Scancode::KpPlus     => 0x6B, // VK_ADD
-        Scancode::KpMinus    => 0x6D, // VK_SUBTRACT
-        Scancode::KpPeriod   => 0x6E, // VK_DECIMAL
-        Scancode::KpDivide   => 0x6F, // VK_DIVIDE
+        Scancode::KpPlus => 0x6B,     // VK_ADD
+        Scancode::KpMinus => 0x6D,    // VK_SUBTRACT
+        Scancode::KpPeriod => 0x6E,   // VK_DECIMAL
+        Scancode::KpDivide => 0x6F,   // VK_DIVIDE
 
         // ── Function keys ─────────────────────────────────────────────────────
-        Scancode::F1  => 0x70,
-        Scancode::F2  => 0x71,
-        Scancode::F3  => 0x72,
-        Scancode::F4  => 0x73,
-        Scancode::F5  => 0x74,
-        Scancode::F6  => 0x75,
-        Scancode::F7  => 0x76,
-        Scancode::F8  => 0x77,
-        Scancode::F9  => 0x78,
+        Scancode::F1 => 0x70,
+        Scancode::F2 => 0x71,
+        Scancode::F3 => 0x72,
+        Scancode::F4 => 0x73,
+        Scancode::F5 => 0x74,
+        Scancode::F6 => 0x75,
+        Scancode::F7 => 0x76,
+        Scancode::F8 => 0x77,
+        Scancode::F9 => 0x78,
         Scancode::F10 => 0x79,
         Scancode::F11 => 0x7A,
         Scancode::F12 => 0x7B,
 
         // ── Lock keys ─────────────────────────────────────────────────────────
         Scancode::NumLockClear => 0x90, // VK_NUMLOCK
-        Scancode::ScrollLock   => 0x91, // VK_SCROLL
+        Scancode::ScrollLock => 0x91,   // VK_SCROLL
 
         // ── Sided modifiers ───────────────────────────────────────────────────
         Scancode::LShift => 0xA0, // VK_LSHIFT
         Scancode::RShift => 0xA1, // VK_RSHIFT
-        Scancode::LCtrl  => 0xA2, // VK_LCONTROL
-        Scancode::RCtrl  => 0xA3, // VK_RCONTROL
-        Scancode::LAlt   => 0xA4, // VK_LMENU
-        Scancode::RAlt   => 0xA5, // VK_RMENU
+        Scancode::LCtrl => 0xA2,  // VK_LCONTROL
+        Scancode::RCtrl => 0xA3,  // VK_RCONTROL
+        Scancode::LAlt => 0xA4,   // VK_LMENU
+        Scancode::RAlt => 0xA5,   // VK_RMENU
 
         // ── OEM punctuation (US layout positions) ─────────────────────────────
-        Scancode::Semicolon        => 0xBA, // VK_OEM_1      ;:
-        Scancode::Equals           => 0xBB, // VK_OEM_PLUS   =+
-        Scancode::Comma            => 0xBC, // VK_OEM_COMMA  ,<
-        Scancode::Minus            => 0xBD, // VK_OEM_MINUS  -_
-        Scancode::Period           => 0xBE, // VK_OEM_PERIOD .>
-        Scancode::Slash            => 0xBF, // VK_OEM_2      /?
-        Scancode::Grave            => 0xC0, // VK_OEM_3      `~
-        Scancode::LeftBracket      => 0xDB, // VK_OEM_4      [{
-        Scancode::Backslash        => 0xDC, // VK_OEM_5      \|
-        Scancode::RightBracket     => 0xDD, // VK_OEM_6      ]}
-        Scancode::Apostrophe       => 0xDE, // VK_OEM_7      '"
-        Scancode::NonUsBackslash   => 0xE2, // VK_OEM_102    ISO extra key
+        Scancode::Semicolon => 0xBA,      // VK_OEM_1      ;:
+        Scancode::Equals => 0xBB,         // VK_OEM_PLUS   =+
+        Scancode::Comma => 0xBC,          // VK_OEM_COMMA  ,<
+        Scancode::Minus => 0xBD,          // VK_OEM_MINUS  -_
+        Scancode::Period => 0xBE,         // VK_OEM_PERIOD .>
+        Scancode::Slash => 0xBF,          // VK_OEM_2      /?
+        Scancode::Grave => 0xC0,          // VK_OEM_3      `~
+        Scancode::LeftBracket => 0xDB,    // VK_OEM_4      [{
+        Scancode::Backslash => 0xDC,      // VK_OEM_5      \|
+        Scancode::RightBracket => 0xDD,   // VK_OEM_6      ]}
+        Scancode::Apostrophe => 0xDE,     // VK_OEM_7      '"
+        Scancode::NonUsBackslash => 0xE2, // VK_OEM_102    ISO extra key
 
         _ => return None,
     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,7 +284,12 @@ mod real {
                     if matches!(app.screen, Screen::About) {
                         /// Licence-wall px per wheel detent — a few lines at a time.
                         const ABOUT_WHEEL_STEP: i32 = 90;
-                        dirty |= app.scroll_about_by(-wheel_y * ABOUT_WHEEL_STEP, fonts);
+                        dirty |= app.scroll_about_by(
+                            -wheel_y * ABOUT_WHEEL_STEP,
+                            display_mode.w as u32,
+                            display_mode.h as u32,
+                            fonts,
+                        );
                         continue;
                     }
                     if matches!(app.screen, Screen::Home) {

--- a/src/ndl.rs
+++ b/src/ndl.rs
@@ -246,13 +246,7 @@ impl NdlVideo {
     /// Caveat worth knowing: this can only detect a load that *fails*. If a device
     /// accepts the config and then produces no sound, that is silent — which is why the
     /// selection is logged loudly by the caller.
-    pub fn load(
-        app_id: &str,
-        width: i32,
-        height: i32,
-        codec: NdlCodec,
-        audio: Option<NdlAudioConfig>,
-    ) -> Result<Self> {
+    pub fn load(app_id: &str, width: i32, height: i32, codec: NdlCodec, audio: Option<NdlAudioConfig>) -> Result<Self> {
         ensure_init(app_id)?;
         let video = NdlVideoInfo {
             width,
@@ -324,9 +318,7 @@ impl NdlVideo {
         let pts_ms = self.load_instant.elapsed().as_millis() as c_longlong;
         let _ffi = self.ffi.lock().expect("NDL FFI mutex poisoned");
         // SAFETY: NDL reads `size` bytes synchronously and does not retain the pointer.
-        let ret = unsafe {
-            NDL_DirectAudioPlay(packet.as_ptr() as *mut c_void, packet.len() as c_uint, pts_ms)
-        };
+        let ret = unsafe { NDL_DirectAudioPlay(packet.as_ptr() as *mut c_void, packet.len() as c_uint, pts_ms) };
         if ret != 0 {
             bail!("NDL_DirectAudioPlay failed: ret={ret} error={}", last_error());
         }
@@ -341,9 +333,7 @@ impl NdlVideo {
         let _ffi = self.ffi.lock().expect("NDL FFI mutex poisoned");
         // SAFETY: NDL reads `size` bytes from `buffer` synchronously and does not
         // retain the pointer.
-        let ret = unsafe {
-            NDL_DirectVideoPlay(au.as_ptr() as *mut c_void, au.len() as c_uint, pts_ms)
-        };
+        let ret = unsafe { NDL_DirectVideoPlay(au.as_ptr() as *mut c_void, au.len() as c_uint, pts_ms) };
         if ret != 0 {
             bail!("NDL_DirectVideoPlay failed: ret={ret} error={}", last_error());
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -833,7 +833,13 @@ fn spawn_vendor_decode_thread_renicer() {
     });
 }
 
-fn video_pump(client: Arc<NativeClient>, player: VideoPlayer, stop: Arc<AtomicBool>, stats: Arc<StreamStats>, is_hdr: bool) {
+fn video_pump(
+    client: Arc<NativeClient>,
+    player: VideoPlayer,
+    stop: Arc<AtomicBool>,
+    stats: Arc<StreamStats>,
+    is_hdr: bool,
+) {
     client.register_hot_thread();
     // Summarized at info, not left as per-tid debug lines: whether these renices work at
     // all is install-mode-dependent (they need CAP_SYS_NICE or a nonzero RLIMIT_NICE —
@@ -848,15 +854,16 @@ fn video_pump(client: Arc<NativeClient>, player: VideoPlayer, stop: Arc<AtomicBo
             reniced += 1;
         } else {
             failed += 1;
-            tracing::debug!(
-                "setpriority(tid={tid}) failed: {}",
-                std::io::Error::last_os_error()
-            );
+            tracing::debug!("setpriority(tid={tid}) failed: {}", std::io::Error::last_os_error());
         }
     }
     tracing::info!(
         "hot-thread renice: {reniced} boosted, {failed} failed{}",
-        if failed > 0 { " (no CAP_SYS_NICE — priorities unchanged)" } else { "" },
+        if failed > 0 {
+            " (no CAP_SYS_NICE — priorities unchanged)"
+        } else {
+            ""
+        },
     );
     spawn_vendor_decode_thread_renicer();
 

--- a/src/ui/about.rs
+++ b/src/ui/about.rs
@@ -4,13 +4,17 @@
 //! Every other punktfunk client shows the version here rather than in its navigation
 //! chrome, which is why the sidebar no longer draws it (see `sidebar::draw_sidebar`).
 //!
-//! **Scrolling is by source line, and only the visible window is ever rasterized.**
-//! `THIRD-PARTY-NOTICES.txt` is ~10,000 lines; laying it out in full — or drawing it
-//! through [`TextCache`] — would be a non-starter on this `SoC` (see
-//! `draw_text_uncached`'s docs for the cache side of that). `draw_about_body` walks
-//! forward from the first visible line and stops as soon as it runs past the bottom
-//! of the viewport, so cost per frame is bounded by the viewport height, not by the
-//! document length.
+//! **Scrolling is hardware-accelerated, the same way the Settings modal's row list
+//! is.** `THIRD-PARTY-NOTICES.txt` is ~10,000 source lines — wrapped to the card
+//! width that's more like ~12,000 visual lines, far too tall to bake into one GPU
+//! texture (see `App::scroll_geometry`/`ui::ContentWindow`'s docs on why About needs
+//! a *windowed* content tile where Settings' 9 rows fit in one). [`wrap_document`]
+//! wraps the whole document once, up front, into a flat list of visual lines with a
+//! uniform per-line stride — the unit `ui::ScrollWindow`/`ui::ContentWindow` scroll
+//! over — and [`draw_about_window`] rasterizes only a bounded slice of it at a time
+//! (not through [`TextCache`], which would be a non-starter on this `SoC` for a
+//! document this size — see `draw_text_uncached`'s docs). Scrolling within that
+//! slice is then a pure `DrawCmd::TexCropped`, never a re-rasterize.
 use anyhow::Result;
 use sdl2::rect::Rect;
 
@@ -93,43 +97,55 @@ pub fn about_body_rect(card: Rect, fonts: &Fonts) -> Rect {
 /// so the body rect stays put regardless of what the build stamped in.
 const ABOUT_SUBTITLE_PROBE: &str = "Version 0.0.0+git.00000000";
 
-/// How many source lines fit in `body` at worst (every line unwrapped) — used to
-/// clamp scrolling so the page can't be scrolled past its own end.
-pub fn about_visible_lines(body: Rect, font: &sdl2::ttf::Font) -> usize {
-    let step = (font.height() + LINE_GAP).max(1);
-    (body.height() as i32 / step).max(1) as usize
+/// Stride (px) between two consecutive wrapped visual lines at `font`'s size —
+/// the uniform unit `ui::ScrollWindow`/`ui::ContentWindow` scroll over.
+pub fn about_line_stride(font: &sdl2::ttf::Font) -> i32 {
+    font.height() + LINE_GAP
 }
 
-/// Draws the document from source line `first` until the viewport is full, wrapping
-/// each line to the viewport width. Only the lines actually shown are rasterized —
-/// see the module docs.
-pub fn draw_about_body(
+/// How many wrapped visual lines fit in `body` — used to clamp scrolling so the
+/// page can't be scrolled past its own end.
+pub fn about_visible_lines(body: Rect, font: &sdl2::ttf::Font) -> usize {
+    (body.height() as i32 / about_line_stride(font).max(1)).max(1) as usize
+}
+
+/// Wraps every source `line` to `width`, flattening into one list of visual
+/// lines — a blank source line becomes one blank visual line (preserving its
+/// paragraph gap), and a wrapped one expands to as many entries as it needs.
+/// This is the one-time cost (text measurement, not rasterization) that gives
+/// the whole document a uniform per-line stride, so it can scroll exactly like
+/// Settings' fixed-height rows instead of needing per-source-line bookkeeping.
+pub fn wrap_document(font: &sdl2::ttf::Font, lines: &[&str], width: u32) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in lines {
+        if line.trim().is_empty() {
+            out.push(String::new());
+        } else {
+            // Wrapped, not clipped: this is licence text, and silently truncating it
+            // would hide terms the screen exists to display.
+            out.extend(wrap_text(font, line, width));
+        }
+    }
+    out
+}
+
+/// Draws wrapped visual lines `[start, start+len)` of `lines`, top-aligned at
+/// this painter's own origin — the content tile's local space, which the GPU
+/// compositor then crops/positions from (see `Tile::ScrollContent`'s docs).
+/// Only called when `ui::ContentWindow` (re)bakes a window, not per frame.
+pub fn draw_about_window(
     painter: &mut Painter,
     font: &sdl2::ttf::Font,
-    lines: &[&str],
-    first: usize,
-    body: Rect,
+    lines: &[String],
+    start: usize,
+    len: usize,
 ) -> Result<()> {
-    let step = font.height() + LINE_GAP;
-    let mut y = body.y();
-    let bottom = body.y() + body.height() as i32;
-    for line in lines.iter().skip(first) {
-        if y + font.height() > bottom {
-            break;
-        }
-        if line.trim().is_empty() {
-            y += step;
+    let step = about_line_stride(font);
+    for (i, line) in lines.iter().skip(start).take(len).enumerate() {
+        if line.is_empty() {
             continue;
         }
-        // Wrapped, not clipped: this is licence text, and silently truncating it at the
-        // card edge would hide terms the screen exists to display.
-        for part in wrap_text(font, line, body.width()) {
-            if y + font.height() > bottom {
-                break;
-            }
-            draw_text_uncached(painter, font, &part, body.x(), y, MUTED)?;
-            y += step;
-        }
+        draw_text_uncached(painter, font, line, 0, i as i32 * step, MUTED)?;
     }
     Ok(())
 }

--- a/src/ui/addhost.rs
+++ b/src/ui/addhost.rs
@@ -2,7 +2,6 @@
 //!
 //! Split out of the former single-file `ui.rs`; see `super`'s module docs.
 
-
 /// punktfunk's conventional host port (see `store::dev_override_connect`'s
 /// fallback) — fixed and not user-editable, so the add-host screen only ever
 /// has to ask for an IP address.

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -1,8 +1,8 @@
 //! Shared animation clocks and the GPU zoom-pop rect math.
 //!
 //! Split out of the former single-file `ui.rs`; see `super`'s module docs.
-use std::time::{Duration, Instant};
 use sdl2::rect::Rect;
+use std::time::{Duration, Instant};
 
 // Shared by every GPU-scale zoom-pop in the app — the grid's card focus-pop
 // (`app.rs`), every pre-stream modal's focused-widget tile, and the in-stream
@@ -39,4 +39,3 @@ pub fn zoom_rect(base: Rect, frac: f32, growth: f32) -> Rect {
     let th = base.height() as f32 * scale;
     Rect::new((cx - tw / 2.0) as i32, (cy - th / 2.0) as i32, tw as u32, th as u32)
 }
-

--- a/src/ui/cards.rs
+++ b/src/ui/cards.rs
@@ -7,7 +7,6 @@ use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use tiny_skia::Pixmap;
 
-
 /// A slight softening of moonlight-tv's near-square (~2px) tile radius.
 pub const CARD_RADIUS: i32 = 10;
 pub const MODAL_RADIUS: i32 = 20;
@@ -181,4 +180,3 @@ pub fn draw_poster_card(
     }
     Ok(())
 }
-

--- a/src/ui/grid.rs
+++ b/src/ui/grid.rs
@@ -3,7 +3,6 @@
 //! Split out of the former single-file `ui.rs`; see `super`'s module docs.
 use sdl2::rect::Rect;
 
-
 pub const GRID_PAD: i32 = 32;
 pub const GRID_GAP: i32 = 24;
 pub const GRID_TOP_Y: i32 = 160;
@@ -48,8 +47,7 @@ pub fn hit_test_grid_card(
     if mouse_x < grid_x {
         return None;
     }
-    (0..count)
-        .find(|&i| grid_card_rect(i, columns, grid_x, available_w).contains_point((mouse_x, mouse_y + scroll)))
+    (0..count).find(|&i| grid_card_rect(i, columns, grid_x, available_w).contains_point((mouse_x, mouse_y + scroll)))
 }
 
 /// Headroom above/below the card rows inside the cached grid layer (see
@@ -64,4 +62,3 @@ pub fn grid_layer_height(count: usize, columns: usize, available_w: u32) -> u32 
     let (_, card_h) = grid_card_size(available_w, columns);
     (rows.max(1) as u32 * (card_h + GRID_GAP as u32)) + 2 * GRID_LAYER_PAD as u32
 }
-

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -2,7 +2,6 @@
 //!
 //! Split out of the former single-file `ui.rs`; see `super`'s module docs.
 
-
 /// A menu event, already debounced from the raw SDL2 input (keyboard arrows — which
 /// the webOS Magic Remote's d-pad mode surfaces as — and gamepad d-pad both map here).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -126,4 +125,3 @@ pub fn digit_key_value(keycode: sdl2::keyboard::Keycode) -> Option<u8> {
         _ => return None,
     })
 }
-

--- a/src/ui/listmodal.rs
+++ b/src/ui/listmodal.rs
@@ -31,13 +31,7 @@ const SIDE_PAD: i32 = 32;
 /// The card rect for a list modal with `row_count` rows and this `subtitle` (whose
 /// wrapped height moves everything below it). Mirrors `App::simple_modal_card`'s
 /// probe trick: measure against a zero-height card at the final width, then place it.
-pub fn list_modal_card_rect(
-    screen_w: u32,
-    screen_h: u32,
-    fonts: &Fonts,
-    subtitle: &str,
-    row_count: usize,
-) -> Rect {
+pub fn list_modal_card_rect(screen_w: u32, screen_h: u32, fonts: &Fonts, subtitle: &str, row_count: usize) -> Rect {
     let w = (screen_w as f32 * LIST_MODAL_WIDTH_FRAC).round() as u32;
     let probe = Rect::new(0, 0, w, 0);
     let header_end = modal_header_end_y(fonts.label, fonts.value, probe, subtitle);
@@ -72,7 +66,15 @@ pub fn render_list_modal(
     rows: &[FocusRow],
 ) -> Result<()> {
     draw_modal_header(
-        painter, text_cache, fonts.label, fonts.value, card, title, WHITE, subtitle, MUTED,
+        painter,
+        text_cache,
+        fonts.label,
+        fonts.value,
+        card,
+        title,
+        WHITE,
+        subtitle,
+        MUTED,
     )?;
     let content = list_modal_content_rect(card, fonts, subtitle, rows.len());
     // `usize::MAX` = nothing focused here; see the module docs.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -19,38 +19,40 @@
 //! icons are glyphs from a small bundled, subsetted icon font (see the icons
 //! section below and `assets/icons/NOTICE.md`).
 
+mod about;
+mod addhost;
 mod animation;
-mod theme;
-mod input;
-mod painter;
-mod text;
 mod cards;
-mod tiles;
-mod sidebar;
 mod grid;
+mod input;
+mod listmodal;
 mod modal;
+mod painter;
 mod pairing;
 mod rows;
+mod scroll;
 mod settings;
-mod addhost;
-mod listmodal;
-mod about;
+mod sidebar;
+mod text;
+mod theme;
+mod tiles;
 
 // Glob re-exports: every item keeps its original `crate::ui::X` path, so splitting
 // this module needed no changes at any call site in `app.rs`/`main.rs`.
+pub use about::*;
+pub use addhost::*;
 pub use animation::*;
-pub use theme::*;
-pub use input::*;
-pub use painter::*;
-pub use text::*;
 pub use cards::*;
-pub use tiles::*;
-pub use sidebar::*;
 pub use grid::*;
+pub use input::*;
+pub use listmodal::*;
 pub use modal::*;
+pub use painter::*;
 pub use pairing::*;
 pub use rows::*;
+pub use scroll::*;
 pub use settings::*;
-pub use addhost::*;
-pub use listmodal::*;
-pub use about::*;
+pub use sidebar::*;
+pub use text::*;
+pub use theme::*;
+pub use tiles::*;

--- a/src/ui/modal.rs
+++ b/src/ui/modal.rs
@@ -2,11 +2,10 @@
 //!
 //! Split out of the former single-file `ui.rs`; see `super`'s module docs.
 use super::*;
+use anyhow::Result;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use sdl2::ttf::Font;
-use anyhow::Result;
-
 
 /// A centered glass card of `(width_frac * screen_w, height)`.
 pub fn modal_card_rect(screen_w: u32, screen_h: u32, width_frac: f32, height: u32) -> Rect {
@@ -71,7 +70,6 @@ pub fn modal_close_rect(card_rect: Rect) -> Rect {
         SIZE,
     )
 }
-
 
 /// A horizontal rule broken by a centred word — the "or" between two mutually exclusive
 /// choices.

--- a/src/ui/painter.rs
+++ b/src/ui/painter.rs
@@ -1,10 +1,12 @@
 //! The anti-aliased software rendering backend every `draw_*` is built from.
 //!
 //! Split out of the former single-file `ui.rs`; see `super`'s module docs.
-use std::collections::HashMap;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
-use tiny_skia::{Color as SkColor, FillRule, FilterQuality, Paint, PathBuilder, Pixmap, PixmapPaint, Stroke, Transform};
+use std::collections::HashMap;
+use tiny_skia::{
+    Color as SkColor, FillRule, FilterQuality, Paint, PathBuilder, Pixmap, PixmapPaint, Stroke, Transform,
+};
 
 // The AA rendering backend: a `tiny_skia::Pixmap` framebuffer plus the handful of
 // primitive ops every higher-level `draw_*` function below is built from. Nothing
@@ -306,4 +308,3 @@ pub fn premultiply_rgba(rgba: &mut [u8]) {
         px[2] = ((u32::from(px[2]) * a) / 255) as u8;
     }
 }
-

--- a/src/ui/pairing.rs
+++ b/src/ui/pairing.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use sdl2::rect::Rect;
 use sdl2::ttf::Font;
 
-
 /// PIN digit box size/gap — shared by `pairing_digit_rect` and the digit
 /// tiles so they can never disagree.
 pub const PAIRING_DIGIT_W: u32 = 64;
@@ -54,7 +53,13 @@ pub fn render_card_text_tile(text_cache: &mut TextCache, font: &Font, text: &str
 /// GPU over the shell's unfocused digit boxes, same pattern as
 /// `render_focus_row_tile`.
 pub fn render_pairing_digit_tile(text_cache: &mut TextCache, font_title: &Font, digit: u8) -> Result<Painter> {
-    render_card_text_tile(text_cache, font_title, &digit.to_string(), PAIRING_DIGIT_W, PAIRING_DIGIT_H)
+    render_card_text_tile(
+        text_cache,
+        font_title,
+        &digit.to_string(),
+        PAIRING_DIGIT_W,
+        PAIRING_DIGIT_H,
+    )
 }
 
 /// The "Request access" button, focused, as its own zoom-animated tile — accent-filled
@@ -72,4 +77,3 @@ pub fn render_pairing_button_tile(text_cache: &mut TextCache, font_label: &Font,
     )?;
     Ok(p)
 }
-

--- a/src/ui/rows.rs
+++ b/src/ui/rows.rs
@@ -149,9 +149,10 @@ pub fn render_focus_row_tile(
 }
 
 /// Every row unfocused, as one tile at its own full (unscrolled) height — the
-/// Settings modal's `Tile::SettingsRows`. Scrolling crops/repositions this via a
-/// GPU-side `DrawCmd::TexCropped` instead of re-rasterizing, so this only needs
-/// rebuilding when a value or the open dropdown changes, never on scroll.
+/// Settings modal's `Tile::ScrollContent(Screen::Settings)`. Scrolling crops/
+/// repositions this via a GPU-side `DrawCmd::TexCropped` instead of
+/// re-rasterizing, so this only needs rebuilding when a value or the open
+/// dropdown changes, never on scroll.
 pub fn render_focus_rows_tile(
     text_cache: &mut TextCache,
     fonts: &Fonts,

--- a/src/ui/scroll.rs
+++ b/src/ui/scroll.rs
@@ -1,0 +1,123 @@
+//! Shared scroll bookkeeping for modal content lists (uniform-stride rows or
+//! wrapped text lines) — extracted from the Settings modal's original
+//! hand-written offset-clamp/scroll-into-view logic so any modal with
+//! overflowing content (About's document, a future long `ListModal`) can
+//! share the same offset clamping, "scroll into view", and scroll-indicator
+//! fade-in bookkeeping instead of re-deriving it. Knows nothing about
+//! rendering, tile identity, or pixels — callers already have their own pure
+//! `total`/`visible` formulas (a row count vs. a wrapped-line count use
+//! different stride math) and pass them in.
+use std::time::Instant;
+
+/// Offset bookkeeping for one scrollable list of uniform-stride units (rows
+/// or wrapped text lines). `total`/`visible` are passed to each call rather
+/// than stored, since callers already compute them from screen geometry —
+/// storing a second, possibly-stale copy here would just invite the two to
+/// disagree.
+pub struct ScrollWindow {
+    pub offset: usize,
+    /// When `offset` last changed — a modal's scrollbar shows briefly after
+    /// this, then fades (see `SCROLL_INDICATOR_HOLD`/`_FADE` in `app::mod`).
+    pub shown_at: Option<Instant>,
+}
+
+impl ScrollWindow {
+    pub fn new() -> Self {
+        Self {
+            offset: 0,
+            shown_at: None,
+        }
+    }
+
+    /// `offset` is only updated by `scroll_into_view`/`scroll_by`/`page`, so it
+    /// can be stale after a resize (a rotated screen, a font-size change) —
+    /// use this instead of the raw field wherever it feeds a layout formula.
+    pub fn clamped(&self, total: usize, visible: usize) -> usize {
+        self.offset.min(total.saturating_sub(visible))
+    }
+
+    /// Moves `offset` just enough to keep `focused` inside the visible
+    /// window (no wraparound — wrapping a scrolled list would silently jump
+    /// the scroll position across the whole thing). Returns whether it moved.
+    pub fn scroll_into_view(&mut self, focused: usize, total: usize, visible: usize) -> bool {
+        let mut offset = self.clamped(total, visible);
+        if focused < offset {
+            offset = focused;
+        } else if focused >= offset + visible {
+            offset = focused + 1 - visible;
+        }
+        self.set(offset)
+    }
+
+    /// Wheel/line-step scroll by `delta` units (+/-), clamped to the valid
+    /// range. Returns whether `offset` moved.
+    pub fn scroll_by(&mut self, delta: i64, total: usize, visible: usize) -> bool {
+        let before = self.clamped(total, visible) as i64;
+        let max_offset = total.saturating_sub(visible) as i64;
+        let next = (before + delta).clamp(0, max_offset) as usize;
+        self.set(next)
+    }
+
+    /// Pages by `page_units` (About's Left/Right paging), clamped the same way.
+    pub fn page(&mut self, page_units: usize, forward: bool, total: usize, visible: usize) -> bool {
+        let step = page_units.max(1) as i64;
+        self.scroll_by(if forward { step } else { -step }, total, visible)
+    }
+
+    fn set(&mut self, offset: usize) -> bool {
+        let moved = offset != self.offset;
+        self.offset = offset;
+        if moved {
+            self.shown_at = Some(Instant::now());
+        }
+        moved
+    }
+}
+
+/// Tracks which contiguous slice `[start, start+len)` of a long, uniform-stride
+/// list is currently baked into a content tile, for lists too tall to fit one
+/// GPU texture whole (About's ~12k wrapped lines). A modal whose whole content
+/// always fits under `budget` (Settings' 9 rows, `HostMenu`'s handful of rows)
+/// never sees `recenter_if_needed` return more than once — this degenerates to
+/// "bake everything, once" for them, same as before this type existed.
+pub struct ContentWindow {
+    pub start: usize,
+    pub len: usize,
+}
+
+impl ContentWindow {
+    pub fn new() -> Self {
+        Self { start: 0, len: 0 }
+    }
+
+    /// Returns `Some(new_start)` if the window needs (re)baking to keep
+    /// `offset` (plus `visible` units after it) within `margin` units of an
+    /// edge — `None` if the currently baked window still covers it. The new
+    /// window is up to `budget` units, recentered around `offset`.
+    pub fn recenter_if_needed(
+        &self,
+        offset: usize,
+        visible: usize,
+        total: usize,
+        budget: usize,
+        margin: usize,
+    ) -> Option<usize> {
+        if total <= budget {
+            return if self.start != 0 || self.len != total {
+                Some(0)
+            } else {
+                None
+            };
+        }
+        let end = self.start + self.len;
+        let near_start = self.start > 0 && offset < self.start + margin;
+        let near_end = end < total && offset + visible + margin > end;
+        if self.len == 0 || near_start || near_end {
+            let half = budget.saturating_sub(visible) / 2;
+            let max_start = total - budget;
+            Some(offset.saturating_sub(half).min(max_start))
+        } else {
+            None
+        }
+    }
+}

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -186,7 +186,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
 pub fn wake_rows(auto_send: bool) -> Vec<FocusRow> {
     vec![FocusRow {
         icon: ICON_SETTINGS,
-        label: "Wake automatically in future".into(),
+        label: "Wake automatically".into(),
         value: if auto_send { "On".into() } else { "Off".into() },
         kind: RowKind::Toggle,
         fraction: 0.0,
@@ -242,7 +242,10 @@ pub fn dropdown_options(settings: &Settings, row_index: usize) -> Vec<String> {
         ROW_RESOLUTION => RESOLUTIONS.iter().map(|(w, h, _)| resolution_label(*w, *h)).collect(),
         ROW_FRAMERATE => REFRESH_RATES.iter().map(|hz| format!("{hz} Hz")).collect(),
         ROW_VIDEO_BACKEND => vec!["NDL".into(), "Starfish".into()],
-        ROW_CODEC => codec_options(settings).iter().map(|&p| codec_label(p).to_string()).collect(),
+        ROW_CODEC => codec_options(settings)
+            .iter()
+            .map(|&p| codec_label(p).to_string())
+            .collect(),
         ROW_AUDIO => AUDIO_CHANNELS.iter().map(|(_, s)| (*s).to_string()).collect(),
         _ => Vec::new(),
     }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -2,12 +2,11 @@
 //!
 //! Split out of the former single-file `ui.rs`; see `super`'s module docs.
 use super::*;
+use crate::discovery::DiscoveredHost;
+use crate::store::KnownHost;
 use anyhow::Result;
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
-use crate::discovery::DiscoveredHost;
-use crate::store::KnownHost;
-
 
 // Sized for a 10-foot TV viewing distance, not a desktop/phone screen.
 pub const SIDEBAR_W: u32 = 460;
@@ -327,4 +326,3 @@ pub fn draw_utility_row(
     let label = label.trim_start_matches('+').trim();
     draw_sidebar_row(painter, text_cache, fonts, rect, glyph, label, focused, 0)
 }
-

--- a/src/ui/text.rs
+++ b/src/ui/text.rs
@@ -2,13 +2,12 @@
 //!
 //! Split out of the former single-file `ui.rs`; see `super`'s module docs.
 use super::*;
-use std::collections::HashMap;
 use anyhow::{Context, Result};
 use sdl2::pixels::Color;
 use sdl2::rect::Rect;
 use sdl2::ttf::Font;
+use std::collections::HashMap;
 use tiny_skia::{IntSize, Pixmap};
-
 
 /// The bundled Geist family (punktfunk's brand font, the same OTFs every other
 /// punktfunk client ships — copied verbatim from `pf-console-ui/assets/fonts/`;
@@ -206,14 +205,7 @@ pub fn draw_text(
 /// process — on a TV with no eviction path. These lines are drawn at most a couple of
 /// times each (once per scroll position that shows them), so rasterizing fresh is both
 /// cheaper overall and bounded in memory.
-pub fn draw_text_uncached(
-    painter: &mut Painter,
-    font: &Font,
-    text: &str,
-    x: i32,
-    y: i32,
-    color: Color,
-) -> Result<u32> {
+pub fn draw_text_uncached(painter: &mut Painter, font: &Font, text: &str, x: i32, y: i32, color: Color) -> Result<u32> {
     if text.is_empty() {
         return Ok(0);
     }
@@ -266,20 +258,35 @@ pub fn ellipsize(font: &Font, text: &str, max_w: u32) -> String {
 /// Greedily word-wraps `text` into lines no wider than `max_w` px in `font` — for modal
 /// copy that's a full sentence or two (status/explanation text), unlike `ellipsize`'s
 /// single-line truncation for card titles.
+///
+/// Tracks the running line width instead of re-measuring the whole (growing) line on
+/// every word — the original did `font.size_of(&candidate)` on the full prefix each
+/// time, which is O(line length) per word and so O(n²) over a line, cheap for a
+/// sentence but the dominant cost of wrapping About's ~10,000-line document on open
+/// (see `ui::wrap_document`). Assumes negligible word-to-word kerning at the space
+/// boundary, same as every other width-budget calculation in this UI already does.
 pub fn wrap_text(font: &Font, text: &str, max_w: u32) -> Vec<String> {
+    let space_w = font.size_of(" ").map_or(0, |(w, _)| w);
     let mut lines = Vec::new();
     let mut current = String::new();
+    let mut current_w = 0u32;
     for word in text.split_whitespace() {
-        let candidate = if current.is_empty() {
-            word.to_string()
+        let word_w = font.size_of(word).map_or(0, |(w, _)| w);
+        let candidate_w = if current.is_empty() {
+            word_w
         } else {
-            format!("{current} {word}")
+            current_w + space_w + word_w
         };
-        if current.is_empty() || font.size_of(&candidate).map_or(0, |(w, _)| w) <= max_w {
-            current = candidate;
+        if current.is_empty() || candidate_w <= max_w {
+            if !current.is_empty() {
+                current.push(' ');
+            }
+            current.push_str(word);
+            current_w = candidate_w;
         } else {
             lines.push(std::mem::take(&mut current));
-            current = word.to_string();
+            current.push_str(word);
+            current_w = word_w;
         }
     }
     if !current.is_empty() {
@@ -343,8 +350,26 @@ pub fn draw_modal_header(
     subtitle_color: Color,
 ) -> Result<i32> {
     let (text_x, subtitle_y, max_w) = modal_header_geometry(title_font, card);
-    draw_text(painter, text_cache, title_font, title, text_x, card.y() + 28, title_color)?;
-    draw_text_wrapped(painter, text_cache, subtitle_font, subtitle, text_x, subtitle_y, max_w, subtitle_color, 6)
+    draw_text(
+        painter,
+        text_cache,
+        title_font,
+        title,
+        text_x,
+        card.y() + 28,
+        title_color,
+    )?;
+    draw_text_wrapped(
+        painter,
+        text_cache,
+        subtitle_font,
+        subtitle,
+        text_x,
+        subtitle_y,
+        max_w,
+        subtitle_color,
+        6,
+    )
 }
 
 /// The same `y` [`draw_modal_header`] would return, computed without drawing —
@@ -356,4 +381,3 @@ pub fn modal_header_end_y(title_font: &Font, subtitle_font: &Font, card: Rect, s
     let lines = wrap_text(subtitle_font, subtitle, max_w).len() as i32;
     subtitle_y + lines * (subtitle_font.height() + 6)
 }
-

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -55,4 +55,3 @@ pub const ICON_EDIT: &str = "\u{E3C9}";
 pub const ICON_INFO: &str = "\u{E88E}";
 /// The host row's "more actions" affordance — see `sidebar_menu_button_rect`.
 pub const ICON_MORE: &str = "\u{E5D3}";
-


### PR DESCRIPTION
## Summary
- About & licenses now scrolls like Settings: GPU-cropped content tile + scroll indicator, instead of re-rasterizing the whole modal per scroll tick.
- Extracted the scroll bookkeeping into reusable `ui::ScrollWindow`/`ui::ContentWindow` (`src/ui/scroll.rs`), shared by Settings and About.
- Fixed an O(n²) hotpath in `wrap_text` (About's slow open) and shrank the About window-rebuild size (scroll hitch).
- Ran `cargo fmt` on the whole crate.

## Test plan
- [ ] `task check` / `task lint` pass (done locally)
- [ ] `task deploy TV_HOST=... TELEMETRY=auto` — verify Settings scroll unchanged, About scrolls smoothly with indicator