### PR TITLE
Fix Diagnostics full re-raster, restyle dropdown control

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -270,6 +270,11 @@ pub(crate) enum ModalShellKey {
         status: String,
         hover_close: bool,
     },
+    Diagnostics {
+        log_level: store::LogLevelOverride,
+        stats_overlay: bool,
+        hover_close: bool,
+    },
 }
 
 /// Focused widget in the open modal. Each variant carries its content,
@@ -1543,11 +1548,16 @@ impl App {
                 status: self.speed_test_status(),
                 hover_close: self.hover_close,
             }),
+            Screen::Diagnostics => Some(ModalShellKey::Diagnostics {
+                log_level: self.settings.log_level_override,
+                stats_overlay: self.settings.stats_overlay,
+                hover_close: self.hover_close,
+            }),
             // `EditHost` joins `AddHost` in having no shell key: its typed-digit
             // display has no separate focus tile to protect, so it just redraws on
             // any `content_dirty` tick — same for `PinLimit`, which is a fixed
             // message plus one always-focused button.
-            Screen::Home | Screen::AddHost | Screen::EditHost | Screen::PinLimit | Screen::Diagnostics => None,
+            Screen::Home | Screen::AddHost | Screen::EditHost | Screen::PinLimit => None,
         };
         let modal_stale = if modal_shell_key.is_some() {
             self.modal_tile.is_none() || self.modal_shell_key != modal_shell_key
@@ -1767,7 +1777,10 @@ impl App {
                         let rows = self.diagnostics_rows();
                         let card = Self::diagnostics_card_rect(screen_w, screen_h, fonts, &subtitle);
                         let content = ui::list_modal_content_rect(card, fonts, &subtitle, rows.len());
-                        let dropdown_open = self.dropdown.as_ref().is_some_and(|dd| dd.row == self.diagnostics_focused);
+                        let dropdown_open = self
+                            .dropdown
+                            .as_ref()
+                            .is_some_and(|dd| dd.row == self.diagnostics_focused);
                         ui::render_focus_row_tile(
                             text_cache,
                             fonts,
@@ -2240,7 +2253,10 @@ impl App {
                     Screen::Diagnostics => {
                         let subtitle = self.diagnostics_subtitle();
                         let card = Self::diagnostics_card_rect(screen_w, screen_h, fonts, &subtitle);
-                        Some((ui::list_modal_content_rect(card, fonts, &subtitle, ui::DIAGNOSTICS_ROW_COUNT), row))
+                        Some((
+                            ui::list_modal_content_rect(card, fonts, &subtitle, ui::DIAGNOSTICS_ROW_COUNT),
+                            row,
+                        ))
                     }
                     _ => None,
                 };
@@ -2356,7 +2372,10 @@ impl App {
                     Screen::Diagnostics => {
                         let subtitle = self.diagnostics_subtitle();
                         let card = Self::diagnostics_card_rect(screen_w, screen_h, fonts, &subtitle);
-                        Some((ui::list_modal_content_rect(card, fonts, &subtitle, ui::DIAGNOSTICS_ROW_COUNT), row))
+                        Some((
+                            ui::list_modal_content_rect(card, fonts, &subtitle, ui::DIAGNOSTICS_ROW_COUNT),
+                            row,
+                        ))
                     }
                     _ => None,
                 };

--- a/src/art.rs
+++ b/src/art.rs
@@ -183,11 +183,15 @@ impl ArtLoader {
         // every frame forever.
         self.requested.insert(game.id.clone());
         // Preference order: portrait (right aspect), then header, then hero.
-        let paths: Vec<String> = [game.art.portrait.as_deref(), game.art.header.as_deref(), game.art.hero.as_deref()]
-            .into_iter()
-            .flatten()
-            .map(str::to_string)
-            .collect();
+        let paths: Vec<String> = [
+            game.art.portrait.as_deref(),
+            game.art.header.as_deref(),
+            game.art.hero.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .map(str::to_string)
+        .collect();
         if paths.is_empty() {
             return;
         }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -47,7 +47,12 @@ fn telemetry_addr() -> Option<&'static str> {
 /// Launch-time log level override from `TELEMETRY_LEVEL` env var.
 /// Folded into settings so Diagnostics can display it. `None` leaves persisted level.
 pub fn launch_level_override() -> Option<LogLevelOverride> {
-    match launch_params().telemetry_level.as_deref()?.to_ascii_lowercase().as_str() {
+    match launch_params()
+        .telemetry_level
+        .as_deref()?
+        .to_ascii_lowercase()
+        .as_str()
+    {
         "debug" => Some(LogLevelOverride::Debug),
         "info" => Some(LogLevelOverride::Info),
         "warn" => Some(LogLevelOverride::Warn),

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,9 +177,12 @@ mod real {
         match log_overlay_state() {
             LogOverlayState::Off => None,
             LogOverlayState::Live => Some(crate::logger::recent_lines(crate::ui::LOG_OVERLAY_LINES)),
-            LogOverlayState::Frozen => {
-                Some(frozen_log_lines().lock().unwrap_or_else(PoisonError::into_inner).clone())
-            }
+            LogOverlayState::Frozen => Some(
+                frozen_log_lines()
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .clone(),
+            ),
         }
     }
 

--- a/src/ui/cards.rs
+++ b/src/ui/cards.rs
@@ -144,7 +144,12 @@ pub fn draw_poster_card(
         }
     }
 
-    let strip = Rect::new(r.x(), r.y() + r.height() as i32 - strip_h, r.width(), strip_h.max(0) as u32);
+    let strip = Rect::new(
+        r.x(),
+        r.y() + r.height() as i32 - strip_h,
+        r.width(),
+        strip_h.max(0) as u32,
+    );
     painter.fill_frosted_rect(strip, 0, Color::RGBA(0x00, 0x00, 0x00, 0x68), 6);
     let label = ellipsize(fonts.value, title, strip.width().saturating_sub(16));
     draw_text(

--- a/src/ui/rows.rs
+++ b/src/ui/rows.rs
@@ -221,14 +221,16 @@ pub fn draw_focus_row(
     let control_pad = 28;
     match row.kind {
         RowKind::Dropdown => {
-            let pill_w = 264u32.min(row_rect.width() / 2);
-            let pill = Rect::new(
-                row_rect.x() + row_rect.width() as i32 - control_pad - pill_w as i32,
-                row_rect.y() + (row_rect.height() as i32 - 52) / 2,
-                pill_w,
-                52,
-            );
-            draw_dropdown_pill(painter, text_cache, fonts, pill, &row.value, dropdown_open)?;
+            let right_edge = row_rect.x() + row_rect.width() as i32 - control_pad;
+            draw_dropdown_value(
+                painter,
+                text_cache,
+                fonts,
+                row_rect,
+                right_edge,
+                &row.value,
+                dropdown_open,
+            )?;
         }
         RowKind::Slider => {
             let value_w = fonts.value.size_of(&row.value).map_or(0, |(w, _)| w);
@@ -283,47 +285,37 @@ pub fn draw_focus_row(
     Ok(())
 }
 
-/// A rounded pill showing the dropdown value + chevron. Gets bright outline only
-/// when the dropdown overlay itself is expanded.
-pub fn draw_dropdown_pill(
+/// The dropdown value + chevron, right-aligned to `right_edge` and vertically
+/// centered on `row_rect` — no box, the row's own focus state already
+/// provides one. Both tint toward accent when the dropdown overlay itself is
+/// expanded.
+pub fn draw_dropdown_value(
     painter: &mut Painter,
     text_cache: &mut TextCache,
     fonts: &Fonts,
-    rect: Rect,
+    row_rect: Rect,
+    right_edge: i32,
     label: &str,
     open: bool,
 ) -> Result<()> {
-    let radius = rect.height() as i32 / 2;
-    painter.fill_rounded_rect(rect, radius, Color::RGBA(0xff, 0xff, 0xff, 0x12));
-    painter.stroke_rounded_rect(
-        rect,
-        radius,
-        if open {
-            ACCENT_BRIGHT
-        } else {
-            Color::RGBA(0xff, 0xff, 0xff, 0x30)
-        },
-        1.5,
-    );
+    let fg = if open { ACCENT_BRIGHT } else { WHITE };
     let chevron_size = 20u32;
-    let chevron_pad = 16;
     let chevron_rect = Rect::new(
-        rect.x() + rect.width() as i32 - chevron_pad - chevron_size as i32,
-        rect.y() + (rect.height() as i32 - chevron_size as i32) / 2,
+        right_edge - chevron_size as i32,
+        row_rect.y() + (row_rect.height() as i32 - chevron_size as i32) / 2,
         chevron_size,
         chevron_size,
     );
-    draw_icon(painter, text_cache, fonts.icon, chevron_rect, ICON_CHEVRON_DOWN, WHITE)?;
+    draw_icon(painter, text_cache, fonts.icon, chevron_rect, ICON_CHEVRON_DOWN, fg)?;
     let text_w = fonts.value.size_of(label).map_or(0, |(w, _)| w);
-    let text_x = rect.x() + ((rect.width() as i32 - chevron_size as i32 - chevron_pad) - text_w as i32) / 2;
     draw_text(
         painter,
         text_cache,
         fonts.value,
         label,
-        text_x.max(rect.x()),
-        rect.y() + (rect.height() as i32 - fonts.value.height()) / 2,
-        WHITE,
+        right_edge - chevron_size as i32 - 10 - text_w as i32,
+        row_rect.y() + (row_rect.height() as i32 - fonts.value.height()) / 2,
+        fg,
     )?;
     Ok(())
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -220,7 +220,10 @@ pub fn log_level_label(l: LogLevelOverride) -> &'static str {
 /// `dropdown_options`/`dropdown_current_index` but for `Screen::Diagnostics`
 /// rather than a `Settings` row (there is no row-index namespace to share).
 pub fn log_level_dropdown_options() -> Vec<String> {
-    LOG_LEVEL_OPTIONS.iter().map(|&l| log_level_label(l).to_string()).collect()
+    LOG_LEVEL_OPTIONS
+        .iter()
+        .map(|&l| log_level_label(l).to_string())
+        .collect()
 }
 
 pub fn log_level_dropdown_current_index(level: LogLevelOverride) -> usize {
@@ -243,7 +246,11 @@ pub fn diagnostics_rows(settings: &Settings) -> Vec<FocusRow> {
         FocusRow {
             icon: ICON_SUN,
             label: "Stats overlay".into(),
-            value: if settings.stats_overlay { "On".into() } else { "Off".into() },
+            value: if settings.stats_overlay {
+                "On".into()
+            } else {
+                "Off".into()
+            },
             kind: RowKind::Toggle,
             fraction: 0.0,
             danger: false,
@@ -310,7 +317,7 @@ pub fn dropdown_options(settings: &Settings, row_index: usize) -> Vec<String> {
     match row_index {
         ROW_RESOLUTION => RESOLUTIONS.iter().map(|(w, h, _)| resolution_label(*w, *h)).collect(),
         ROW_FRAMERATE => REFRESH_RATES.iter().map(|hz| format!("{hz} Hz")).collect(),
-        ROW_VIDEO_BACKEND => vec!["NDL".into(), "Starfish".into()],
+        ROW_VIDEO_BACKEND => vec!["NDL (DirectMedia)".into(), "SMP (Starfish Media Pipeline)".into()],
         ROW_CODEC => codec_options(settings)
             .iter()
             .map(|&p| codec_label(p).to_string())

--- a/src/ui/tiles.rs
+++ b/src/ui/tiles.rs
@@ -266,7 +266,15 @@ pub fn render_log_overlay_tile(font: &Font, screen_w: u32, lines: &[String]) -> 
     );
     for (i, line) in lines.iter().enumerate() {
         let clipped = ellipsize(font, line, inner_w);
-        draw_text(&mut p, &mut tc, font, &clipped, pad, pad + i as i32 * line_h, log_line_color(line))?;
+        draw_text(
+            &mut p,
+            &mut tc,
+            font,
+            &clipped,
+            pad,
+            pad + i as i32 * line_h,
+            log_line_color(line),
+        )?;
     }
     Ok(p)
 }


### PR DESCRIPTION
## Summary
- Diagnostics screen now has a `ModalShellKey`, so focus moves/scroll no longer force a full CPU re-raster of the modal.
- Dropdown control on settings rows dropped its boxed pill for plain right-aligned text (tints accent when open).
- Video-backend dropdown options now spell out NDL/SMP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)