### PR TITLE
Cache grid cards by pin id; simplify pin/unpin reorder; card focus glow+outline

### DIFF
--- a/src/app/home.rs
+++ b/src/app/home.rs
@@ -1,7 +1,7 @@
 //! Home screen: sidebar/grid navigation, host selection, game library fetch, launching.
 use super::*;
 use crate::store::{self};
-use crate::ui::{self, AddHostState, HostEntry, MenuEvent, TextCache};
+use crate::ui::{self, AddHostState, HostEntry, MenuEvent};
 use std::time::Instant;
 
 impl App {
@@ -51,14 +51,9 @@ impl App {
         self.grid_layout(columns).card_at(&self.games, idx)
     }
 
-    /// The pin id for whatever's at grid index `idx` — a `GameEntry::id`, or
-    /// `store::DESKTOP_PIN_ID` for "Desktop" — `None` for the padding after a
-    /// partial pinned row, or out of range.
+    /// The pin id for whatever's at grid index `idx` — see `GridLayout::pin_id_at`.
     pub(crate) fn pin_id_at_grid_idx(&self, idx: usize, columns: usize) -> Option<&str> {
-        match self.grid_card_at(idx, columns)? {
-            GridCard::Desktop => Some(store::DESKTOP_PIN_ID),
-            GridCard::Game(g) => Some(g.id.as_str()),
-        }
+        self.grid_layout(columns).pin_id_at(&self.games, idx)
     }
 
     /// Inverse of `pin_id_at_grid_idx`: grid index for a pin ID, keeping focus after reorder.
@@ -211,14 +206,9 @@ impl App {
         }
     }
 
