### PR TITLE
Keep the log overlay off the streaming hot loop

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -165,16 +165,22 @@ pub fn log_file_path(app_dir: &Path) -> std::path::PathBuf {
     app_dir.join(format!("punktfunk-webos-{VERSION}.log"))
 }
 
-/// The newest log file to upload — the active file, or the most recently modified
-/// rotation if there's no active file (e.g. a TCP-telemetry session wrote none).
-/// `None` if nothing has been logged to disk at all.
+/// The newest log file to upload, by mtime, across all rotations and app versions —
+/// a version bump changes `VERSION` in `log_file_path`, so scanning only the current
+/// name would orphan older logs. `None` if nothing has been logged yet.
 pub fn latest_log_file(app_dir: &Path) -> Option<std::path::PathBuf> {
-    let base = log_file_path(app_dir);
-    (0..=MAX_LOG_ROTATIONS)
-        .map(|n| if n == 0 { base.clone() } else { numbered_log(&base, n) })
-        .filter_map(|p| {
-            let meta = p.metadata().ok()?;
-            (meta.len() > 0).then(|| (p, meta.modified().ok()))
+    std::fs::read_dir(app_dir)
+        .ok()?
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with("punktfunk-webos-") && name.contains(".log"))
+        })
+        .filter_map(|entry| {
+            let meta = entry.metadata().ok()?;
+            (meta.len() > 0).then(|| (entry.path(), meta.modified().ok()))
         })
         .max_by_key(|(_, mtime)| *mtime)
         .map(|(p, _)| p)

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,12 +220,9 @@ mod real {
         match log_overlay_state() {
             LogOverlayState::Off => None,
             LogOverlayState::Live => Some(crate::logger::recent_lines(crate::ui::LOG_OVERLAY_LINES)),
-            LogOverlayState::Frozen => Some(
-                frozen_log_lines()
-                    .lock()
-                    .unwrap_or_else(PoisonError::into_inner)
-                    .clone(),
-            ),
+            LogOverlayState::Frozen => {
+                Some(frozen_log_lines().lock().unwrap_or_else(PoisonError::into_inner).clone())
+            }
         }
     }
 
@@ -1715,12 +1712,15 @@ mod real {
                 // trigger/lightbar effects via the Bluetooth service. Called unconditionally
                 // so both planes keep draining even with no pad attached — see the fn's docs.
                 session::pump_feedback_once(&connected.client, controller.as_mut(), ds_feedback.as_mut());
-                // Skipped whenever the dialog block drew this tick (open or still
-                // fading out) — its own redraw above already owns the canvas. Stats
-                // and the log overlay share one clear/execute/present: each does its
-                // own `canvas.clear()` otherwise, which would erase whichever tile the
-                // other just drew.
-                let log_lines = log_overlay_lines();
+                // Skipped whenever the dialog block drew this tick (open or still fading
+                // out) — its own redraw above already owns the canvas. Stats and the log
+                // overlay share one clear/execute/present so neither erases the other's
+                // tile with its own `canvas.clear()`.
+                //
+                // `log_overlay_lines()` is deferred to the throttled block below rather
+                // than called every ~2ms tick — it locks the same ring-buffer mutex every
+                // log call writes to, which was contending with log writes ~500x/s and
+                // stuttering this thread's input polling.
                 let notif_frame = if dialog_frame.is_none() { notif.frame() } else { None };
                 let notif_active = notif_frame.is_some();
                 // Stats/log fade in on their toggle and fade out the same way the toast does
@@ -1853,11 +1853,11 @@ mod real {
                             });
                         }
                     }
-                    // Re-rendered only while actually on (`log_lines` is `None` during the
-                    // fade-out, once the toggle has already flipped the state to Off) — the
-                    // fade keeps recompositing the last uploaded tile via `log_dst`.
-                    if let Some(lines) = &log_lines {
-                        match crate::ui::render_log_overlay_tile(fonts.caption, display_mode.w as u32, lines) {
+                    // Re-rendered only while actually on (`None` during the fade-out, once
+                    // the toggle has already flipped the state to Off) — the fade keeps
+                    // recompositing the last uploaded tile via `log_dst`.
+                    if let Some(lines) = log_overlay_lines() {
+                        match crate::ui::render_log_overlay_tile(fonts.caption, display_mode.w as u32, &lines) {
                             Ok(tile) => {
                                 let (tw, th) = (tile.width(), tile.height());
                                 compositor.upload(&texture_creator, Tile::LogOverlay, &tile)?;

--- a/src/ui/tiles.rs
+++ b/src/ui/tiles.rs
@@ -241,7 +241,7 @@ pub fn render_stats_overlay_tile(font: &Font, caption_font: &Font, lines: &[Stri
 
     let mut p = Painter::new(w.max(1), h.max(1));
     let mut tc = TextCache::new();
-    p.fill_rounded_rect(Rect::new(0, 0, w, h), 14, Color::RGBA(0x14, 0x10, 0x1f, 0x90));
+    p.fill_rounded_rect(Rect::new(0, 0, w, h), 14, Color::RGBA(0x14, 0x10, 0x1f, 0x70));
 
     for (i, line) in lines.iter().enumerate() {
         let color = if i == 0 { WHITE } else { MUTED };
@@ -257,7 +257,7 @@ pub fn render_stats_overlay_tile(font: &Font, caption_font: &Font, lines: &[Stri
 }
 
 /// Number of lines shown in the log-tail overlay.
-pub const LOG_OVERLAY_LINES: usize = 12;
+pub const LOG_OVERLAY_LINES: usize = 9;
 
 /// Color for log line by level prefix; errors/warnings highlighted to stand out.
 fn log_line_color(line: &str) -> Color {
@@ -272,8 +272,9 @@ fn log_line_color(line: &str) -> Color {
 /// Left indent for a wrapped log line's 2nd+ row, so it reads as a continuation.
 const LOG_OVERLAY_WRAP_INDENT: i32 = 20;
 
-/// Full-width log-tail at screen bottom (all screens, unlike stats overlay).
-/// Long lines word-wrap instead of clipping.
+/// Full-width log-tail at screen bottom (all screens, unlike stats overlay) — a
+/// constant left-to-right size regardless of content. Long lines word-wrap
+/// instead of clipping, only once they'd actually reach the screen edge.
 pub fn render_log_overlay_tile(font: &Font, screen_w: u32, lines: &[String]) -> Result<Painter> {
     let pad = 14i32;
     let line_h = font.height() + 4;
@@ -291,7 +292,7 @@ pub fn render_log_overlay_tile(font: &Font, screen_w: u32, lines: &[String]) -> 
     p.fill_rounded_rect(
         Rect::new(0, 0, screen_w.max(1), h),
         14,
-        Color::RGBA(0x14, 0x10, 0x1f, 0x90),
+        Color::RGBA(0x14, 0x10, 0x1f, 0xb8),
     );
     let mut row = 0i32;
     for (wrapped_rows, color) in &wrapped {


### PR DESCRIPTION
The streaming loop was reading the log ring buffer on every ~2ms event tick, so it contended with concurrent log writes (~500x/s) and added stutter to input forwarding. Now that read only happens inside the throttled overlay block (≤~30Hz). Also `latest_log_file` now scans all rotations/versions by mtime so a version bump doesn't orphan older logs, plus minor overlay cosmetics (shorter tail, alpha tweaks).