### PR TITLE
Fix missing cover art and stale pin slots

### DIFF
--- a/src/app/home.rs
+++ b/src/app/home.rs
@@ -266,23 +266,38 @@ impl App {
         }
     }
 
-    /// Re-sorts games: pinned first (in pin order), rest untouched; drops missing pins.
+    /// Re-sorts games: pinned first (in pin order), rest untouched. Also prunes
+    /// `known_hosts`' persisted pins for games the host no longer lists — otherwise
+    /// a removed game keeps counting toward `MAX_PINNED_GAMES` forever.
     pub(crate) fn reorder_games_by_pin(&mut self) {
-        let pinned_ids = self
+        let Some(known_idx) = self
             .selected_host
             .as_ref()
-            .and_then(|(h, p)| self.known_hosts.iter().find(|k| k.host == *h && k.port == *p))
-            .map(|k| k.pinned.clone())
-            .unwrap_or_default();
+            .and_then(|(h, p)| self.known_hosts.iter().position(|k| k.host == *h && k.port == *p))
+        else {
+            self.pinned_count = 0;
+            return;
+        };
+        let pinned_ids = self.known_hosts[known_idx].pinned.clone();
         let mut pinned = Vec::new();
+        let mut still_pinned = Vec::new();
         for id in &pinned_ids {
-            if let Some(pos) = self.games.iter().position(|g| &g.id == id) {
+            // Desktop isn't in `self.games`, so it's never "missing".
+            if id == store::DESKTOP_PIN_ID {
+                still_pinned.push(id.clone());
+            } else if let Some(pos) = self.games.iter().position(|g| &g.id == id) {
                 pinned.push(self.games.remove(pos));
+                still_pinned.push(id.clone());
             }
         }
         self.pinned_count = pinned.len();
         pinned.append(&mut self.games);
         self.games = pinned;
+
+        if still_pinned.len() != pinned_ids.len() {
+            self.known_hosts[known_idx].pinned = still_pinned;
+            let _ = store::save_known_hosts(&self.known_hosts);
+        }
     }
 
     /// Extra vertical offset for grid index `idx`'s row — `ui::PINNED_SECTION_GAP`

--- a/src/art.rs
+++ b/src/art.rs
@@ -18,8 +18,9 @@ pub struct ArtLoaded {
 /// A cover the UI wants soon.
 struct ArtRequest {
     game_id: String,
-    /// Host-relative art path (`/api/v1/library/art/...`).
-    path: String,
+    /// Candidate art paths (host-relative or external URL), tried in order — a
+    /// host-reported path can 404 even when another variant works fine.
+    paths: Vec<String>,
 }
 
 /// Max decoded dimension (panel can't show oversized art anyway).
@@ -181,13 +182,19 @@ impl ArtLoader {
         // Remember the id either way: a game with no art at all must not be re-queued
         // every frame forever.
         self.requested.insert(game.id.clone());
-        let Some(path) = game.art.portrait.as_deref().or(game.art.header.as_deref()) else {
+        // Preference order: portrait (right aspect), then header, then hero.
+        let paths: Vec<String> = [game.art.portrait.as_deref(), game.art.header.as_deref(), game.art.hero.as_deref()]
+            .into_iter()
+            .flatten()
+            .map(str::to_string)
+            .collect();
+        if paths.is_empty() {
             return;
-        };
+        }
         // A closed channel means the worker is gone; the card keeps its placeholder.
         let _ = self.tx.send(ArtRequest {
             game_id: game.id.clone(),
-            path: path.to_string(),
+            paths,
         });
     }
 
@@ -245,13 +252,26 @@ fn worker(config: &WorkerConfig, rx: &Receiver<ArtRequest>, tx: &Sender<ArtLoade
             Ok(b) if !b.is_empty() => b,
             _ => {
                 if agent.is_none() {
-                    let Ok(a) = crate::library::agent(identity, fingerprint) else {
-                        continue;
-                    };
-                    agent = Some(a);
+                    match crate::library::agent(identity, fingerprint) {
+                        Ok(a) => agent = Some(a),
+                        Err(e) => {
+                            tracing::warn!("art: {} building mTLS agent failed: {e}", req.game_id);
+                            continue;
+                        }
+                    }
                 }
                 let Some(a) = agent.as_ref() else { continue };
-                let Ok(fetched) = crate::library::fetch_art(a, host, mgmt_port, &req.path) else {
+                let mut fetched = None;
+                for path in &req.paths {
+                    match crate::library::fetch_art(a, host, mgmt_port, path) {
+                        Ok(b) => {
+                            fetched = Some(b);
+                            break;
+                        }
+                        Err(e) => tracing::warn!("art: {} fetch {} failed: {e}", req.game_id, path),
+                    }
+                }
+                let Some(fetched) = fetched else {
                     continue;
                 };
                 // Write-then-rename, never truncate-in-place: a kill mid-write would
@@ -265,11 +285,15 @@ fn worker(config: &WorkerConfig, rx: &Receiver<ArtRequest>, tx: &Sender<ArtLoade
             }
         };
 
-        let Ok(decoded) = image::load_from_memory(&bytes) else {
-            // Drop a cache entry that won't decode — otherwise it poisons this card for
-            // the life of the install.
-            let _ = std::fs::remove_file(&cached);
-            continue;
+        let decoded = match image::load_from_memory(&bytes) {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!("art: {} decode failed ({} bytes): {e}", req.game_id, bytes.len());
+                // Drop a cache entry that won't decode — otherwise it poisons this card for
+                // the life of the install.
+                let _ = std::fs::remove_file(&cached);
+                continue;
+            }
         };
         let decoded = crop_to_aspect(decoded, TARGET_ART_ASPECT);
         let longer_side = decoded.width().max(decoded.height());
@@ -285,11 +309,13 @@ fn worker(config: &WorkerConfig, rx: &Receiver<ArtRequest>, tx: &Sender<ArtLoade
         let rgba = decoded.to_rgba8();
         let (width, height) = rgba.dimensions();
         let Some(size) = IntSize::from_wh(width, height) else {
+            tracing::warn!("art: {} decoded to zero size ({width}x{height})", req.game_id);
             continue;
         };
         let mut buf = rgba.into_raw();
         premultiply_rgba(&mut buf);
         let Some(pixmap) = Pixmap::from_vec(buf, size) else {
+            tracing::warn!("art: {} Pixmap::from_vec failed ({width}x{height})", req.game_id);
             continue;
         };
         write_raw_cache(&raw_cached, &pixmap);

--- a/src/library.rs
+++ b/src/library.rs
@@ -156,17 +156,35 @@ pub fn load_games_async(
 }
 
 /// Fetches one piece of cover art's raw bytes (JPEG/PNG, undecoded) from a
-/// host-relative `art_path` (one of `GameEntry::art`'s fields) — same mTLS pinning
-/// as `fetch_games`, but takes an already-built `agent` so a caller fetching many
-/// art paths in a row (see `art.rs`) reuses one connection instead of a fresh mTLS
-/// handshake per call. Decoding happens in `art.rs`, off this module's REST concern.
+/// host-relative `art_path` (one of `GameEntry::art`'s fields), reusing an
+/// already-built `agent` (see `fetch_games`) to avoid a fresh mTLS handshake per
+/// cover. Decoding happens in `art.rs`, off this module's REST concern.
 pub fn fetch_art(agent: &ureq::Agent, addr: &str, mgmt_port: u16, art_path: &str) -> Result<Vec<u8>, LibraryError> {
+    // Some hosts hand back a full external URL (e.g. a SteamGridDB CDN link) instead
+    // of a host-relative path — that can't go through the pinned agent (wrong CA,
+    // and prefixing it with base_url would double up the authority).
+    if art_path.starts_with("http://") || art_path.starts_with("https://") {
+        return fetch_external_art(art_path);
+    }
     let url = format!("{}{art_path}", base_url(addr, mgmt_port));
     match agent.get(url.as_str()).call() {
         Ok(mut resp) => resp
             .body_mut()
             .read_to_vec()
             .map_err(|e| LibraryError::Unreachable(format!("read art body: {e}"))),
+        Err(e) => Err(classify(e)),
+    }
+}
+
+/// Fetches art from a full external URL with the system's default CA trust (no
+/// client cert) — the host's pinned `agent` would reject this CA.
+fn fetch_external_art(url: &str) -> Result<Vec<u8>, LibraryError> {
+    let agent = ureq::Agent::new_with_defaults();
+    match agent.get(url).call() {
+        Ok(mut resp) => resp
+            .body_mut()
+            .read_to_vec()
+            .map_err(|e| LibraryError::Unreachable(format!("read external art body: {e}"))),
         Err(e) => Err(classify(e)),
     }
 }


### PR DESCRIPTION
## Summary
- Falls back through `portrait` -> `header` -> `hero` art paths when the host's preferred one 404s (confirmed on-device: a game had a broken portrait but working hero/header)
- Fetches full external art URLs (e.g. SteamGridDB CDN links) via a plain default-TLS client instead of the host's mTLS-pinned agent, which rejected the CA and mangled the URL
- Prunes pinned game IDs that vanished from the host's library out of `known_hosts`' persisted pin list, so a removed game no longer permanently occupies one of the 5 `MAX_PINNED_GAMES` slots

## Test plan
- [x] `cargo check` (native stub target)
- [x] Deployed to real TV via `task deploy`; confirmed both previously-missing covers now load
- [ ] On-device: pin 5 games, remove one from host, reload library, confirm a 6th pin is now allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)