### PR TITLE
Cap on-device log file size to bound disk usage

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,6 +1,6 @@
 //! Routes `tracing` to TCP (dev machine) or log file. Destination from argv[1] at
 //! runtime (webOS SAM passes launch `params` as JSON argv), not compile-time.
-use std::io::Write;
+use std::io::{Seek, Write};
 use std::net::TcpStream;
 use std::path::Path;
 use std::sync::OnceLock;
@@ -45,29 +45,46 @@ fn telemetry_level() -> tracing::Level {
         .unwrap_or(tracing::Level::DEBUG)
 }
 
+const MAX_LOG_BYTES: u64 = 2 * 1024 * 1024;
+
 /// Log destination (file or TCP). Non-blocking dispatch prevents blocking video pump.
 enum Sink {
-    File(std::fs::File),
+    File { file: std::fs::File, written: u64 },
     Tcp(TcpStream),
 }
 
 impl Write for Sink {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         match self {
-            Self::File(f) => f.write(buf),
+            Self::File { file, written } => {
+                let n = file.write(buf)?;
+                *written += n as u64;
+                Ok(n)
+            }
             Self::Tcp(s) => s.write(buf),
         }
     }
 
+    /// `tracing_appender`'s worker thread flushes after each drained batch, not per
+    /// line — so the wrap check runs once per batch instead of once per write.
     fn flush(&mut self) -> std::io::Result<()> {
         match self {
-            Self::File(f) => f.flush(),
+            Self::File { file, written } => {
+                file.flush()?;
+                if *written >= MAX_LOG_BYTES {
+                    file.set_len(0)?;
+                    file.seek(std::io::SeekFrom::Start(0))?;
+                    *written = 0;
+                }
+                Ok(())
+            }
             Self::Tcp(s) => s.flush(),
         }
     }
 }
 
-/// Truncate log file per run (was unbounded). Info-only to bound disk usage without telemetry.
+/// Truncated on every launch, then wiped and restarted mid-run if it hits
+/// `MAX_LOG_BYTES` — bounds disk usage regardless of session length.
 fn open_file(app_dir: &Path) -> Result<Sink> {
     let path = app_dir.join(format!("punktfunk-webos-{VERSION}.log"));
     let file = std::fs::OpenOptions::new()
@@ -76,7 +93,7 @@ fn open_file(app_dir: &Path) -> Result<Sink> {
         .truncate(true)
         .open(&path)
         .with_context(|| format!("open log file {}", path.display()))?;
-    Ok(Sink::File(file))
+    Ok(Sink::File { file, written: 0 })
 }
 
 /// Open TCP or file sink; fall back to file if unreachable (dev convenience, not critical).


### PR DESCRIPTION
## Summary
- `$HOME` (the app's own install dir, per `docs/NOTES.md`) is the only confirmed-writable location for the on-device log file, and it was previously only truncated once at launch — an unbounded write over a long session could fill the TV's filesystem.
- Adds a 2MB cap: once hit, the file is wiped and writing restarts from byte 0.
- The check runs in `flush()`, not `write()` — `tracing_appender`'s non-blocking worker flushes once per drained batch, not per log line, so this adds no per-write overhead or extra I/O on the hot path.

## Test plan
- [ ] `cargo check` passes (verified locally)
- [ ] `task deploy TELEMETRY=auto` on a TV and confirm the log file truncates at launch and wraps once past 2MB during a long session

🤖 Generated with [Claude Code](https://claude.com/claude-code)