### PR TITLE
Launch zoom/fade transition, connect started in parallel

### DIFF
--- a/src/app/home.rs
+++ b/src/app/home.rs
@@ -147,6 +147,13 @@ impl App {
         }
         None
     }
+    /// `grid_card_rect`, translated by the current scroll offset — every
+    /// draw-list card position starts from this.
+    pub(crate) fn scrolled_card_rect(&self, idx: usize, columns: usize, grid_x: i32, available_w: u32) -> Rect {
+        let r = ui::grid_card_rect(idx, columns, grid_x, available_w);
+        Rect::new(r.x(), r.y() - self.grid_scroll, r.width(), r.height())
+    }
+
     /// The largest useful `grid_scroll` for the current library/layout — 0 when
     /// everything already fits on screen.
     pub(crate) fn max_grid_scroll(&self, columns: usize, available_w: u32, screen_h: u32) -> i32 {
@@ -368,6 +375,7 @@ impl App {
             fingerprint,
             launch,
             rx,
+            idx,
         });
     }
 
@@ -387,6 +395,7 @@ impl App {
             port,
             fingerprint,
             launch,
+            idx,
             ..
         } = self.pending_launch.take().expect("just matched Some above");
         match loaded.result {
@@ -397,6 +406,7 @@ impl App {
                     .is_some_and(|(h, p)| *h == host && *p == port)
                 {
                     self.home_status = None;
+                    self.launch_anim_idx = Some(idx);
                     self.launch_ready = Some(ConnectTarget {
                         host,
                         port,
@@ -410,8 +420,11 @@ impl App {
                 self.handle_library_error(host, port, e);
             }
         }
+        // Not `grid_dirty`: this is a reachability probe only (`loaded.games` is
+        // discarded), so the grid's contents haven't changed — marking it dirty
+        // would rebuild every card tile and re-arm the loading spinner right as
+        // the launch zoom is about to start.
         self.sidebar_dirty = true;
-        self.grid_dirty = true;
         true
     }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -104,6 +104,9 @@ const SPINNER_MAX_WAIT: Duration = Duration::from_millis(900);
 /// How much the grid's focused card (and its ring) grows during
 /// `ui::FOCUS_POP` — see `ui::zoom_rect`.
 pub(crate) const CARD_GROWTH: f32 = 0.028;
+/// How much the launched card grows over `ui::LAUNCH_FADE` — same `zoom_rect`
+/// technique as `CARD_GROWTH`, just a bigger scale for the launch flourish.
+pub(crate) const LAUNCH_GROWTH: f32 = 3.5;
 /// How long a modal's fade/slide-in runs.
 pub(crate) const MODAL_FADE: Duration = Duration::from_millis(170);
 /// How long a scroll indicator (Settings' row list, About's document, ...) stays
@@ -231,6 +234,9 @@ pub(crate) struct PendingLaunch {
     pub(crate) fingerprint: [u8; 32],
     pub(crate) launch: Option<String>,
     pub(crate) rx: std::sync::mpsc::Receiver<crate::library::GamesLoaded>,
+    /// The confirmed card, so `launch_anim` zooms the right one even if focus
+    /// has since moved elsewhere on the grid.
+    pub(crate) idx: usize,
 }
 
 /// An open dropdown on the settings modal — `row` is the settings row index that
@@ -381,6 +387,11 @@ pub struct App {
     /// `take_ready_launch` and starts the stream. Separate from `pending_launch`
     /// since that's cleared as soon as a result arrives, before `main.rs` can act.
     pub(crate) launch_ready: Option<ConnectTarget>,
+    /// Started once `launch_ready` is set — the launch zoom/fade `main.rs` plays
+    /// before breaking into the stream. See `ui::LAUNCH_FADE`.
+    pub(crate) launch_anim: Option<Instant>,
+    /// Which grid card `launch_anim` zooms — set alongside `launch_ready`.
+    pub(crate) launch_anim_idx: Option<usize>,
     pub settings: Settings,
     /// Persists `settings` off the UI thread — see its docs on why a blocking
     /// `store::save_settings` on every adjustment read as input lag.
@@ -611,6 +622,8 @@ impl App {
             card_size: (0, 0),
             pending_launch: None,
             launch_ready: None,
+            launch_anim: None,
+            launch_anim_idx: None,
             settings: store::load_settings(),
             settings_writer: store::SettingsWriter::spawn(),
             settings_focused: 0,
@@ -869,6 +882,9 @@ impl App {
             if t.elapsed() >= MODAL_FADE {
                 self.modal_anim = None;
             }
+            animating = true;
+        }
+        if self.launch_anim.is_some_and(|t| t.elapsed() < ui::LAUNCH_FADE) {
             animating = true;
         }
         if let Some(t) = self.modal_focus_anim {
@@ -1789,9 +1805,7 @@ impl App {
             // `main.rs`), never rasterized as a `Painter`; the rest are stream-side only
             // (uploaded directly by `run_inner`'s overlay refresh) — never one of App's
             // menu tiles.
-            Tile::SpinnerFrame(_) | Tile::StatsOverlay | Tile::DisconnectDialog | Tile::DisconnectFocusButton => {
-                None
-            }
+            Tile::SpinnerFrame(_) | Tile::StatsOverlay | Tile::DisconnectDialog | Tile::DisconnectFocusButton => None,
         }
     }
 
@@ -1843,16 +1857,15 @@ impl App {
                 if Some(idx) == focused {
                     continue; // drawn last, on top of its neighbors
                 }
-                let r = ui::grid_card_rect(idx, columns, grid_x, available_w);
-                let y = r.y() - self.grid_scroll;
-                if y + r.height() as i32 + pad < 0 || y - pad > screen_h as i32 {
+                let r = self.scrolled_card_rect(idx, columns, grid_x, available_w);
+                if r.y() + r.height() as i32 + pad < 0 || r.y() - pad > screen_h as i32 {
                     continue; // culled — fully off-screen at this scroll offset
                 }
                 cmds.push(DrawCmd::Tex {
                     tile: Tile::Card(idx),
                     dst: Rect::new(
                         r.x() - pad,
-                        y - pad,
+                        r.y() - pad,
                         r.width() + 2 * pad as u32,
                         r.height() + 2 * pad as u32,
                     ),
@@ -1864,11 +1877,10 @@ impl App {
                 // around its center as the pop progresses, with the shared ring
                 // tile fading in over it at the same scale.
                 let f = ui::anim_frac(self.focus_anim, ui::FOCUS_POP);
-                let r = ui::grid_card_rect(idx, columns, grid_x, available_w);
-                let y = r.y() - self.grid_scroll;
+                let r = self.scrolled_card_rect(idx, columns, grid_x, available_w);
                 let card_base = Rect::new(
                     r.x() - pad,
-                    y - pad,
+                    r.y() - pad,
                     r.width() + 2 * pad as u32,
                     r.height() + 2 * pad as u32,
                 );
@@ -1880,7 +1892,7 @@ impl App {
                 let rp = ui::FOCUS_RING_PAD;
                 let ring_base = Rect::new(
                     r.x() - rp,
-                    y - rp,
+                    r.y() - rp,
                     r.width() + 2 * rp as u32,
                     r.height() + 2 * rp as u32,
                 );
@@ -2139,6 +2151,23 @@ impl App {
                     }
                 }
             }
+        }
+        // The launch transition: the confirmed card zooms in around its own
+        // center (same `zoom_rect` technique as the focus pop, so its aspect
+        // ratio never changes) while a black scrim blends in over it, both driven
+        // by the same clock — the card keeps zooming for the whole fade.
+        if let (Some(t), Some(idx)) = (self.launch_anim, self.launch_anim_idx) {
+            let f = ui::anim_frac(Some(t), ui::LAUNCH_FADE);
+            let base = self.scrolled_card_rect(idx, columns, grid_x, available_w);
+            cmds.push(DrawCmd::Tex {
+                tile: Tile::Card(idx),
+                dst: ui::zoom_rect(base, f, LAUNCH_GROWTH),
+                alpha: 0xff,
+            });
+            cmds.push(DrawCmd::Fill {
+                rect: Rect::new(0, 0, screen_w, screen_h),
+                color: sdl2::pixels::Color::RGBA(0, 0, 0, (255.0 * f) as u8),
+            });
         }
         cmds
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,9 +57,69 @@ mod real {
     use crate::store;
     use crate::ui::MenuEvent;
 
-    /// What `run_ui_flow` resolved: host, port, the pinned fingerprint (`None` for a
-    /// fresh TOFU connect), and an optional library entry id to launch into.
-    type ConnectOutcome = (String, u16, Option<[u8; 32]>, Option<String>);
+    /// What `run_ui_flow` resolved: a `session::connect` already running on its own
+    /// thread (started as soon as the target was confirmed, so it overlaps the
+    /// launch zoom/fade instead of running after it — see `spawn_connect`), plus
+    /// the settings it was started with.
+    type ConnectOutcome = (std::thread::JoinHandle<Result<session::Connected>>, store::Settings);
+
+    /// Starts `session::connect` on its own thread and returns immediately — the
+    /// caller joins it once it's actually needed (after the launch animation, or
+    /// straight away for the dev-override path). Letting connect run alongside the
+    /// launch animation means a fast local handshake often finishes before the
+    /// animation does, so the stream starts the instant it ends instead of after.
+    #[allow(clippy::too_many_arguments)]
+    fn spawn_connect(
+        identity: (String, String),
+        host: String,
+        port: u16,
+        fp: Option<[u8; 32]>,
+        launch: Option<String>,
+        settings: store::Settings,
+        display_w: i32,
+        display_h: i32,
+    ) -> Result<std::thread::JoinHandle<Result<session::Connected>>> {
+        std::thread::Builder::new()
+            .name("punktfunk-webos-connect".into())
+            .spawn(move || {
+                // SDL2/Wayland reports refresh_rate=0 in some launch contexts
+                // (confirmed: the host's virtual-display driver rejected a literal
+                // "0 Hz" mode request with "the parameter is incorrect") — the
+                // settings' own nominal rate (never 0; see `store::Settings::default`)
+                // is what drives the wire value directly.
+                let mode = Mode {
+                    width: settings.width,
+                    height: settings.height,
+                    refresh_hz: settings.refresh_hz,
+                };
+                tracing::info!(
+                    "requesting {}x{}@{}",
+                    settings.width,
+                    settings.height,
+                    settings.refresh_hz
+                );
+                session::connect(
+                    &host,
+                    port,
+                    mode,
+                    settings.bitrate_kbps,
+                    settings.hdr_enabled,
+                    settings.audio_channels,
+                    identity,
+                    fp,
+                    launch,
+                    // The host PARKS an unpinned/TOFU connect until an operator approves it —
+                    // matching clients/session's PENDING_APPROVAL_WAIT convention, not the
+                    // plain 15s handshake budget (too short for a human to notice and click).
+                    Duration::from_secs(185),
+                    display_w,
+                    display_h,
+                    settings.video_backend,
+                    settings.codec,
+                )
+            })
+            .context("spawn connect thread")
+    }
 
     /// Set by [`handle_term_signal`], read by both event loops below as an extra
     /// "should we quit" condition alongside SDL's own `Event::Quit`. webOS can ask a
@@ -213,7 +273,18 @@ mod real {
         // Bypasses the library screen too (`launch: None`, a plain desktop session).
         if let Some((host, port)) = store::dev_override_connect() {
             tracing::info!("dev override: connecting to {host}:{port}");
-            return Ok(Some((host, port, None, None)));
+            let settings = store::load_settings();
+            let handle = spawn_connect(
+                identity.clone(),
+                host,
+                port,
+                None,
+                None,
+                settings,
+                display_mode.w,
+                display_mode.h,
+            )?;
+            return Ok(Some((handle, settings)));
         }
 
         canvas.window_mut().show();
@@ -268,7 +339,11 @@ mod real {
         // unconditionally every 16ms forever, even sitting on an untouched menu.
         // Starts `true` so the first frame always draws.
         let mut dirty = true;
-        let target = 'ui: loop {
+        // Set once the reachability check passes — `spawn_connect` is already
+        // running by then, so this just carries its handle out of the loop for
+        // `run_inner` to join once the launch animation finishes.
+        let mut connect_handle: Option<ConnectOutcome> = None;
+        'ui: loop {
             let tick_start = Instant::now();
             if QUIT_REQUESTED.load(Ordering::Relaxed) {
                 tracing::warn!("SIGTERM/SIGINT received during UI");
@@ -283,8 +358,29 @@ mod real {
             dirty |= app.drain_reachability();
             dirty |= app.tick_wake();
             dirty |= app.drain_launch_check();
-            if let Some(target) = app.take_ready_launch() {
-                break 'ui target;
+            // Reachability check passed — start connecting now, in parallel with the
+            // launch zoom/fade, so a fast handshake finishes before the animation
+            // does rather than only starting once it's done.
+            if app.launch_ready.is_some() && connect_handle.is_none() {
+                app.launch_anim = Some(Instant::now());
+                dirty = true;
+                if let Some(target) = app.take_ready_launch() {
+                    let settings = store::load_settings();
+                    let handle = spawn_connect(
+                        identity.clone(),
+                        target.host,
+                        target.port,
+                        Some(target.fingerprint),
+                        target.launch,
+                        settings,
+                        display_mode.w,
+                        display_mode.h,
+                    )?;
+                    connect_handle = Some((handle, settings));
+                }
+            }
+            if app.launch_anim.is_some_and(|t| t.elapsed() >= crate::ui::LAUNCH_FADE) {
+                break 'ui;
             }
             for event in events.poll_iter() {
                 use sdl2::event::Event;
@@ -342,10 +438,13 @@ mod real {
                         y,
                         ..
                     } => {
-                        if let Some(target) =
-                            app.handle_mouse_click(x, y, display_mode.w as u32, display_mode.h as u32, fonts)
+                        // A grid-card click resolves via `confirm_grid_card`'s async check
+                        // above, same as a remote Confirm — never a target directly here.
+                        if app
+                            .handle_mouse_click(x, y, display_mode.w as u32, display_mode.h as u32, fonts)
+                            .is_some()
                         {
-                            break 'ui target;
+                            break 'ui;
                         }
                         continue;
                     }
@@ -430,13 +529,16 @@ mod real {
                     // routed through `back` anyway so the policy lives in one place.
                     Screen::Home => {
                         if menu_ev == MenuEvent::Back {
-                            if let Some(target) = app.back() {
-                                break 'ui target;
+                            if app.back().is_some() {
+                                break 'ui;
                             }
-                        } else if let Some(target) =
-                            app.handle_home_event(menu_ev, display_mode.w as u32, display_mode.h as u32)
+                        // Same async path as the mouse click above — a grid-card
+                        // Confirm never resolves to a target directly here.
+                        } else if app
+                            .handle_home_event(menu_ev, display_mode.w as u32, display_mode.h as u32)
+                            .is_some()
                         {
-                            break 'ui target;
+                            break 'ui;
                         }
                     }
                     Screen::Pairing => app.handle_pairing_event(menu_ev),
@@ -537,16 +639,11 @@ mod real {
             if elapsed < TICK_BUDGET {
                 std::thread::sleep(TICK_BUDGET - elapsed);
             }
-        };
+        }
         if text_input_active {
             text_input.stop();
         }
-        Ok(Some((
-            target.host,
-            target.port,
-            Some(target.fingerprint),
-            target.launch,
-        )))
+        Ok(connect_handle)
     }
 
     fn run_inner() -> Result<()> {
@@ -621,7 +718,7 @@ mod real {
         let mut menu_status: Option<String> = None;
 
         loop {
-            let Some((host, port, fp, launch)) = run_ui_flow(
+            let Some((connect_thread, settings)) = run_ui_flow(
                 &mut canvas,
                 &mut compositor,
                 &texture_creator,
@@ -637,8 +734,6 @@ mod real {
                 tracing::info!("punktfunk-webos exiting cleanly");
                 return Ok(());
             };
-
-            let settings = store::load_settings();
             tracing::debug!("settings: {settings:?}");
 
             // `hide()` (the previous approach here, when `set_opacity` fails — confirmed
@@ -669,40 +764,10 @@ mod real {
             // same standard SDL2 API on any platform, not webOS-specific).
             sdl.mouse().show_cursor(false);
 
-            // SDL2/Wayland reports refresh_rate=0 in some launch contexts (confirmed:
-            // the host's virtual-display driver rejected a literal "0 Hz" mode request
-            // with "the parameter is incorrect") — the settings' own nominal rate (never
-            // 0; see store::Settings::default) is what drives the wire value directly.
-            tracing::info!(
-                "requesting {}x{}@{}",
-                settings.width,
-                settings.height,
-                settings.refresh_hz
-            );
-            let mode = Mode {
-                width: settings.width,
-                height: settings.height,
-                refresh_hz: settings.refresh_hz,
-            };
-            let connected = match session::connect(
-                &host,
-                port,
-                mode,
-                settings.bitrate_kbps,
-                settings.hdr_enabled,
-                settings.audio_channels,
-                identity.clone(),
-                fp,
-                launch,
-                // The host PARKS an unpinned/TOFU connect until an operator approves it —
-                // matching clients/session's PENDING_APPROVAL_WAIT convention, not the
-                // plain 15s handshake budget (too short for a human to notice and click).
-                Duration::from_secs(185),
-                display_mode.w,
-                display_mode.h,
-                settings.video_backend,
-                settings.codec,
-            ) {
+            // Already running (started back in `run_ui_flow`, overlapping the launch
+            // zoom/fade) — joining just waits out whatever's left of the handshake,
+            // which for a fast local connect is often nothing at all.
+            let connected = match connect_thread.join().expect("connect thread panicked") {
                 Ok(c) => c,
                 Err(e) => {
                     // A failed connect (host went down in the race, codec/launch

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -13,6 +13,10 @@ use std::time::{Duration, Instant};
 /// pre-stream modal's focused widget, and the disconnect dialog's button.
 pub const FOCUS_POP: Duration = Duration::from_millis(140);
 
+/// How long the launch zoom/fade-to-black runs once a grid card is confirmed
+/// — the card keeps zooming for the whole span, not just its start.
+pub const LAUNCH_FADE: Duration = Duration::from_millis(600);
+
 /// Cubic ease-out for the animation fractions below.
 pub fn ease(f: f32) -> f32 {
     1.0 - (1.0 - f).powi(3)


### PR DESCRIPTION
## Summary
- Confirming a grid card plays a brief zoom+fade-to-black over the selected art before streaming.
- `session::connect` now starts on its own thread as soon as the reachability check passes, overlapping the transition instead of running after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)