### PR TITLE
Add CPU%/RAM to stats overlay, backend name to header

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1122,6 +1122,7 @@ mod real {
             let mut overlay_last: Option<Instant> = None;
             let mut overlay_prev_frames: u64 = 0;
             let mut overlay_prev_bytes: u64 = 0;
+            let mut overlay_prev_cpu_ticks: Option<u64> = None;
             let mut overlay_prev_at = Instant::now();
             // 0 = "Disconnect" focused, 1 = "Cancel" (default on open — safer).
             let mut disconnect = DisconnectDialog::new();
@@ -1429,14 +1430,32 @@ mod real {
                         let mode = connected.client.mode();
                         let feed_ms = connected.stats.feed_us.load(Ordering::Relaxed) as f32 / 1000.0;
                         let holding = connected.stats.holding.load(Ordering::Relaxed);
-                        let lines = vec![
+                        // CPU% (of one core) + RSS; only read while the overlay is up.
+                        let cpu_mem_line = session::process_cpu_mem().map(|(cpu_ticks, mem_bytes)| {
+                            // No baseline on the first sample, so CPU shows only from the 2nd on.
+                            let cpu = overlay_prev_cpu_ticks.map(|prev| {
+                                let pct = (cpu_ticks.saturating_sub(prev)) as f32
+                                    / session::clock_ticks_per_sec() as f32
+                                    / dt
+                                    * 100.0;
+                                format!("CPU {pct:.0}% · ")
+                            });
+                            overlay_prev_cpu_ticks = Some(cpu_ticks);
                             format!(
-                                "{}x{}@{} {}{}",
+                                "{}RAM {:.0} MB",
+                                cpu.unwrap_or_default(),
+                                mem_bytes as f32 / (1024.0 * 1024.0)
+                            )
+                        });
+                        let mut lines = vec![
+                            format!(
+                                "{}x{}@{} {}{} · {}",
                                 mode.width,
                                 mode.height,
                                 mode.refresh_hz,
                                 session::codec_name(connected.client.codec),
                                 if connected.client.color.is_hdr() { " HDR" } else { "" },
+                                connected.backend_name,
                             ),
                             format!("Video {fps:.1} fps · {frames} frames"),
                             {
@@ -1462,6 +1481,9 @@ mod real {
                                 connected.client.resolved_bitrate_kbps / 1000,
                             ),
                         ];
+                        if let Some(line) = cpu_mem_line {
+                            lines.push(line);
+                        }
                         match crate::ui::render_stats_overlay_tile(
                             fonts.value,
                             fonts.caption,

--- a/src/session.rs
+++ b/src/session.rs
@@ -96,7 +96,7 @@ impl VideoPlayer {
 
     fn backend_name(&self) -> &'static str {
         match self {
-            Self::Starfish(_) => "Starfish/SMP",
+            Self::Starfish(_) => "Starfish",
             Self::Ndl(_) => "NDL",
         }
     }
@@ -113,6 +113,9 @@ pub struct Connected {
     audio_thread: Option<std::thread::JoinHandle<()>>,
     /// True when NDL accepted Opus config; prevents opening SDL2 audio device.
     pub audio_offloaded: bool,
+    /// Resolved decode backend name for the stats overlay — the *actual* player,
+    /// which can differ from the requested `VideoBackend` (Starfish falls back to NDL).
+    pub backend_name: &'static str,
 }
 
 /// Live video-pump counters for stats overlay (read at ~2Hz); relaxed atomics written per frame.
@@ -137,6 +140,28 @@ pub fn codec_name(codec: u8) -> &'static str {
         c if c == quic::CODEC_AV1 => "AV1",
         _ => "?",
     }
+}
+
+/// Process CPU time (user+sys clock ticks, see `clock_ticks_per_sec`) and resident
+/// memory (bytes), for the stats overlay's CPU/RAM line. Plain `/proc/self` reads.
+pub fn process_cpu_mem() -> Option<(u64, u64)> {
+    let stat = std::fs::read_to_string("/proc/self/stat").ok()?;
+    // `comm` (field 2) may contain spaces/parens, so split after the last ')'.
+    let after_comm = stat.rsplit_once(')')?.1;
+    let mut fields = after_comm.split_whitespace();
+    let utime: u64 = fields.nth(11)?.parse().ok()?;
+    let stime: u64 = fields.next()?.parse().ok()?;
+
+    let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+    let rss_pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as u64; // SAFETY: no pointers
+
+    Some((utime + stime, rss_pages * page_size))
+}
+
+/// Clock ticks per second, for converting `process_cpu_mem`'s ticks to seconds.
+pub fn clock_ticks_per_sec() -> u64 {
+    (unsafe { libc::sysconf(libc::_SC_CLK_TCK) } as u64).max(1) // SAFETY: no pointers
 }
 
 impl Connected {
@@ -433,6 +458,7 @@ pub fn connect(
         color.full_range,
     );
 
+    let backend_name = player.backend_name();
     let audio_offloaded = player.audio_offloaded();
     tracing::info!(
         "audio path: {} (host resolved {} channel(s))",
@@ -484,6 +510,7 @@ pub fn connect(
         video_thread,
         audio_thread,
         audio_offloaded,
+        backend_name,
     })
 }
 

--- a/src/ui/tiles.rs
+++ b/src/ui/tiles.rs
@@ -220,33 +220,38 @@ pub fn render_wrapped_text_tile(
     Ok(p)
 }
 
-/// A worst-case stat line, measured to fix the overlay's width — see
-/// `render_stats_overlay_tile`. The Drop/FEC/hold/buf line is the widest of the
-/// bunch once all four counters hit multiple digits.
-pub const STATS_OVERLAY_REF_LINE: &str = "Drop 99  FEC 99  hold yes  buf 99";
+/// Worst-case stat line used to lock overlay width.
+pub const STATS_OVERLAY_REF_LINE: &str = "3840x2160@120 HEVC HDR Starfish";
 
-/// In-stream stats overlay: translucent card with stat lines + Green-button hint.
-/// Width is FIXED (measured from `STATS_OVERLAY_REF_LINE`) so panel doesn't jitter
-/// as numbers change digit count. `lines[0]` is highlighted; rest muted.
+/// In-stream stats overlay with fixed width and centered hint.
+/// `lines[0]` is highlighted; remaining lines are muted.
 pub fn render_stats_overlay_tile(font: &Font, caption_font: &Font, lines: &[String], hint: &str) -> Result<Painter> {
     let pad = 18i32;
-    let safety = 16u32;
-    let line_h = font.height() + 6;
-    let hint_h = caption_font.height() + 8;
-    let inner_w = font.size_of(STATS_OVERLAY_REF_LINE).map_or(0, |(w, _)| w) + safety;
+    let content_safety = 16u32;
+    let line_font = font;
+    let line_h = line_font.height() + 6;
+    let caption_h = caption_font.height();
+    let hint_h = caption_h + 8;
+    let line_count = lines.len() as i32;
+
+    let inner_w = line_font.size_of(STATS_OVERLAY_REF_LINE).map_or(0, |(w, _)| w) + content_safety;
     let w = inner_w + 2 * pad as u32;
-    let h = (lines.len() as i32 * line_h + hint_h + 2 * pad) as u32;
+    let h = (line_count * line_h + hint_h + 2 * pad) as u32;
+    let content_w_i32 = w as i32 - 2 * pad;
+
     let mut p = Painter::new(w.max(1), h.max(1));
     let mut tc = TextCache::new();
     p.fill_rounded_rect(Rect::new(0, 0, w, h), 14, Color::RGBA(0x14, 0x10, 0x1f, 0x90));
+
     for (i, line) in lines.iter().enumerate() {
         let color = if i == 0 { WHITE } else { MUTED };
-        let clipped = ellipsize(font, line, inner_w);
-        draw_text(&mut p, &mut tc, font, &clipped, pad, pad + i as i32 * line_h, color)?;
+        let y = pad + i as i32 * line_h;
+        draw_text(&mut p, &mut tc, line_font, line, pad, y, color)?;
     }
-    let hint_y = pad + lines.len() as i32 * line_h + (hint_h - caption_font.height());
+
+    let hint_y = pad + line_count * line_h + (hint_h - caption_h);
     let hint_w = caption_font.size_of(hint).map_or(0, |(w, _)| w) as i32;
-    let hint_x = pad + (w as i32 - 2 * pad - hint_w) / 2;
+    let hint_x = pad + (content_w_i32 - hint_w) / 2;
     draw_text(&mut p, &mut tc, caption_font, hint, hint_x, hint_y, MUTED)?;
     Ok(p)
 }


### PR DESCRIPTION
## Summary
- Adds a CPU%/RAM line to the in-stream stats overlay (Green button), read from `/proc/self/stat`/`/proc/self/statm` only while the overlay is enabled — no always-on sampling.
- Adds the resolved decode backend name (NDL vs Starfish/SMP) to the overlay's header line.

## Test plan
- [ ] `task deploy TELEMETRY=auto` on the TV, toggle the stats overlay (Green button), confirm CPU%/RAM line appears and updates, and backend name shows correctly for both NDL and Starfish paths.