### PR TITLE
Stop webOS launcher intercepting HID keyboard's Windows key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.19.1#ebddffa4c8d76301b43c5c6be5355a62e2f8b102"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.19.2#f4fe4d07924d540bd4142306f6210b86c6af9cfd"
 
 [[package]]
 name = "fiat-crypto"
@@ -1109,8 +1109,8 @@ dependencies = [
 
 [[package]]
 name = "punktfunk-core"
-version = "0.19.1"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.19.1#ebddffa4c8d76301b43c5c6be5355a62e2f8b102"
+version = "0.19.2"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.19.2#f4fe4d07924d540bd4142306f6210b86c6af9cfd"
 dependencies = [
  "aes-gcm",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,12 +51,14 @@ tracing-appender = "0.2"
 # pf-client-core's session::start() (see session.rs docs for why we don't use that).
 # Pinned to a tagged punktfunk release (not a branch tip) this client was
 # developed/tested against — bump deliberately, not automatically, since
-# punktfunk-core's wire/ABI surface can move. Currently v0.19.1 — bumped from
-# v0.17.2 to track the latest release; the ChaCha20-Poly1305 session cipher
-# (session.rs advertises `VIDEO_CAP_CHACHA20`) lifts the soft-AES decrypt ceiling
-# on this armv7 target. The C ABI in `abi.rs` stays irrelevant to us (we link the
+# punktfunk-core's wire/ABI surface can move. Currently v0.19.2 — bumped from
+# v0.19.1 to track the latest release; the `punktfunk-core` crate itself is
+# byte-for-byte unchanged between the two tags (verified via diff), so this is
+# a no-op bump for this client. The ChaCha20-Poly1305 session cipher (session.rs
+# advertises `VIDEO_CAP_CHACHA20`) lifts the soft-AES decrypt ceiling on this
+# armv7 target. The C ABI in `abi.rs` stays irrelevant to us (we link the
 # Rust `client` API directly), so upstream's ABI_VERSION bumps don't reach us.
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.19.1", features = [
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.19.2", features = [
     "quic",
 ] }
 serde = { version = "1", features = ["derive"] }

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -150,7 +150,14 @@ a host-side capture/encode throughput question, not this client. See
   app. aurora-tv/moonlight-tv/Kodi all only read it. Panel scan-out is fixed at the system level.
 - **Magic Remote Back requires `SDL_WEBOS_ACCESS_POLICY_KEYS_BACK`** set before window creation (else
   the launcher intercepts it). With it, Back arrives as `keycode = 2097155` (`WEBOS_BACK_KEYCODE` in
-  `ui.rs`), caught via raw `i32` compare → `MenuEvent::Back`.
+  `ui.rs`), caught via raw `i32` compare → `MenuEvent::Back`. Same story for a connected HID
+  keyboard's Windows/Meta key (`SDL_WEBOS_ACCESS_POLICY_KEYS_HOME`/`_META`) and a gamepad's Guide
+  button (`SDL_WEBOS_ACCESS_POLICY_KEYS_GUIDE`) — all three otherwise background the app into the
+  launcher instead of reaching SDL2. The `KEYS_*` hints alone stop the *key event* from
+  backgrounding the app but the launcher's card-switcher ribbon overlay is gated separately —
+  also needs `SDL_WEBOS_ACCESS_POLICY_RIBBON=false` (paired the same way in aurora-tv's `app.c`)
+  or it can still pop over the foregrounded app. (Hint names confirmed via `strings` on a real
+  `webosbrew/SDL-webOS` `libSDL2-2.0.so.0`, not from any header available in this repo.)
 - **A hidden/unmapped window gets no pointer input.** Don't `.hide()` the stream-time window (that
   broke Magic Remote pointer → host-mouse forwarding). Keep it mapped and cleared fully transparent
   (`RGBA(0,0,0,0)`) each frame so the NDL plane shows through — same as aurora-tv.

--- a/src/main.rs
+++ b/src/main.rs
@@ -551,8 +551,13 @@ mod real {
 
     fn run_inner() -> Result<()> {
         // Prevents webOS's system launcher from intercepting the Magic Remote's Back
-        // key. Must be set before window creation.
+        // key, and a connected HID keyboard's Windows/Meta key (which webOS otherwise
+        // treats as its own Home shortcut, backgrounding the app into the launcher —
+        // see `keyboard.rs`'s LGui/RGui mapping, which needs these to actually reach
+        // the app instead). Must be set before window creation.
         sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_BACK", "true");
+        sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_HOME", "true");
+        sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_META", "true");
         // Linear texture filtering (SDL defaults to nearest) — the focus pop
         // scales card textures slightly, which shimmers without it.
         sdl2::hint::set("SDL_RENDER_SCALE_QUALITY", "1");

--- a/src/main.rs
+++ b/src/main.rs
@@ -551,13 +551,20 @@ mod real {
 
     fn run_inner() -> Result<()> {
         // Prevents webOS's system launcher from intercepting the Magic Remote's Back
-        // key, and a connected HID keyboard's Windows/Meta key (which webOS otherwise
-        // treats as its own Home shortcut, backgrounding the app into the launcher —
-        // see `keyboard.rs`'s LGui/RGui mapping, which needs these to actually reach
-        // the app instead). Must be set before window creation.
+        // key, a connected HID keyboard's Windows/Meta key, and a gamepad's Guide
+        // button (which webOS otherwise treats as its own Home shortcut, backgrounding
+        // the app into the launcher — see `keyboard.rs`'s LGui/RGui mapping and
+        // `gamepad.rs`'s BTN_GUIDE mapping, which need these to actually reach the app
+        // instead). Must be set before window creation.
         sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_BACK", "true");
         sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_HOME", "true");
         sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_META", "true");
+        sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_GUIDE", "true");
+        // The Home-equivalent hints above stop the key itself from backgrounding the
+        // app, but webOS's card-switcher ribbon overlay is gated separately — without
+        // this it can still pop the launcher UI on top even though the app stays
+        // foregrounded (confirmed pairing in aurora-tv's app.c).
+        sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_RIBBON", "false");
         // Linear texture filtering (SDL defaults to nearest) — the focus pop
         // scales card textures slightly, which shimmers without it.
         sdl2::hint::set("SDL_RENDER_SCALE_QUALITY", "1");


### PR DESCRIPTION
## Summary
- Pressing the Windows/Meta key on a connected HID keyboard was opening the webOS launchpad instead of reaching the host, and returning to the client afterward left the stream frozen on the last frame until a manual reconnect.
- Sets `SDL_WEBOS_ACCESS_POLICY_KEYS_HOME`/`..._META` hints (alongside the existing `..._BACK` hint) so the app keeps these keys instead of webOS backgrounding it into the launcher.

## Test plan
- [ ] `task deploy TV_HOST=root@<tv-ip>` with a USB/HID keyboard connected
- [ ] Press Windows key during streaming — confirm no launchpad and host receives the key
- [ ] Confirm returning from Home/launcher no longer leaves the stream frozen

🤖 Generated with [Claude Code](https://claude.com/claude-code)