### PR TITLE
Decode spinner GIF at runtime, fix loading-spinner choppiness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ rustls = { version = "0.23", features = ["ring"] }
 # no system libjpeg/libpng dependency to find on-device. No "gif" feature here — the
 # animated loading spinner is decoded at build time instead (see
 # `[build-dependencies]` below and `build.rs`'s `build_spinner_frames`).
-image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif"] }
 # The whole pre-stream UI's rendering backend (ui.rs) — a pure-Rust software
 # rasterizer (anti-aliased fills/strokes, real box-blurred shadows), replacing the
 # previous hand-rolled per-scanline SDL2 2D primitives (no Skia/Vulkan available on
@@ -110,11 +110,6 @@ tiny-skia = { version = "0.12", default-features = false, features = ["std"] }
 # transitive dependency (punktfunk-core itself uses `libc::gettid` for its hot-thread
 # registry), pulled in directly since we call our own libc function against those ids.
 libc = "0.2"
-
-[build-dependencies]
-# GIF decode for `build.rs`'s spinner-frame precompute — host-side only, so its
-# LZW/color-quant cost never runs on-device.
-image = { version = "0.25", default-features = false, features = ["gif"] }
 
 [profile.release]
 # The per-packet hot loops this client actually burns CPU in — AEAD decrypt, FEC

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,6 @@ fn main() {
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR set by cargo");
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo");
 
-    build_spinner_frames(&out_dir, &manifest_dir);
-
     // webOS's shipped glibc predates getauxval/gettid/sendmmsg (see
     // glibc_compat_shim.c) — only the real webOS cross target needs the shim; a
     // native Linux dev box's system glibc already has all three.
@@ -78,56 +76,4 @@ fn main() {
     // binary links against into the ipk's lib/ dir (sibling of bin/, where appinfo.json's
     // "main" points), so $ORIGIN is relative to bin/.
     println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/../lib");
-}
-
-/// Decodes `assets/logo/punktfunk-spinner.gif` into `$OUT_DIR/spinner_frames.bin`
-/// for `ui/tiles.rs`'s `spinner_frames` to `include_bytes!` — no GIF/LZW decode
-/// on-device. Layout (little-endian): `u32` width, `u32` height, `u32` frame
-/// count, then per frame a `u32` delay in milliseconds followed by
-/// `width * height * 4` bytes of premultiplied RGBA8, at the GIF's native size
-/// (no resize — every frame must share the first frame's dimensions).
-fn build_spinner_frames(out_dir: &str, manifest_dir: &str) {
-    use image::{codecs::gif::GifDecoder, AnimationDecoder};
-
-    let gif_path = format!("{manifest_dir}/assets/logo/punktfunk-spinner.gif");
-    println!("cargo:rerun-if-changed={gif_path}");
-    let gif_bytes = std::fs::read(&gif_path).unwrap_or_else(|e| panic!("read {gif_path}: {e}"));
-    let decoder = GifDecoder::new(std::io::Cursor::new(gif_bytes.as_slice()))
-        .unwrap_or_else(|e| panic!("decode {gif_path}: {e}"));
-    let frames = decoder
-        .into_frames()
-        .collect::<image::ImageResult<Vec<_>>>()
-        .unwrap_or_else(|e| panic!("decode {gif_path} frames: {e}"));
-    let (width, height) = frames.first().map_or((0, 0), |f| f.buffer().dimensions());
-
-    let mut blob = Vec::new();
-    blob.extend_from_slice(&width.to_le_bytes());
-    blob.extend_from_slice(&height.to_le_bytes());
-    blob.extend_from_slice(&u32::try_from(frames.len()).expect("frame count fits u32").to_le_bytes());
-    for frame in frames {
-        assert_eq!(
-            frame.buffer().dimensions(),
-            (width, height),
-            "{gif_path}: mismatched frame size"
-        );
-        let (numer, denom) = frame.delay().numer_denom_ms();
-        let delay_ms = numer.checked_div(denom).unwrap_or(0);
-        let mut rgba = frame.into_buffer().into_raw();
-        premultiply_rgba(&mut rgba);
-        blob.extend_from_slice(&delay_ms.to_le_bytes());
-        blob.extend_from_slice(&rgba);
-    }
-
-    std::fs::write(format!("{out_dir}/spinner_frames.bin"), blob).expect("write spinner_frames.bin");
-}
-
-/// Straight-alpha -> premultiplied RGBA8, in place — mirrors
-/// `ui::painter::premultiply_rgba` (build.rs can't `use` the main crate).
-fn premultiply_rgba(rgba: &mut [u8]) {
-    for px in rgba.chunks_exact_mut(4) {
-        let a = u32::from(px[3]);
-        px[0] = ((u32::from(px[0]) * a) / 255) as u8;
-        px[1] = ((u32::from(px[1]) * a) / 255) as u8;
-        px[2] = ((u32::from(px[2]) * a) / 255) as u8;
-    }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -86,8 +86,15 @@ const CARD_KEEP_ROWS: i32 = 5;
 ///
 /// Only bounds the visible+prefetch window (a few dozen tiles), not the whole library, so
 /// it can be much higher than the original whole-library concern without reintroducing
-/// the freeze. Raised from 3, which took 7-10 frames to fill a 20-30 card window.
-const CARD_BUILD_BUDGET: usize = 2;
+/// the freeze.
+///
+/// Lowered from 2 to 1 after on-device telemetry (`TELEMETRY=auto`) during the loading
+/// spinner showed `prepare_tiles` costing 60-165ms per tick — several times the ~33ms the
+/// spinner's own GIF frame needs — with the cost squarely in `render_card_tile`'s text
+/// rasterization (cold `TextCache`/`FreeType`, expensive on this armv7 softfloat target,
+/// not the windowed bookkeeping around it). One card per tick roughly halves the
+/// worst-case stall at the cost of taking twice as many ticks to fill the window.
+const CARD_BUILD_BUDGET: usize = 1;
 
 /// How long the loading spinner waits for the whole window to become art-ready before
 /// revealing anyway — a fetch that fails (rather than being merely slow) never becomes
@@ -515,13 +522,13 @@ pub struct App {
     /// The static "No host selected" hint line.
     pub(crate) nohost_tile: Option<Painter>,
     /// Whether the grid's initial build for the current library has finished — while
-    /// `false`, the grid shows the loading spinner (`Tile::Spinner`) instead of
+    /// `false`, the grid shows the loading spinner (`Tile::SpinnerFrame`) instead of
     /// popping cards in one by one. One-shot per library: only `prepare_tiles`'s
     /// full-reset branch sets it `false` again; later scrolling into a fresh row
     /// does not.
     pub(crate) grid_reveal_ready: bool,
-    /// The rasterized spinner tile, rebuilt every tick it's shown.
-    pub(crate) spinner_tile: Option<Painter>,
+    /// The active spinner frame index shown while grid is loading.
+    pub(crate) spinner_frame: Option<usize>,
     /// When the grid last became not-ready — feeds the spinner's rotation phase.
     pub(crate) spinner_since: Option<Instant>,
     // ------------------------------------------------------------ animations --
@@ -653,7 +660,7 @@ impl App {
             status_tile: None,
             nohost_tile: None,
             grid_reveal_ready: true,
-            spinner_tile: None,
+            spinner_frame: None,
             spinner_since: None,
             grid_scroll: 0,
             grid_scroll_target: 0,
@@ -676,6 +683,13 @@ impl App {
                 app.select_host(host, port, mgmt_port);
             }
         }
+        // Decodes the spinner GIF now, off the render thread, so the LZW/frame-compose
+        // cost lands here instead of stalling the first `draw_list` call that needs a
+        // frame (right when the grid starts loading — the worst possible moment for a
+        // render-thread hitch). `spinner_frames`'s `OnceLock` makes this a pure warm-up:
+        // harmless if the spinner is drawn before this thread finishes, redundant work
+        // (never a race) if it finishes first.
+        std::thread::spawn(ui::spinner_frames);
         app
     }
 
@@ -1225,6 +1239,7 @@ impl App {
                 // prefetch window must not hide the grid again.
                 self.grid_reveal_ready = false;
                 self.spinner_since = None;
+                self.spinner_frame = None;
             } else {
                 for idx in std::mem::take(&mut self.grid_cards_dirty) {
                     if idx < count {
@@ -1322,9 +1337,13 @@ impl App {
                 self.grid_reveal_ready = window_ready || since.elapsed() >= SPINNER_MAX_WAIT;
                 if self.grid_reveal_ready {
                     self.spinner_since = None;
+                    self.spinner_frame = None;
                 } else {
-                    self.spinner_tile = Some(ui::render_spinner_tile(since.elapsed().as_secs_f32()));
-                    updated.push(Tile::Spinner);
+                    let (frame_idx, _) = ui::spinner_frame_at(since.elapsed().as_secs_f32());
+                    if self.spinner_frame != Some(frame_idx) {
+                        self.spinner_frame = Some(frame_idx);
+                        updated.push(Tile::SpinnerFrame(frame_idx));
+                    }
                 }
             }
 
@@ -1766,10 +1785,13 @@ impl App {
             Tile::ScrollContent(_) => self.scroll_content_tile.as_ref().map(|(_, p)| p),
             Tile::Status => self.status_tile.as_ref().map(|(_, p)| p),
             Tile::NoHost => self.nohost_tile.as_ref(),
-            Tile::Spinner => self.spinner_tile.as_ref(),
-            // Stream-side only (uploaded directly by `run_inner`'s overlay
-            // refresh) — never one of App's menu tiles.
-            Tile::StatsOverlay | Tile::DisconnectDialog | Tile::DisconnectFocusButton => None,
+            // `SpinnerFrame` is uploaded directly from its raw decoded pixels (see
+            // `main.rs`), never rasterized as a `Painter`; the rest are stream-side only
+            // (uploaded directly by `run_inner`'s overlay refresh) — never one of App's
+            // menu tiles.
+            Tile::SpinnerFrame(_) | Tile::StatsOverlay | Tile::DisconnectDialog | Tile::DisconnectFocusButton => {
+                None
+            }
         }
     }
 
@@ -1799,17 +1821,17 @@ impl App {
                 });
             }
         } else if !self.grid_reveal_ready {
-            if let Some(p) = &self.spinner_tile {
-                let x = grid_x + (available_w as i32 - p.width() as i32) / 2;
-                // 40% down rather than dead-center, which reads as slightly low on a TV.
-                let area_h = screen_h as i32 - ui::GRID_TOP_Y;
-                let y = ui::GRID_TOP_Y + (area_h - p.height() as i32) * 2 / 5;
-                cmds.push(DrawCmd::Tex {
-                    tile: Tile::Spinner,
-                    dst: Rect::new(x, y, p.width(), p.height()),
-                    alpha: 0xff,
-                });
-            }
+            let phase = self.spinner_since.map_or(0.0, |s| s.elapsed().as_secs_f32());
+            let (idx, frame) = ui::spinner_frame_at(phase);
+            let x = grid_x + (available_w as i32 - frame.width as i32) / 2;
+            // 40% down rather than dead-center, which reads as slightly low on a TV.
+            let area_h = screen_h as i32 - ui::GRID_TOP_Y;
+            let y = ui::GRID_TOP_Y + (area_h - frame.height as i32) * 2 / 5;
+            cmds.push(DrawCmd::Tex {
+                tile: Tile::SpinnerFrame(idx),
+                dst: Rect::new(x, y, frame.width, frame.height),
+                alpha: 0xff,
+            });
         } else {
             let count = self.grid_len();
             let focused = match self.home_focus {

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -67,11 +67,11 @@ pub enum Tile {
     /// content itself changes (a value/dropdown, or About's window
     /// recentering), never when the list merely scrolls within it.
     ScrollContent(Screen),
-    /// The loading spinner shown over the grid while it fills in
-    /// (`ui::render_spinner_tile`) — rebuilt every tick it's shown, but that's just
-    /// an index pick + small `Pixmap` copy (frames are decoded at build time), so
-    /// one reused tile is cheap enough.
-    Spinner,
+    /// One spinner frame's GPU texture, keyed by frame index within the GIF.
+    /// Frames are uploaded at most once (see `Compositor::upload_raw`) and held
+    /// in VRAM for the duration of the UI session; `clear_all` reclaims them
+    /// when a stream starts.
+    SpinnerFrame(usize),
     /// The in-stream stats overlay panel (`ui::render_stats_overlay_tile`).
     StatsOverlay,
     /// The in-stream disconnect-confirmation dialog's shell — card, title,
@@ -104,9 +104,8 @@ pub enum DrawCmd {
 
 pub struct Compositor {
     textures: HashMap<Tile, Texture>,
-    /// Reused un-premultiply staging buffer (tiny-skia pixmaps are premultiplied;
-    /// SDL's `BlendMode::Blend` expects straight alpha — converted once per
-    /// *upload*, never per frame).
+    /// Reused staging buffer for the premultiplied → straight-alpha conversion
+    /// performed once per `upload` call (never per frame).
     staging: Vec<u8>,
 }
 
@@ -116,6 +115,31 @@ impl Compositor {
             textures: HashMap::new(),
             staging: Vec::new(),
         }
+    }
+
+    /// Uploads straight-RGBA8 bytes directly into a new static GPU texture for
+    /// `tile`. No-ops if `tile` is already cached — caller only needs to push it
+    /// to `updated` the first time.
+    pub fn upload_raw(
+        &mut self,
+        creator: &TextureCreator<WindowContext>,
+        tile: Tile,
+        w: u32,
+        h: u32,
+        rgba_straight: &[u8],
+    ) -> Result<()> {
+        if self.textures.contains_key(&tile) {
+            return Ok(());
+        }
+        let mut tex = creator
+            .create_texture_static(PixelFormatEnum::RGBA32, w, h)
+            .map_err(|e| anyhow::anyhow!("create texture {tile:?} {w}x{h}: {e}"))?;
+        let pitch = w as usize * 4;
+        tex.update(None, rgba_straight, pitch)
+            .map_err(|e| anyhow::anyhow!("upload {tile:?}: {e}"))?;
+        tex.set_blend_mode(BlendMode::Blend);
+        self.textures.insert(tile, tex);
+        Ok(())
     }
 
     /// Creates/updates `tile`'s texture from a freshly rasterized painter.
@@ -166,19 +190,30 @@ impl Compositor {
         Ok(())
     }
 
+    /// Destroys every cached GPU texture at once.
+    ///
+    /// Call this when the UI is no longer visible (e.g. stream start) so all
+    /// VRAM held by the compositor is returned to the driver in one shot.
+    /// Safe to call with an empty map.
+    pub fn clear_all(&mut self) {
+        // SAFETY: `unsafe_textures` detaches each `Texture` from its creator's
+        // lifetime, making the owner responsible for destruction. We drain the
+        // map so nothing can reach these textures again, then destroy each one
+        // exactly once. Same invariant as `drop_tile`.
+        for (_, tex) in self.textures.drain() {
+            unsafe { tex.destroy() };
+        }
+    }
+
     /// Drops `tile`'s GPU texture, if it has one.
     ///
-    /// Needed because card tiles are now windowed: a texture for a card scrolled far out
-    /// of view is pure retained memory, and with `unsafe_textures` a `Texture` is not
-    /// freed by dropping the map entry alone — the SDL object must be destroyed. Safe to
-    /// call for a tile that was never uploaded.
+    /// Needed because card tiles are windowed: a texture for a card scrolled far
+    /// out of view is pure retained VRAM, and with `unsafe_textures` a `Texture`
+    /// is not freed by dropping the map entry — the SDL object must be destroyed.
+    /// Safe to call for a tile that was never uploaded.
     pub fn drop_tile(&mut self, tile: Tile) {
         if let Some(tex) = self.textures.remove(&tile) {
-            // SAFETY: `unsafe_textures` detaches a `Texture` from its `TextureCreator`'s
-            // lifetime, making destruction the owner's responsibility. This texture came
-            // from `self`'s own creator, is removed from the map above so nothing can
-            // reach it again, and every draw goes through `execute`, which only ever
-            // borrows from that same map.
+            // SAFETY: see `clear_all`.
             unsafe { tex.destroy() };
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,6 +200,14 @@ mod real {
         fonts: &crate::ui::Fonts,
         initial_status: Option<String>,
     ) -> Result<Option<ConnectOutcome>> {
+        // Target period for this loop's render ticks, animating or not. Each active
+        // (render) iteration used to sleep a flat 16ms *on top of* whatever the tick's own
+        // work cost, so its real period was `work + 16ms` rather than 16ms — at a GIF frame
+        // delay of ~33ms that was enough overshoot to occasionally miss a frame's window
+        // and skip straight to the next one. Pacing off each tick's own start time keeps
+        // the loop at a steady ~60Hz regardless of work cost, which comfortably samples
+        // every 33ms spinner frame.
+        const TICK_BUDGET: Duration = Duration::from_millis(16);
         // Test/dev override: skip the UI entirely if a connect.conf was dropped
         // alongside sideloading (see store.rs docs) — the UI flow is the normal path.
         // Bypasses the library screen too (`launch: None`, a plain desktop session).
@@ -210,6 +218,22 @@ mod real {
 
         canvas.window_mut().show();
         let mut app = App::new(identity.clone());
+        // Upload every spinner frame's GPU texture now, once, rather than letting each
+        // frame's first appearance create it lazily inside the render loop. `upload_raw`
+        // creates a *new* static texture (allocation, not just a pixel copy) the first
+        // time a `Tile::SpinnerFrame(idx)` is seen — done inline during the animation
+        // that meant the first spin cycle stalled once per unique frame, right when the
+        // spinner is supposed to look smooth. `clear_all` (stream handoff) drops these
+        // along with everything else, so this needs redoing on every re-entry here.
+        for (idx, frame) in crate::ui::spinner_frames().iter().enumerate() {
+            compositor.upload_raw(
+                texture_creator,
+                Tile::SpinnerFrame(idx),
+                frame.width,
+                frame.height,
+                &frame.pixels,
+            )?;
+        }
         // E.g. "the last connect attempt failed, and here's why" — shown on the
         // Home screen the user just got dropped back onto (see `run_inner`'s
         // connect-error path).
@@ -245,6 +269,7 @@ mod real {
         // Starts `true` so the first frame always draws.
         let mut dirty = true;
         let target = 'ui: loop {
+            let tick_start = Instant::now();
             if QUIT_REQUESTED.load(Ordering::Relaxed) {
                 tracing::warn!("SIGTERM/SIGINT received during UI");
                 return Ok(None);
@@ -460,17 +485,17 @@ mod real {
                     text_input.is_screen_keyboard_shown(canvas.window())
                 );
             }
-            // Animations advance every 16ms tick and keep frames flowing on their
-            // own; `dirty` (an event/drain changed actual content) additionally
-            // forces stale tiles to re-rasterize.
-            // `tiles_pending` keeps frames flowing while the card window is still being
-            // filled a few tiles at a time (see `CARD_BUILD_BUDGET`) — the
-            // redraw-on-change loop would otherwise go idle mid-build and leave the rest
-            // of the visible cards blank until the next input. `!grid_reveal_ready` keeps
-            // it flowing the same way while waiting on art still in flight.
+            // Three reasons to render another frame:
+            // 1. `dirty`         — an event or drain changed state (tiles need re-rasterizing).
+            // 2. `tiles_pending` — card window still filling in a few tiles at a time.
+            // 3. `!grid_reveal_ready` — spinner is animating (one frame per ~33 ms tick).
+            // The 16ms sleep when none of these holds keeps the SoC idle between frames.
             let animating = app.tick_animations() || app.tiles_pending || !app.grid_reveal_ready;
             if !dirty && !animating {
-                std::thread::sleep(Duration::from_millis(16));
+                let elapsed = tick_start.elapsed();
+                if elapsed < TICK_BUDGET {
+                    std::thread::sleep(TICK_BUDGET - elapsed);
+                }
                 continue;
             }
             let content_dirty = dirty;
@@ -489,8 +514,17 @@ mod real {
                 compositor.drop_tile(tile);
             }
             for tile in updated {
-                if let Some(pm) = app.tile_pixmap(tile) {
-                    compositor.upload(texture_creator, tile, pm)?;
+                match tile {
+                    Tile::SpinnerFrame(idx) => {
+                        if let Some(frame) = crate::ui::spinner_frame(idx) {
+                            compositor.upload_raw(texture_creator, tile, frame.width, frame.height, &frame.pixels)?;
+                        }
+                    }
+                    _ => {
+                        if let Some(pm) = app.tile_pixmap(tile) {
+                            compositor.upload(texture_creator, tile, pm)?;
+                        }
+                    }
                 }
             }
             let cmds = app.draw_list(display_mode.w as u32, display_mode.h as u32, fonts);
@@ -499,7 +533,10 @@ mod real {
             canvas.clear();
             compositor.execute(canvas, &cmds)?;
             canvas.present();
-            std::thread::sleep(Duration::from_millis(16));
+            let elapsed = tick_start.elapsed();
+            if elapsed < TICK_BUDGET {
+                std::thread::sleep(TICK_BUDGET - elapsed);
+            }
         };
         if text_input_active {
             text_input.stop();
@@ -618,6 +655,11 @@ mod real {
             canvas.set_draw_color(sdl2::pixels::Color::RGBA(0, 0, 0, 0));
             canvas.clear();
             canvas.present();
+            // Release all UI GPU textures (spinner frames, card art, sidebar …)
+            // before the stream takes the GPU. The compositor is re-populated
+            // from scratch when the user returns to the menu.
+            tracing::debug!("releasing all compositor textures for stream handoff");
+            compositor.clear_all();
             // The system draws its own cursor (a real SDL2 cursor this fork loads from
             // `/usr/share/im/...` — confirmed via `SDL_waylandwebos_cursor.c`) tracking
             // the physical remote directly; the host draws a second, independent one

--- a/src/ui/tiles.rs
+++ b/src/ui/tiles.rs
@@ -44,90 +44,79 @@ pub fn render_card_tile(
 }
 
 /// The animated loading spinner (purple, from
-/// lottiefiles.com/free-animation/purple-spinner-peYjszu1K5, exported as
-/// `assets/logo/punktfunk-spinner.gif`), decoded at build time by `build.rs`'s
-/// `build_spinner_frames` — no GIF/LZW decode on-device. Layout: `u32` width,
-/// `u32` height, `u32` frame count, then per frame a `u32` delay in milliseconds
-/// followed by `width * height * 4` bytes of premultiplied RGBA8, at the GIF's
-/// native size (no resize).
-static SPINNER_FRAMES_BLOB: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/spinner_frames.bin"));
+/// lottiefiles.com/free-animation/purple-spinner-peYjszu1K5, embedded as
+/// `assets/logo/punktfunk-spinner.gif`).
+static SPINNER_GIF_BYTES: &[u8] = include_bytes!("../../assets/logo/punktfunk-spinner.gif");
 
-/// One pre-decoded spinner frame and how long it stays on screen.
-struct SpinnerFrame {
-    pixmap: Pixmap,
-    delay: std::time::Duration,
+/// One decoded spinner frame (straight RGBA8) and how long it stays on screen.
+pub struct SpinnerFrame {
+    pub width: u32,
+    pub height: u32,
+    pub delay: std::time::Duration,
+    pub pixels: Vec<u8>,
 }
 
-/// Parses `SPINNER_FRAMES_BLOB` once. Just slicing already-decoded bytes into
-/// `Pixmap`s — no image decode, no resize, cheap enough to not need a background
-/// warm-up thread.
-fn spinner_frames() -> &'static [SpinnerFrame] {
+/// Decodes `SPINNER_GIF_BYTES` once into pre-decoded straight RGBA8 frames.
+pub fn spinner_frames() -> &'static [SpinnerFrame] {
     static FRAMES: std::sync::OnceLock<Vec<SpinnerFrame>> = std::sync::OnceLock::new();
     FRAMES.get_or_init(|| {
-        let mut data = SPINNER_FRAMES_BLOB;
-        let Some((width_bytes, rest)) = data.split_first_chunk::<4>() else {
+        use image::{codecs::gif::GifDecoder, AnimationDecoder};
+        let Ok(decoder) = GifDecoder::new(std::io::Cursor::new(SPINNER_GIF_BYTES)) else {
             return Vec::new();
         };
-        data = rest;
-        let Some((height_bytes, rest)) = data.split_first_chunk::<4>() else {
+        let Ok(raw_frames) = decoder.into_frames().collect::<image::ImageResult<Vec<_>>>() else {
             return Vec::new();
         };
-        data = rest;
-        let Some((count_bytes, rest)) = data.split_first_chunk::<4>() else {
-            return Vec::new();
-        };
-        data = rest;
-        let width = u32::from_le_bytes(*width_bytes);
-        let height = u32::from_le_bytes(*height_bytes);
-        let count = u32::from_le_bytes(*count_bytes) as usize;
-        let Some(size) = tiny_skia::IntSize::from_wh(width, height) else {
-            return Vec::new();
-        };
-        let frame_bytes = (width * height * 4) as usize;
-        let mut frames = Vec::with_capacity(count);
-        for _ in 0..count {
-            let Some((delay_bytes, rest)) = data.split_first_chunk::<4>() else {
-                break;
-            };
-            let delay = std::time::Duration::from_millis(u32::from_le_bytes(*delay_bytes).into());
-            if rest.len() < frame_bytes {
-                break;
-            }
-            let (pixels, rest) = rest.split_at(frame_bytes);
-            data = rest;
-            let Some(pixmap) = Pixmap::from_vec(pixels.to_vec(), size) else {
-                break;
-            };
-            frames.push(SpinnerFrame { pixmap, delay });
+        let mut frames = Vec::with_capacity(raw_frames.len());
+        for frame in raw_frames {
+            let (w, h) = frame.buffer().dimensions();
+            let (numer, denom) = frame.delay().numer_denom_ms();
+            let raw_delay = numer.checked_div(denom).unwrap_or(0);
+            // Clamp ultra-fast or unset delays to ~30 FPS (33 ms) so the
+            // animation stays smooth without busy-looping the render thread.
+            let delay_ms = if raw_delay < 20 { 33 } else { raw_delay };
+            let delay = std::time::Duration::from_millis(u64::from(delay_ms));
+            let pixels = frame.into_buffer().into_raw();
+            frames.push(SpinnerFrame {
+                width: w,
+                height: h,
+                delay,
+                pixels,
+            });
         }
         frames
     })
 }
 
-/// The spinner frame showing `phase` seconds after the spinner started
-/// (`App::spinner_since`), looped over the animation's total duration. Frames are
-/// already decoded (build time, see `SPINNER_FRAMES_BLOB`), so this is just an
-/// index pick + one small `Pixmap` copy — cheap enough to rebuild every tick the
-/// spinner is shown, no per-frame GPU texture caching needed. `1x1` (invisible)
-/// if the embedded blob is somehow empty.
-pub fn render_spinner_tile(phase: f32) -> Painter {
+/// Returns `SpinnerFrame` at index `idx`, or `None` when the GIF decoded to zero frames.
+pub fn spinner_frame(idx: usize) -> Option<&'static SpinnerFrame> {
+    spinner_frames().get(idx)
+}
+
+/// Returns the frame index and reference for `phase` seconds after the spinner started.
+/// Falls back to a 1×1 transparent dummy if the GIF decoded to zero frames.
+pub fn spinner_frame_at(phase: f32) -> (usize, &'static SpinnerFrame) {
     let frames = spinner_frames();
-    let Some(first) = frames.first() else {
-        return Painter::new(1, 1);
-    };
-    let total: std::time::Duration = frames.iter().map(|f| f.delay).sum();
-    let mut elapsed = std::time::Duration::from_secs_f32(phase.max(0.0)).as_nanos() % total.as_nanos().max(1);
-    let mut frame = first;
-    for f in frames {
-        if elapsed < f.delay.as_nanos() {
-            frame = f;
-            break;
+    if let Some(first) = frames.first() {
+        let total: std::time::Duration = frames.iter().map(|f| f.delay).sum();
+        let mut elapsed = std::time::Duration::from_secs_f32(phase.max(0.0)).as_nanos() % total.as_nanos().max(1);
+        for (idx, f) in frames.iter().enumerate() {
+            if elapsed < f.delay.as_nanos() {
+                return (idx, f);
+            }
+            elapsed -= f.delay.as_nanos();
         }
-        elapsed -= f.delay.as_nanos();
+        (0, first)
+    } else {
+        static DUMMY: std::sync::OnceLock<SpinnerFrame> = std::sync::OnceLock::new();
+        let dummy = DUMMY.get_or_init(|| SpinnerFrame {
+            width: 1,
+            height: 1,
+            delay: std::time::Duration::from_millis(100),
+            pixels: vec![0, 0, 0, 0],
+        });
+        (0, dummy)
     }
-    let mut p = Painter::new(frame.pixmap.width(), frame.pixmap.height());
-    p.draw_pixmap(0, 0, &frame.pixmap);
-    p
 }
 
 /// Transparent padding around the focus-ring tile (the ring's outer glow pass


### PR DESCRIPTION
## Summary
- Warms the spinner GIF decode on a background thread at `App::new` and eagerly uploads every frame's GPU texture once at UI-flow start, instead of letting the render thread hit a first-use full decode and a per-frame texture-allocation stall during the first spin cycle.
- Paces the render loop off each tick's own start time rather than sleeping a flat 16ms on top of whatever the tick's work cost, so it holds a steady ~60Hz instead of drifting past the spinner's ~33ms frame budget.
- Lowers `CARD_BUILD_BUDGET` from 2 to 1: on-device telemetry (`TELEMETRY=auto`) showed `prepare_tiles` costing 60-165ms per tick while the spinner is up, dominated by `render_card_tile`'s text rasterization (cold `TextCache`/`FreeType`, expensive on this armv7 softfloat target) — not the windowed bookkeeping around it. One card per tick roughly halves that per-tick cost.

## Test plan
- [x] `task check` (native cross-target) and `task lint` (clippy) both clean
- [x] Deployed to a real LG CX (webOS 5.6) with `TELEMETRY=auto` twice, comparing `prepare_tiles`/`present-to-present` timings before and after the `CARD_BUILD_BUDGET` change
- [x] Confirmed on-device: loading spinner now looks smooth