### PR TITLE
Gate HDR to HEVC; stop SDR streams forcing NDL HDR mode

### DIFF
--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -29,6 +29,7 @@ Hybrid software/GPU design: `tiny_skia` rasterizes tiles, SDL2 composites. Redra
 - **Loss recovery required** — no periodic IDRs in stream. `video_pump` calls `note_frame_index()` every frame (throttled RFI on gaps) + `request_keyframe()` backstop when `frames_dropped()` climbs.
 - **Freeze-until-reanchor adapted for NDL**: NDL does decode+present in one opaque call (no split); client reimplements skip-until-reanchor subset. Forward gap arms `holding` flag; frames withheld until one arrives with `FLAG_SOF` (IDR) or recovery anchor.
 - HDR mastering metadata can change mid-session — drain `next_hdr_meta` every frame.
+- **`NDL_DirectVideoSetHDRInfo` forces the panel into HDR mode on *any* call** (OLED65CX, webOS 5): it ignores the SDR `transfer`/`primaries` triplet and emits an HDR infoframe regardless, so an SDR/H.264 stream got shown in HDR picture mode. Fix: `ndl.rs::set_color_info` no-ops when `meta` is `None` (SDR) — only genuine HDR mastering metadata reaches NDL. Cost: NDL can no longer be used to fix a bitstream's missing VUI colour info; SDR relies on the bitstream VUI. HDR is also gated to HEVC end-to-end (`session::connect`: `apply_hdr = host_hdr && codec==H265`, and an explicit H.264 pick drops the HDR caps + hides the Settings toggle).
 
 ## Known platform limitations (don't retry)
 

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -30,6 +30,9 @@ impl App {
                     ui::apply_dropdown_choice(&mut self.settings, logical, choice);
                     self.dropdown_fade.close((row, dd.focused));
                     self.dropdown = None;
+                    // A codec change hides/shows the HDR row above; keep focus on the
+                    // row just edited rather than letting the shift slide it away.
+                    self.refocus_logical(logical);
                 }
                 MenuEvent::Back => {
                     self.dropdown_fade.close((row, dd.focused));
@@ -115,6 +118,19 @@ impl App {
                 self.switch_anim = Some((Instant::now(), from));
             }
         }
+        // Cycling the codec can hide/show the HDR row above; keep focus on `row`.
+        self.refocus_logical(row);
+    }
+
+    /// After a mutation that may have shown or hidden rows (a codec change toggles the
+    /// HDR row's visibility), re-derive the display index of `logical` so focus stays on
+    /// the same setting instead of sliding to whatever now occupies its old slot.
+    fn refocus_logical(&mut self, logical: usize) {
+        let rows = ui::settings_visible_logical_rows(&self.settings);
+        self.settings_focused = rows
+            .iter()
+            .position(|&r| r == logical)
+            .unwrap_or_else(|| self.settings_focused.min(rows.len().saturating_sub(1)));
     }
     /// Settings rows visible on screen (1080p card scrolls if needed). Capped at
     /// the live row count so a hidden row (Color range on NDL) leaves no empty slot.

