### PR TITLE
Add experimental video pacing (PtsPacer)

### DIFF
--- a/src/app/diagnostics.rs
+++ b/src/app/diagnostics.rs
@@ -26,12 +26,10 @@ impl App {
         ui::list_modal_card_rect(screen_w, screen_h, fonts, subtitle, ui::DIAGNOSTICS_ROW_COUNT)
     }
 
-    /// Three rows (`ui::DIAG_ROW_*`): Log level (Left/Right cycles, Confirm opens the
-    /// same dropdown picker every `Settings` dropdown uses — its row `0` is
-    /// disambiguated from `Settings`' row 0 by `self.screen`, see
-    /// `dropdown_overlay_tile`'s docs), Stats overlay, and Show logs (both
-    /// Left/Right/Confirm toggle). Back saves and returns to Settings — this is
-    /// reached from there.
+    /// `ui::DIAG_ROW_*` rows: Log level opens the same dropdown picker every
+    /// `Settings` dropdown uses (its row `0` is disambiguated from `Settings`' row 0
+    /// by `self.screen`, see `dropdown_overlay_tile`'s docs); the rest are plain
+    /// Left/Right/Confirm toggles. Back saves and returns to Settings.
     pub(crate) fn handle_diagnostics_event(&mut self, ev: MenuEvent) {
         if let Some(dd) = self.dropdown.as_mut() {
             let len = ui::LOG_LEVEL_OPTIONS.len();

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -111,6 +111,7 @@ impl App {
         let row = ui::settings_logical_row(&self.settings, display_row);
         let toggled_from = match row {
             ui::ROW_HDR => Some(self.settings.hdr_enabled),
+            ui::ROW_VIDEO_PACING => Some(self.settings.video_pacing),
             _ => None,
         };
         if ui::adjust_setting(&mut self.settings, row, forward) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,7 @@ mod real {
                     settings.video_backend,
                     settings.codec,
                     settings.color_range_override,
+                    settings.video_pacing,
                 )
             })
             .context("spawn connect thread")
@@ -522,6 +523,14 @@ mod real {
                     const WHEEL_STEP: i32 = 120;
                     *dirty |= app.scroll_grid_by(-wheel_y * WHEEL_STEP, w, h);
                 }
+                // List-modal screens (row-per-page, not pixel scroll): one detent
+                // moves focus exactly one row, same as an Up/Down key press.
+                Screen::Settings | Screen::HostMenu | Screen::WakeSettings | Screen::Diagnostics
+                    if wheel_y != 0 =>
+                {
+                    let menu_ev = if wheel_y > 0 { MenuEvent::Up } else { MenuEvent::Down };
+                    dispatch_menu_event(app, menu_ev, display_mode, fonts);
+                }
                 _ => {}
             }
             return EventAction::Next;
