### PR TITLE
Move Wake-on-LAN auto-send to a per-host setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,9 @@ this client lacks.
 
 - **Pre-stream UI** (`app/` + `ui/`): `app/` owns the screen state machine (`Screen::Home` —
   sidebar of known hosts + game grid — with `Pairing`/`Settings`/`AddHost`/`EditHost`/`Wake`/
-  `HostMenu`/`ForgetHost`/`About` as modals over it — `HostMenu` opens from the ⋯ button on each
-  sidebar host row), one module per screen (`app/mod.rs` keeps
+  `HostMenu`/`WakeSettings`/`ForgetHost`/`About` as modals over it — `HostMenu` opens from the ⋯
+  button on each sidebar host row, and `WakeSettings` from the ⋯ on its own "Wake host" row),
+  one module per screen (`app/mod.rs` keeps
   the `App` struct, the shared drains, and the tile orchestration; its fields are `pub(crate)` so
   the screen modules can reach them). `ui/` owns drawing primitives and key-to-`MenuEvent`
   mapping, split along the same seams (`painter`/`text`/`rows`/`sidebar`/`grid`/`listmodal`/…) and

--- a/src/app/addhost.rs
+++ b/src/app/addhost.rs
@@ -49,6 +49,8 @@ impl App {
                 fingerprint: None,
                 mgmt_port: None,
                 mac: Vec::new(),
+                // Preserved across a re-add by `upsert_known_host`; off for a genuinely new host.
+                wol_auto: false,
                 // Only reaches a genuinely new host — `upsert_known_host` keeps an
                 // existing record's pins.
                 pinned: vec![store::DESKTOP_PIN_ID.to_string()],

--- a/src/app/edithost.rs
+++ b/src/app/edithost.rs
@@ -74,6 +74,7 @@ impl App {
                 fingerprint: old.fingerprint,
                 mgmt_port: old.mgmt_port,
                 mac: old.mac.clone(),
+                wol_auto: old.wol_auto,
                 pinned: old.pinned.clone(),
             },
         );

--- a/src/app/home.rs
+++ b/src/app/home.rs
@@ -324,6 +324,13 @@ impl App {
         Rect::new(r.x(), r.y() + extra, r.width(), r.height())
     }
 