-    /// Toggles focused card pin state; animates move if snapshot succeeds; opens pin-limit alert on overflow.
-    pub(crate) fn toggle_focused_pin(
-        &mut self,
-        text_cache: &mut TextCache,
-        fonts: &ui::Fonts,
-        screen_w: u32,
-        screen_h: u32,
-    ) {
+    /// Toggles focused card pin state and reorders the grid; opens pin-limit
+    /// alert on overflow.
+    pub(crate) fn toggle_focused_pin(&mut self, screen_w: u32, screen_h: u32) {
         let available_w = screen_w.saturating_sub(ui::SIDEBAR_W);
         let columns = ui::grid_columns(available_w);
         let HomeFocus::Grid(old_idx) = self.home_focus else {
@@ -235,14 +225,7 @@ impl App {
             self.open_pin_limit();
             return;
         }
-
-        // Snapshot the moved card's own look and grid position *before* the
-        // toggle below — both read pin state live from `known_hosts`, so
-        // toggling first would capture a Desktop card already in its new spot.
-        let (card_w, card_h) = self.card_size;
-        let (title, art) = self.grid_card_content(old_idx, columns);
-        let old_rect = self.unscrolled_card_rect(old_idx, columns, ui::SIDEBAR_W as i32, available_w);
-        let snapshot = ui::render_card_tile(text_cache, fonts, card_w, card_h, title, art).ok();
+        let was_pinned = known.is_pinned(&id);
 
         let Some(known) = self.selected_known_host_mut() else {
             return;
@@ -251,17 +234,34 @@ impl App {
         let _ = store::save_known_hosts(&self.known_hosts);
 
         self.reorder_games_by_pin();
-        // Rebuild the moved tiles quietly — unlike `drain_games`' fresh library
-        // load, this isn't a reason to hide the grid behind the spinner again
-        // (see `grid_reorder_dirty`'s docs).
-        self.grid_reorder_dirty = true;
         if let Some(new_idx) = self.grid_idx_for_pin_id(&id, columns) {
             self.home_focus = HomeFocus::Grid(new_idx);
             self.ensure_grid_visible(new_idx, columns, screen_w, screen_h);
-            if let Some(tile) = snapshot {
-                let new_rect = self.unscrolled_card_rect(new_idx, columns, ui::SIDEBAR_W as i32, available_w);
-                self.pin_move_tile = Some(tile);
-                self.pin_move_anim = Some((Instant::now(), old_rect, new_rect));
+        }
+        self.replay_reorder_pop(&id, was_pinned, columns);
+    }
+
+    /// Reorder's appear animation — the same "every card pops in together" look
+    /// as a fresh library reveal (see `grid_reveal_ready`), scoped to what
+    /// actually needs it: the newly pinned card alone (top row — an already-
+    /// pinned card that just changed order doesn't replay), plus every card in
+    /// the unpinned "rest" section, which reshuffles regardless of direction.
+    /// Card tiles themselves need no rebuilding either way — they're keyed by
+    /// pin id (see `card_tiles`), which reordering never changes.
+    fn replay_reorder_pop(&mut self, id: &str, was_pinned: bool, columns: usize) {
+        let now = Instant::now();
+        let layout = self.grid_layout(columns);
+        let rest_ids: Vec<String> = (layout.unpinned_start..layout.len(self.games.len()))
+            .filter_map(|idx| layout.pin_id_at(&self.games, idx).map(str::to_string))
+            .collect();
+        if !was_pinned {
+            if let Some(card) = self.card_tiles.get_mut(id) {
+                card.pop_since = Some(now);
+            }
+        }
+        for pin_id in rest_ids {
+            if let Some(card) = self.card_tiles.get_mut(&pin_id) {
+                card.pop_since = Some(now);
             }
         }
     }
@@ -313,19 +313,17 @@ impl App {
     }
 
     /// `grid_card_rect`, translated by `extra_row_gap` — everything except the
-    /// current scroll offset. Used for the pin-move animation's start/end rects,
-    /// which apply scroll themselves at draw time (see `App::pin_move_anim`).
+    /// current scroll offset; `scrolled_card_rect` applies that on top.
     pub(crate) fn unscrolled_card_rect(&self, idx: usize, columns: usize, grid_x: i32, available_w: u32) -> Rect {
         let r = ui::grid_card_rect(idx, columns, grid_x, available_w);
         let extra = self.extra_row_gap(idx, columns);
         Rect::new(r.x(), r.y() + extra, r.width(), r.height())
     }
 
-    /// Eased 0..=1 progress of grid index `idx`'s zoom-in (see
-    /// `CardTile::pop_since`) — 1.0, full size, for anything not animating.
-    pub(crate) fn card_pop_frac(&self, idx: usize) -> f32 {
-        let card = self.card_tiles.get(idx).and_then(|t| t.as_ref());
-        ui::anim_frac(card.and_then(|c| c.pop_since), CARD_POP)
+    /// Eased 0..=1 progress of pin id `id`'s zoom-in (see `CardTile::pop_since`)
+    /// — 1.0, full size, for anything not animating.
+    pub(crate) fn card_pop_frac(&self, id: &str) -> f32 {
+        ui::anim_frac(self.card_tiles.get(id).and_then(|c| c.pop_since), CARD_POP)
     }
 
     /// `unscrolled_card_rect`, translated by the current scroll offset — every

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -65,7 +65,6 @@ const SPINNER_MAX_WAIT: Duration = Duration::from_millis(900);
 pub(crate) const CARD_GROWTH: f32 = 0.028;
 pub(crate) const LAUNCH_GROWTH: f32 = 3.5;
 const PIN_BADGE_MARGIN: i32 = 10;
-pub(crate) const PIN_MOVE_ANIM: Duration = Duration::from_millis(300);
 pub(crate) const CARD_POP: Duration = Duration::from_millis(300);
 pub(crate) const CARD_POP_SHRINK: f32 = 0.14;
 pub(crate) const MODAL_FADE: Duration = Duration::from_millis(200);
@@ -182,6 +181,18 @@ impl GridLayout {
         match self.card_at(games, idx)? {
             GridCard::Game(g) => Some(g),
             GridCard::Desktop => None,
+        }
+    }
+
+    /// The pin id for whatever's at grid index `idx` — a `GameEntry::id`, or
+    /// `store::DESKTOP_PIN_ID` for "Desktop" — `None` for the padding after a
+    /// partial pinned row. The one place this mapping is spelled out; every
+    /// caller (`App::pin_id_at_grid_idx`, tile build/evict, `draw_list`)
+    /// delegates here instead of matching `card_at` itself.
+    pub(crate) fn pin_id_at<'a>(&self, games: &'a [GameEntry], idx: usize) -> Option<&'a str> {
+        match self.card_at(games, idx)? {
+            GridCard::Desktop => Some(store::DESKTOP_PIN_ID),
+            GridCard::Game(g) => Some(g.id.as_str()),
         }
     }
 
@@ -423,38 +434,33 @@ pub struct App {
     /// (`sidebar_dirty`), never on focus movement.
     pub(crate) sidebar_layer: Option<Painter>,
     pub(crate) sidebar_dirty: bool,
-    /// Per-card tiles (shadow baked in, transparent padding), index-aligned
-    /// with the grid. `None` = not yet rasterized (or invalidated).
-    pub(crate) card_tiles: Vec<Option<CardTile>>,
+    /// Per-card tiles (shadow baked in, transparent padding), keyed by pin id
+    /// (a `GameEntry::id`, or `store::DESKTOP_PIN_ID`) rather than grid index —
+    /// a pin/unpin reorder only shuffles which index a game sits at, so keying
+    /// by identity instead means the reorder never has to rebuild anything;
+    /// see `App::replay_reorder_pop`. Absent = not yet rasterized (or evicted).
+    pub(crate) card_tiles: std::collections::HashMap<String, CardTile>,
     /// All card tiles stale (games list / host changed) — a fresh library load,
     /// so `prepare_tiles` also re-arms the loading spinner (`grid_reveal_ready`).
     pub(crate) grid_dirty: bool,
-    /// All card tiles stale from a pin toggle's reorder — rebuilt like
-    /// `grid_dirty`, but without re-arming the spinner: the grid is already on
-    /// screen, just re-sorted, so re-pinning must not flash a reload over it.
-    pub(crate) grid_reorder_dirty: bool,
     /// Card tiles still waiting to be rasterized inside the prefetch window. Keeps the
     /// main loop ticking until the window is filled — without it the redraw-on-change
     /// loop would go idle mid-build and leave blank cards on screen.
     pub(crate) tiles_pending: bool,
-    /// Individual card tiles stale (cover art arrived) — cheaper than
+    /// Individual card tiles stale (cover art arrived), by pin id — cheaper than
     /// `grid_dirty` when the layout is unchanged.
-    pub(crate) grid_cards_dirty: Vec<usize>,
+    pub(crate) grid_cards_dirty: Vec<String>,
     /// Tiles whose GPU texture should be released this frame — drained by `main.rs`,
     /// which owns the `Compositor`.
     pub(crate) evicted_tiles: Vec<Tile>,
     /// The shared focus-ring glow tile (one per card size).
     pub(crate) ring_tile: Option<Painter>,
+    /// The shared card-outline tile (one per card size) — composited on top
+    /// of the focused card's art, unlike `ring_tile` which sits behind it.
+    pub(crate) outline_tile: Option<Painter>,
     /// The shared pinned badge tile — built once (it doesn't depend on card
     /// size), composited over the focused card when that card is pinned.
     pub(crate) pin_badge_tile: Option<Painter>,
-    /// A pin/unpin toggle's moved card, snapshotted at `toggle_focused_pin` time
-    /// (only its position changes) — cleared once `PIN_MOVE_ANIM` elapses.
-    pub(crate) pin_move_tile: Option<Painter>,
-    /// The in-flight pin-move animation: start time, and the moved card's
-    /// start/end rects in *unscrolled* grid space — `grid_scroll` is subtracted
-    /// at draw time, so scrolling mid-flight doesn't detach it from the grid.
-    pub(crate) pin_move_anim: Option<(Instant, Rect, Rect)>,
     /// The focused sidebar row's tile, keyed by row index.
     pub(crate) focused_row_tile: Option<((usize, bool), Painter)>,
     /// The active modal rasterized full-screen (transparent surroundings);
@@ -623,16 +629,14 @@ impl App {
             identity,
             sidebar_layer: None,
             sidebar_dirty: true,
-            card_tiles: Vec::new(),
+            card_tiles: std::collections::HashMap::new(),
             grid_dirty: true,
-            grid_reorder_dirty: false,
             tiles_pending: false,
             grid_cards_dirty: Vec::new(),
             evicted_tiles: Vec::new(),
             ring_tile: None,
+            outline_tile: None,
             pin_badge_tile: None,
-            pin_move_tile: None,
-            pin_move_anim: None,
             focused_row_tile: None,
             modal_tile: None,
             modal_shell_key: None,
@@ -757,19 +761,16 @@ impl App {
     /// Drains any cover art that's finished decoding since the last tick — called
     /// alongside `drain_discovery`. Returns whether any new art actually arrived
     /// (see `drain_discovery`'s docs on why).
-    pub fn drain_art(&mut self, screen_w: u32) -> bool {
+    pub fn drain_art(&mut self) -> bool {
         let Some(loader) = &self.art_loader else { return false };
         let loaded = loader.drain();
         if loaded.is_empty() {
             return false;
         }
-        let columns = ui::grid_columns(screen_w.saturating_sub(ui::SIDEBAR_W));
         for item in loaded {
             // Layout is unchanged by art arriving — queue a repaint of just that
             // card's tile (see `grid_cards_dirty`) rather than a full layer rebuild.
-            if let Some(idx) = self.grid_idx_for_pin_id(&item.game_id, columns) {
-                self.grid_cards_dirty.push(idx);
-            }
+            self.grid_cards_dirty.push(item.game_id.clone());
             self.art.insert(item.game_id, item.pixmap);
         }
         true
@@ -897,18 +898,10 @@ impl App {
             }
             animating = true;
         }
-        if let Some((t, _, _)) = self.pin_move_anim {
-            if t.elapsed() >= PIN_MOVE_ANIM {
-                self.pin_move_anim = None;
-                self.pin_move_tile = None;
-            }
-            animating = true;
-        }
         // A scan, not one clock: every card zooms on its own (`CardTile::pop_since`).
         if self
             .card_tiles
-            .iter()
-            .flatten()
+            .values()
             .any(|c| c.pop_since.is_some_and(|t| t.elapsed() < CARD_POP))
         {
             animating = true;
@@ -1319,29 +1312,23 @@ impl App {
             // Captured before it's cleared below: a fresh library load is the only
             // rebuild that also re-arms the spinner.
             let full_reset = self.grid_dirty;
-            if full_reset || self.grid_reorder_dirty || self.card_tiles.len() != count {
-                // Every existing texture is stale (different games, different grid
-                // shape) — drop them rather than leaving them to be overwritten one by
-                // one, which would strand the tail of a longer previous library.
-                for idx in 0..self.card_tiles.len() {
-                    self.evicted_tiles.push(Tile::Card(idx));
+            if full_reset {
+                // Every existing texture is stale (different games, different host) —
+                // drop them rather than leaving them to be overwritten one by one,
+                // which would strand the tail of a longer previous library.
+                for (id, _) in self.card_tiles.drain() {
+                    self.evicted_tiles.push(Tile::Card(id));
                 }
-                self.card_tiles = std::iter::repeat_with(|| None).take(count).collect();
                 self.grid_dirty = false;
-                self.grid_reorder_dirty = false;
                 self.grid_cards_dirty.clear();
-                if full_reset {
-                    // Scrolling, a resize, or re-pinning a card must not hide the
-                    // already-visible grid behind the spinner again.
-                    self.grid_reveal_ready = false;
-                    self.spinner_since = None;
-                    self.spinner_frame = None;
-                }
+                // Scrolling or re-pinning a card must not hide the already-visible
+                // grid behind the spinner again.
+                self.grid_reveal_ready = false;
+                self.spinner_since = None;
+                self.spinner_frame = None;
             } else {
-                for idx in std::mem::take(&mut self.grid_cards_dirty) {
-                    if idx < count {
-                        self.card_tiles[idx] = None;
-                    }
+                for id in std::mem::take(&mut self.grid_cards_dirty) {
+                    self.card_tiles.remove(&id);
                 }
             }
 
@@ -1364,15 +1351,19 @@ impl App {
             // ones rather than a frame later.
             for idx in 0..count {
                 let row = row_of(idx);
-                if (row < keep_lo || row > keep_hi) && self.card_tiles[idx].is_some() {
-                    self.card_tiles[idx] = None;
-                    self.evicted_tiles.push(Tile::Card(idx));
-                    if let Some(game) = layout.game_at(&self.games, idx) {
+                if row < keep_lo || row > keep_hi {
+                    let Some(id) = layout.pin_id_at(&self.games, idx) else {
+                        continue;
+                    };
+                    if self.card_tiles.remove(id).is_some() {
+                        self.evicted_tiles.push(Tile::Card(id.to_string()));
+                    }
+                    if layout.game_at(&self.games, idx).is_some() {
                         // Drop the decoded cover too — it is several times the size of the
                         // tile it feeds. Re-requested from the disk cache on scroll back.
-                        self.art.remove(&game.id);
+                        self.art.remove(id);
                         if let Some(loader) = &mut self.art_loader {
-                            loader.forget(&game.id);
+                            loader.forget(id);
                         }
                     }
                 }
@@ -1397,23 +1388,23 @@ impl App {
                 }
                 // Nothing to build or fetch art for in the padding after a partial
                 // pinned row.
-                if layout.card_at(&self.games, idx).is_none() {
+                let Some(id) = layout.pin_id_at(&self.games, idx) else {
                     continue;
-                }
+                };
                 // Ask for this card's cover as it enters the window, not for the whole
                 // library at once (see `art::ArtLoader`).
                 if let (Some(loader), Some(game)) = (&mut self.art_loader, layout.game_at(&self.games, idx)) {
                     loader.request(game);
                 }
-                if self.card_tiles[idx].is_some() {
+                if self.card_tiles.contains_key(id) {
                     continue;
                 }
-                to_build.push((idx, art_ready(idx)));
+                to_build.push((idx, id.to_string(), art_ready(idx)));
             }
-            to_build.sort_by_key(|(_, ready)| !ready);
+            to_build.sort_by_key(|(_, _, ready)| !ready);
 
             let mut pending = false;
-            for (built, (idx, _)) in to_build.into_iter().enumerate() {
+            for (built, (idx, id, _)) in to_build.into_iter().enumerate() {
                 if built >= CARD_BUILD_BUDGET {
                     pending = true;
                     break;
@@ -1422,11 +1413,14 @@ impl App {
                     let (title, art) = self.grid_card_content(idx, columns);
                     ui::render_card_tile(text_cache, fonts, card_w, card_h, title, art)?
                 };
-                self.card_tiles[idx] = Some(CardTile {
-                    tile,
-                    pop_since: self.grid_reveal_ready.then(Instant::now),
-                });
-                updated.push(Tile::Card(idx));
+                self.card_tiles.insert(
+                    id.clone(),
+                    CardTile {
+                        tile,
+                        pop_since: self.grid_reveal_ready.then(Instant::now),
+                    },
+                );
+                updated.push(Tile::Card(id));
             }
             self.tiles_pending = pending;
 
@@ -1446,7 +1440,11 @@ impl App {
                         let row = row_of(idx);
                         row >= build_lo && row <= build_hi
                     })
-                    .all(|idx| self.card_tiles[idx].is_some() && art_ready(idx));
+                    .all(|idx| {
+                        layout
+                            .pin_id_at(&self.games, idx)
+                            .is_none_or(|id| self.card_tiles.contains_key(id) && art_ready(idx))
+                    });
                 let since = *self.spinner_since.get_or_insert_with(Instant::now);
                 self.grid_reveal_ready = window_ready || since.elapsed() >= SPINNER_MAX_WAIT;
                 if self.grid_reveal_ready {
@@ -1455,7 +1453,7 @@ impl App {
                     // Everything built behind the spinner becomes visible in this
                     // one frame, so it all zooms in off a single clock.
                     let now = Instant::now();
-                    for card in self.card_tiles.iter_mut().flatten() {
+                    for card in self.card_tiles.values_mut() {
                         card.pop_since.get_or_insert(now);
                     }
                 } else {
@@ -1471,6 +1469,11 @@ impl App {
             if !matches!(&self.ring_tile, Some(p) if p.width() == ring_w) {
                 self.ring_tile = Some(ui::render_focus_ring_tile(card_w, card_h));
                 updated.push(Tile::Ring);
+            }
+            let outline_w = card_w + 2 * ui::CARD_OUTLINE_PAD as u32;
+            if !matches!(&self.outline_tile, Some(p) if p.width() == outline_w) {
+                self.outline_tile = Some(ui::render_card_outline_tile(card_w, card_h));
+                updated.push(Tile::CardOutline);
             }
             match &self.home_status {
                 Some(s) => {
@@ -1969,14 +1972,14 @@ impl App {
     }
 
     /// The pixmap behind `tile`, for the compositor to upload.
-    pub fn tile_pixmap(&self, tile: Tile) -> Option<&Painter> {
+    pub fn tile_pixmap(&self, tile: &Tile) -> Option<&Painter> {
         match tile {
             Tile::Sidebar => self.sidebar_layer.as_ref(),
             Tile::FocusRow => self.focused_row_tile.as_ref().map(|(_, p)| p),
-            Tile::Card(i) => self.card_tiles.get(i).and_then(|t| t.as_ref()).map(|c| &c.tile),
+            Tile::Card(id) => self.card_tiles.get(id).map(|c| &c.tile),
             Tile::Ring => self.ring_tile.as_ref(),
+            Tile::CardOutline => self.outline_tile.as_ref(),
             Tile::PinBadge => self.pin_badge_tile.as_ref(),
-            Tile::PinMove => self.pin_move_tile.as_ref(),
             Tile::Modal => self.modal_tile.as_ref(),
             Tile::ModalFocusElement => self.modal_focus_tile.as_ref().map(|(_, p)| p),
             Tile::DropdownOverlay => self.dropdown_overlay_tile.as_ref().map(|(_, p)| p),
@@ -2046,15 +2049,16 @@ impl App {
                 if Some(idx) == focused {
                     continue; // drawn last, on top of its neighbors
                 }
-                if layout.card_at(&self.games, idx).is_none() {
-                    continue; // padding after a partial pinned row — nothing to draw
-                }
+                // padding after a partial pinned row — nothing to draw
+                let Some(pin_id) = layout.pin_id_at(&self.games, idx) else {
+                    continue;
+                };
                 let r = self.scrolled_card_rect(idx, columns, grid_x, available_w);
                 if r.y() + r.height() as i32 + pad < 0 || r.y() - pad > screen_h as i32 {
                     continue; // culled — fully off-screen at this scroll offset
                 }
                 // A card that just landed is still zooming up to full size.
-                let pop = self.card_pop_frac(idx);
+                let pop = self.card_pop_frac(pin_id);
                 let base = Rect::new(
                     r.x() - pad,
                     r.y() - pad,
@@ -2062,7 +2066,7 @@ impl App {
                     r.height() + 2 * pad as u32,
                 );
                 cmds.push(DrawCmd::Tex {
-                    tile: Tile::Card(idx),
+                    tile: Tile::Card(pin_id.to_string()),
                     dst: ui::pop_in_rect(base, pop, CARD_POP_SHRINK),
                     alpha: (255.0 * pop) as u8,
                 });
@@ -2079,79 +2083,74 @@ impl App {
                 }
             }
             if let Some(idx) = focused {
-                // The focus pop: the GPU scales the (unfocused) card tile up
-                // around its center as the pop progresses, with the shared ring
-                // tile fading in over it at the same scale.
-                let f = ui::anim_frac(self.focus_anim, ui::FOCUS_POP);
-                let r = self.scrolled_card_rect(idx, columns, grid_x, available_w);
-                let card_base = Rect::new(
-                    r.x() - pad,
-                    r.y() - pad,
-                    r.width() + 2 * pad as u32,
-                    r.height() + 2 * pad as u32,
-                );
-                // The focused card zooms in on first appearance like any other,
-                // composed with its focus pop — both scale around the card's own
-                // center, so they can't fight over position.
-                let pop = self.card_pop_frac(idx);
-                let popped = |base: Rect| ui::pop_in_rect(base, pop, CARD_POP_SHRINK);
-                cmds.push(DrawCmd::Tex {
-                    tile: Tile::Card(idx),
-                    dst: popped(ui::zoom_rect(card_base, f, CARD_GROWTH)),
-                    alpha: (255.0 * pop) as u8,
-                });
-                let rp = ui::FOCUS_RING_PAD;
-                let ring_base = Rect::new(
-                    r.x() - rp,
-                    r.y() - rp,
-                    r.width() + 2 * rp as u32,
-                    r.height() + 2 * rp as u32,
-                );
-                cmds.push(DrawCmd::Tex {
-                    tile: Tile::Ring,
-                    dst: popped(ui::zoom_rect(ring_base, f, CARD_GROWTH)),
-                    alpha: (255.0 * f * pop) as u8,
-                });
-                // The pinned badge — only on a focused card that's actually
-                // pinned, be it a game or "Desktop" (see `store::DESKTOP_PIN_ID`).
-                let pin_id = match layout.card_at(&self.games, idx) {
-                    Some(GridCard::Desktop) => Some(store::DESKTOP_PIN_ID),
-                    Some(GridCard::Game(g)) => Some(g.id.as_str()),
-                    None => None,
-                };
-                if pin_id.is_some_and(|id| self.selected_known_host().is_some_and(|h| h.is_pinned(id))) {
-                    let badge = ui::PIN_BADGE_SIZE;
-                    let badge_base = Rect::new(
-                        r.x() + r.width() as i32 - badge as i32 - PIN_BADGE_MARGIN,
-                        r.y() + PIN_BADGE_MARGIN,
-                        badge,
-                        badge,
+                if let Some(pin_id) = layout.pin_id_at(&self.games, idx) {
+                    // The focus pop: the GPU scales the (unfocused) card tile up
+                    // around its center as the pop progresses, with the shared glow
+                    // tile fading in behind it at the same scale.
+                    let f = ui::anim_frac(self.focus_anim, ui::FOCUS_POP);
+                    let r = self.scrolled_card_rect(idx, columns, grid_x, available_w);
+                    let card_base = Rect::new(
+                        r.x() - pad,
+                        r.y() - pad,
+                        r.width() + 2 * pad as u32,
+                        r.height() + 2 * pad as u32,
                     );
-                    // Corner-anchored, so it only fades — scaling it around its
-                    // own center would drift it off the shrunken card.
+                    let pop = self.card_pop_frac(pin_id);
+                    let popped = |base: Rect| ui::pop_in_rect(base, pop, CARD_POP_SHRINK);
+                    // Glow drawn first — it's a halo behind the card, not an outline
+                    // on top of it.
+                    let rp = ui::FOCUS_RING_PAD;
+                    let ring_base = Rect::new(
+                        r.x() - rp,
+                        r.y() - rp,
+                        r.width() + 2 * rp as u32,
+                        r.height() + 2 * rp as u32,
+                    );
                     cmds.push(DrawCmd::Tex {
-                        tile: Tile::PinBadge,
-                        dst: ui::zoom_rect(badge_base, f, CARD_GROWTH),
+                        tile: Tile::Ring,
+                        dst: popped(ui::zoom_rect(ring_base, f, CARD_GROWTH)),
+                        alpha: (255.0 * f * pop) as u8,
+                    });
+                    // The focused card zooms in on first appearance like any other,
+                    // composed with its focus pop — both scale around the card's own
+                    // center, so they can't fight over position.
+                    cmds.push(DrawCmd::Tex {
+                        tile: Tile::Card(pin_id.to_string()),
+                        dst: popped(ui::zoom_rect(card_base, f, CARD_GROWTH)),
                         alpha: (255.0 * pop) as u8,
                     });
+                    // The crisp outline, on top of the card art — a clean edge
+                    // between it and the glow behind, unlike the glow's own
+                    // soft, blurred boundary.
+                    let op = ui::CARD_OUTLINE_PAD;
+                    let outline_base = Rect::new(
+                        r.x() - op,
+                        r.y() - op,
+                        r.width() + 2 * op as u32,
+                        r.height() + 2 * op as u32,
+                    );
+                    cmds.push(DrawCmd::Tex {
+                        tile: Tile::CardOutline,
+                        dst: popped(ui::zoom_rect(outline_base, f, CARD_GROWTH)),
+                        alpha: (255.0 * f * pop) as u8,
+                    });
+                    if self.selected_known_host().is_some_and(|h| h.is_pinned(pin_id)) {
+                        let badge = ui::PIN_BADGE_SIZE;
+                        let badge_base = Rect::new(
+                            r.x() + r.width() as i32 - badge as i32 - PIN_BADGE_MARGIN,
+                            r.y() + PIN_BADGE_MARGIN,
+                            badge,
+                            badge,
+                        );
+                        // Corner-anchored, so it only fades — scaling it around its
+                        // own center would drift it off the shrunken card.
+                        cmds.push(DrawCmd::Tex {
+                            tile: Tile::PinBadge,
+                            dst: ui::zoom_rect(badge_base, f, CARD_GROWTH),
+                            alpha: (255.0 * pop) as u8,
+                        });
+                    }
                 }
-            }
-            // The toggled card's snapshot flies from its old grid position to its
-            // new one, over everything drawn above — see `pin_move_anim`.
-            if let Some((t, start, end)) = self.pin_move_anim {
-                let f = ui::anim_frac(Some(t), PIN_MOVE_ANIM);
-                let scrolled = |r: Rect| Rect::new(r.x(), r.y() - self.grid_scroll, r.width(), r.height());
-                let base = ui::lerp_rect(scrolled(start), scrolled(end), f);
-                cmds.push(DrawCmd::Tex {
-                    tile: Tile::PinMove,
-                    dst: Rect::new(
-                        base.x() - pad,
-                        base.y() - pad,
-                        base.width() + 2 * pad as u32,
-                        base.height() + 2 * pad as u32,
-                    ),
-                    alpha: 0xff,
-                });
             }
         }
         if self.selected_host.is_some() && self.home_status.is_some() {
@@ -2437,11 +2436,13 @@ impl App {
         if let (Some(t), Some(idx)) = (self.launch_anim, self.launch_anim_idx) {
             let f = ui::anim_frac(Some(t), ui::LAUNCH_FADE);
             let base = self.scrolled_card_rect(idx, columns, grid_x, available_w);
-            cmds.push(DrawCmd::Tex {
-                tile: Tile::Card(idx),
-                dst: ui::zoom_rect(base, f, LAUNCH_GROWTH),
-                alpha: 0xff,
-            });
+            if let Some(pin_id) = self.pin_id_at_grid_idx(idx, columns) {
+                cmds.push(DrawCmd::Tex {
+                    tile: Tile::Card(pin_id.to_string()),
+                    dst: ui::zoom_rect(base, f, LAUNCH_GROWTH),
+                    alpha: 0xff,
+                });
+            }
             cmds.push(DrawCmd::Fill {
                 rect: Rect::new(0, 0, screen_w, screen_h),
                 color: sdl2::pixels::Color::RGBA(0, 0, 0, (255.0 * f) as u8),

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -17,24 +17,26 @@ use sdl2::video::{Window, WindowContext};
 use crate::app::Screen;
 use crate::ui::Painter;
 
-/// Identity of one cached tile/texture. `Card` is keyed by grid index.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+/// Identity of one cached tile/texture. `Card` is keyed by pin id (a
+/// `GameEntry::id`, or `store::DESKTOP_PIN_ID`) rather than grid index, so a
+/// pin/unpin reorder — which only shuffles positions, not which games exist —
+/// never needs to re-upload a card's texture.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub enum Tile {
     /// The focus-free sidebar strip (opaque, screen-height).
     Sidebar,
     /// The currently focused sidebar row (transparent padding + shadow).
     FocusRow,
-    /// One grid card, shadow included (transparent padding).
-    Card(usize),
+    /// One grid card, shadow included (transparent padding), keyed by pin id.
+    Card(String),
     /// The shared focus-ring glow (all cards are the same size).
     Ring,
+    /// The focused card's crisp edge outline, composited on top of the card
+    /// art (unlike `Ring`, which sits behind it). Shared, like `Ring`.
+    CardOutline,
     /// The pinned badge composited over the focused grid card's top-right
     /// corner, only when that card is pinned. Shared by every card, like `Ring`.
     PinBadge,
-    /// A pin/unpin toggle's moved card, snapshotted once and flown from its old
-    /// grid position to its new one — see `App::pin_move_anim`. Only one such
-    /// animation ever runs at a time, so there's no per-card key like `Card`.
-    PinMove,
     /// The active modal, full-screen with transparent surroundings.
     Modal,
     /// One modal's focused, zoom-animated widget (row, PIN digit, button, etc).
@@ -135,7 +137,7 @@ impl Compositor {
             let tex = creator
                 .create_texture_static(PixelFormatEnum::RGBA32, w, h)
                 .map_err(|e| anyhow::anyhow!("create texture {tile:?} {w}x{h}: {e}"))?;
-            self.textures.insert(tile, tex);
+            self.textures.insert(tile.clone(), tex);
         }
         let tex = self.textures.get_mut(&tile).expect("just inserted");
         let pitch = w as usize * 4;

--- a/src/main.rs
+++ b/src/main.rs
@@ -728,7 +728,7 @@ mod real {
             }
             yellow_held = yellow_down;
             dirty |= app.drain_discovery();
-            dirty |= app.drain_art(display_mode.w as u32);
+            dirty |= app.drain_art();
             dirty |= app.drain_games();
             dirty |= app.drain_pairing();
             dirty |= app.drain_speed_test();
@@ -745,7 +745,7 @@ mod real {
                 hold.fired = true;
                 let still_there = matches!(app.screen, Screen::Home) && hold.focus == app.home_focus;
                 if still_there {
-                    app.toggle_focused_pin(&mut text_cache, fonts, display_mode.w as u32, display_mode.h as u32);
+                    app.toggle_focused_pin(display_mode.w as u32, display_mode.h as u32);
                 }
                 dirty = true;
             }
@@ -851,14 +851,14 @@ mod real {
                 compositor.drop_tile(tile);
             }
             for tile in updated {
-                match tile {
-                    Tile::SpinnerFrame(idx) => {
+                match &tile {
+                    &Tile::SpinnerFrame(idx) => {
                         if let Some(frame) = crate::ui::spinner_frame(idx) {
                             compositor.upload_raw(texture_creator, tile, frame.width, frame.height, &frame.pixels)?;
                         }
                     }
                     _ => {
-                        if let Some(pm) = app.tile_pixmap(tile) {
+                        if let Some(pm) = app.tile_pixmap(&tile) {
                             compositor.upload(texture_creator, tile, pm)?;
                         }
                     }

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -40,10 +40,3 @@ pub fn pop_in_rect(base: Rect, frac: f32, shrink: f32) -> Rect {
         zoom_rect(base, 1.0 - frac, -shrink)
     }
 }
-
-/// Translate from start to end. Used for pin/unpin move animation.
-pub fn lerp_rect(start: Rect, end: Rect, frac: f32) -> Rect {
-    let x = start.x() as f32 + (end.x() - start.x()) as f32 * frac;
-    let y = start.y() as f32 + (end.y() - start.y()) as f32 * frac;
-    Rect::new(x as i32, y as i32, end.width(), end.height())
-}

--- a/src/ui/cards.rs
+++ b/src/ui/cards.rs
@@ -29,19 +29,30 @@ pub fn draw_card_shadow(painter: &mut Painter, rect: Rect, radius: i32) {
     painter.fill_shadow(rect, radius, 3.0, 5.0, SHADOW_BLUR, 0x60);
 }
 
-/// Focus ring: outline offset outward (moonlight-tv style). Used only for game grid selection.
+/// How far the focused-card glow's blur extends past the card edge — the
+/// pad `render_focus_ring_tile`'s canvas must leave for it not to clip.
+pub const FOCUS_GLOW_BLUR: f32 = 16.0;
+
+/// Soft glow behind a focused card — a blurred halo in the accent color,
+/// replacing the old hard double-outline ring for a more pleasant look. Same
+/// cached-shape technique as a drop shadow (`Painter::fill_glow`), so it costs
+/// one shared texture, reused by every card, not a per-frame re-blur. Rounded
+/// noticeably less than the card itself (`radius`) — a smaller pre-blur radius
+/// leaves more straight edge for the blur to soften, which reads as hugging
+/// the card's actual corners rather than blooming into a big round blob.
 pub fn draw_focus_ring(painter: &mut Painter, rect: Rect, radius: i32) {
-    let passes = [(3, 0xff), (6, 0x60)];
-    for (offset, alpha) in passes {
-        let ring = Rect::new(
-            rect.x() - offset,
-            rect.y() - offset,
-            rect.width() + 2 * offset as u32,
-            rect.height() + 2 * offset as u32,
-        );
-        let color = Color::RGBA(ACCENT_BRIGHT.r, ACCENT_BRIGHT.g, ACCENT_BRIGHT.b, alpha);
-        painter.stroke_rounded_rect(ring, radius + offset, color, 2.0);
-    }
+    painter.fill_glow(rect, radius / 2, ACCENT_BRIGHT, FOCUS_GLOW_BLUR);
+}
+
+/// A crisp thin outline right at the card's own edge — composited on top of
+/// the card art (unlike the soft glow behind it), so the transition from
+/// glow to art reads as a clean rectangle rather than a smudge. Square, not
+/// `CARD_RADIUS`-rounded: the art itself is a plain blit with square corners
+/// (see `draw_poster_card`), so a rounded outline would float visibly outside
+/// the actual art edge whenever a cover is loaded.
+pub fn draw_card_outline(painter: &mut Painter, rect: Rect) {
+    let color = Color::RGBA(ACCENT_BRIGHT.r, ACCENT_BRIGHT.g, ACCENT_BRIGHT.b, 0xd0);
+    painter.stroke_rounded_rect(rect, 0, color, 1.5);
 }
 
 /// Draw text-entry card (PIN/IP boxes); always visible, zoom when focused.

--- a/src/ui/painter.rs
+++ b/src/ui/painter.rs
@@ -4,7 +4,7 @@ use sdl2::rect::Rect;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use tiny_skia::{
-    Color as SkColor, FillRule, FilterQuality, Paint, PathBuilder, Pixmap, PixmapPaint, Stroke, Transform,
+    Color as SkColor, FillRule, FilterQuality, IntSize, Paint, PathBuilder, Pixmap, PixmapPaint, Stroke, Transform,
 };
 
 pub fn sk_color(c: Color) -> SkColor {
@@ -69,6 +69,22 @@ thread_local! {
     /// without `unsafe`/atomics since every `Painter` is built on the single
     /// SDL/render thread.
     static SHADOW_CACHE: RefCell<HashMap<ShadowKey, Pixmap>> = RefCell::new(HashMap::new());
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct GlowKey {
+    w: u32,
+    h: u32,
+    radius: i32,
+    blur_bits: u32,
+    color: u32,
+}
+
+thread_local! {
+    /// Same cached-shape technique as `SHADOW_CACHE`, for the focused-card glow
+    /// (`fill_glow`) — one blurred colored shape shared by every card of the same
+    /// size, since focus only ever moves, it never changes card dimensions.
+    static GLOW_CACHE: RefCell<HashMap<GlowKey, Pixmap>> = RefCell::new(HashMap::new());
 }
 
 impl Painter {
@@ -192,6 +208,43 @@ impl Painter {
         });
     }
 
+    /// A soft colored glow centered on a rounded-rect shape — same cached-shape,
+    /// box-blurred technique as `fill_shadow`, just tinted and un-offset (a glow
+    /// surrounds its shape evenly; a shadow falls to one side).
+    pub fn fill_glow(&mut self, rect: Rect, radius: i32, color: Color, blur: f32) {
+        if rect.width() == 0 || rect.height() == 0 {
+            return;
+        }
+        let pad = blur.ceil().max(0.0) as i32 + 1;
+        let key = GlowKey {
+            w: rect.width(),
+            h: rect.height(),
+            radius,
+            blur_bits: blur.to_bits(),
+            color: u32::from_be_bytes([color.r, color.g, color.b, color.a]),
+        };
+        GLOW_CACHE.with(|cache| {
+            let mut cache = cache.borrow_mut();
+            let shape = match cache.entry(key) {
+                std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    let Some(shape) = render_glow_shape(rect.width(), rect.height(), radius, pad, blur, color) else {
+                        return;
+                    };
+                    e.insert(shape)
+                }
+            };
+            self.pixmap.draw_pixmap(
+                rect.x() - pad,
+                rect.y() - pad,
+                shape.as_ref(),
+                &PixmapPaint::default(),
+                Transform::identity(),
+                None,
+            );
+        });
+    }
+
     /// Blurs the pixmap content already drawn within `rect`, in place (clamped to bounds).
     pub fn blur_rect(&mut self, rect: Rect, radius: usize) {
         if radius == 0 {
@@ -293,6 +346,37 @@ pub fn render_shadow_shape(w: u32, h: u32, radius: i32, pad: i32, blur: f32, opa
     }
 
     Some(shape)
+}
+
+/// Rasterizes a `(w, h)` rounded-rect shape filled with `color` and box-blurs it
+/// on all four channels (unlike `render_shadow_shape`, a colored glow can't
+/// reduce to a single alpha channel) — see `Painter::fill_glow`'s cache, keyed
+/// on everything that determines these pixels.
+pub fn render_glow_shape(w: u32, h: u32, radius: i32, pad: i32, blur: f32, color: Color) -> Option<Pixmap> {
+    let (pw, ph) = (w as i32 + 2 * pad, h as i32 + 2 * pad);
+    if pw <= 0 || ph <= 0 {
+        return None;
+    }
+    let mut shape = Pixmap::new(pw as u32, ph as u32)?;
+    let path = rounded_rect_path(pad as f32, pad as f32, w as f32, h as f32, radius as f32)?;
+    shape.fill_path(
+        &path,
+        &solid_paint(color),
+        FillRule::Winding,
+        Transform::identity(),
+        None,
+    );
+
+    let (pwu, phu) = (pw as usize, ph as usize);
+    let mut data = shape.data().to_vec();
+    let mut scratch = vec![0u8; pwu * phu];
+    let radius_px = (blur / 2.0).round().max(1.0) as usize;
+    for _ in 0..3 {
+        for channel in 0..4 {
+            box_blur_channel(&mut data, &mut scratch, pwu, phu, channel, radius_px);
+        }
+    }
+    Pixmap::from_vec(data, IntSize::from_wh(pw as u32, ph as u32)?)
 }
 
 /// Separable box blur (horizontal pass into `tmp`, then vertical back into

--- a/src/ui/tiles.rs
+++ b/src/ui/tiles.rs
@@ -116,15 +116,28 @@ pub fn spinner_frame_at(phase: f32) -> (usize, &'static SpinnerFrame) {
     }
 }
 
-/// Transparent padding around the focus-ring tile (the ring's outer glow pass
-/// sits 6px out + stroke width).
-pub const FOCUS_RING_PAD: i32 = 12;
+/// Transparent padding around the focus-ring tile — must clear
+/// `FOCUS_GLOW_BLUR`'s blur radius or the glow clips against the canvas edge.
+pub const FOCUS_RING_PAD: i32 = 20;
 
 /// Focus-ring glow as shared tile (all cards same size). GPU scales + fades.
 pub fn render_focus_ring_tile(w: u32, h: u32) -> Painter {
     let pad = FOCUS_RING_PAD;
     let mut p = Painter::new(w + 2 * pad as u32, h + 2 * pad as u32);
     draw_focus_ring(&mut p, Rect::new(pad, pad, w, h), CARD_RADIUS);
+    p
+}
+
+/// Transparent padding around the card-outline tile — just enough for the
+/// stroke's own width/AA, not a blur radius like `FOCUS_RING_PAD`.
+pub const CARD_OUTLINE_PAD: i32 = 4;
+
+/// The focused card's crisp edge outline as a shared tile (all cards same
+/// size), composited on top of the card art — see `draw_card_outline`.
+pub fn render_card_outline_tile(w: u32, h: u32) -> Painter {
+    let pad = CARD_OUTLINE_PAD;
+    let mut p = Painter::new(w + 2 * pad as u32, h + 2 * pad as u32);
+    draw_card_outline(&mut p, Rect::new(pad, pad, w, h));
     p
 }
 


### PR DESCRIPTION
## Summary
- Card tiles/textures (`Tile::Card`, `App::card_tiles`) are now keyed by pin id (`GameEntry::id` / `store::DESKTOP_PIN_ID`) instead of grid index, so a pin/unpin reorder no longer forces every visible card to rebuild and re-upload — only positions change, existing tiles stay valid.
- Replaced the old "fly the snapshotted card from A to B" pin/unpin animation with the same synchronized pop-in used for a fresh library reveal, scoped to the newly pinned card (if any) plus the reshuffled unpinned section.
- Grid-index → pin-id resolution, previously duplicated across `App::pin_id_at_grid_idx`, an inline closure in `prepare_tiles`, and two inline matches in `draw_list`, is now a single `GridLayout::pin_id_at` method.
- Focused grid card now gets a soft blurred glow behind it (`Painter::fill_glow`, reusing the existing cached-shadow-shape/box-blur technique) instead of a hard double-outline ring, plus a separate crisp, unrounded outline composited on top of the card art (the art itself is a square blit, so a rounded outline would float outside its edge).

## Test plan
- [x] `task check` (cross Docker/Linux target) — clean
- [x] `task lint` (clippy) — clean
- [x] `task fmt`
- [ ] On-device: `task deploy TELEMETRY=auto` — verify pin/unpin animation and focus glow/outline look correct on the TV

🤖 Generated with [Claude Code](https://claude.com/claude-code)