### PR TITLE
Tune target-cpu for Cortex-A73

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -17,16 +17,19 @@ linker = "scripts/cc-shim.sh"
 # VFP/NEON instructions); it does not change the calling convention, so FFI calls
 # into the sysroot's softfp-ABI libraries stay correct.
 #
-# `target-cpu=cortex-a53`, not the vendor toolchain's `-mcpu=cortex-a9`: that vendor
+# `target-cpu=cortex-a73`, not the vendor toolchain's `-mcpu=cortex-a9`: that vendor
 # default is a lowest-common-denominator for webOS generations back to genuinely
 # ARMv7 silicon, but this client targets webOS 5.x+ (see README), where every LG SoC
 # (α5/α7/α9 gen 3+, and the MTK-based budget models) is an ARMv8-A core running
-# 32-bit userland. Tuning for the A53 (the conservative in-order baseline — fine on
-# the bigger A73-class cores too) additionally unlocks ARMv8's A32 instruction set:
-# hardware integer divide (cortex-a9 codegen calls `__aeabi_idiv` instead) and
-# VFPv4 fused multiply-add. ABI is unchanged (still softfp, as above). If a
-# pre-ARMv8 webOS device ever needs supporting, revert this one value to cortex-a9.
-rustflags = ["-C", "target-feature=+neon,+vfp3,-soft-float", "-C", "target-cpu=cortex-a53"]
+# 32-bit userland. The LG CX's α9-gen3 SoC is a Cortex-A73-class core (verified on
+# device), so we tune for it directly. This is a scheduling/tuning change at the same
+# ARMv8.0-A baseline as the prior `cortex-a53` — NOT an ISA bump — so a binary tuned
+# for the out-of-order A73 still runs on an in-order A53 and vice-versa; Like a53 it unlocks ARMv8's A32
+# instruction set (hardware integer divide — cortex-a9 codegen calls `__aeabi_idiv`
+# instead — and VFPv4 fused multiply-add), and adds A73 instruction scheduling on top.
+# ABI is unchanged (still softfp, as above). If a pre-ARMv8 webOS device ever needs
+# supporting, revert this one value to cortex-a9.
+rustflags = ["-C", "target-feature=+neon,+vfp3,-soft-float", "-C", "target-cpu=cortex-a73"]
 
 [env]
 CC_armv7_unknown_linux_gnueabi = { value = "scripts/cc-shim.sh", relative = true }

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -15,7 +15,9 @@ narratives have been pruned; what remains is the load-bearing current state.
   `armv7-unknown-linux-gnueabi` defaults to *software-emulated* FP, not just a soft-float ABI —
   Rust's non-`hf` target spec bakes in LLVM's `soft-float` feature, disabling hardware FP codegen
   even though the platform (softfp, real VFP3/NEON) supports it. Fix in `.cargo/config.toml`:
-  `target-feature=+neon,+vfp3,-soft-float` + `target-cpu=cortex-a9`. `-soft-float` changes *codegen*
+  `target-feature=+neon,+vfp3,-soft-float` + `target-cpu=cortex-a73` (the CX's α9-gen3 is an
+  ARMv8-A Cortex-A73-class core; see `.cargo/config.toml` for why this is a tuning change, not an
+  ISA bump, and why hardware AES is unreachable on this 32-bit target). `-soft-float` changes *codegen*
   only, not the calling convention, so FFI into softfp-ABI sysroot libs stays correct. (The
   "unstable feature" warning it emits is harmless. rustup's prebuilt `std`/`core` still carry the old
   default — closing that needs nightly `-Z build-std`, not yet done; the hot path is our code, not std.)
@@ -457,14 +459,17 @@ string was listed together:
 
 ## Presentation research: the target device is no longer a CX (2026-07-25)
 
-Everything above this line was written against an **LG CX, webOS 5.6, Cortex-A9, 3 cores**.
-The device now under test reports something quite different, and several load-bearing
-assumptions in these notes do not carry over:
+Everything above this line was written against an **LG CX, webOS 5.6**. The CX's CPU was
+originally recorded here as "Cortex-A9, ARMv7-A"; that was **stale/wrong** — its α9-gen3 SoC is
+an ARMv8-A **Cortex-A73-class** core running a 32-bit userland (confirmed on device; the earlier
+A9 note contradicted `.cargo/config.toml`'s own reasoning). The 32-bit-userland consequences below
+(software AES ⇒ ChaCha20) still stand regardless of the exact core. The device now under test is a
+different model, and several load-bearing assumptions do not carry over:
 
 | | CX (these notes) | G5 (`OLED65G58LW`, measured 2026-07-25) |
 |---|---|---|
 | webOS | 5.6 | **10.3.1** (Rockhopper, kernel 5.4.268) |
-| CPU | Cortex-A9, ARMv7-A | **ARMv8-A `aarch64` kernel**, `Features: aes pmull sha1 sha2 crc32 asimddp` |
+| CPU | Cortex-A73-class, ARMv8-A (32-bit userland) | **ARMv8-A `aarch64` kernel**, `Features: aes pmull sha1 sha2 crc32 asimddp` |
 | Cores | 3 | **2** (`/sys/devices/system/cpu/online` = `0-1`), max 1.4 GHz |
 | Userland | 32-bit | 32-bit (`webos_imagename: lib32-starfish-global-secured`) |
 | RAM | — | 2.5 GB (1.9 GB visible) |


### PR DESCRIPTION
## What

- Retune `target-cpu` in `.cargo/config.toml` from `cortex-a53` to `cortex-a73`. The LG CX's α9-gen3 SoC is an ARMv8-A **Cortex-A73-class** core (the notes' old "Cortex-A9/ARMv7" claim was stale and contradicted the config's own reasoning). This is a **scheduling/tuning change at the same ARMv8.0-A baseline** — not an ISA bump — so a binary tuned for the out-of-order A73 still runs on an A53 and vice-versa, and it drops no support the prior `a53` baseline didn't already drop.
- Correct the stale CX CPU description in `docs/NOTES.md`.

