### PR TITLE
Unify confirm-dialog modals

### DIFF
--- a/src/app/forget.rs
+++ b/src/app/forget.rs
@@ -2,7 +2,6 @@
 use super::*;
 use crate::ui::{self, HostEntry, MenuEvent, Painter};
 use anyhow::Result;
-use sdl2::rect::Rect;
 use std::time::Instant;
 
 impl App {
@@ -48,13 +47,6 @@ impl App {
             MenuEvent::Up | MenuEvent::Down | MenuEvent::Secondary => {}
         }
     }
-    /// Forget confirmation card rect (shared by render and hit-testing).
-    pub(crate) fn forget_host_card_rect(screen_w: u32, screen_h: u32, name: &str, fonts: &ui::Fonts) -> Rect {
-        Self::simple_modal_card(screen_w, screen_h, |probe| {
-            let header_end = ui::modal_header_end_y(fonts.label, fonts.value, probe, &Self::forget_host_subtitle(name));
-            (header_end + 32 + 72 + 32) as u32
-        })
-    }
     pub(crate) fn render_forget_host(
         &self,
         painter: &mut Painter,
@@ -70,7 +62,7 @@ impl App {
         else {
             return Ok(());
         };
-        let card = Self::forget_host_card_rect(screen_w, screen_h, name, fonts);
+        let (card, content) = ui::confirm_dialog_layout(screen_w, screen_h, fonts, &Self::forget_host_subtitle(name));
         self.draw_modal_shell(painter, text_cache, fonts.icon, card)?;
 
         ui::draw_modal_header(
@@ -85,7 +77,6 @@ impl App {
             ui::MUTED,
         )?;
 
-        let content = Self::forget_host_content_rect(card, name, fonts);
         ui::draw_confirm_buttons(painter, text_cache, fonts, content, &Self::forget_buttons(), usize::MAX)?;
         Ok(())
     }
@@ -99,20 +90,5 @@ impl App {
 
     pub(crate) fn forget_host_subtitle(name: &str) -> String {
         format!("{name} will be removed from this TV. You can pair with it again later.")
-    }
-
-    /// The Forget/Cancel button row's rect — depends on the host-name
-    /// subtitle's wrapped height, computed via `ui::modal_header_end_y`
-    /// without drawing so `prepare_tiles`/`draw_list` can position the
-    /// focused-button tile without re-rendering the header.
-    pub(crate) fn forget_host_content_rect(card: Rect, name: &str, fonts: &ui::Fonts) -> Rect {
-        let after_subtitle_y =
-            ui::modal_header_end_y(fonts.label, fonts.value, card, &Self::forget_host_subtitle(name));
-        Rect::new(
-            card.x() + 32,
-            after_subtitle_y + 32,
-            card.width().saturating_sub(64),
-            72,
-        )
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1028,6 +1028,27 @@ impl App {
         focus_changed || close_changed
     }
 
+    /// Button index under `(x, y)` for a two-button confirm modal with `subtitle`, or
+    /// `None` off both buttons — every confirm modal's hover arm shares this, against the
+    /// same `confirm_dialog_layout` geometry the modal is drawn with.
+    fn confirm_button_at(screen_w: u32, screen_h: u32, fonts: &ui::Fonts, subtitle: &str, x: i32, y: i32) -> Option<usize> {
+        let (_, content) = ui::confirm_dialog_layout(screen_w, screen_h, fonts, subtitle);
+        ui::confirm_button_at(content, x, y)
+    }
+
+    /// Rect of confirm button `index` for a two-button modal with `subtitle` — the shared
+    /// geometry the focused-button tile and its hit-rect are positioned against.
+    fn confirm_focus_button_rect(
+        screen_w: u32,
+        screen_h: u32,
+        fonts: &ui::Fonts,
+        subtitle: &str,
+        index: usize,
+    ) -> Rect {
+        let (_, content) = ui::confirm_dialog_layout(screen_w, screen_h, fonts, subtitle);
+        ui::confirm_button_rect(content, index)
+    }
+
     /// Moves the positional focus/selection onto whatever interactive element sits
     /// under the pointer, so the Magic Remote's pointer highlights elements on hover
     /// exactly where a click would land. Returns whether the selection actually
@@ -1127,18 +1148,17 @@ impl App {
                     false
                 }
             }
-            // Two-button confirm modals: hovering a button focuses it so the pointer
-            // can pick Forget-vs-Cancel / Send-vs-Cancel, not just confirm whatever
-            // the D-pad last focused.
+            // Two-button confirm modals (Forget/SendLogs/Wake — the same modal type as the
+            // in-stream Disconnect dialog): hovering a button focuses it, so the pointer can
+            // pick action-vs-Cancel, not just confirm whatever the D-pad last focused. All
+            // three share `confirm_button_at`; only the focus field they set differs.
             Screen::ForgetHost => {
                 let name = self
                     .host_menu_index
                     .and_then(|i| self.entries.get(i))
                     .map(HostEntry::name)
                     .unwrap_or_default();
-                let card = Self::forget_host_card_rect(screen_w, screen_h, name, fonts);
-                let content = Self::forget_host_content_rect(card, name, fonts);
-                match (0..2).find(|&i| ui::confirm_button_rect(content, i).contains_point((x, y))) {
+                match Self::confirm_button_at(screen_w, screen_h, fonts, &Self::forget_host_subtitle(name), x, y) {
                     Some(i) => {
                         let changed = self.host_menu_focused != i;
                         self.host_menu_focused = i;
@@ -1148,9 +1168,7 @@ impl App {
                 }
             }
             Screen::SendLogs => {
-                let card = Self::send_logs_card_rect(screen_w, screen_h, fonts);
-                let content = Self::send_logs_content_rect(card, fonts);
-                match (0..2).find(|&i| ui::confirm_button_rect(content, i).contains_point((x, y))) {
+                match Self::confirm_button_at(screen_w, screen_h, fonts, Self::SEND_LOGS_SUBTITLE, x, y) {
                     Some(i) => {
                         let changed = self.send_logs_focused != i;
                         self.send_logs_focused = i;
@@ -1159,9 +1177,23 @@ impl App {
                     None => false,
                 }
             }
+            // Only with a MAC — the no-MAC wake variant is a button-less message.
+            Screen::Wake => {
+                let Some(wake) = self.wake.as_ref().filter(|w| !w.mac.is_empty()) else {
+                    return false;
+                };
+                let Some(i) = Self::confirm_button_at(screen_w, screen_h, fonts, &Self::wake_status_text(wake), x, y)
+                else {
+                    return false;
+                };
+                let wake = self.wake.as_mut().expect("filtered to Some above");
+                let changed = wake.focused != i;
+                wake.focused = i;
+                changed
+            }
             // No positional focus to move: single-card info/entry modals (AddHost,
-            // EditHost, About, Wake, WakeSettings, PinLimit, SpeedTest) and Settings
-            // with a dropdown open.
+            // EditHost, About, WakeSettings, PinLimit, SpeedTest) and Settings with a
+            // dropdown open.
             _ => false,
         }
     }
@@ -1270,7 +1302,7 @@ impl App {
                     .and_then(|i| self.entries.get(i))
                     .map(HostEntry::name)
                     .unwrap_or_default();
-                Self::forget_host_card_rect(screen_w, screen_h, name, fonts)
+                ui::confirm_dialog_card(screen_w, screen_h, fonts, &Self::forget_host_subtitle(name))
             }
             Screen::HostMenu => {
                 let subtitle = self.host_menu_subtitle();
@@ -1292,7 +1324,7 @@ impl App {
                 let subtitle = self.experimental_subtitle();
                 Self::experimental_card_rect(screen_w, screen_h, fonts, &subtitle)
             }
-            Screen::SendLogs => Self::send_logs_card_rect(screen_w, screen_h, fonts),
+            Screen::SendLogs => ui::confirm_dialog_card(screen_w, screen_h, fonts, Self::SEND_LOGS_SUBTITLE),
         })
     }
 
@@ -2005,8 +2037,14 @@ impl App {
                             .wake
                             .as_ref()
                             .expect("focus_key only Some for a Wake with a focusable widget");
-                        let card = Self::wake_card_rect(screen_w, screen_h, wake, fonts);
-                        let rect = ui::confirm_button_rect(Self::wake_buttons_rect(card, wake, fonts), wake.focused);
+                        // focus_key is only Some for a Wake with a MAC, so this is the confirm dialog.
+                        let rect = Self::confirm_focus_button_rect(
+                            screen_w,
+                            screen_h,
+                            fonts,
+                            &Self::wake_status_text(wake),
+                            wake.focused,
+                        );
                         let buttons = Self::wake_buttons();
                         ui::render_confirm_button_tile(
                             text_cache,
@@ -2034,9 +2072,13 @@ impl App {
                             .and_then(|i| self.entries.get(i))
                             .map(HostEntry::name)
                             .unwrap_or_default();
-                        let card = Self::forget_host_card_rect(screen_w, screen_h, name, fonts);
-                        let content = Self::forget_host_content_rect(card, name, fonts);
-                        let rect = ui::confirm_button_rect(content, self.host_menu_focused);
+                        let rect = Self::confirm_focus_button_rect(
+                            screen_w,
+                            screen_h,
+                            fonts,
+                            &Self::forget_host_subtitle(name),
+                            self.host_menu_focused,
+                        );
                         let buttons = Self::forget_buttons();
                         ui::render_confirm_button_tile(
                             text_cache,
@@ -2136,9 +2178,13 @@ impl App {
                         )?
                     }
                     Screen::SendLogs => {
-                        let card = Self::send_logs_card_rect(screen_w, screen_h, fonts);
-                        let content = Self::send_logs_content_rect(card, fonts);
-                        let rect = ui::confirm_button_rect(content, self.send_logs_focused);
+                        let rect = Self::confirm_focus_button_rect(
+                            screen_w,
+                            screen_h,
+                            fonts,
+                            Self::SEND_LOGS_SUBTITLE,
+                            self.send_logs_focused,
+                        );
                         let buttons = Self::send_logs_buttons();
                         ui::render_confirm_button_tile(
                             text_cache,
@@ -2740,8 +2786,7 @@ impl App {
                     Some(ui::focus_row_rect_at_px(content, self.settings_focused, px))
                 }
                 Screen::Wake => self.wake.as_ref().filter(|w| !w.mac.is_empty()).map(|w| {
-                    let card = Self::wake_card_rect(screen_w, screen_h, w, fonts);
-                    ui::confirm_button_rect(Self::wake_buttons_rect(card, w, fonts), w.focused)
+                    Self::confirm_focus_button_rect(screen_w, screen_h, fonts, &Self::wake_status_text(w), w.focused)
                 }),
                 Screen::Pairing => {
                     let card = Self::pairing_card_rect(screen_w, screen_h, fonts);
@@ -2759,9 +2804,13 @@ impl App {
                         .and_then(|i| self.entries.get(i))
                         .map(HostEntry::name)
                         .unwrap_or_default();
-                    let card = Self::forget_host_card_rect(screen_w, screen_h, name, fonts);
-                    let content = Self::forget_host_content_rect(card, name, fonts);
-                    Some(ui::confirm_button_rect(content, self.host_menu_focused))
+                    Some(Self::confirm_focus_button_rect(
+                        screen_w,
+                        screen_h,
+                        fonts,
+                        &Self::forget_host_subtitle(name),
+                        self.host_menu_focused,
+                    ))
                 }
                 Screen::HostMenu => {
                     let subtitle = self.host_menu_subtitle();
@@ -2796,11 +2845,13 @@ impl App {
                     let content = ui::list_modal_content_rect(card, fonts, &subtitle, ui::EXPERIMENTAL_ROW_COUNT);
                     Some(ui::focus_row_rect(content, self.experimental_focused))
                 }
-                Screen::SendLogs => {
-                    let card = Self::send_logs_card_rect(screen_w, screen_h, fonts);
-                    let content = Self::send_logs_content_rect(card, fonts);
-                    Some(ui::confirm_button_rect(content, self.send_logs_focused))
-                }
+                Screen::SendLogs => Some(Self::confirm_focus_button_rect(
+                    screen_w,
+                    screen_h,
+                    fonts,
+                    Self::SEND_LOGS_SUBTITLE,
+                    self.send_logs_focused,
+                )),
                 Screen::Home | Screen::AddHost | Screen::EditHost | Screen::About | Screen::PinLimit => None,
             };
             if let Some(rect) = focus_rect {

--- a/src/app/sendlogs.rs
+++ b/src/app/sendlogs.rs
@@ -9,7 +9,6 @@
 use super::*;
 use crate::ui::{self, MenuEvent, Painter};
 use anyhow::Result;
-use sdl2::rect::Rect;
 use std::path::Path;
 use std::time::Instant;
 
@@ -111,24 +110,6 @@ impl App {
         ui::confirm_buttons(Some(ui::ICON_SEND), "Send", ui::ERROR_RED)
     }
 
-    pub(crate) fn send_logs_card_rect(screen_w: u32, screen_h: u32, fonts: &ui::Fonts) -> Rect {
-        Self::simple_modal_card(screen_w, screen_h, |probe| {
-            let header_end = ui::modal_header_end_y(fonts.label, fonts.value, probe, Self::SEND_LOGS_SUBTITLE);
-            (header_end + 32 + 72 + 32) as u32
-        })
-    }
-
-    /// The Cancel/Send button row's rect, below the warning copy.
-    pub(crate) fn send_logs_content_rect(card: Rect, fonts: &ui::Fonts) -> Rect {
-        let after_subtitle_y = ui::modal_header_end_y(fonts.label, fonts.value, card, Self::SEND_LOGS_SUBTITLE);
-        Rect::new(
-            card.x() + 32,
-            after_subtitle_y + 32,
-            card.width().saturating_sub(64),
-            72,
-        )
-    }
-
     pub(crate) fn render_send_logs(
         &self,
         painter: &mut Painter,
@@ -137,7 +118,7 @@ impl App {
         screen_w: u32,
         screen_h: u32,
     ) -> Result<()> {
-        let card = Self::send_logs_card_rect(screen_w, screen_h, fonts);
+        let (card, content) = ui::confirm_dialog_layout(screen_w, screen_h, fonts, Self::SEND_LOGS_SUBTITLE);
         self.draw_modal_shell(painter, text_cache, fonts.icon, card)?;
         ui::draw_modal_header(
             painter,
@@ -150,7 +131,6 @@ impl App {
             Self::SEND_LOGS_SUBTITLE,
             ui::MUTED,
         )?;
-        let content = Self::send_logs_content_rect(card, fonts);
         // `usize::MAX` = nothing focused here; the focused button is a separate
         // `Tile::ModalFocusElement` (see `prepare_tiles`).
         ui::draw_confirm_buttons(

--- a/src/app/wake.rs
+++ b/src/app/wake.rs
@@ -181,17 +181,25 @@ impl App {
             _ => self.home_status = self.wake.take().map(|w| w.reason),
         }
     }
-    /// Wake modal card rect; height includes status + buttons (absent if no MAC).
-    pub(crate) fn wake_card_rect(screen_w: u32, screen_h: u32, wake: &WakeState, fonts: &ui::Fonts) -> Rect {
+    /// Card for the no-MAC modal: an informational "Host unreachable" message with no
+    /// button row (nothing to send), so it's a plain message card, not a confirm dialog.
+    pub(crate) fn wake_message_card(screen_w: u32, screen_h: u32, fonts: &ui::Fonts, status: &str) -> Rect {
         Self::simple_modal_card(screen_w, screen_h, |probe| {
-            let header_end = ui::modal_header_end_y(fonts.title, fonts.label, probe, &Self::wake_status_text(wake));
-            if wake.mac.is_empty() {
-                (header_end + 32) as u32
-            } else {
-                (header_end + 28 + 72 + 32) as u32
-            }
+            (ui::modal_header_end_y(fonts.label, fonts.value, probe, status) + 32) as u32
         })
     }
+
+    /// Wake modal card rect. With a MAC it's the shared confirmation dialog; without one
+    /// it's the button-less informational card.
+    pub(crate) fn wake_card_rect(screen_w: u32, screen_h: u32, wake: &WakeState, fonts: &ui::Fonts) -> Rect {
+        let status = Self::wake_status_text(wake);
+        if wake.mac.is_empty() {
+            Self::wake_message_card(screen_w, screen_h, fonts, &status)
+        } else {
+            ui::confirm_dialog_card(screen_w, screen_h, fonts, &status)
+        }
+    }
+
     pub(crate) fn render_wake(
         &self,
         painter: &mut Painter,
@@ -201,28 +209,25 @@ impl App {
         screen_h: u32,
     ) -> Result<()> {
         let Some(wake) = &self.wake else { return Ok(()) };
-        let card = Self::wake_card_rect(screen_w, screen_h, wake, fonts);
-        self.draw_modal_shell(painter, text_cache, fonts.icon, card)?;
-
         let status = Self::wake_status_text(wake);
-        ui::draw_modal_header(
-            painter,
-            text_cache,
-            fonts.title,
-            fonts.label,
-            card,
-            Self::wake_title(wake),
-            ui::WHITE,
-            &status,
-            ui::MUTED,
-        )?;
 
-        // No MAC = nothing to draw (status text explains why). drain_discovery reconnects
-        // automatically when host reappears on mDNS.
-        if !wake.mac.is_empty() {
+        // With a MAC it's the shared confirmation dialog (card + Wake/Cancel row); without
+        // one it's a button-less informational card ("unreachable", status explains why —
+        // drain_discovery reconnects automatically once the host reappears on mDNS).
+        let (card, buttons) = if wake.mac.is_empty() {
+            (Self::wake_message_card(screen_w, screen_h, fonts, &status), None)
+        } else {
+            let (card, content) = ui::confirm_dialog_layout(screen_w, screen_h, fonts, &status);
+            (card, Some(content))
+        };
+
+        self.draw_modal_shell(painter, text_cache, fonts.icon, card)?;
+        ui::draw_modal_header(
+            painter, text_cache, fonts.label, fonts.value, card, Self::wake_title(wake), ui::WHITE, &status, ui::MUTED,
+        )?;
+        if let Some(content) = buttons {
             // usize::MAX = no focus; focused button is a separate ModalFocusElement.
-            let buttons = Self::wake_buttons_rect(card, wake, fonts);
-            ui::draw_confirm_buttons(painter, text_cache, fonts, buttons, &Self::wake_buttons(), usize::MAX)?;
+            ui::draw_confirm_buttons(painter, text_cache, fonts, content, &Self::wake_buttons(), usize::MAX)?;
         }
         Ok(())
     }
@@ -283,11 +288,5 @@ impl App {
         } else {
             format!("{} isn't responding. It may be powered off or asleep.", wake.name)
         }
-    }
-
-    /// Wake/Cancel button row rect, stacked under status text whose height it depends on.
-    pub(crate) fn wake_buttons_rect(card: Rect, wake: &WakeState, fonts: &ui::Fonts) -> Rect {
-        let after_status_y = ui::modal_header_end_y(fonts.title, fonts.label, card, &Self::wake_status_text(wake));
-        Rect::new(card.x() + 32, after_status_y + 28, card.width().saturating_sub(64), 72)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -449,8 +449,7 @@ mod real {
             // with what's on screen. `content` is a plain Rect (captured by copy), so
             // the closure holds no borrow of `self` that `set_focus` would collide with.
             let (_, content) = crate::ui::confirm_dialog_layout(w, h, fonts, self.subtitle);
-            let button_at =
-                |x: i32, y: i32| (0..2).find(|&i| crate::ui::confirm_button_rect(content, i).contains_point((x, y)));
+            let button_at = |x: i32, y: i32| crate::ui::confirm_button_at(content, x, y);
             match *event {
                 Event::MouseMotion { x, y, .. } => {
                     return match button_at(x, y) {
@@ -1060,7 +1059,7 @@ mod real {
         // `quit_dialog_was_active` catches the close-fade's final frame so it gets one last
         // redraw-on-change tick to wipe the dialog off the menu.
         let mut quit_dialog = ConfirmDialog::new(
-            "Quit app?",
+            "Quit?",
             "punktfunk will close and you'll return to the webOS home screen.",
             crate::ui::confirm_buttons(Some(crate::ui::ICON_CLOSE), "Quit app", crate::ui::ERROR_RED),
         );

--- a/src/ui/tiles.rs
+++ b/src/ui/tiles.rs
@@ -310,14 +310,22 @@ pub fn render_log_overlay_tile(font: &Font, screen_w: u32, lines: &[String]) -> 
     Ok(p)
 }
 
+/// Confirm dialog card rect: [`SIMPLE_MODAL_WIDTH_FRAC`] wide, height driven by the
+/// wrapped subtitle plus room for the button row. Split from [`confirm_dialog_layout`]
+/// so callers that only need the card (hit-testing the close button, positioning the
+/// shell) skip the second subtitle wrap the button-row rect would cost.
+pub fn confirm_dialog_card(screen_w: u32, screen_h: u32, fonts: &Fonts, subtitle: &str) -> Rect {
+    simple_modal_card(screen_w, screen_h, |probe| {
+        let header_end = modal_header_end_y(fonts.label, fonts.value, probe, subtitle);
+        (header_end + 32 + 72 + 32) as u32
+    })
+}
+
 /// Confirm dialog card + button-row rects, sized exactly like the `App`'s simple modals
 /// (forget host, send logs): [`SIMPLE_MODAL_WIDTH_FRAC`] wide, height driven by the wrapped
 /// subtitle. Shared with `main.rs`'s in-stream/quit dialog so all four modals match.
 pub fn confirm_dialog_layout(screen_w: u32, screen_h: u32, fonts: &Fonts, subtitle: &str) -> (Rect, Rect) {
-    let card = simple_modal_card(screen_w, screen_h, |probe| {
-        let header_end = modal_header_end_y(fonts.label, fonts.value, probe, subtitle);
-        (header_end + 32 + 72 + 32) as u32
-    });
+    let card = confirm_dialog_card(screen_w, screen_h, fonts, subtitle);
     let after_subtitle_y = modal_header_end_y(fonts.label, fonts.value, card, subtitle);
     let content = Rect::new(
         card.x() + 32,
@@ -326,6 +334,13 @@ pub fn confirm_dialog_layout(screen_w: u32, screen_h: u32, fonts: &Fonts, subtit
         72,
     );
     (card, content)
+}
+
+/// Button index under `(x, y)` within a confirm dialog's button-row `content` rect, or
+/// `None` off both buttons — the shared hit-test the App confirm modals' hover arms and
+/// the in-stream Disconnect dialog use so pointer focus behaves identically.
+pub fn confirm_button_at(content: Rect, x: i32, y: i32) -> Option<usize> {
+    (0..2).find(|&i| confirm_button_rect(content, i).contains_point((x, y)))
 }
 
 /// Confirm dialog shell (full-screen tile): the same card + close (X) + header + unfocused


### PR DESCRIPTION
The forget-host, send-logs, and wake modals were each hand-rolling the same card and button-row geometry, so I routed them all through `ui::confirm_dialog_layout` and dropped the per-modal `*_card_rect`/`*_content_rect` helpers. Along the way the wake buttons finally get Magic Remote hover-to-focus (that arm was just missing from `hover_focus_at`), the button hit-test is now shared with the in-stream disconnect dialog, and there's a card-only `confirm_dialog_card` so the close-hover path doesn't compute a button-row rect it throws away.

No behavior change beyond the wake hover fix. Worth a quick pass on the real TV since pointer hover can't be exercised off the Magic Remote.