+    /// Eased 0..=1 progress of grid index `idx`'s zoom-in (see
+    /// `CardTile::pop_since`) — 1.0, full size, for anything not animating.
+    pub(crate) fn card_pop_frac(&self, idx: usize) -> f32 {
+        let card = self.card_tiles.get(idx).and_then(|t| t.as_ref());
+        ui::anim_frac(card.and_then(|c| c.pop_since), CARD_POP)
+    }
+
     /// `unscrolled_card_rect`, translated by the current scroll offset — every
     /// draw-list card position starts from this.
     pub(crate) fn scrolled_card_rect(&self, idx: usize, columns: usize, grid_x: i32, available_w: u32) -> Rect {
@@ -442,7 +449,12 @@ impl App {
     pub(crate) fn select_host(&mut self, host: String, port: u16, mgmt_port: Option<u16>) {
         let _ = store::save_selected_host(&host, port);
         self.selected_host = Some((host.clone(), port));
-        self.home_status = Some("Loading library…".into());
+        let name = self
+            .known_hosts
+            .iter()
+            .find(|h| h.host == host && h.port == port)
+            .map_or_else(|| host.clone(), |h| h.name.clone());
+        self.home_status = Some(format!("Loading library from {name}…"));
         self.games = Vec::new();
         self.pinned_count = 0;
         self.games_loaded = false;
@@ -570,21 +582,22 @@ impl App {
             return;
         };
         let Some(fingerprint) = known.fingerprint else { return };
-        let launch = match self.grid_card_at(idx, columns) {
-            Some(GridCard::Desktop) => None,
-            Some(GridCard::Game(game)) => Some(game.id.clone()),
+        let (launch, title) = match self.grid_card_at(idx, columns) {
+            Some(GridCard::Desktop) => (None, "Desktop".to_string()),
+            Some(GridCard::Game(game)) => (Some(game.id.clone()), game.title.clone()),
             None => return,
         };
         let mgmt_port = known.mgmt_port.unwrap_or(crate::library::DEFAULT_MGMT_PORT);
         let identity = (self.identity.0.clone(), self.identity.1.clone());
         tracing::debug!("launch: checking {host}:{port} is still reachable before connecting…");
-        self.home_status = Some("Checking connection…".into());
+        self.home_status = Some(format!("Checking the host is still reachable before starting {title}…"));
         let rx = crate::library::load_games_async(host.clone(), port, mgmt_port, identity, Some(fingerprint));
         self.pending_launch = Some(PendingLaunch {
             host,
             port,
             fingerprint,
             launch,
+            title,
             rx,
             idx,
         });
@@ -606,6 +619,7 @@ impl App {
             port,
             fingerprint,
             launch,
+            title,
             idx,
             ..
         } = self.pending_launch.take().expect("just matched Some above");
@@ -616,7 +630,9 @@ impl App {
                     .as_ref()
                     .is_some_and(|(h, p)| *h == host && *p == port)
                 {
-                    self.home_status = None;
+                    // Stays up through the launch zoom and the connect that follows it —
+                    // `run_inner` puts its own UI on screen from there.
+                    self.home_status = Some(format!("Starting {title}…"));
                     self.launch_anim_idx = Some(idx);
                     self.launch_ready = Some(ConnectTarget {
                         host,

--- a/src/app/hostmenu.rs
+++ b/src/app/hostmenu.rs
@@ -31,7 +31,15 @@ impl App {
     pub(crate) fn open_host_menu(&mut self, idx: usize) {
         self.host_menu_index = Some(idx);
         self.menu_focused = 0;
+        self.host_menu_dots = false;
         self.screen = Screen::HostMenu;
+    }
+
+    /// Whether the focused row has a ⋯ button to move onto (only "Wake host" does).
+    pub(crate) fn host_menu_row_has_dots(&self) -> bool {
+        self.host_menu_actions()
+            .get(self.menu_focused)
+            .is_some_and(|(a, _)| *a == HostAction::Wake)
     }
 
     /// The menu's rows, paired with what each one does. Conditional on the host's
@@ -60,7 +68,16 @@ impl App {
             ),
         ];
         if !entry.mac().is_empty() {
-            rows.push((HostAction::Wake, FocusRow::action(ui::ICON_POWER, "Wake host")));
+            // The one row with a ⋯: Confirm wakes now, the button holds the per-host
+            // wake settings (`Screen::WakeSettings`). Same affordance and the same
+            // Right-to-reach-it gesture as a sidebar host row's. Always built
+            // *un*focused — whether the button is lit is `host_menu_dots`, applied by
+            // the focused-row tile alone (see `App::modal_focus_tile`), so the shell
+            // underneath can't bake in a highlight that outlives it.
+            rows.push((
+                HostAction::Wake,
+                FocusRow::action(ui::ICON_POWER, "Wake host").with_menu(false),
+            ));
         }
         if saved {
             rows.push((HostAction::Edit, FocusRow::action(ui::ICON_EDIT, "Edit address…")));
@@ -113,10 +130,24 @@ impl App {
     pub(crate) fn handle_host_menu_event(&mut self, ev: MenuEvent) {
         let len = self.host_menu_actions().len();
         if ui::list_nav(&mut self.menu_focused, len, ev) {
+            // Vertical movement always lands on the row body — a ⋯ belongs to the row
+            // it's on, so leaving that row leaves the button too.
+            self.host_menu_dots = false;
             self.modal_focus_anim = Some(Instant::now());
             return;
         }
         match ev {
+            // Right/Left move onto and off the focused row's ⋯, mirroring the sidebar's
+            // `HomeFocus::SidebarMenu`; on a row without one they do nothing.
+            MenuEvent::Right if !self.host_menu_dots && self.host_menu_row_has_dots() => {
+                self.host_menu_dots = true;
+                self.modal_focus_anim = Some(Instant::now());
+            }
+            MenuEvent::Left if self.host_menu_dots => {
+                self.host_menu_dots = false;
+                self.modal_focus_anim = Some(Instant::now());
+            }
+            MenuEvent::Confirm if self.host_menu_dots => self.open_wake_settings(),
             MenuEvent::Confirm => self.confirm_host_menu_row(),
             MenuEvent::Back => {
                 self.host_menu_index = None;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -26,6 +26,7 @@ mod reach;
 mod settings;
 mod speedtest;
 mod wake;
+mod wakesettings;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Screen {
@@ -54,6 +55,10 @@ pub enum Screen {
     /// Per-host network speed test (`HostMenu` -> "Test network speed"), measuring over
     /// the real data plane. See `app::speedtest`.
     SpeedTest,
+    /// Per-host Wake-on-LAN settings (`HostMenu` -> the ⋯ on "Wake host"), currently
+    /// just the auto-send toggle. Which host is `App::host_menu_index`, same as the
+    /// menu it opens from. See `app::wakesettings`.
+    WakeSettings,
     /// "You can only pin 5 games" — a single-OK-button alert, reached from Home
     /// when `App::toggle_focused_pin` hits `store::MAX_PINNED_GAMES`. See `app::pinlimit`.
     PinLimit,
@@ -116,6 +121,11 @@ const PIN_BADGE_MARGIN: i32 = 10;
 /// How long a pin/unpin toggle's fly-to-new-position animation runs — see
 /// `App::pin_move_anim`.
 pub(crate) const PIN_MOVE_ANIM: Duration = Duration::from_millis(380);
+/// How long a card's zoom-in runs when it first appears — see
+/// `CardTile::pop_since`.
+pub(crate) const CARD_POP: Duration = Duration::from_millis(300);
+/// How far below full size a card starts that zoom-in — see `ui::pop_in_rect`.
+pub(crate) const CARD_POP_SHRINK: f32 = 0.14;
 /// How long a modal's fade/slide-in runs.
 pub(crate) const MODAL_FADE: Duration = Duration::from_millis(170);
 /// How long a scroll indicator (Settings' row list, About's document, ...) stays
@@ -161,13 +171,11 @@ pub(crate) const PAIRING_SUBTITLE: &str = "Two ways to pair with this host — e
 /// confirmation.
 pub(crate) const SIMPLE_MODAL_WIDTH_FRAC: f32 = 0.40;
 
-/// How often the magic packet is re-sent while a wake is in flight — see
-/// `App::tick_wake`.
-pub(crate) const WAKE_RESEND_INTERVAL: Duration = Duration::from_secs(15);
-
-/// How long a *silent* auto-send (`Settings::wol_auto_send`) waits before giving up on
-/// staying quiet and surfacing the wake prompt anyway — see `App::tick_wake`.
-pub(crate) const WAKE_ESCALATE_AFTER: Duration = Duration::from_secs(60);
+/// How often the magic packet is re-sent while a wake is in flight, and — the same
+/// moment, for a silent auto-send — how long it stays silent before showing the wake
+/// prompt: a minute of retrying without the host coming back is the point at which the
+/// user should be looking at it rather than at an unexplained grid. See `App::tick_wake`.
+pub(crate) const WAKE_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 
 /// How often `App::tick_wake` actively re-checks reachability, independent of the WOL
 /// timers above and of whether a MAC is even on record.
@@ -178,7 +186,12 @@ pub(crate) const WAKE_PROBE_INTERVAL: Duration = Duration::from_secs(10);
 /// distinguished by `silent`. Entered from `App::start_wake` whenever a known/paired
 /// host's library fetch fails as genuinely unreachable, replacing the old plain grid
 /// error message in every case — even with no MAC on record, where `render_wake` just
-/// hides the send/auto-send controls instead.
+/// hides the send controls instead.
+///
+/// Whether the packet goes out silently is `KnownHost::wol_auto`, edited per host from
+/// the host menu's Wake row (⋯ → `Screen::WakeSettings`). It used to be a global
+/// `Settings` flag toggled *inside this prompt*, which meant the only way to reach the
+/// setting was to have a host fail on you first.
 pub struct WakeState {
     pub(crate) host: String,
     pub(crate) port: u16,
@@ -188,20 +201,24 @@ pub struct WakeState {
     /// without sending — so declining the prompt looks exactly like it did before this
     /// flow existed.
     pub(crate) reason: String,
-    /// Focus on the modal: `0` = the "Always send automatically" toggle row,
-    /// `1` = the "Wake" button, `2` = the "Cancel" button (see `render_wake`'s
-    /// shell/buttons split, mirroring `Screen::ForgetHost`'s).
+    /// Focus on the modal: `0` = the "Wake host" button, `1` = "Cancel" (see
+    /// `render_wake`, mirroring `Screen::ForgetHost`'s shell/buttons split).
     pub(crate) focused: usize,
     /// Whether a packet has gone out for the current wait window.
     pub(crate) sent: bool,
-    /// When the current wait window started (its first send) — drives the 60s
-    /// escalation.
+    /// How many magic packets have actually gone out for this wait (the initial send
+    /// plus `tick_wake`'s resends) — only shown, in `wake_home_status`, so a silent
+    /// wait visibly progresses instead of sitting on one unchanging line.
+    pub(crate) attempts: u32,
+    /// When the current wait window started (its first send).
     pub(crate) since: Option<Instant>,
+    /// When the last magic packet went out — drives both the resend and, for a silent
+    /// wait, the moment the prompt appears (one `WAKE_RETRY_INTERVAL`, same clock).
     pub(crate) last_attempt: Option<Instant>,
-    /// `true` while this wait is running quietly because `wol_auto_send` fired it with
-    /// no prompt shown — `App::tick_wake` flips it (and shows the prompt) once
-    /// `WAKE_ESCALATE_AFTER` passes with the host still unreachable, so the user gets a
-    /// chance to turn auto-send back off instead of it failing forever in silence.
+    /// `true` while this wait is running quietly because `KnownHost::wol_auto` fired it
+    /// with no prompt shown. `App::tick_wake` flips it (and shows the prompt) once
+    /// `WAKE_RETRY_INTERVAL` has passed since the last packet with the host still
+    /// unreachable — once shown, it stays shown-or-dismissed rather than re-popping.
     pub(crate) silent: bool,
     /// When the last active reachability probe went out — see `App::tick_wake`.
     pub(crate) last_probe: Option<Instant>,
@@ -233,6 +250,17 @@ pub enum HomeFocus {
 pub(crate) enum GridCard<'a> {
     Desktop,
     Game(&'a GameEntry),
+}
+
+/// One rasterized grid card, with the clock for its zoom-in.
+pub(crate) struct CardTile {
+    pub(crate) tile: Painter,
+    /// When this card started zooming up to full size. Cards land a few per tick
+    /// as their art arrives (`CARD_BUILD_BUDGET`), so each runs its own clock and
+    /// a filling grid ripples in. `None` behind the loading spinner — nothing
+    /// built there is visible yet, so `prepare_tiles` stamps them all together
+    /// when `grid_reveal_ready` flips.
+    pub(crate) pop_since: Option<Instant>,
 }
 
 /// The Home grid's shape at one column count: the pinned front block leads
@@ -319,6 +347,10 @@ pub(crate) struct PendingLaunch {
     pub(crate) port: u16,
     pub(crate) fingerprint: [u8; 32],
     pub(crate) launch: Option<String>,
+    /// The card's display title ("Desktop" or the game's), for the status bar —
+    /// resolving it here keeps `drain_launch_check` off the grid geometry it would
+    /// otherwise need (a column count) just to name the thing it's starting.
+    pub(crate) title: String,
     pub(crate) rx: std::sync::mpsc::Receiver<crate::library::GamesLoaded>,
     /// The confirmed card, so `launch_anim` zooms the right one even if focus
     /// has since moved elsewhere on the grid.
@@ -354,7 +386,6 @@ pub(crate) enum ModalShellKey {
         name: String,
         mac_empty: bool,
         sent: bool,
-        auto_send: bool,
         hover_close: bool,
     },
     Pairing {
@@ -381,6 +412,13 @@ pub(crate) enum ModalShellKey {
     /// tile, cropped/positioned by the GPU same as Settings' row list. So this shell
     /// is invalidated only by the same thing every other shell already excludes
     /// focus/scroll for: nothing screen-specific here at all.
+    /// One toggle whose state is the only thing on the card that can change (the
+    /// title names the host, which can't change while this is open).
+    WakeSettings {
+        title: String,
+        auto: bool,
+        hover_close: bool,
+    },
     About {
         hover_close: bool,
     },
@@ -402,6 +440,8 @@ pub(crate) enum ModalShellKey {
 #[derive(PartialEq)]
 pub(crate) enum ModalFocusKey {
     SettingsRow(usize, Settings),
+    /// `Screen::WakeSettings`' auto-send switch, carrying its state so flipping it
+    /// re-bakes the tile.
     WakeToggle(bool),
     WakeButton(usize),
     PairingDigit(usize, u8),
@@ -413,8 +453,10 @@ pub(crate) enum ModalFocusKey {
     SpeedTestButton(usize, String),
     /// Any `ListModal`-based screen's focused row. Carries the row's label as well as
     /// its index so a row list that changes shape under a fixed index (e.g. "Wake
-    /// host" appearing once a MAC is learned) still invalidates the tile.
-    MenuRow(usize, String),
+    /// host" appearing once a MAC is learned) still invalidates the tile, plus whether
+    /// focus is on the row's ⋯ button rather than its body (the tile draws that
+    /// highlight, so it isn't a mere focus move — see `FocusRow::menu`).
+    MenuRow(usize, String, bool),
 }
 
 /// What invalidates whichever modal's `Tile::ScrollContent(Screen)` is currently
@@ -512,6 +554,14 @@ pub struct App {
     /// Forget confirmation's two-button focus — the two screens can be open in
     /// sequence and must not share a cursor.
     pub menu_focused: usize,
+    /// Whether focus is on the ⋯ button of the host menu's focused row rather than on
+    /// the row body — the list-modal counterpart of `HomeFocus::SidebarMenu`. Only the
+    /// "Wake host" row has one (see `host_menu_actions`).
+    pub host_menu_dots: bool,
+    /// Focused row of `Screen::WakeSettings`. Its own cursor rather than `menu_focused`:
+    /// that screen sits *over* the host menu and Back returns there, so the menu's
+    /// cursor has to survive the round trip.
+    pub wake_settings_focused: usize,
     /// The sidebar row `Screen::EditHost` is editing, `None` otherwise.
     pub edit_host_index: Option<usize>,
     /// The in-flight/finished speed test, `None` when that screen isn't open.
@@ -568,7 +618,7 @@ pub struct App {
     pub(crate) sidebar_dirty: bool,
     /// Per-card tiles (shadow baked in, transparent padding), index-aligned
     /// with the grid. `None` = not yet rasterized (or invalidated).
-    pub(crate) card_tiles: Vec<Option<Painter>>,
+    pub(crate) card_tiles: Vec<Option<CardTile>>,
     /// All card tiles stale (games list / host changed) — a fresh library load,
     /// so `prepare_tiles` also re-arms the loading spinner (`grid_reveal_ready`).
     pub(crate) grid_dirty: bool,
@@ -739,6 +789,8 @@ impl App {
             host_menu_index: None,
             host_menu_focused: 1,
             menu_focused: 0,
+            host_menu_dots: false,
+            wake_settings_focused: 0,
             edit_host_index: None,
             speed_test: None,
             speed_test_rx: None,
@@ -881,9 +933,15 @@ impl App {
     /// (`tick_wake`'s reachability probe succeeding). `source` is just for the log line.
     pub(crate) fn wake_succeeded(&mut self, host: String, port: u16, mgmt_port: Option<u16>, source: &str) {
         tracing::info!("wake succeeded: {host}:{port} back ({source})");
-        self.wake = None;
+        let name = self.wake.take().map(|w| w.name);
         self.screen = Screen::Home;
         self.select_host(host, port, mgmt_port);
+        // Overrides `select_host`'s plain "Loading library…": after a wait that may
+        // have run for minutes with no modal up, the bar's job is to report that the
+        // host came back, not just that a fetch started.
+        if let Some(name) = name {
+            self.home_status = Some(format!("{name} is back online — loading its library…"));
+        }
     }
 
     /// Drains any cover art that's finished decoding since the last tick — called
@@ -942,6 +1000,10 @@ impl App {
             }
             Screen::HostMenu => {
                 self.handle_host_menu_event(MenuEvent::Back);
+                None
+            }
+            Screen::WakeSettings => {
+                self.handle_wake_settings_event(MenuEvent::Back);
                 None
             }
             Screen::SpeedTest => {
@@ -1025,6 +1087,15 @@ impl App {
                 self.pin_move_anim = None;
                 self.pin_move_tile = None;
             }
+            animating = true;
+        }
+        // A scan, not one clock: every card zooms on its own (`CardTile::pop_since`).
+        if self
+            .card_tiles
+            .iter()
+            .flatten()
+            .any(|c| c.pop_since.is_some_and(|t| t.elapsed() < CARD_POP))
+        {
             animating = true;
         }
         animating
@@ -1121,6 +1192,11 @@ impl App {
                 let subtitle = self.host_menu_subtitle();
                 let rows = self.host_menu_actions().len();
                 let card = Self::host_menu_card_rect(screen_w, screen_h, fonts, &subtitle, rows);
+                self.set_hover_close(ui::modal_close_rect(card).contains_point((x, y)))
+            }
+            Screen::WakeSettings => {
+                let subtitle = self.wake_settings_subtitle();
+                let card = Self::wake_settings_card_rect(screen_w, screen_h, fonts, &subtitle);
                 self.set_hover_close(ui::modal_close_rect(card).contains_point((x, y)))
             }
             Screen::EditHost => {
@@ -1249,7 +1325,21 @@ impl App {
                 let content = ui::list_modal_content_rect(card, fonts, &subtitle, rows);
                 let i = (0..rows).find(|&i| ui::focus_row_rect(content, i).contains_point((x, y)))?;
                 self.menu_focused = i;
+                // A click that landed on the row's ⋯ opens that instead of the row's own
+                // action — same split as a sidebar host row's button.
+                let row = ui::focus_row_rect(content, i);
+                self.host_menu_dots =
+                    self.host_menu_row_has_dots() && ui::sidebar_menu_button_rect(row).contains_point((x, y));
                 self.handle_host_menu_event(MenuEvent::Confirm);
+                None
+            }
+            Screen::WakeSettings => {
+                let subtitle = self.wake_settings_subtitle();
+                let card = Self::wake_settings_card_rect(screen_w, screen_h, fonts, &subtitle);
+                let content = ui::list_modal_content_rect(card, fonts, &subtitle, 1);
+                if ui::focus_row_rect(content, 0).contains_point((x, y)) {
+                    self.handle_wake_settings_event(MenuEvent::Confirm);
+                }
                 None
             }
             Screen::SpeedTest => {
@@ -1487,7 +1577,10 @@ impl App {
                     let (title, art) = self.grid_card_content(idx, columns);
                     ui::render_card_tile(text_cache, fonts, card_w, card_h, title, art)?
                 };
-                self.card_tiles[idx] = Some(tile);
+                self.card_tiles[idx] = Some(CardTile {
+                    tile,
+                    pop_since: self.grid_reveal_ready.then(Instant::now),
+                });
                 updated.push(Tile::Card(idx));
             }
             self.tiles_pending = pending;
@@ -1514,6 +1607,12 @@ impl App {
                 if self.grid_reveal_ready {
                     self.spinner_since = None;
                     self.spinner_frame = None;
+                    // Everything built behind the spinner becomes visible in this
+                    // one frame, so it all zooms in off a single clock.
+                    let now = Instant::now();
+                    for card in self.card_tiles.iter_mut().flatten() {
+                        card.pop_since.get_or_insert(now);
+                    }
                 } else {
                     let (frame_idx, _) = ui::spinner_frame_at(since.elapsed().as_secs_f32());
                     if self.spinner_frame != Some(frame_idx) {
@@ -1570,7 +1669,6 @@ impl App {
                 name: w.name.clone(),
                 mac_empty: w.mac.is_empty(),
                 sent: w.sent,
-                auto_send: self.settings.wol_auto_send,
                 hover_close: self.hover_close,
             }),
             Screen::Pairing => Some(ModalShellKey::Pairing {
@@ -1590,6 +1688,11 @@ impl App {
                 name: self.host_menu_title(),
                 subtitle: self.host_menu_subtitle(),
                 rows: self.host_menu_actions().len(),
+                hover_close: self.hover_close,
+            }),
+            Screen::WakeSettings => Some(ModalShellKey::WakeSettings {
+                title: self.wake_settings_title(),
+                auto: self.wake_settings_host().is_some_and(|h| h.wol_auto),
                 hover_close: self.hover_close,
             }),
             Screen::About => Some(ModalShellKey::About {
@@ -1637,6 +1740,9 @@ impl App {
                 Screen::HostMenu => {
                     self.render_host_menu(&mut p, text_cache, fonts, screen_w, screen_h)?;
                 }
+                Screen::WakeSettings => {
+                    self.render_wake_settings(&mut p, text_cache, fonts, screen_w, screen_h)?;
+                }
                 Screen::EditHost => self.render_edit_host(&mut p, text_cache, fonts, screen_w, screen_h)?,
                 Screen::About => self.render_about(&mut p, text_cache, fonts, screen_w, screen_h)?,
                 Screen::SpeedTest => self.render_speed_test(&mut p, text_cache, fonts, screen_w, screen_h)?,
@@ -1651,13 +1757,11 @@ impl App {
         // see `handle_wake_event`'s matching guard).
         let focus_key = match self.screen {
             Screen::Settings => Some(ModalFocusKey::SettingsRow(self.settings_focused, self.settings)),
-            Screen::Wake => self.wake.as_ref().filter(|w| !w.mac.is_empty()).map(|w| {
-                if w.focused == 0 {
-                    ModalFocusKey::WakeToggle(self.settings.wol_auto_send)
-                } else {
-                    ModalFocusKey::WakeButton(w.focused)
-                }
-            }),
+            Screen::Wake => self
+                .wake
+                .as_ref()
+                .filter(|w| !w.mac.is_empty())
+                .map(|w| ModalFocusKey::WakeButton(w.focused)),
             Screen::Pairing => Some(match self.pairing_focus {
                 PairingFocus::Pin => {
                     ModalFocusKey::PairingDigit(self.pin_digit_index, self.pin_digits[self.pin_digit_index])
@@ -1668,7 +1772,10 @@ impl App {
             Screen::HostMenu => self
                 .host_menu_actions()
                 .get(self.menu_focused)
-                .map(|(_, row)| ModalFocusKey::MenuRow(self.menu_focused, row.label.clone())),
+                .map(|(_, row)| ModalFocusKey::MenuRow(self.menu_focused, row.label.clone(), self.host_menu_dots)),
+            Screen::WakeSettings => Some(ModalFocusKey::WakeToggle(
+                self.wake_settings_host().is_some_and(|h| h.wol_auto),
+            )),
             // Only once there are buttons to focus — while measuring there is nothing
             // on the card but text.
             Screen::SpeedTest => matches!(
@@ -1715,30 +1822,15 @@ impl App {
                             .as_ref()
                             .expect("focus_key only Some for a Wake with a focusable widget");
                         let card = Self::wake_card_rect(screen_w, screen_h, wake, fonts);
-                        if wake.focused == 0 {
-                            let rows = ui::wake_rows(self.settings.wol_auto_send);
-                            let content_w = Self::wake_toggle_rect(card, wake, fonts).width();
-                            ui::render_focus_row_tile(
-                                text_cache,
-                                fonts,
-                                &rows,
-                                content_w,
-                                0,
-                                false,
-                                self.toggle_frac(self.settings.wol_auto_send),
-                            )?
-                        } else {
-                            let toggle = Self::wake_toggle_rect(card, wake, fonts);
-                            let rect = ui::confirm_button_rect(Self::wake_buttons_rect(toggle), wake.focused - 1);
-                            let buttons = Self::wake_buttons();
-                            ui::render_confirm_button_tile(
-                                text_cache,
-                                fonts,
-                                &buttons[wake.focused - 1],
-                                rect.width(),
-                                rect.height(),
-                            )?
-                        }
+                        let rect = ui::confirm_button_rect(Self::wake_buttons_rect(card, wake, fonts), wake.focused);
+                        let buttons = Self::wake_buttons();
+                        ui::render_confirm_button_tile(
+                            text_cache,
+                            fonts,
+                            &buttons[wake.focused],
+                            rect.width(),
+                            rect.height(),
+                        )?
                     }
                     Screen::Pairing => match self.pairing_focus {
                         PairingFocus::Pin => ui::render_pairing_digit_tile(
@@ -1772,7 +1864,11 @@ impl App {
                     }
                     Screen::HostMenu => {
                         let subtitle = self.host_menu_subtitle();
-                        let rows = self.host_menu_rows();
+                        let mut rows = self.host_menu_rows();
+                        // The only place a row's ⋯ is drawn lit — see `host_menu_actions`.
+                        if let Some(row) = rows.get_mut(self.menu_focused) {
+                            row.menu = row.menu.map(|_| self.host_menu_dots);
+                        }
                         let card = Self::host_menu_card_rect(screen_w, screen_h, fonts, &subtitle, rows.len());
                         let content = ui::list_modal_content_rect(card, fonts, &subtitle, rows.len());
                         ui::render_focus_row_tile(
@@ -1783,6 +1879,22 @@ impl App {
                             self.menu_focused,
                             false,
                             0.0,
+                        )?
+                    }
+                    Screen::WakeSettings => {
+                        let subtitle = self.wake_settings_subtitle();
+                        let rows = self.wake_settings_rows();
+                        let card = Self::wake_settings_card_rect(screen_w, screen_h, fonts, &subtitle);
+                        let content = ui::list_modal_content_rect(card, fonts, &subtitle, rows.len());
+                        let on = self.wake_settings_host().is_some_and(|h| h.wol_auto);
+                        ui::render_focus_row_tile(
+                            text_cache,
+                            fonts,
+                            &rows,
+                            content.width(),
+                            self.wake_settings_focused,
+                            false,
+                            self.toggle_frac(on),
                         )?
                     }
                     Screen::SpeedTest => {
@@ -1954,7 +2066,7 @@ impl App {
         match tile {
             Tile::Sidebar => self.sidebar_layer.as_ref(),
             Tile::FocusRow => self.focused_row_tile.as_ref().map(|(_, p)| p),
-            Tile::Card(i) => self.card_tiles.get(i).and_then(|t| t.as_ref()),
+            Tile::Card(i) => self.card_tiles.get(i).and_then(|t| t.as_ref()).map(|c| &c.tile),
             Tile::Ring => self.ring_tile.as_ref(),
             Tile::PinBadge => self.pin_badge_tile.as_ref(),
             Tile::PinMove => self.pin_move_tile.as_ref(),
@@ -2030,15 +2142,18 @@ impl App {
                 if r.y() + r.height() as i32 + pad < 0 || r.y() - pad > screen_h as i32 {
                     continue; // culled — fully off-screen at this scroll offset
                 }
+                // A card that just landed is still zooming up to full size.
+                let pop = self.card_pop_frac(idx);
+                let base = Rect::new(
+                    r.x() - pad,
+                    r.y() - pad,
+                    r.width() + 2 * pad as u32,
+                    r.height() + 2 * pad as u32,
+                );
                 cmds.push(DrawCmd::Tex {
                     tile: Tile::Card(idx),
-                    dst: Rect::new(
-                        r.x() - pad,
-                        r.y() - pad,
-                        r.width() + 2 * pad as u32,
-                        r.height() + 2 * pad as u32,
-                    ),
-                    alpha: 0xff,
+                    dst: ui::pop_in_rect(base, pop, CARD_POP_SHRINK),
+                    alpha: (255.0 * pop) as u8,
                 });
             }
             // The divider between pinned games and the rest — scrolled with
@@ -2064,10 +2179,15 @@ impl App {
                     r.width() + 2 * pad as u32,
                     r.height() + 2 * pad as u32,
                 );
+                // The focused card zooms in on first appearance like any other,
+                // composed with its focus pop — both scale around the card's own
+                // center, so they can't fight over position.
+                let pop = self.card_pop_frac(idx);
+                let popped = |base: Rect| ui::pop_in_rect(base, pop, CARD_POP_SHRINK);
                 cmds.push(DrawCmd::Tex {
                     tile: Tile::Card(idx),
-                    dst: ui::zoom_rect(card_base, f, CARD_GROWTH),
-                    alpha: 0xff,
+                    dst: popped(ui::zoom_rect(card_base, f, CARD_GROWTH)),
+                    alpha: (255.0 * pop) as u8,
                 });
                 let rp = ui::FOCUS_RING_PAD;
                 let ring_base = Rect::new(
@@ -2078,8 +2198,8 @@ impl App {
                 );
                 cmds.push(DrawCmd::Tex {
                     tile: Tile::Ring,
-                    dst: ui::zoom_rect(ring_base, f, CARD_GROWTH),
-                    alpha: (255.0 * f) as u8,
+                    dst: popped(ui::zoom_rect(ring_base, f, CARD_GROWTH)),
+                    alpha: (255.0 * f * pop) as u8,
                 });
                 // The pinned badge — only on a focused card that's actually
                 // pinned, be it a game or "Desktop" (see `store::DESKTOP_PIN_ID`).
@@ -2096,10 +2216,12 @@ impl App {
                         badge,
                         badge,
                     );
+                    // Corner-anchored, so it only fades — scaling it around its
+                    // own center would drift it off the shrunken card.
                     cmds.push(DrawCmd::Tex {
                         tile: Tile::PinBadge,
                         dst: ui::zoom_rect(badge_base, f, CARD_GROWTH),
-                        alpha: 0xff,
+                        alpha: (255.0 * pop) as u8,
                     });
                 }
             }
@@ -2247,12 +2369,7 @@ impl App {
                 }
                 Screen::Wake => self.wake.as_ref().filter(|w| !w.mac.is_empty()).map(|w| {
                     let card = Self::wake_card_rect(screen_w, screen_h, w, fonts);
-                    let toggle = Self::wake_toggle_rect(card, w, fonts);
-                    if w.focused == 0 {
-                        ui::focus_row_rect(toggle, 0)
-                    } else {
-                        ui::confirm_button_rect(Self::wake_buttons_rect(toggle), w.focused - 1)
-                    }
+                    ui::confirm_button_rect(Self::wake_buttons_rect(card, w, fonts), w.focused)
                 }),
                 Screen::Pairing => {
                     let card = Self::pairing_card_rect(screen_w, screen_h, fonts);
@@ -2280,6 +2397,12 @@ impl App {
                     let card = Self::host_menu_card_rect(screen_w, screen_h, fonts, &subtitle, rows);
                     let content = ui::list_modal_content_rect(card, fonts, &subtitle, rows);
                     Some(ui::focus_row_rect(content, self.menu_focused))
+                }
+                Screen::WakeSettings => {
+                    let subtitle = self.wake_settings_subtitle();
+                    let card = Self::wake_settings_card_rect(screen_w, screen_h, fonts, &subtitle);
+                    let content = ui::list_modal_content_rect(card, fonts, &subtitle, 1);
+                    Some(ui::focus_row_rect(content, self.wake_settings_focused))
                 }
                 Screen::SpeedTest => matches!(
                     self.speed_test,

--- a/src/app/pairing.rs
+++ b/src/app/pairing.rs
@@ -159,6 +159,8 @@ impl App {
                         fingerprint: Some(fingerprint),
                         mgmt_port: outcome.mgmt_port,
                         mac: outcome.mac,
+                        // Preserved across a re-add by `upsert_known_host`; off for a genuinely new host.
+                        wol_auto: false,
                         // Only reaches a genuinely new host — `upsert_known_host` keeps an
                         // existing record's pins.
                         pinned: vec![store::DESKTOP_PIN_ID.to_string()],

--- a/src/app/wake.rs
+++ b/src/app/wake.rs
@@ -1,5 +1,6 @@
-//! The "host unreachable — wake it?" flow: the Wake-on-LAN prompt, its resend/
-//! escalate/probe timers, and its modal.
+//! The "host unreachable — wake it?" flow: the Wake-on-LAN prompt, its retry/probe
+//! timers, and its modal. The per-host auto-send setting the prompt obeys lives in
+//! `app::wakesettings`.
 //!
 //! Split out of the former single-file `app.rs`; see `super`'s module docs.
 use super::*;
@@ -11,32 +12,26 @@ use std::time::Instant;
 
 impl App {
     /// Enters the "host unreachable — wake it?" flow (see `WakeState`'s docs). With
-    /// `Settings::wol_auto_send` off, this shows the prompt right away, replacing what
-    /// used to be a plain error message. With it on, the packet fires immediately and
-    /// silently — the prompt only appears if the host still hasn't come back a minute
-    /// later (`tick_wake`), which is also the one place that setting can be turned back
-    /// off (no separate settings row for it — see `Settings::wol_auto_send`).
+    /// this host's `KnownHost::wol_auto` off, this shows the prompt right away,
+    /// replacing what used to be a plain error message. With it on, the packet fires
+    /// immediately and silently, and the prompt only appears if the host still hasn't
+    /// come back one `WAKE_RETRY_INTERVAL` later (`tick_wake`).
     pub(crate) fn start_wake(&mut self, host: String, port: u16, mac: Vec<String>, reason: String) {
-        let name = self
-            .known_hosts
-            .iter()
-            .find(|h| h.host == host && h.port == port)
-            .map_or_else(|| host.clone(), |h| h.name.clone());
+        let known = self.known_hosts.iter().find(|h| h.host == host && h.port == port);
+        let name = known.map_or_else(|| host.clone(), |h| h.name.clone());
         // Nothing to send without a MAC on record — never pretend to auto-send in
         // that case, just show the (mac-less) interactive explanation instead.
-        let auto = self.settings.wol_auto_send && !mac.is_empty();
+        let auto = known.is_some_and(|h| h.wol_auto) && !mac.is_empty();
         let mut wake = WakeState {
             host,
             port,
             name,
             mac,
             reason,
-            // Lands on the "Wake" button by default — the likely reason the
-            // user is here (`tick_wake`'s silent-escalation path below moves
-            // focus to the toggle instead, since that's what needs revisiting
-            // there).
-            focused: 1,
+            // Lands on the "Wake host" button — the reason the user is here.
+            focused: 0,
             sent: false,
+            attempts: 0,
             since: None,
             last_attempt: None,
             silent: auto,
@@ -47,6 +42,10 @@ impl App {
         };
         if auto {
             Self::send_wake(&mut wake);
+            // No modal is up in this branch, so the Home bar is the only place the
+            // wait is visible at all — without this it would sit on `select_host`'s
+            // stale "Loading library…" until the host came back (or didn't).
+            self.home_status = Some(Self::wake_home_status(&wake));
         } else {
             self.screen = Screen::Wake;
         }
@@ -65,6 +64,7 @@ impl App {
         let now = Instant::now();
         if sent {
             wake.sent = true;
+            wake.attempts += 1;
             wake.since.get_or_insert(now);
         } else {
             wake.reason = "Couldn't send the wake signal — no usable MAC address or network interface.".into();
@@ -72,9 +72,9 @@ impl App {
         wake.last_attempt = Some(now);
     }
 
-    /// Advances an in-flight wake: resends the WOL packet every `WAKE_RESEND_INTERVAL`
-    /// (once a MAC is on record — see `WakeState::mac`'s docs), escalates a silent
-    /// auto-send to the visible prompt after `WAKE_ESCALATE_AFTER`, and — regardless of
+    /// Advances an in-flight wake: resends the WOL packet every `WAKE_RETRY_INTERVAL`
+    /// (once a MAC is on record — see `WakeState::mac`'s docs), surfaces a silent
+    /// auto-send as the visible prompt at that same mark, and — regardless of
     /// either — actively re-checks reachability every `WAKE_PROBE_INTERVAL` via
     /// `wake_probe`, ending the wake via `wake_succeeded` on success. This runs whether
     /// or not `Screen::Wake` is actually showing (same as the WOL timers), since a
@@ -86,6 +86,7 @@ impl App {
         let Some(wake) = &mut self.wake else { return false };
         let now = Instant::now();
         let mut changed = false;
+        let mut new_status = None;
 
         if let Some(rx) = &wake.probe_rx {
             if let Ok(loaded) = rx.try_recv() {
@@ -107,25 +108,26 @@ impl App {
         let Some(wake) = &mut self.wake else { return changed };
 
         // Only ever *resend*, gated on `wake.sent` — without it, this fired the first
-        // WOL packet on the very next tick after `start_wake` regardless of
-        // `Settings::wol_auto_send` (`last_attempt: None` reads as "due"). The first
-        // send is either `start_wake`'s own immediate call (auto-send on) or the user's
-        // explicit Confirm on "Send" (`handle_wake_event`).
-        if !wake.mac.is_empty() {
-            let due = wake.sent
-                && wake
-                    .last_attempt
-                    .is_some_and(|t| now.duration_since(t) >= WAKE_RESEND_INTERVAL);
-            if due {
-                Self::send_wake(wake);
-                changed = true;
-            }
-        }
-
-        if wake.silent && wake.since.is_some_and(|t| now.duration_since(t) >= WAKE_ESCALATE_AFTER) {
+        // WOL packet on the very next tick after `start_wake` regardless of the host's
+        // `wol_auto` (`last_attempt: None` reads as "due"). The first send is either
+        // `start_wake`'s own immediate call (auto-send on) or the user's explicit
+        // Confirm on "Wake host" (`handle_wake_event`).
+        let retry_due = !wake.mac.is_empty()
+            && wake.sent
+            && wake
+                .last_attempt
+                .is_some_and(|t| now.duration_since(t) >= WAKE_RETRY_INTERVAL);
+        // A minute of retrying hasn't brought the host back, so a silent wait stops
+        // being silent — the user should be looking at this rather than at a grid that
+        // just isn't loading. Only ever once: after this the prompt is up (or was, and
+        // they dismissed it), and re-popping it every minute would be nagging.
+        let reveal = retry_due && wake.silent;
+        if retry_due {
+            Self::send_wake(wake);
             wake.silent = false;
-            wake.focused = 0; // land on the toggle — it's what this silent escalation is about
-            self.screen = Screen::Wake;
+            // Deferred rather than assigned here: `wake` still borrows `self.wake` for
+            // the rest of the function.
+            new_status = Some(Self::wake_home_status(wake));
             changed = true;
         }
 
@@ -137,6 +139,15 @@ impl App {
             let (host, port) = (wake.host.clone(), wake.port);
             wake.probe_rx = Some(Self::wake_probe(&self.known_hosts, &self.identity, &host, port));
             wake.last_probe = Some(now);
+        }
+        // Past `wake`'s last use, so these can take `&mut self` again.
+        if reveal {
+            self.screen = Screen::Wake;
+        }
+        // Only touched when a resend actually happened — a wake the user is watching in
+        // the modal still updates the bar underneath it, which is what they'll see on Back.
+        if let Some(status) = new_status {
+            self.home_status = Some(status);
         }
         changed
     }
@@ -159,14 +170,12 @@ impl App {
         crate::library::load_games_async(host.to_string(), port, mgmt_port, identity.clone(), fingerprint)
     }
 
-    /// Handles one menu event on the Wake modal — the auto-send toggle row
-    /// (focus `0`) above a Forget-host-style "Wake"/"Cancel" button pair
-    /// (focus `1`/`2`, see `render_wake`). Up/Down move between the toggle
-    /// and the button row (always re-entering on "Wake"); Left/Right flip the
-    /// toggle when it's focused, or switch between the two buttons otherwise;
-    /// Confirm flips the toggle, sends, or cancels depending on which is
-    /// focused. Back always dismisses back to the plain error text
-    /// `WakeState::reason` carries, same as Cancel.
+    /// Handles one menu event on the Wake modal — a Forget-host-style
+    /// "Wake host"/"Cancel" button pair (focus `0`/`1`, see `render_wake`) and
+    /// nothing else. Any direction key moves between the two; Confirm sends or
+    /// cancels. Back dismisses the modal, same as Cancel — see `dismiss_wake` for
+    /// what that leaves on the Home status bar. The auto-send toggle that used to
+    /// live here is now per-host, in `Screen::WakeSettings`.
     pub fn handle_wake_event(&mut self, ev: MenuEvent) {
         let Some(wake) = self.wake.as_mut() else { return };
         // No MAC on record for this host yet — there's nothing to send or automate
@@ -176,47 +185,53 @@ impl App {
             return;
         }
         if ev == MenuEvent::Back {
-            self.home_status = self.wake.take().map(|w| w.reason);
-            self.screen = Screen::Home;
+            self.dismiss_wake();
             return;
         }
         match ev {
-            MenuEvent::Up | MenuEvent::Down => {
-                wake.focused = if wake.focused == 0 { 1 } else { 0 };
+            MenuEvent::Up | MenuEvent::Down | MenuEvent::Left | MenuEvent::Right => {
+                wake.focused = usize::from(wake.focused == 0);
                 self.modal_focus_anim = Some(Instant::now());
             }
-            // On the toggle row, Left/Right/Confirm all flip it (matching the
-            // Settings modal's toggle idiom); on a button, Left/Right instead
-            // switch which one has focus and Confirm activates it.
-            MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm if wake.focused == 0 => {
-                let from = self.settings.wol_auto_send;
-                self.settings.wol_auto_send = !from;
-                self.settings_writer.save(self.settings);
-                self.switch_anim = Some((Instant::now(), from));
-            }
-            MenuEvent::Left | MenuEvent::Right => {
-                wake.focused = if wake.focused == 1 { 2 } else { 1 };
-                self.modal_focus_anim = Some(Instant::now());
-            }
-            MenuEvent::Confirm if wake.focused == 1 => Self::send_wake(wake),
+            MenuEvent::Confirm if wake.focused == 0 => Self::send_wake(wake),
             MenuEvent::Confirm => {
-                // focused == 2 ("Cancel") — same as Back.
-                self.home_status = self.wake.take().map(|w| w.reason);
-                self.screen = Screen::Home;
+                // focused == 1 ("Cancel") — same as Back.
+                self.dismiss_wake();
             }
             MenuEvent::Back | MenuEvent::Secondary => {}
         }
     }
+
+    /// Closes the Wake modal (Back or "Cancel"). A wake with a packet already out
+    /// keeps running in the background — the resend/probe timers are what actually
+    /// bring the host back, and dropping them because the user stopped watching the
+    /// modal would silently abandon a wake in progress; it just goes quiet, with the
+    /// Home status bar carrying the wait from here (`wake_home_status`). Nothing
+    /// sent means there's nothing to keep, so that case drops the wake entirely and
+    /// leaves the plain error text behind, as this always used to.
+    fn dismiss_wake(&mut self) {
+        self.screen = Screen::Home;
+        match self.wake.as_mut() {
+            Some(wake) if wake.sent => {
+                // Left `false` deliberately (`tick_wake`'s escalation is gated on it):
+                // the user has now seen this prompt and chosen to close it, so it must
+                // not pop itself back up a minute later.
+                wake.silent = false;
+                self.home_status = Some(Self::wake_home_status(wake));
+            }
+            _ => self.home_status = self.wake.take().map(|w| w.reason),
+        }
+    }
     /// The wake modal's card rect — shared by `render_wake` and mouse
     /// hit-testing. Height fits `wake`'s status (one or two lines) plus the
-    /// toggle/buttons, which are absent entirely with no MAC on record.
+    /// buttons, which are absent entirely with no MAC on record.
     pub(crate) fn wake_card_rect(screen_w: u32, screen_h: u32, wake: &WakeState, fonts: &ui::Fonts) -> Rect {
         Self::simple_modal_card(screen_w, screen_h, |probe| {
             let header_end = ui::modal_header_end_y(fonts.title, fonts.label, probe, &Self::wake_status_text(wake));
             if wake.mac.is_empty() {
                 (header_end + 32) as u32
             } else {
-                (header_end + 28 + ui::SETTINGS_ROW_H as i32 + 18 + 72 + 32) as u32
+                (header_end + 28 + 72 + 32) as u32
             }
         })
     }
@@ -245,18 +260,14 @@ impl App {
             ui::MUTED,
         )?;
 
-        // No MAC on record — nothing to send or automate, so there's nothing
-        // else to draw (see `handle_wake_event`'s matching guard); the status
-        // text above already explains why, and `App::drain_discovery` still
-        // reconnects automatically the moment this host reappears on mDNS.
+        // No MAC on record — nothing to send, so there's nothing else to draw (see
+        // `handle_wake_event`'s matching guard); the status text above already
+        // explains why, and `App::drain_discovery` still reconnects automatically the
+        // moment this host reappears on mDNS.
         if !wake.mac.is_empty() {
-            let toggle = Self::wake_toggle_rect(card, wake, fonts);
-            let rows = ui::wake_rows(self.settings.wol_auto_send);
-            // `usize::MAX` = nothing focused; the focused row/button is a
-            // separate `Tile::ModalFocusElement` (see `prepare_tiles`).
-            ui::draw_focus_rows(painter, text_cache, fonts, &rows, usize::MAX, None, toggle)?;
-
-            let buttons = Self::wake_buttons_rect(toggle);
+            // `usize::MAX` = nothing focused; the focused button is a separate
+            // `Tile::ModalFocusElement` (see `prepare_tiles`).
+            let buttons = Self::wake_buttons_rect(card, wake, fonts);
             ui::draw_confirm_buttons(painter, text_cache, fonts, buttons, &Self::wake_buttons(), usize::MAX)?;
         }
         Ok(())
@@ -293,11 +304,31 @@ impl App {
         }
     }
 
-    /// The Wake modal's status line — depends on the host's name and whether
-    /// a wake was just sent, so unlike Pairing's fixed subtitle this isn't a
-    /// constant, but it's still reconstructible from `wake` alone. Shared by
-    /// `render_wake` (drawing it) and `wake_toggle_rect` (measuring it,
-    /// without drawing, to position the toggle row).
+    /// The Home bottom-bar line for a wake that is running with no modal in front
+    /// of it — an auto-send wait (`KnownHost::wol_auto`), or one the user sent
+    /// and then dismissed. Separate from `wake_status_text` because that one is a
+    /// modal subtitle sitting under a title that already says "Waking host…",
+    /// whereas this line has to carry the whole state on its own.
+    pub(crate) fn wake_home_status(wake: &WakeState) -> String {
+        match wake.attempts {
+            // Nothing went out — `send_wake` has already put the why in `reason`.
+            0 => wake.reason.clone(),
+            1 => format!(
+                "Wake signal sent to {} — waiting for it to come back online…",
+                wake.name
+            ),
+            n => format!(
+                "Wake signal re-sent to {} ({n} attempts) — still waiting for it to come back online…",
+                wake.name
+            ),
+        }
+    }
+
+    /// The Wake modal's status line — depends on the host's name and whether a wake
+    /// was just sent, so unlike Pairing's fixed subtitle this isn't a constant, but
+    /// it's still reconstructible from `wake` alone. Shared by `render_wake` (drawing
+    /// it) and `wake_buttons_rect` (measuring it, without drawing, to place the
+    /// buttons under it).
     pub(crate) fn wake_status_text(wake: &WakeState) -> String {
         if wake.mac.is_empty() {
             format!(
@@ -312,23 +343,13 @@ impl App {
         }
     }
 
-    /// The Wake modal's toggle row rect — depends on the status text's
-    /// wrapped height, computed via `ui::modal_header_end_y` without drawing
-    /// so `prepare_tiles`/`draw_list` can position the focused-row tile
-    /// without re-rendering the header.
-    pub(crate) fn wake_toggle_rect(card: Rect, wake: &WakeState, fonts: &ui::Fonts) -> Rect {
+    /// The Wake/Cancel button row's rect, stacked under the status text — whose
+    /// wrapped height it therefore depends on, computed via `ui::modal_header_end_y`
+    /// without drawing so `prepare_tiles`/`draw_list` can position the focused-button
+    /// tile without re-rendering the header. Mirrors `forget_host_content_rect`'s
+    /// button-row sizing.
+    pub(crate) fn wake_buttons_rect(card: Rect, wake: &WakeState, fonts: &ui::Fonts) -> Rect {
         let after_status_y = ui::modal_header_end_y(fonts.title, fonts.label, card, &Self::wake_status_text(wake));
-        Rect::new(
-            card.x() + 32,
-            after_status_y + 28,
-            card.width().saturating_sub(64),
-            ui::SETTINGS_ROW_H,
-        )
-    }
-
-    /// The Wake/Cancel button row's rect, stacked below the toggle row —
-    /// mirrors `forget_host_content_rect`'s button-row sizing.
-    pub(crate) fn wake_buttons_rect(toggle: Rect) -> Rect {
-        Rect::new(toggle.x(), toggle.y() + toggle.height() as i32 + 18, toggle.width(), 72)
+        Rect::new(card.x() + 32, after_status_y + 28, card.width().saturating_sub(64), 72)
     }
 }

--- a/src/app/wakesettings.rs
+++ b/src/app/wakesettings.rs
@@ -1,0 +1,107 @@
+//! Per-host Wake-on-LAN settings — the ⋯ on the host menu's "Wake host" row.
+//!
+//! Split out of the former single-file `app.rs`; see `super`'s module docs. Built on
+//! `ui::ListModal` exactly like `hostmenu.rs`, so this module is only the rows, what
+//! Confirm does to them, and where Back goes.
+//!
+//! One toggle today (`KnownHost::wol_auto`). It used to be a global `Settings` field
+//! flipped from inside the wake prompt itself, which made it reachable only by having
+//! a host fail on you, and applied it to every host at once.
+use super::*;
+use sdl2::rect::Rect;
+use std::time::Instant;
+
+use crate::ui::{self, FocusRow, MenuEvent, Painter};
+
+impl App {
+    /// Opens the Wake settings for the host menu's current host. Keeps
+    /// `host_menu_index` set: Back returns to the menu this was opened from, and the
+    /// rows are read straight off that host.
+    pub(crate) fn open_wake_settings(&mut self) {
+        self.wake_settings_focused = 0;
+        self.screen = Screen::WakeSettings;
+    }
+
+    /// The host this screen is editing — always the host menu's, since that's the only
+    /// way in.
+    pub(crate) fn wake_settings_host(&self) -> Option<&store::KnownHost> {
+        let entry = self.host_menu_index.and_then(|i| self.entries.get(i))?;
+        let (host, port) = (entry.host(), entry.port());
+        self.known_hosts.iter().find(|h| h.host == host && h.port == port)
+    }
+
+    pub(crate) fn wake_settings_rows(&self) -> Vec<FocusRow> {
+        ui::wake_settings_rows(self.wake_settings_host().is_some_and(|h| h.wol_auto))
+    }
+
+    pub(crate) fn wake_settings_title(&self) -> String {
+        format!("Wake · {}", self.host_menu_title())
+    }
+
+    pub(crate) fn wake_settings_subtitle(&self) -> String {
+        // Spells out both halves of the behaviour, because the alternative to "On" is
+        // not "never wake" — it's "ask first", which the switch alone can't say.
+        "On: an unreachable host is sent a wake signal straight away, retried every \
+         minute until it answers. Off: it asks first."
+            .to_string()
+    }
+
+    pub(crate) fn wake_settings_card_rect(screen_w: u32, screen_h: u32, fonts: &ui::Fonts, subtitle: &str) -> Rect {
+        ui::list_modal_card_rect(screen_w, screen_h, fonts, subtitle, 1)
+    }
+
+    /// Handles one menu event. Left/Right/Confirm all flip the toggle, matching the
+    /// Settings modal's toggle idiom; Back returns to the host menu.
+    pub(crate) fn handle_wake_settings_event(&mut self, ev: MenuEvent) {
+        let len = self.wake_settings_rows().len();
+        if ui::list_nav(&mut self.wake_settings_focused, len, ev) {
+            self.modal_focus_anim = Some(Instant::now());
+            return;
+        }
+        match ev {
+            MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm => self.toggle_wol_auto(),
+            MenuEvent::Back => self.screen = Screen::HostMenu,
+            MenuEvent::Up | MenuEvent::Down | MenuEvent::Secondary => {}
+        }
+    }
+
+    /// Flips this host's auto-send flag and persists it. A discovered-but-never-saved
+    /// host has no record to write to, so there's nothing to flip.
+    fn toggle_wol_auto(&mut self) {
+        let Some(entry) = self.host_menu_index.and_then(|i| self.entries.get(i)) else {
+            return;
+        };
+        let (host, port) = (entry.host().to_string(), entry.port());
+        let Some(known) = self.known_hosts.iter_mut().find(|h| h.host == host && h.port == port) else {
+            return;
+        };
+        let from = known.wol_auto;
+        known.wol_auto = !from;
+        let _ = store::save_known_hosts(&self.known_hosts);
+        // Captures the value it's flipping *from*, so the knob slides rather than
+        // snapping — same contract as the Settings modal's switch rows.
+        self.switch_anim = Some((Instant::now(), from));
+    }
+
+    pub(crate) fn render_wake_settings(
+        &self,
+        painter: &mut Painter,
+        text_cache: &mut crate::ui::TextCache,
+        fonts: &ui::Fonts,
+        screen_w: u32,
+        screen_h: u32,
+    ) -> Result<()> {
+        let subtitle = self.wake_settings_subtitle();
+        let card = Self::wake_settings_card_rect(screen_w, screen_h, fonts, &subtitle);
+        self.draw_modal_shell(painter, text_cache, fonts.icon, card)?;
+        ui::render_list_modal(
+            painter,
+            text_cache,
+            fonts,
+            card,
+            &self.wake_settings_title(),
+            &subtitle,
+            &self.wake_settings_rows(),
+        )
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,7 @@ mod real {
     const GUIDE_HOLD: Duration = Duration::from_secs(2);
 
     /// How long OK must be held on a focused Home game card to pin/unpin it instead
-    /// of launching it — see `run_ui_flow`'s interception.
+    /// of launching it — see `pin_hold_gate`.
     const PIN_HOLD: Duration = Duration::from_millis(500);
 
     /// An in-flight hold-to-pin gesture: OK is down on a pinnable Home card. The
@@ -246,6 +246,271 @@ mod real {
             *held = true;
             ev
         }
+    }
+
+    /// The UI loop's input state that outlives a single event: the Back debounce,
+    /// an in-flight hold-to-pin, and analogue-stick nav.
+    #[derive(Default)]
+    struct UiInput {
+        /// Whether a Back-mapped key/button is currently held, per the
+        /// keyboard/gamepad event stream — edge-detected so a single physical press
+        /// dispatches Back exactly once no matter how SDL reports (or misreports)
+        /// repeats for it.
+        menu_back_down: bool,
+        /// Hold-to-pin on Home (see `PIN_HOLD`), while OK is held on a pinnable card.
+        pin_held: Option<PinHold>,
+        stick_nav: crate::ui::StickMenuNav,
+    }
+
+    /// What the UI loop should do with the event `handle_ui_event` just consumed.
+    enum EventAction {
+        /// Handled — carry on with the next event.
+        Next,
+        /// A launch is under way; leave the UI flow.
+        Launch,
+    }
+
+    /// Hold-to-pin arbitration (see `PIN_HOLD`). `MenuEvent` has no press/release
+    /// notion, so the gesture works off raw SDL events: OK down on a pinnable Home
+    /// card starts the hold and is swallowed, and the launch can only ever come
+    /// from the release. `Some` means the event was the gesture's and goes no
+    /// further.
+    fn pin_hold_gate(
+        app: &mut App,
+        event: &sdl2::event::Event,
+        input: &mut UiInput,
+        display_mode: sdl2::video::DisplayMode,
+        dirty: &mut bool,
+    ) -> Option<EventAction> {
+        use sdl2::event::Event;
+        // No `repeat: false` filter, deliberately — OS auto-repeats while OK is held
+        // have to be caught here too, not dispatched as fresh presses.
+        let confirm_down = matches!(
+            *event,
+            Event::KeyDown { keycode: Some(k), .. }
+                if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Confirm)
+        ) || matches!(
+            *event,
+            Event::ControllerButtonDown { button, .. }
+                if crate::ui::menu_event_for_button(button) == Some(MenuEvent::Confirm)
+        );
+        if confirm_down {
+            // OK stays the gesture's until released, whatever the toggle put on
+            // screen: a hold that hit the pin limit opens the `PinLimit` alert
+            // *under the still-held button*, and the next auto-repeat KeyDown would
+            // otherwise dispatch Confirm to it and dismiss it instantly.
+            if input.pin_held.is_some() {
+                return Some(EventAction::Next);
+            }
+            let columns = crate::ui::grid_columns((display_mode.w as u32).saturating_sub(crate::ui::SIDEBAR_W));
+            if matches!(app.screen, Screen::Home) && app.focused_pin_id(columns).is_some() {
+                input.pin_held = Some(PinHold {
+                    since: Instant::now(),
+                    focus: app.home_focus,
+                    fired: false,
+                });
+                return Some(EventAction::Next);
+            }
+            return None;
+        }
+        let ends_hold = matches!(
+            *event,
+            Event::KeyUp { keycode: Some(k), .. }
+                if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Confirm)
+        ) || matches!(
+            *event,
+            Event::ControllerButtonUp { button, .. }
+                if crate::ui::menu_event_for_button(button) == Some(MenuEvent::Confirm)
+        );
+        // This press was ours (tap or hold) — swallow the release.
+        let hold = ends_hold.then(|| input.pin_held.take()).flatten()?;
+        *dirty = true;
+        // A quick tap: the press never dispatched, so do it now. A hold that already
+        // toggled, or one whose screen/focus moved out from under it, resolves to
+        // nothing.
+        let tapped = !hold.fired && matches!(app.screen, Screen::Home) && hold.focus == app.home_focus;
+        let launched = tapped
+            && app
+                .handle_home_event(MenuEvent::Confirm, display_mode.w as u32, display_mode.h as u32)
+                .is_some();
+        Some(if launched {
+            EventAction::Launch
+        } else {
+            EventAction::Next
+        })
+    }
+
+    /// Routes a resolved `MenuEvent` to whichever screen is up — one of the
+    /// dispatch sites a new screen has to be added to.
+    fn dispatch_menu_event(
+        app: &mut App,
+        menu_ev: MenuEvent,
+        display_mode: sdl2::video::DisplayMode,
+        fonts: &crate::ui::Fonts,
+    ) -> EventAction {
+        let (w, h) = (display_mode.w as u32, display_mode.h as u32);
+        match app.screen {
+            // Back on Home is a no-op (root screen — `App::back` decides); routed
+            // through `back` anyway so the policy lives in one place. A grid-card
+            // Confirm goes the same async route as a mouse click and never resolves
+            // to a target directly here.
+            Screen::Home => {
+                let launched = match menu_ev {
+                    MenuEvent::Back => app.back().is_some(),
+                    _ => app.handle_home_event(menu_ev, w, h).is_some(),
+                };
+                if launched {
+                    return EventAction::Launch;
+                }
+            }
+            Screen::Pairing => app.handle_pairing_event(menu_ev),
+            Screen::Settings => app.handle_settings_event(menu_ev, h),
+            Screen::AddHost => app.handle_add_host_event(menu_ev),
+            Screen::Wake => app.handle_wake_event(menu_ev),
+            Screen::ForgetHost => app.handle_forget_host_event(menu_ev),
+            Screen::HostMenu => app.handle_host_menu_event(menu_ev),
+            Screen::WakeSettings => app.handle_wake_settings_event(menu_ev),
+            Screen::SpeedTest => app.handle_speed_test_event(menu_ev),
+            Screen::EditHost => app.handle_edit_host_event(menu_ev),
+            Screen::About => app.handle_about_event(menu_ev, w, h, fonts),
+            Screen::PinLimit => app.handle_pin_limit_event(menu_ev),
+        }
+        EventAction::Next
+    }
+
+    /// One SDL event from the pre-stream UI's pump, routed into `app`. `dirty` is
+    /// set whenever the event can have changed what's on screen. Device-level
+    /// events (quit, controller hotplug) are the caller's and never arrive here.
+    fn handle_ui_event(
+        app: &mut App,
+        event: sdl2::event::Event,
+        input: &mut UiInput,
+        display_mode: sdl2::video::DisplayMode,
+        fonts: &crate::ui::Fonts,
+        dirty: &mut bool,
+    ) -> EventAction {
+        use sdl2::event::Event;
+        let (w, h) = (display_mode.w as u32, display_mode.h as u32);
+        // The Magic Remote's pointer mode surfaces as a plain SDL2 MouseMotion
+        // event fired continuously while the remote is moving — unlike every other
+        // event handled below, redraw only if the motion actually changed the
+        // focused/hovered element, not on every no-op tick.
+        if let Event::MouseMotion { x, y, .. } = event {
+            *dirty |= app.handle_mouse_motion(x, y, w, h, fonts);
+            return EventAction::Next;
+        }
+        // The Magic Remote's scroll wheel — scrolls the game grid on Home (wheel
+        // y > 0 = "scroll up" = content moves down). Like motion above, only
+        // redraws when the offset actually moved (a wheel tick at either clamp
+        // edge is a no-op).
+        if let Event::MouseWheel { y: wheel_y, .. } = event {
+            match app.screen {
+                Screen::About => {
+                    /// Licence-wall px per wheel detent — a few lines at a time.
+                    const ABOUT_WHEEL_STEP: i32 = 90;
+                    *dirty |= app.scroll_about_by(-wheel_y * ABOUT_WHEEL_STEP, w, h, fonts);
+                }
+                Screen::Home => {
+                    /// Grid px scrolled per wheel detent — about a third of a card
+                    /// row, so a few ticks walk one row.
+                    const WHEEL_STEP: i32 = 120;
+                    *dirty |= app.scroll_grid_by(-wheel_y * WHEEL_STEP, w, h);
+                }
+                _ => {}
+            }
+            return EventAction::Next;
+        }
+        if let Some(action) = pin_hold_gate(app, &event, input, display_mode, dirty) {
+            return action;
+        }
+        // Any other event might change what's on screen (focus/hover, a typed
+        // digit, a screen transition) — simplest to mark dirty for all of them
+        // rather than re-litigate that per event kind.
+        *dirty = true;
+        match event {
+            // The Magic Remote's pointer delivers OK as a plain mouse click.
+            // Dispatch it on press: there is no hold gesture to disambiguate any
+            // more (per-host actions have their own ⋯ button — see
+            // `ui::sidebar_menu_button_rect`), so nothing needs to wait for the
+            // release.
+            Event::MouseButtonDown {
+                mouse_btn: sdl2::mouse::MouseButton::Left,
+                x,
+                y,
+                ..
+            } => {
+                // A grid-card click resolves via `confirm_grid_card`'s async check,
+                // same as a remote Confirm — never a target directly here.
+                return if app.handle_mouse_click(x, y, w, h, fonts).is_some() {
+                    EventAction::Launch
+                } else {
+                    EventAction::Next
+                };
+            }
+            // Direct digit entry via the remote's number buttons — PIN entry on the
+            // pairing screen, IP entry on the add/edit-host screens.
+            Event::KeyDown { keycode: Some(k), .. }
+                if matches!(app.screen, Screen::Pairing | Screen::AddHost | Screen::EditHost) =>
+            {
+                if let Some(digit) = crate::ui::digit_key_value(k) {
+                    match app.screen {
+                        Screen::Pairing => app.enter_pin_digit(digit),
+                        Screen::AddHost | Screen::EditHost => app.enter_add_host_digit(digit),
+                        _ => unreachable!(),
+                    }
+                    return EventAction::Next;
+                }
+            }
+            // Text committed by webOS's on-screen keyboard (see `SOFTWARE_KEYBOARD`
+            // in this module): the OSK delivers whole strings via SDL_TEXTINPUT, not
+            // synthetic key events, so it has to be consumed separately from the
+            // number-pad path above. Each character is fed through the same entry
+            // state machine, so typing "192.168.1.5" on the keyboard and tapping it
+            // out on the remote produce identical results.
+            Event::TextInput { ref text, .. } => {
+                match app.screen {
+                    Screen::Pairing => {
+                        for d in text.chars().filter_map(|c| c.to_digit(10)) {
+                            app.enter_pin_digit(d as u8);
+                        }
+                    }
+                    Screen::AddHost | Screen::EditHost => {
+                        for c in text.chars() {
+                            app.enter_host_address_char(c);
+                        }
+                    }
+                    _ => {}
+                }
+                return EventAction::Next;
+            }
+            _ => {}
+        }
+        let menu_ev = match event {
+            Event::KeyDown { keycode: Some(k), .. } => {
+                edge_trigger_back(crate::ui::menu_event_for_key(k), &mut input.menu_back_down)
+            }
+            Event::KeyUp { keycode: Some(k), .. } => {
+                if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back) {
+                    input.menu_back_down = false;
+                }
+                None
+            }
+            Event::ControllerButtonDown { button, .. } => {
+                edge_trigger_back(crate::ui::menu_event_for_button(button), &mut input.menu_back_down)
+            }
+            Event::ControllerButtonUp { button, .. } => {
+                if crate::ui::menu_event_for_button(button) == Some(MenuEvent::Back) {
+                    input.menu_back_down = false;
+                }
+                None
+            }
+            Event::ControllerAxisMotion { axis, value, .. } => input.stick_nav.axis_event(axis, value),
+            _ => None,
+        };
+        let Some(menu_ev) = menu_ev else {
+            return EventAction::Next;
+        };
+        dispatch_menu_event(app, menu_ev, display_mode, fonts)
     }
 
     enum StreamOutcome {
@@ -331,14 +596,7 @@ mod real {
         // already-rasterized+premultiplied `Pixmap` instead of re-rasterizing
         // freetype glyphs on every ~60fps tick.
         let mut text_cache = crate::ui::TextCache::new();
-        // Whether a Back-mapped key/button is currently held, per the
-        // keyboard/gamepad event stream — edge-detected so a single physical
-        // press dispatches Back exactly once no matter how SDL reports (or
-        // misreports) repeats for it.
-        let mut menu_back_down = false;
-        // Hold-to-pin on Home (see `PIN_HOLD`), while OK is held on a pinnable card.
-        let mut pin_held: Option<PinHold> = None;
-        let mut stick_nav = crate::ui::StickMenuNav::default();
+        let mut input = UiInput::default();
         // Owned handle (it just clones the video subsystem's refcount), so taking it
         // here doesn't hold a borrow on `canvas` for the rest of the loop.
         let text_input = canvas.window().subsystem().text_input();
@@ -347,13 +605,12 @@ mod real {
             text_input.has_screen_keyboard_support()
         );
         let mut text_input_active = false;
-        // Redraw-on-change: this screen has no time-based animation at all (no
-        // spinner/blink/marquee), so every pixel that can change only ever changes
-        // as a reaction to one of: an SDL event or a Discovery/art/library
-        // background result — anything else is a no-op tick. Without this,
-        // `app.render(...)` (and the `canvas.present()` vsync swap inside it) ran
-        // unconditionally every 16ms forever, even sitting on an untouched menu.
-        // Starts `true` so the first frame always draws.
+        // Redraw-on-change: outside a running animation (which the tick below asks
+        // `App` about separately), pixels only ever change in reaction to an SDL
+        // event or a discovery/art/library background result — anything else is a
+        // no-op tick. Without this, `app.render(...)` (and the `canvas.present()`
+        // vsync swap inside it) ran unconditionally every 16ms forever, even sitting
+        // on an untouched menu. Starts `true` so the first frame always draws.
         let mut dirty = true;
         // Set once the reachability check passes — `spawn_connect` is already
         // running by then, so this just carries its handle out of the loop for
@@ -376,7 +633,11 @@ mod real {
             dirty |= app.drain_launch_check();
             // Hold-to-pin fires here rather than on release, so the pin lands the
             // instant `PIN_HOLD` elapses and the user can see it before letting go.
-            if let Some(hold) = pin_held.as_mut().filter(|h| !h.fired && h.since.elapsed() >= PIN_HOLD) {
+            if let Some(hold) = input
+                .pin_held
+                .as_mut()
+                .filter(|h| !h.fired && h.since.elapsed() >= PIN_HOLD)
+            {
                 hold.fired = true;
                 let still_there = matches!(app.screen, Screen::Home) && hold.focus == app.home_focus;
                 if still_there {
@@ -410,186 +671,12 @@ mod real {
             }
             for event in events.poll_iter() {
                 use sdl2::event::Event;
-                if let Event::Quit { .. } = event {
-                    tracing::info!("quit during UI");
-                    return Ok(None);
-                }
-                // The Magic Remote's pointer mode surfaces as a plain SDL2
-                // MouseMotion event fired continuously while the remote is
-                // moving — unlike every other event handled below, redraw only
-                // if the motion actually changed the focused/hovered element,
-                // not on every no-op tick.
-                if let Event::MouseMotion { x, y, .. } = event {
-                    dirty |= app.handle_mouse_motion(x, y, display_mode.w as u32, display_mode.h as u32, fonts);
-                    continue;
-                }
-                // The Magic Remote's scroll wheel — scrolls the game grid on Home
-                // (wheel y > 0 = "scroll up" = content moves down). Like motion
-                // above, only redraws when the offset actually moved (a wheel tick
-                // at either clamp edge is a no-op).
-                if let Event::MouseWheel { y: wheel_y, .. } = event {
-                    if matches!(app.screen, Screen::About) {
-                        /// Licence-wall px per wheel detent — a few lines at a time.
-                        const ABOUT_WHEEL_STEP: i32 = 90;
-                        dirty |= app.scroll_about_by(
-                            -wheel_y * ABOUT_WHEEL_STEP,
-                            display_mode.w as u32,
-                            display_mode.h as u32,
-                            fonts,
-                        );
-                        continue;
-                    }
-                    if matches!(app.screen, Screen::Home) {
-                        /// Grid px scrolled per wheel detent — about a third of a
-                        /// card row, so a few ticks walk one row.
-                        const WHEEL_STEP: i32 = 120;
-                        dirty |=
-                            app.scroll_grid_by(-wheel_y * WHEEL_STEP, display_mode.w as u32, display_mode.h as u32);
-                    }
-                    continue;
-                }
-                // Hold-to-pin: OK on a focused Home card ("Desktop" or a game — both
-                // pinnable) pins/unpins once `PIN_HOLD` elapses, or launches on a quick
-                // tap. `MenuEvent` has no press/release notion, so this intercepts the
-                // raw SDL event: a Confirm-mapped KeyDown/ControllerButtonDown on a
-                // pinnable card starts the hold and is swallowed rather than dispatched
-                // immediately — the launch can only ever come from the release.
-                if matches!(app.screen, Screen::Home)
-                    && app
-                        .focused_pin_id(crate::ui::grid_columns(
-                            (display_mode.w as u32).saturating_sub(crate::ui::SIDEBAR_W),
-                        ))
-                        .is_some()
-                {
-                    // Also matches OS auto-repeat KeyDowns while held, so a repeat
-                    // can't fall through to the dispatch below and launch mid-hold.
-                    let confirm_down = matches!(
-                        event,
-                        Event::KeyDown { keycode: Some(k), .. }
-                            if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Confirm)
-                    ) || matches!(
-                        event,
-                        Event::ControllerButtonDown { button, .. }
-                            if crate::ui::menu_event_for_button(button) == Some(MenuEvent::Confirm)
-                    );
-                    if confirm_down {
-                        pin_held.get_or_insert(PinHold {
-                            since: Instant::now(),
-                            focus: app.home_focus,
-                            fired: false,
-                        });
-                        continue;
-                    }
-                }
-                let ends_hold = matches!(
-                    event,
-                    Event::KeyUp { keycode: Some(k), .. }
-                        if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Confirm)
-                ) || matches!(
-                    event,
-                    Event::ControllerButtonUp { button, .. }
-                        if crate::ui::menu_event_for_button(button) == Some(MenuEvent::Confirm)
-                );
-                if ends_hold {
-                    if let Some(hold) = pin_held.take() {
-                        dirty = true;
-                        // A quick tap: the press never dispatched, so do it now. A hold
-                        // that already toggled, or one whose screen/focus moved out from
-                        // under it, resolves to nothing.
-                        let tapped = !hold.fired && matches!(app.screen, Screen::Home) && hold.focus == app.home_focus;
-                        if tapped
-                            && app
-                                .handle_home_event(MenuEvent::Confirm, display_mode.w as u32, display_mode.h as u32)
-                                .is_some()
-                        {
-                            break 'ui;
-                        }
-                        continue; // this press was ours (tap or hold) — swallow the release
-                    }
-                }
-                // Any other event might change what's on screen (focus/hover, a typed
-                // digit, a screen transition) — simplest to mark dirty for all of
-                // them rather than re-litigate that per event kind.
-                dirty = true;
+                // Device-level events, handled before anything screen-specific:
+                // shutdown and controller hotplug.
                 match event {
-                    // The Magic Remote's pointer delivers OK as a plain mouse click.
-                    // Dispatch it on press: there is no hold gesture to disambiguate
-                    // any more (per-host actions have their own ⋯ button — see
-                    // `ui::sidebar_menu_button_rect`), so nothing needs to wait for
-                    // the release.
-                    Event::MouseButtonDown {
-                        mouse_btn: sdl2::mouse::MouseButton::Left,
-                        x,
-                        y,
-                        ..
-                    } => {
-                        // A grid-card click resolves via `confirm_grid_card`'s async check
-                        // above, same as a remote Confirm — never a target directly here.
-                        if app
-                            .handle_mouse_click(x, y, display_mode.w as u32, display_mode.h as u32, fonts)
-                            .is_some()
-                        {
-                            break 'ui;
-                        }
-                        continue;
-                    }
-                    // Direct digit entry via the remote's number buttons — PIN entry
-                    // on the pairing screen, IP entry on the add/edit-host screens.
-                    Event::KeyDown { keycode: Some(k), .. }
-                        if matches!(app.screen, Screen::Pairing | Screen::AddHost | Screen::EditHost) =>
-                    {
-                        if let Some(digit) = crate::ui::digit_key_value(k) {
-                            match app.screen {
-                                Screen::Pairing => app.enter_pin_digit(digit),
-                                Screen::AddHost | Screen::EditHost => app.enter_add_host_digit(digit),
-                                _ => unreachable!(),
-                            }
-                            continue;
-                        }
-                    }
-                    // Text committed by webOS's on-screen keyboard (see
-                    // `SOFTWARE_KEYBOARD` in this module): the OSK delivers whole
-                    // strings via SDL_TEXTINPUT, not synthetic key events, so it has
-                    // to be consumed separately from the number-pad path above. Each
-                    // character is fed through the same entry state machine, so typing
-                    // "192.168.1.5" on the keyboard and tapping it out on the remote
-                    // produce identical results.
-                    Event::TextInput { ref text, .. } => {
-                        match app.screen {
-                            Screen::Pairing => {
-                                for d in text.chars().filter_map(|c| c.to_digit(10)) {
-                                    app.enter_pin_digit(d as u8);
-                                }
-                            }
-                            Screen::AddHost | Screen::EditHost => {
-                                for c in text.chars() {
-                                    app.enter_host_address_char(c);
-                                }
-                            }
-                            _ => {}
-                        }
-                        continue;
-                    }
-                    _ => {}
-                }
-                let menu_ev = match event {
-                    Event::KeyDown { keycode: Some(k), .. } => {
-                        edge_trigger_back(crate::ui::menu_event_for_key(k), &mut menu_back_down)
-                    }
-                    Event::KeyUp { keycode: Some(k), .. } => {
-                        if crate::ui::menu_event_for_key(k) == Some(MenuEvent::Back) {
-                            menu_back_down = false;
-                        }
-                        None
-                    }
-                    Event::ControllerButtonDown { button, .. } => {
-                        edge_trigger_back(crate::ui::menu_event_for_button(button), &mut menu_back_down)
-                    }
-                    Event::ControllerButtonUp { button, .. } => {
-                        if crate::ui::menu_event_for_button(button) == Some(MenuEvent::Back) {
-                            menu_back_down = false;
-                        }
-                        None
+                    Event::Quit { .. } => {
+                        tracing::info!("quit during UI");
+                        return Ok(None);
                     }
                     Event::ControllerDeviceAdded { which, .. } if controller.is_none() => {
                         match game_controller.open(which) {
@@ -599,45 +686,17 @@ mod real {
                             }
                             Err(e) => tracing::warn!("controller open failed: {e}"),
                         }
-                        None
+                        continue;
                     }
                     Event::ControllerDeviceRemoved { .. } => {
                         *controller = None;
-                        None
+                        continue;
                     }
-                    Event::ControllerAxisMotion { axis, value, .. } => stick_nav.axis_event(axis, value),
-                    _ => None,
-                };
-                let Some(menu_ev) = menu_ev else { continue };
-                match app.screen {
-                    // Back on Home is a no-op (root screen — `App::back` decides);
-                    // routed through `back` anyway so the policy lives in one place.
-                    Screen::Home => {
-                        if menu_ev == MenuEvent::Back {
-                            if app.back().is_some() {
-                                break 'ui;
-                            }
-                        // Same async path as the mouse click above — a grid-card
-                        // Confirm never resolves to a target directly here.
-                        } else if app
-                            .handle_home_event(menu_ev, display_mode.w as u32, display_mode.h as u32)
-                            .is_some()
-                        {
-                            break 'ui;
-                        }
-                    }
-                    Screen::Pairing => app.handle_pairing_event(menu_ev),
-                    Screen::Settings => app.handle_settings_event(menu_ev, display_mode.h as u32),
-                    Screen::AddHost => app.handle_add_host_event(menu_ev),
-                    Screen::Wake => app.handle_wake_event(menu_ev),
-                    Screen::ForgetHost => app.handle_forget_host_event(menu_ev),
-                    Screen::HostMenu => app.handle_host_menu_event(menu_ev),
-                    Screen::SpeedTest => app.handle_speed_test_event(menu_ev),
-                    Screen::EditHost => app.handle_edit_host_event(menu_ev),
-                    Screen::About => {
-                        app.handle_about_event(menu_ev, display_mode.w as u32, display_mode.h as u32, fonts)
-                    }
-                    Screen::PinLimit => app.handle_pin_limit_event(menu_ev),
+                    _ => {}
+                }
+                match handle_ui_event(&mut app, event, &mut input, display_mode, fonts, &mut dirty) {
+                    EventAction::Next => {}
+                    EventAction::Launch => break 'ui,
                 }
             }
             // Track whether the panel is actually up, not merely whether text input was
@@ -673,10 +732,11 @@ mod real {
                     text_input.is_screen_keyboard_shown(canvas.window())
                 );
             }
-            // Three reasons to render another frame:
+            // Four reasons to render another frame:
             // 1. `dirty`         — an event or drain changed state (tiles need re-rasterizing).
-            // 2. `tiles_pending` — card window still filling in a few tiles at a time.
-            // 3. `!grid_reveal_ready` — spinner is animating (one frame per ~33 ms tick).
+            // 2. `tick_animations` — a scroll/pop/fade clock is still running.
+            // 3. `tiles_pending` — card window still filling in a few tiles at a time.
+            // 4. `!grid_reveal_ready` — spinner is animating (one frame per ~33 ms tick).
             // The 16ms sleep when none of these holds keeps the SoC idle between frames.
             let animating = app.tick_animations() || app.tiles_pending || !app.grid_reveal_ready;
             if !dirty && !animating {

--- a/src/store.rs
+++ b/src/store.rs
@@ -47,6 +47,15 @@ pub struct KnownHost {
     /// can't be woken, so `app.rs` falls back to the plain unreachable message.
     #[serde(default)]
     pub mac: Vec<String>,
+    /// Whether an unreachable-at-connect-time host gets a Wake-on-LAN packet sent
+    /// straight away, with no prompt. Per-host rather than global: waking the desktop
+    /// rig on demand is the point, while a laptop that's off is usually off on purpose.
+    /// Off by default (also for a `known-hosts.json` written before this field
+    /// existed): a host that turns out to be unreachable asks first, via the wake
+    /// prompt, and only auto-sends once this has been turned on for it. Lives on the
+    /// host menu's Wake row (⋯ → Wake settings).
+    #[serde(default)]
+    pub wol_auto: bool,
     /// Up to `MAX_PINNED_GAMES` pinned `GameEntry::id`s for this host, in pin order.
     /// `#[serde(default)]` so an older `known-hosts.json` still loads.
     #[serde(default)]
@@ -126,6 +135,8 @@ pub fn upsert_known_host(hosts: &mut Vec<KnownHost>, mut new: KnownHost) {
             new.mac.clone_from(&existing.mac);
         }
         new.pinned.clone_from(&existing.pinned);
+        // Per-host preference, not something a re-pair/re-add should reset.
+        new.wol_auto = existing.wol_auto;
         *existing = new;
     } else {
         hosts.push(new);
@@ -203,14 +214,6 @@ pub struct Settings {
     /// slider — see `ui::BITRATE_MIN_KBPS`/`BITRATE_MAX_KBPS`.
     pub bitrate_kbps: u32,
     pub hdr_enabled: bool,
-    /// Whether a Wake-on-LAN magic packet is sent automatically (no prompt) when a
-    /// known host turns out to be unreachable. Off by default — a first-time
-    /// unreachable host always asks. There's deliberately no settings-screen row for
-    /// this: it's toggled from the wake prompt itself (`app::App::handle_wake_event`),
-    /// which is also the only place that re-surfaces if turning it on doesn't
-    /// actually get the host back within a minute (see `app.rs`'s `tick_wake` docs).
-    #[serde(default)]
-    pub wol_auto_send: bool,
     /// Which hardware decode pipeline to use. Defaults to `Ndl` (stable baseline);
     /// switch to `Starfish` to test `pauseAtDecodeTime` + smooth-pacing above 1080p.
     /// Persisted across restarts; takes effect on the next stream.
@@ -250,7 +253,6 @@ impl Default for Settings {
             // own client-side AIMD controller does — see `ui::BITRATE_AUTOMATIC`.
             bitrate_kbps: 0,
             hdr_enabled: true,
-            wol_auto_send: false,
             stats_overlay: false,
             video_backend: VideoBackend::Ndl,
             codec: CodecPref::Auto,

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -44,6 +44,18 @@ pub fn zoom_rect(base: Rect, frac: f32, growth: f32) -> Rect {
     Rect::new((cx - tw / 2.0) as i32, (cy - th / 2.0) as i32, tw as u32, th as u32)
 }
 
+/// Scales `base` up from `1.0 - shrink` to full size as `frac` runs 0→1 — the
+/// "pop in" counterpart to `zoom_rect`'s "grow past full size" focus pop. A
+/// settled animation returns `base` untouched, so a static frame doesn't drift
+/// through a no-op scale's rounding.
+pub fn pop_in_rect(base: Rect, frac: f32, shrink: f32) -> Rect {
+    if frac >= 1.0 {
+        base
+    } else {
+        zoom_rect(base, 1.0 - frac, -shrink)
+    }
+}
+
 /// Translates from `start` toward `end` by `frac` (0.0 = `start`, 1.0 = `end`)
 /// — the "fly to a new grid position" counterpart to `zoom_rect`'s scale-around-
 /// center, used by the pin/unpin move animation. Size follows `end`'s (the two

--- a/src/ui/rows.rs
+++ b/src/ui/rows.rs
@@ -37,6 +37,12 @@ pub struct FocusRow {
     /// Destructive action (Forget host) — drawn in `ERROR_RED` rather than the
     /// normal muted/white pair, so it reads as dangerous before it's confirmed.
     pub danger: bool,
+    /// `Some` gives this row its own ⋯ actions button, drawn and focused exactly like
+    /// a sidebar host row's (`draw_sidebar_menu_button`) — the bool is whether the
+    /// *button* has focus rather than the row body. A row with one has a second thing
+    /// Confirm can mean, reached with Right, so the row's own action stays a single
+    /// press. `None` (the default) draws no button at all.
+    pub menu: Option<bool>,
 }
 
 impl FocusRow {
@@ -49,6 +55,7 @@ impl FocusRow {
             kind: RowKind::Action,
             fraction: 0.0,
             danger: false,
+            menu: None,
         }
     }
 
@@ -63,6 +70,13 @@ impl FocusRow {
     /// Marks this row destructive (see [`FocusRow::danger`]).
     pub fn danger(mut self) -> Self {
         self.danger = true;
+        self
+    }
+
+    /// Gives this row a ⋯ actions button (see [`FocusRow::menu`]); `focused` is
+    /// whether the button, rather than the row body, currently has focus.
+    pub fn with_menu(mut self, focused: bool) -> Self {
+        self.menu = Some(focused);
         self
     }
 }
@@ -270,18 +284,23 @@ pub fn draw_focus_row(
         // is a muted right-aligned hint (an address, a state), never interactive.
         RowKind::Action => {
             if !row.value.is_empty() {
+                // A ⋯ button occupies the same right edge, so the hint stops short of it.
+                let menu_w = row.menu.map_or(0, |_| SIDEBAR_MENU_BTN as i32 + 10);
                 let value_w = fonts.value.size_of(&row.value).map_or(0, |(w, _)| w);
                 draw_text(
                     painter,
                     text_cache,
                     fonts.value,
                     &row.value,
-                    row_rect.x() + row_rect.width() as i32 - control_pad - value_w as i32,
+                    row_rect.x() + row_rect.width() as i32 - control_pad - menu_w - value_w as i32,
                     row_rect.y() + (row_rect.height() as i32 - fonts.value.height()) / 2,
                     MUTED,
                 )?;
             }
         }
+    }
+    if let Some(menu_focused) = row.menu {
+        draw_sidebar_menu_button(painter, text_cache, fonts, row_rect, focused, menu_focused)?;
     }
     Ok(())
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -91,6 +91,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             kind: RowKind::Dropdown,
             fraction: 0.0,
             danger: false,
+            menu: None,
         },
         FocusRow {
             icon: ICON_SCHEDULE,
@@ -99,6 +100,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             kind: RowKind::Dropdown,
             fraction: 0.0,
             danger: false,
+            menu: None,
         },
         FocusRow {
             icon: ICON_SIGNAL,
@@ -111,6 +113,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             kind: RowKind::Slider,
             fraction: bitrate_frac,
             danger: false,
+            menu: None,
         },
         FocusRow {
             icon: ICON_SUN,
@@ -123,6 +126,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             kind: RowKind::Toggle,
             fraction: 0.0,
             danger: false,
+            menu: None,
         },
         FocusRow {
             icon: ICON_TV,
@@ -134,6 +138,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             kind: RowKind::Dropdown,
             fraction: 0.0,
             danger: false,
+            menu: None,
         },
         FocusRow {
             icon: ICON_MONITOR,
@@ -149,6 +154,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             kind: RowKind::Dropdown,
             fraction: 0.0,
             danger: false,
+            menu: None,
         },
         FocusRow {
             icon: ICON_SUN,
@@ -161,6 +167,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             kind: RowKind::Toggle,
             fraction: 0.0,
             danger: false,
+            menu: None,
         },
         FocusRow {
             icon: ICON_SIGNAL,
@@ -169,6 +176,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             kind: RowKind::Dropdown,
             fraction: 0.0,
             danger: false,
+            menu: None,
         },
         // The build version rides along as this row's value, so it's visible without
         // opening the screen — matching where the other clients surface it.
@@ -176,21 +184,19 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
     ]
 }
 
-/// The Wake modal's one row — the "Always send automatically" toggle (see
-/// `app::WakeState`) — as a single-element `FocusRow` list, so it draws and
-/// zoom-animates through the exact same `draw_focus_rows`/
-/// `render_focus_row_tile` machinery as the settings modal. The actual
-/// "Wake"/"Cancel" actions are a `draw_confirm_buttons` row below this one
-/// (see `app.rs`'s `render_wake`), not rows here — mirroring the
-/// Forget-host confirmation's shell/buttons split.
-pub fn wake_rows(auto_send: bool) -> Vec<FocusRow> {
+/// The per-host Wake settings modal's rows (`Screen::WakeSettings`, opened from the
+/// ⋯ on the host menu's Wake row) — just the auto-send toggle today. A `FocusRow`
+/// list so it draws and zoom-animates through the exact same `draw_focus_rows`/
+/// `render_focus_row_tile` machinery as every other list modal.
+pub fn wake_settings_rows(auto_send: bool) -> Vec<FocusRow> {
     vec![FocusRow {
-        icon: ICON_SETTINGS,
+        icon: ICON_POWER,
         label: "Wake automatically".into(),
         value: if auto_send { "On".into() } else { "Off".into() },
         kind: RowKind::Toggle,
         fraction: 0.0,
         danger: false,
+        menu: None,
     }]
 }
 


### PR DESCRIPTION
Auto-send was a global flag toggled from inside the wake prompt — reachable only by having a host fail on you. It's now `KnownHost::wol_auto`, edited from a new `Screen::WakeSettings` behind a ⋯ on the host menu's "Wake host" row. Defaults off; preserved across re-pair/re-add.

- **Wake loop**: one 60s `WAKE_RETRY_INTERVAL` replaces the 15s resend + separate 60s escalation. A silent auto-send resends *and* reveals the prompt at that mark, once. Probes stay at 10s.
- **⋯ on list-modal rows**: `FocusRow::menu` — same affordance and Right-to-reach-it gesture as a sidebar host row's.
- **Home status bar**: strings for wake sent/re-sent/host back online, which host's library is loading, and what's starting.
- Cancel on the wake prompt no longer abandons a wake whose packet already went out.
- Unrelated, already in the tree: grid card pop-in animation, and `run_ui_flow`'s event loop split into `handle_ui_event`/`UiInput`.

Not yet run on hardware — `task check`/`lint` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)