--- a/src/ndl.rs
+++ b/src/ndl.rs
@@ -271,30 +271,32 @@ impl NdlVideo {
 
     /// Apply HDR mastering metadata. `meta` and `color` use the same SEI-standard
     /// units NDL expects (G/B/R order per ST.2086), so no conversion is needed.
-    /// Forwards the stream's colorimetry (and, for HDR, its mastering metadata)
-    /// to NDL. `meta: None` = an SDR stream: the mastering/light-level fields are
-    /// zeroed (the SEI "unknown" convention) and only the colour triplet
-    /// (transfer/primaries/matrix) is meaningful — without it, a bitstream with
-    /// missing/unspecified VUI colour info leaves the panel to guess colorimetry
-    /// from resolution, and a 4K SDR stream then decodes as BT.2020 instead of
-    /// the BT.709 punktfunk actually encodes (a visibly washed-out picture).
+    ///
+    /// `meta: None` (an SDR stream) is a **no-op**: on this platform
+    /// `NDL_DirectVideoSetHDRInfo` emits an HDR infoframe on *any* call — it ignores the
+    /// SDR `transfer`/`primaries` triplet and flips the panel into HDR picture mode
+    /// regardless (observed on OLED65CX with an H.264 SDR stream). So an SDR stream must
+    /// not call it at all; its colorimetry rides the bitstream VUI instead. (This means
+    /// NDL can't be used to correct a bitstream with missing/"unspecified" VUI colour
+    /// info — the earlier reason this was called unconditionally — but forcing the panel
+    /// into HDR for SDR content is the worse outcome.)
     pub fn set_color_info(
         &self,
         meta: Option<&punktfunk_core::quic::HdrMeta>,
         color: punktfunk_core::quic::ColorInfo,
     ) -> Result<()> {
-        // G/B/R order (ST.2086 convention; same as starfish.rs).
-        let ([g, b, r], white, max_dml, min_dml, cll, fall) = match meta {
-            Some(m) => (
-                m.display_primaries,
-                m.white_point,
-                m.max_display_mastering_luminance,
-                m.min_display_mastering_luminance,
-                m.max_cll,
-                m.max_fall,
-            ),
-            None => ([[0; 2]; 3], [0; 2], 0, 0, 0, 0),
+        let Some(m) = meta else {
+            return Ok(());
         };
+        // G/B/R order (ST.2086 convention; same as starfish.rs).
+        let ([g, b, r], white, max_dml, min_dml, cll, fall) = (
+            m.display_primaries,
+            m.white_point,
+            m.max_display_mastering_luminance,
+            m.min_display_mastering_luminance,
+            m.max_cll,
+            m.max_fall,
+        );
         let info = NdlHdrInfo {
             display_primaries_x0: c_int::from(g[0]),
             display_primaries_y0: c_int::from(g[1]),

--- a/src/session.rs
+++ b/src/session.rs
@@ -254,6 +254,11 @@ pub fn connect(
     codec_pref: CodecPref,
     color_range_override: ColorRangeOverride,
 ) -> Result<Connected> {
+    // HDR only ever applies to HEVC. An explicit H.264 pick disables it end to end
+    // (the Settings toggle is hidden too — see `ui::hdr_row_shown`); on Automatic the
+    // caps are still advertised and the host resolves the codec, with application gated
+    // on the *negotiated* codec being HEVC further below.
+    let hdr_enabled = hdr_enabled && codec_pref != CodecPref::H264;
     // VIDEO_CAP_CHACHA20: unconditional — armv7 has no hardware AES, so ChaCha20 is
     // faster. A ≥0.17.2 host picks it up; older hosts ignore the unknown bit.
     let video_caps = quic::VIDEO_CAP_CHACHA20
@@ -434,12 +439,17 @@ pub fn connect(
     // which shows up as exactly the washed-out/desaturated picture reported
     // on-device. `client.color` arrives out-of-band in `Welcome` for precisely
     // this purpose; HDR streams additionally carry mastering metadata.
-    let is_hdr = client.color.is_hdr();
+    // HDR mastering metadata is applied only when the *negotiated* codec is HEVC: the
+    // `NdlHdrInfo`/`setHdrInfo` fields are HEVC SEI syntax, and no other codec carries
+    // HDR on this platform. Colorimetry (the SDR washed-out fix) is still sent below for
+    // every codec — only the mastering metadata is gated.
+    let host_hdr = client.color.is_hdr();
+    let is_hdr = host_hdr && matches!(codec, NdlCodec::H265);
     let initial_meta = is_hdr.then(cx_display_hdr);
     // What the host actually signalled in `Welcome`, before any user override —
     // the reference point for the washed-out-colour investigation.
     tracing::info!(
-        "host colour info: hdr={is_hdr} transfer={} primaries={} matrix={} full_range={}",
+        "host colour info: hdr={host_hdr} apply_hdr={is_hdr} codec={codec:?} transfer={} primaries={} matrix={} full_range={}",
         client.color.transfer,
         client.color.primaries,
         client.color.matrix,

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -29,16 +29,20 @@ pub const BITRATE_WARN_KBPS: u32 = 150_000;
 pub const ROW_RESOLUTION: usize = 0;
 pub const ROW_FRAMERATE: usize = 1;
 pub const ROW_BITRATE: usize = 2;
-pub const ROW_HDR: usize = 3;
-pub const ROW_VIDEO_BACKEND: usize = 4;
-/// Directly below Video backend, deliberately: the AV1 option's availability depends
-/// on that row's value (see `codec_options`), and adjacency is what makes the
-/// dependency discoverable without explaining it in copy.
+pub const ROW_VIDEO_BACKEND: usize = 3;
+/// Directly below Video backend: only Starfish honours the VUI range flag, so the row
+/// is hidden on NDL (see `color_range_row_shown`) — adjacency keeps that dependency
+/// discoverable. Forces the VUI range flag sent to the decoder — see
+/// `store::ColorRangeOverride`. Debug aid for the washed-out-colour investigation.
+pub const ROW_COLOR_RANGE: usize = 4;
+/// Below Video backend, deliberately: the AV1 option's availability depends on that
+/// row's value (see `codec_options`), and adjacency is what makes the dependency
+/// discoverable without explaining it in copy.
 pub const ROW_CODEC: usize = 5;
-pub const ROW_AUDIO: usize = 6;
-/// Forces the VUI range flag sent to the decoder — see `store::ColorRangeOverride`.
-/// Debug aid for the washed-out-colour investigation.
-pub const ROW_COLOR_RANGE: usize = 7;
+/// Directly below Codec: HDR applies only to HEVC, so the row is hidden on an explicit
+/// H.264 pick (see `hdr_row_shown`) — adjacency keeps that dependency discoverable.
+pub const ROW_HDR: usize = 6;
+pub const ROW_AUDIO: usize = 7;
 /// Not a setting — a link to `Screen::Diagnostics` (log level + stats overlay).
 /// A debug aid, not something a normal user needs to find quickly.
 pub const ROW_DIAGNOSTICS: usize = 8;
@@ -71,22 +75,38 @@ pub fn color_range_row_shown(settings: &Settings) -> bool {
     settings.video_backend == VideoBackend::Starfish
 }
 
-/// Live row count (vs. `SETTINGS_ROW_COUNT`, the maximum).
-pub fn settings_row_count(settings: &Settings) -> usize {
-    if color_range_row_shown(settings) {
-        SETTINGS_ROW_COUNT
-    } else {
-        SETTINGS_ROW_COUNT - 1
-    }
+/// HDR only applies to HEVC — the host never resolves HDR for an explicit H.264
+/// session, and the toggle would be a no-op. On Automatic the row stays (the host may
+/// still resolve HEVC); it's hidden only when H.264 is picked explicitly. Application
+/// is gated on the *negotiated* codec too — see `session::connect`.
+pub fn hdr_row_shown(settings: &Settings) -> bool {
+    settings.codec != CodecPref::H264
 }
 
-/// On-screen row position -> logical `ROW_*` index, shifted past Color range when hidden.
+/// Logical `ROW_*` indices currently visible, in display order. Some rows are dropped
+/// (rather than shown disabled) depending on other settings — Color range off NDL, HDR
+/// on explicit H.264. Every visibility-aware helper derives from this one list.
+pub fn settings_visible_logical_rows(settings: &Settings) -> Vec<usize> {
+    (0..SETTINGS_ROW_COUNT)
+        .filter(|&row| match row {
+            ROW_HDR => hdr_row_shown(settings),
+            ROW_COLOR_RANGE => color_range_row_shown(settings),
+            _ => true,
+        })
+        .collect()
+}
+
+/// Live row count (vs. `SETTINGS_ROW_COUNT`, the maximum).
+pub fn settings_row_count(settings: &Settings) -> usize {
+    settings_visible_logical_rows(settings).len()
+}
+
+/// On-screen row position -> logical `ROW_*` index, skipping past any hidden rows.
 pub fn settings_logical_row(settings: &Settings, display: usize) -> usize {
-    if !color_range_row_shown(settings) && display >= ROW_COLOR_RANGE {
-        display + 1
-    } else {
-        display
-    }
+    settings_visible_logical_rows(settings)
+        .get(display)
+        .copied()
+        .unwrap_or(display)
 }
 
 pub fn color_range_label(o: ColorRangeOverride) -> &'static str {
@@ -163,25 +183,21 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             menu: None,
         },
         FocusRow {
-            icon: ICON_SUN,
-            label: "HDR".into(),
-            value: if settings.hdr_enabled {
-                "On".into()
-            } else {
-                "Off".into()
-            },
-            kind: RowKind::Toggle,
-            fraction: 0.0,
-            danger: false,
-            menu: None,
-        },
-        FocusRow {
             icon: ICON_MEMORY,
             label: "Video backend".into(),
             value: match settings.video_backend {
                 VideoBackend::Ndl => "NDL".into(),
                 VideoBackend::Starfish => "Starfish".into(),
             },
+            kind: RowKind::Dropdown,
+            fraction: 0.0,
+            danger: false,
+            menu: None,
+        },
+        FocusRow {
+            icon: ICON_PALETTE,
+            label: "Color range".into(),
+            value: color_range_label(settings.color_range_override).into(),
             kind: RowKind::Dropdown,
             fraction: 0.0,
             danger: false,
@@ -204,18 +220,22 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             menu: None,
         },
         FocusRow {
-            icon: ICON_SIGNAL,
-            label: "Audio".into(),
-            value: audio_label(settings.audio_channels),
-            kind: RowKind::Dropdown,
+            icon: ICON_SUN,
+            label: "HDR".into(),
+            value: if settings.hdr_enabled {
+                "On".into()
+            } else {
+                "Off".into()
+            },
+            kind: RowKind::Toggle,
             fraction: 0.0,
             danger: false,
             menu: None,
         },
         FocusRow {
-            icon: ICON_PALETTE,
-            label: "Color range".into(),
-            value: color_range_label(settings.color_range_override).into(),
+            icon: ICON_SIGNAL,
+            label: "Audio".into(),
+            value: audio_label(settings.audio_channels),
             kind: RowKind::Dropdown,
             fraction: 0.0,
             danger: false,
@@ -227,7 +247,11 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
         // every other punktfunk client puts version + licences at the very bottom.
         FocusRow::action_with_value(ICON_INFO, "About & licenses", format!("v{VERSION}")),
     ];
-    // Mirrors `settings_logical_row`: drop rather than disable when hidden.
+    // Mirrors `settings_visible_logical_rows`: drop rather than disable when hidden.
+    // Remove highest index first so an earlier removal doesn't shift a later one.
+    if !hdr_row_shown(settings) {
+        rows.remove(ROW_HDR);
+    }
     if !color_range_row_shown(settings) {
         rows.remove(ROW_COLOR_RANGE);
     }


### PR DESCRIPTION
Gates HDR to HEVC (hides toggle on explicit H.264, applies only when HEVC negotiated), reorders Settings rows, and no-ops NDL `set_color_info` for SDR so SDR/H.264 streams no longer force the panel into HDR mode.