### PR TITLE
Fix Diagnostics focus row rendering below modal after Settings scroll

### DIFF
--- a/src/app/diagnostics.rs
+++ b/src/app/diagnostics.rs
@@ -9,6 +9,8 @@ impl App {
     /// bottom of Settings (`ui::ROW_DIAGNOSTICS`), not a hidden/remote-button menu.
     pub(crate) fn open_diagnostics(&mut self) {
         self.diagnostics_focused = 0;
+        // Stash scroll so Back can restore it; Diagnostics doesn't use it.
+        self.settings_scroll = self.scroll;
         self.screen = Screen::Diagnostics;
     }
 


### PR DESCRIPTION
## Summary
- `open_diagnostics` never stashed `self.scroll` into `settings_scroll` before switching screens (unlike `open_about`, which does this correctly).
- On Back from Diagnostics, `self.scroll = self.settings_scroll` therefore restored a stale/default scroll offset while `settings_focused` still pointed at the (possibly scrolled-out-of-view) Diagnostics row, placing the focus tile below the modal's bounds.
- Fixed by stashing `self.scroll` into `settings_scroll` in `open_diagnostics`, mirroring `open_about`.

## Test plan
- [ ] `cargo check` passes (done)
- [ ] On-device: scroll Settings down, open Diagnostics, close it, confirm the focused row renders inside the modal without needing an Up/Down press to "fix" it

🤖 Generated with [Claude Code](https://claude.com/claude-code)