@@ -769,7 +778,11 @@ mod real {
                 app.launch_anim = Some(Instant::now());
                 dirty = true;
                 if let Some(target) = app.take_ready_launch() {
-                    let settings = store::load_settings();
+                    // In-memory settings, not `store::load_settings()`: a just-flipped
+                    // toggle (e.g. video pacing) is persisted asynchronously by
+                    // `SettingsWriter`, so re-reading disk here could race the write and
+                    // connect with the stale value. `app.settings` is updated synchronously.
+                    let settings = app.settings;
                     let handle = spawn_connect(
                         identity.clone(),
                         target.host,
@@ -1117,6 +1130,10 @@ mod real {
             // Settings-screen default; the Green button below flips it live for the rest
             // of this stream only, without writing back to `settings`.
             let mut stats_enabled = settings.stats_overlay;
+            // Not live-toggleable like `stats_enabled` — pacing takes effect at connect
+            // time (`spawn_connect`'s `session::connect` call), so flipping it mid-stream
+            // wouldn't do anything.
+            let pacing_enabled = settings.video_pacing;
             let mut green_held = false;
             let mut yellow_held = false;
             let mut overlay_last: Option<Instant> = None;
@@ -1483,6 +1500,11 @@ mod real {
                         ];
                         if let Some(line) = cpu_mem_line {
                             lines.push(line);
+                        }
+                        if pacing_enabled {
+                            let delta_ms =
+                                connected.stats.pacing_delta_ns.load(Ordering::Relaxed) as f32 / 1_000_000.0;
+                            lines.push(format!("Pace {delta_ms:+.1} ms (experimental)"));
                         }
                         match crate::ui::render_stats_overlay_tile(
                             fonts.value,

--- a/src/ndl.rs
+++ b/src/ndl.rs
@@ -254,11 +254,15 @@ impl NdlVideo {
         Ok(())
     }
 
-    /// Feed one access unit. The host's `pts_ns` is deliberately ignored — NDL wants
-    /// milliseconds since `load`, not wall-clock or the host's capture clock, so the
-    /// PTS is derived from `load_instant` instead (see the [`NdlVideo`] doc comment).
-    pub fn play(&self, au: &[u8]) -> Result<()> {
-        let pts_ms = self.load_instant.elapsed().as_millis() as c_longlong;
+    /// Nanoseconds since `load()` (NDL PTS domain). `video_pump`'s pacer clamps its accumulator around this.
+    pub(crate) fn elapsed_ns(&self) -> u64 {
+        self.load_instant.elapsed().as_nanos() as u64
+    }
+
+    /// Feed one access unit at `pts_ns` (ns since `load()`), truncated to ms for NDL.
+    /// Pass a paced value, not raw `elapsed_ns()`, to preserve inter-frame spacing.
+    pub fn play(&self, au: &[u8], pts_ns: u64) -> Result<()> {
+        let pts_ms = (pts_ns / 1_000_000) as c_longlong;
         let _ffi = self.ffi.lock().expect("NDL FFI mutex poisoned");
         // SAFETY: NDL reads `size` bytes from `buffer` synchronously and does not
         // retain the pointer.

--- a/src/session.rs
+++ b/src/session.rs
@@ -47,13 +47,26 @@ enum VideoPlayer {
 
 impl VideoPlayer {
     /// Feed access unit; return (result, `feed_duration`) for ABR latency reporting.
+    /// `pts_ns` must already be in this backend's PTS clock domain (see
+    /// [`Self::pace_base_ns`]).
     fn play(&self, au: &[u8], pts_ns: u64) -> (anyhow::Result<()>, Duration) {
         let t = Instant::now();
         let result = match self {
             Self::Starfish(sf) => sf.play(au, pts_ns),
-            Self::Ndl(ndl) => ndl.play(au),
+            Self::Ndl(ndl) => ndl.play(au, pts_ns),
         };
         (result, t.elapsed())
+    }
+
+    /// Unpaced PTS reference for `frame` in this backend's clock domain: nanoseconds
+    /// since `load()` for NDL (it has none of its own — see `NdlVideo::elapsed_ns`),
+    /// or the host's capture-clock PTS untouched for Starfish. [`PtsPacer`] smooths
+    /// this before it reaches [`Self::play`].
+    fn pace_base_ns(&self, frame_pts_ns: u64) -> u64 {
+        match self {
+            Self::Starfish(_) => frame_pts_ns,
+            Self::Ndl(ndl) => ndl.elapsed_ns(),
+        }
     }
 
     fn flush(&self) -> anyhow::Result<()> {
@@ -130,6 +143,8 @@ pub struct StreamStats {
     pub feed_us: std::sync::atomic::AtomicU32,
     /// NDL render-buffer backlog or -1 if unavailable.
     pub render_backlog: std::sync::atomic::AtomicI32,
+    /// Latency `PtsPacer` added vs. the unpaced reference (ns); 0 when pacing is off.
+    pub pacing_delta_ns: std::sync::atomic::AtomicI64,
 }
 
 /// Short display name for a resolved wire codec id (the stats overlay's header).
@@ -253,6 +268,7 @@ pub fn connect(
     video_backend: VideoBackend,
     codec_pref: CodecPref,
     color_range_override: ColorRangeOverride,
+    video_pacing: bool,
 ) -> Result<Connected> {
     // HDR only ever applies to HEVC. An explicit H.264 pick disables it end to end
     // (the Settings toggle is hidden too — see `ui::hdr_row_shown`); on Automatic the
@@ -496,6 +512,7 @@ pub fn connect(
                 video_stats,
                 is_hdr,
                 color_range_override,
+                video_pacing,
             )
         })
         .context("spawn video thread")?;
@@ -797,6 +814,62 @@ const FEED_BACKPRESSURE_WARN: Duration = Duration::from_millis(20);
 /// three samples per 750 ms report window; see the fold in [`video_pump`].
 const BACKLOG_POLL: Duration = Duration::from_millis(250);
 
+/// Max drift ([`PtsPacer`]) from the unpaced reference, as a fraction of one frame
+/// interval — same figure aurora-tv ships as `SS4S_SMOOTH_PACING_MAX_DRIFT_FRAMES` for
+/// these same NDL/Starfish backends.
+const PACE_MAX_DRIFT_FRAMES: f64 = 0.5;
+/// Minimum step between successive paced PTS values, so NDL's ms-truncation
+/// (`NdlVideo::play`) never sees two equal/decreasing timestamps in a row.
+const PACE_MIN_STEP_NS: u64 = 1_000_000;
+
+/// Smooths the PTS fed to the decoder against delivery jitter — an "ideal" value
+/// advances by a fixed frame interval each call, clamped to a small drift window
+/// around the real (unpaced) reference (see [`VideoPlayer::pace_base_ns`]). Changes
+/// only *what* timestamp is attached, never *when* `play()` runs — the decoder
+/// schedules presentation off the PTS itself, so a burst of frames landing together
+/// still gets spaced one interval apart instead of stamped with ~the same time. Same
+/// technique as aurora-tv's `SS4S_SMOOTH_PACING`.
+struct PtsPacer {
+    interval_ns: u64,
+    max_drift_ns: u64,
+    ideal_ns: Option<u64>,
+}
+
+impl PtsPacer {
+    fn new(interval_ns: u64) -> Self {
+        Self {
+            interval_ns,
+            max_drift_ns: (interval_ns as f64 * PACE_MAX_DRIFT_FRAMES) as u64,
+            ideal_ns: None,
+        }
+    }
+
+    /// Drops the accumulator — call after a freeze-until-reanchor hold, where the real
+    /// timeline just jumped and there's no "ideal" continuation worth preserving.
+    fn reset(&mut self) {
+        self.ideal_ns = None;
+    }
+
+    /// Next paced PTS (ns) for `base_ns`, this frame's unpaced reference value. The
+    /// first call after construction/reset anchors on `base_ns` verbatim; each later
+    /// call advances one interval from the previous paced value, clamped to the drift
+    /// window around `base_ns` and floored to a strictly-increasing step.
+    fn next(&mut self, base_ns: u64) -> u64 {
+        let paced = match self.ideal_ns {
+            None => base_ns,
+            Some(prev) => prev
+                .saturating_add(self.interval_ns)
+                .clamp(
+                    base_ns.saturating_sub(self.max_drift_ns),
+                    base_ns.saturating_add(self.max_drift_ns),
+                )
+                .max(prev.saturating_add(PACE_MIN_STEP_NS)),
+        };
+        self.ideal_ns = Some(paced);
+        paced
+    }
+}
+
 /// Suffix identifying a `GStreamer` pad-task thread (`"<element-name>:<pad-name>"`,
 /// truncated to the kernel's 15-char `comm` limit) — both the NDL and Starfish vendor
 /// `.so`s build their internal decode pipeline out of `GStreamer` elements, each with its
@@ -884,6 +957,7 @@ fn video_pump(
     stats: Arc<StreamStats>,
     is_hdr: bool,
     color_range_override: ColorRangeOverride,
+    video_pacing: bool,
 ) {
     client.register_hot_thread();
     // Summarized at info, not left as per-tid debug lines: whether these renices work at
@@ -924,6 +998,9 @@ fn video_pump(
     // query is cheap enough for per-frame use is exactly the mistake docs/NOTES.md warns
     // against; between polls the cached depth is reused.
     let frame_period_us = 1_000_000 / u64::from(client.mode().refresh_hz.max(1));
+    // Only instantiated when the setting is on — off means no pacer state at all and a
+    // bit-for-bit-unchanged PTS (the raw per-backend reference reaches `play` directly).
+    let mut pacer = video_pacing.then(|| PtsPacer::new(frame_period_us * 1_000));
     let mut backlog_cached: u64 = 0;
     let mut last_backlog_poll: Option<Instant> = None;
     let mut last_dropped_seen = client.frames_dropped();
@@ -1001,12 +1078,26 @@ fn video_pump(
                             frame.frame_index,
                             frame.flags,
                         );
+                        // The real timeline just jumped (freeze then reanchor/give-up) —
+                        // nothing about the pre-hold accumulator is worth continuing.
+                        if let Some(pacer) = pacer.as_mut() {
+                            pacer.reset();
+                        }
                     }
                     holding = false;
                     stats.holding.store(false, Ordering::Relaxed);
                     hold_started = None;
 
-                    let pts_ns = frame.pts_ns;
+                    let base_ns = player.pace_base_ns(frame.pts_ns);
+                    let pts_ns = if let Some(pacer) = pacer.as_mut() {
+                        let paced = pacer.next(base_ns);
+                        stats
+                            .pacing_delta_ns
+                            .store(paced as i64 - base_ns as i64, Ordering::Relaxed);
+                        paced
+                    } else {
+                        base_ns
+                    };
                     let (play_result, feed_elapsed) = player.play(&frame.data, pts_ns);
                     stats.feed_us.store(
                         u32::try_from(feed_elapsed.as_micros()).unwrap_or(u32::MAX),

--- a/src/store.rs
+++ b/src/store.rs
@@ -257,6 +257,10 @@ pub struct Settings {
     /// which stays ephemeral and never writes here.
     #[serde(default)]
     pub show_logs: bool,
+    /// Experimental PTS smoothing for the video pump (see `session::PtsPacer`). Off
+    /// by default — untested on real hardware; takes effect on the next stream.
+    #[serde(default)]
+    pub video_pacing: bool,
 }
 
 fn default_audio_channels() -> u8 {
@@ -282,6 +286,7 @@ impl Default for Settings {
             color_range_override: ColorRangeOverride::Auto,
             log_level_override: LogLevelOverride::Info,
             show_logs: false,
+            video_pacing: false,
         }
     }
 }
@@ -323,25 +328,36 @@ pub fn save_settings(settings: &Settings) -> Result<()> {
 /// out of order the way N independently-spawned threads racing the filesystem could.
 pub struct SettingsWriter {
     pending: std::sync::Arc<(std::sync::Mutex<Option<Settings>>, std::sync::Condvar)>,
+    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// `None` only after `Drop` has taken and joined it.
+    thread: Option<std::thread::JoinHandle<()>>,
 }
 
 impl SettingsWriter {
     pub fn spawn() -> Self {
         let state = std::sync::Arc::new((std::sync::Mutex::new(None::<Settings>), std::sync::Condvar::new()));
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let worker_state = state.clone();
-        std::thread::spawn(move || {
+        let worker_stop = stop.clone();
+        let thread = std::thread::spawn(move || {
             let (lock, cvar) = &*worker_state;
             loop {
                 let mut guard = lock.lock().expect("settings-writer mutex poisoned");
-                while guard.is_none() {
+                while guard.is_none() && !worker_stop.load(std::sync::atomic::Ordering::Relaxed) {
                     guard = cvar.wait(guard).expect("settings-writer mutex poisoned");
                 }
-                let settings = guard.take().expect("just checked Some");
+                let Some(settings) = guard.take() else {
+                    return; // stopped with nothing pending
+                };
                 drop(guard);
                 let _ = save_settings(&settings);
             }
         });
-        Self { pending: state }
+        Self {
+            pending: state,
+            stop,
+            thread: Some(thread),
+        }
     }
 
     /// Queues `settings` to be written, replacing any not-yet-written value already
@@ -350,6 +366,19 @@ impl SettingsWriter {
         let (lock, cvar) = &*self.pending;
         *lock.lock().expect("settings-writer mutex poisoned") = Some(settings);
         cvar.notify_one();
+    }
+}
+
+impl Drop for SettingsWriter {
+    /// Wakes the worker with `stop` set so it exits after flushing any pending save,
+    /// then joins it — otherwise every menu re-entry (a fresh `App`, a fresh
+    /// `SettingsWriter`) leaked one thread parked forever on the `Condvar`.
+    fn drop(&mut self) {
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        self.pending.1.notify_one();
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
     }
 }
 

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -43,14 +43,17 @@ pub const ROW_CODEC: usize = 5;
 /// H.264 pick (see `hdr_row_shown`) — adjacency keeps that dependency discoverable.
 pub const ROW_HDR: usize = 6;
 pub const ROW_AUDIO: usize = 7;
+/// Experimental PTS smoothing (`session::PtsPacer`) — off by default, untested on
+/// real hardware; the "(experimental)" suffix in its label is the user-facing warning.
+pub const ROW_VIDEO_PACING: usize = 8;
 /// Not a setting — a link to `Screen::Diagnostics` (log level + stats overlay).
 /// A debug aid, not something a normal user needs to find quickly.
-pub const ROW_DIAGNOSTICS: usize = 8;
+pub const ROW_DIAGNOSTICS: usize = 9;
 /// Not a setting — a link to `Screen::About`. Sits last: every other punktfunk
 /// client puts the version + licences at the very bottom of Settings, and a
 /// `RowKind::Action` row costs nothing extra to render.
-pub const ROW_ABOUT: usize = 9;
-pub const SETTINGS_ROW_COUNT: usize = 10;
+pub const ROW_ABOUT: usize = 10;
+pub const SETTINGS_ROW_COUNT: usize = 11;
 
 /// Diagnostics modal row indices (see `diagnostics_rows`). Log level keeps index
 /// 0 so its dropdown's `(Screen, row)` tile key stays stable.
@@ -237,6 +240,15 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             label: "Audio".into(),
             value: audio_label(settings.audio_channels),
             kind: RowKind::Dropdown,
+            fraction: 0.0,
+            danger: false,
+            menu: None,
+        },
+        FocusRow {
+            icon: ICON_SCHEDULE,
+            label: "Video pacing (experimental)".into(),
+            value: if settings.video_pacing { "On".into() } else { "Off".into() },
+            kind: RowKind::Toggle,
             fraction: 0.0,
             danger: false,
             menu: None,
@@ -505,6 +517,10 @@ pub fn adjust_setting(settings: &mut Settings, row_index: usize, forward: bool) 
         }
         ROW_HDR => {
             settings.hdr_enabled = !settings.hdr_enabled;
+            true
+        }
+        ROW_VIDEO_PACING => {
+            settings.video_pacing = !settings.video_pacing;
             true
         }
         ROW_VIDEO_BACKEND => {


### PR DESCRIPTION
## Summary

Adds a client-side PTS smoothing layer for the video pump, gated behind a Settings toggle — **off by default, untested on real hardware** (needs an on-device `task deploy TELEMETRY=auto` pass before it's validated or turned on by default).

- `PtsPacer` (`session.rs`): an "ideal" PTS accumulator that advances one nominal frame interval per call, clamped to a ±0.5-frame drift window around the per-backend unpaced reference, with a 1ms monotonic floor. Instantiated **only when the toggle is on** (`Option<PtsPacer>`); when off, the raw reference reaches `play()` bit-for-bit unchanged.
- `NdlVideo::play` now takes an explicit `pts_ns` (was always stamping "now", discarding burst spacing); added `elapsed_ns()`.
- Settings row **"Video pacing (experimental)"**; takes effect at connect time (like HDR/backend/codec), not live-toggleable. Stats overlay gains a `Pace ±X.X ms` line when on.

## Also folded in (unrelated fixes)

- **`SettingsWriter` thread leak**: now signals + joins its worker on `Drop` instead of leaking a thread parked on the condvar per menu re-entry.
- **Mouse wheel** moves focus one row on list-modal screens (Settings/HostMenu/WakeSettings/Diagnostics).
- **Connect reads in-memory `app.settings`** instead of re-reading disk, so a just-flipped toggle can't race the async settings write.

## Testing

`task check` + `task lint` clean (cross-toolchain). No on-device validation yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)