### PR TITLE
Speed up modal opening

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -40,6 +40,11 @@ pub(crate) const MODAL_FADE: Duration = Duration::from_millis(200);
 pub(crate) const DROPDOWN_FADE: Duration = MODAL_FADE;
 /// Scale during open — subtle, since fade dominates for full-screen modal.
 pub(crate) const MODAL_POP_SHRINK: f32 = 0.05;
+/// Transparent margin the modal tile leaves around the card so its drop shadow
+/// (`draw_card_shadow`: blur `SHADOW_BLUR`=14, offset dy 5) fits inside the tile.
+/// The tile is sized to the card's bounding box plus this pad rather than the whole
+/// screen, so every open rasterizes and uploads a fraction of the pixels it used to.
+pub(crate) const MODAL_TILE_PAD: i32 = 24;
 pub(crate) const SCROLL_INDICATOR_HOLD: Duration = Duration::from_millis(700);
 pub(crate) const SCROLL_INDICATOR_FADE: Duration = Duration::from_millis(350);
 pub(crate) const SCROLL_INDICATOR_LIFETIME: Duration =
@@ -402,6 +407,12 @@ pub struct App {
     /// Which screen `modal_scroll_px` describes, so opening a different modal snaps instead of
     /// gliding from the previous one's offset.
     pub(crate) modal_scroll_screen: Option<Screen>,
+    /// Screen-space region the `Tile::Modal` painter currently covers (card bbox +
+    /// [`MODAL_TILE_PAD`]) — set by `prepare_modal` when it (re)builds the tile, read by
+    /// `compose_modal` to place it. Held across frames so the close-fade, which renders
+    /// the still-uploaded tile after `self.screen` has moved to Home, still knows where
+    /// to draw it.
+    pub(crate) modal_tile_region: Rect,
     /// Whether the grid's initial build for the current library has finished — while
     /// `false`, the grid shows the loading spinner (`Tile::SpinnerFrame`) instead of
     /// popping cards in one by one. One-shot per library: only `prepare_tiles`'s
@@ -545,6 +556,7 @@ impl App {
             modal_scroll_px: 0,
             modal_scroll_target_px: 0,
             modal_scroll_screen: None,
+            modal_tile_region: Rect::new(0, 0, 1, 1),
             grid_reveal_ready: true,
             spinner_frame: None,
             spinner_since: None,
@@ -1042,9 +1054,31 @@ impl App {
                 wake.focused = i;
                 changed
             }
+            // The finished/failed speed test shows the same two-button confirm row as
+            // ForgetHost et al., so hover picks apply-vs-Close there too. While the test
+            // is still running there are no buttons — `speed_test_buttons_rect` is only
+            // meaningful once `render_speed_test` draws them (Done/Failed).
+            Screen::SpeedTest
+                if matches!(
+                    self.speed_test,
+                    Some(crate::app::state::speedtest::SpeedTestState::Done { .. })
+                        | Some(crate::app::state::speedtest::SpeedTestState::Failed(_))
+                ) =>
+            {
+                let card = self.speed_test_card_rect(screen_w, screen_h, fonts);
+                let content = self.speed_test_buttons_rect(card, fonts);
+                match ui::confirm_button_at(content, x, y) {
+                    Some(i) => {
+                        let changed = self.speed_test_focused != i;
+                        self.speed_test_focused = i;
+                        changed
+                    }
+                    None => false,
+                }
+            }
             // No positional focus to move: single-card info/entry modals (AddHost,
-            // EditHost, About, WakeSettings, PinLimit, SpeedTest) and Settings with a
-            // dropdown open.
+            // EditHost, About, WakeSettings, PinLimit, running SpeedTest) and Settings
+            // with a dropdown open.
             _ => false,
         }
     }
@@ -1177,6 +1211,21 @@ impl App {
             }
             Screen::SendLogs => ui::confirm_dialog_card(screen_w, screen_h, fonts, Self::SEND_LOGS_SUBTITLE),
         })
+    }
+
+    /// The current screen's modal *tile* region: its card rect grown by
+    /// [`MODAL_TILE_PAD`] on every side for the shadow. The `Tile::Modal` painter is
+    /// sized and positioned to this instead of the whole screen — see `compose_modal`,
+    /// which composites the tile here. `None` on a screen with no modal card.
+    fn modal_tile_region(&self, screen_w: u32, screen_h: u32, fonts: &ui::Fonts) -> Option<Rect> {
+        let c = self.modal_card_rect(screen_w, screen_h, fonts)?;
+        let pad = MODAL_TILE_PAD;
+        Some(Rect::new(
+            c.x() - pad,
+            c.y() - pad,
+            c.width() + 2 * pad as u32,
+            c.height() + 2 * pad as u32,
+        ))
     }
 
     /// The list-modal row index under the pointer, for the plain list modals whose
@@ -1789,11 +1838,17 @@ impl App {
         };
         self.modal_shell_key = modal_shell_key;
         if modal_open && (screen_changed || modal_stale) {
-            let mut p = match tiles.modal_tile.take() {
-                Some(p) => p,
-                None => Painter::new(screen_w, screen_h),
-            };
-            p.clear_transparent();
+            // Size the tile to the card's bounding box, not the whole screen: the
+            // render fns below draw at absolute, screen-centered coordinates, and the
+            // painter's origin shift (see `Painter::set_origin`) maps that geometry into
+            // this smaller buffer. Falls back to full-screen only for a screen with no
+            // card rect (shouldn't happen while `modal_open`).
+            let region = self
+                .modal_tile_region(screen_w, screen_h, fonts)
+                .unwrap_or_else(|| Rect::new(0, 0, screen_w, screen_h));
+            self.modal_tile_region = region;
+            let mut p = Painter::new(region.width(), region.height());
+            p.set_origin(region.x(), region.y());
             match self.screen {
                 Screen::Home => unreachable!("modal_open checked above"),
                 Screen::Pairing => {
@@ -2245,6 +2300,31 @@ impl App {
         Ok(())
     }
 
+    /// Warms the caches a modal's first open would otherwise fill cold, off the
+    /// open path — call once on an idle Home frame. The first real open pays a
+    /// burst of `SDL2_ttf` glyph renders plus the card's shadow blur; on the very
+    /// first open of a session nothing is cached, which is the hitch the user
+    /// sees. Rendering the Settings shell + rows into throwaway painters here has
+    /// three surviving side effects: `text_cache` (per-line pixmaps), the
+    /// thread-local shadow/glow caches, and `SDL2_ttf`'s own freetype glyph cache.
+    /// The last is font-wide, so it speeds up every modal's cold renders — not
+    /// just Settings — even where the exact strings differ (e.g. the host menu).
+    pub fn prewarm_modal_caches(
+        &self,
+        text_cache: &mut crate::ui::TextCache,
+        fonts: &ui::Fonts,
+        screen_w: u32,
+        screen_h: u32,
+    ) -> Result<()> {
+        let mut scratch = Painter::new(screen_w, screen_h);
+        self.render_settings(&mut scratch, text_cache, fonts, screen_w, screen_h)?;
+        let (_, content) = self.settings_layout(screen_w, screen_h);
+        let rows = ui::settings_rows(&self.settings);
+        let _ = ui::render_focus_rows_tile(text_cache, fonts, &rows, content.width(), None)?;
+        let _ = ui::render_focus_row_tile(text_cache, fonts, &rows, content.width(), 0, false, 0.0)?;
+        Ok(())
+    }
+
     /// Rasterizes every stale tile (tiny-skia, CPU — the only place rasterization
     /// happens) and returns which tiles need their GPU texture re-uploaded.
     /// `content_dirty` is the main loop's "an event/drain changed something this
@@ -2511,7 +2591,10 @@ impl App {
                 color: crate::ui::render::Color::RGBA(0, 0, 0, (f32::from(ui::MODAL_SCRIM.a) * m) as u8),
             });
             let dy = ((1.0 - m) * 26.0) as i32;
-            let modal_base = Rect::new(0, dy, screen_w, screen_h);
+            // The tile now covers only the card region (see `prepare_modal`), so it
+            // composites there rather than full-screen. `pop_in_rect` scaling around this
+            // rect's center is the card's own center — the same visual pop as before.
+            let modal_base = self.modal_tile_region.offset(0, dy);
             let modal_dst = if closing_frame.is_some() {
                 modal_base
             } else {
@@ -2597,88 +2680,105 @@ impl App {
             }
             // Focused widget of the active modal (setting row, button, etc.);
             // composites on shell at its on-screen position (no re-rasterize on move).
-            let focus_rect = match screen {
-                Screen::Settings => {
-                    let (total, _, _, content) = scroll_geom.expect("screen is Screen::Settings");
-                    // Positioned from the animated pixel offset, not the row index: the baked
-                    // list is cropped at that offset, and the focus tile *is* the focused row
-                    // re-rendered — so anchoring it to the quantized row would show that row's
-                    // content twice, in two places, for the length of every scroll.
-                    let stride = ui::settings_row_stride() as i32;
-                    let px = self
-                        .modal_scroll_px
-                        .clamp(0, Self::max_scroll_px(total, stride, content.height()));
-                    Some(ui::focus_row_rect_at_px(content, self.settings_focused, px))
-                }
-                Screen::Wake => self.wake.as_ref().filter(|w| !w.mac.is_empty()).map(|w| {
-                    Self::confirm_focus_button_rect(screen_w, screen_h, fonts, &Self::wake_status_text(w), w.focused)
-                }),
-                Screen::Pairing => {
-                    let card = Self::pairing_card_rect(screen_w, screen_h, fonts);
-                    Some(match self.pairing_focus {
-                        PairingFocus::Pin => {
-                            let digit_y = Self::pairing_pin_row_y(card, fonts);
-                            ui::pairing_digit_rect(card, digit_y, self.pin_digit_index)
-                        }
-                        PairingFocus::RequestAccess => Self::pairing_request_button_rect(card, fonts),
-                    })
-                }
-                Screen::ForgetHost => {
-                    let name = self
-                        .host_menu_index
-                        .and_then(|i| self.entries.get(i))
-                        .map(HostEntry::name)
-                        .unwrap_or_default();
-                    Some(Self::confirm_focus_button_rect(
+            //
+            // Skipped entirely once the modal is closing: the position is recomputed
+            // from live per-screen state, which Back may have already torn down (e.g.
+            // `host_menu_index` cleared, collapsing the host-menu card to the screen
+            // centre and floating the highlight there). The shell and scroll-content
+            // tiles still render the focused row through the fade, so dropping just the
+            // zoom-highlight overlay is invisible — and correct.
+            let focus_rect = if closing_frame.is_some() {
+                None
+            } else {
+                match screen {
+                    Screen::Settings => {
+                        let (total, _, _, content) = scroll_geom.expect("screen is Screen::Settings");
+                        // Positioned from the animated pixel offset, not the row index: the baked
+                        // list is cropped at that offset, and the focus tile *is* the focused row
+                        // re-rendered — so anchoring it to the quantized row would show that row's
+                        // content twice, in two places, for the length of every scroll.
+                        let stride = ui::settings_row_stride() as i32;
+                        let px = self
+                            .modal_scroll_px
+                            .clamp(0, Self::max_scroll_px(total, stride, content.height()));
+                        Some(ui::focus_row_rect_at_px(content, self.settings_focused, px))
+                    }
+                    Screen::Wake => self.wake.as_ref().filter(|w| !w.mac.is_empty()).map(|w| {
+                        Self::confirm_focus_button_rect(
+                            screen_w,
+                            screen_h,
+                            fonts,
+                            &Self::wake_status_text(w),
+                            w.focused,
+                        )
+                    }),
+                    Screen::Pairing => {
+                        let card = Self::pairing_card_rect(screen_w, screen_h, fonts);
+                        Some(match self.pairing_focus {
+                            PairingFocus::Pin => {
+                                let digit_y = Self::pairing_pin_row_y(card, fonts);
+                                ui::pairing_digit_rect(card, digit_y, self.pin_digit_index)
+                            }
+                            PairingFocus::RequestAccess => Self::pairing_request_button_rect(card, fonts),
+                        })
+                    }
+                    Screen::ForgetHost => {
+                        let name = self
+                            .host_menu_index
+                            .and_then(|i| self.entries.get(i))
+                            .map(HostEntry::name)
+                            .unwrap_or_default();
+                        Some(Self::confirm_focus_button_rect(
+                            screen_w,
+                            screen_h,
+                            fonts,
+                            &Self::forget_host_subtitle(name),
+                            self.host_menu_focused,
+                        ))
+                    }
+                    Screen::HostMenu => {
+                        let subtitle = self.host_menu_subtitle();
+                        let rows = self.host_menu_actions().len();
+                        let card = Self::host_menu_card_rect(screen_w, screen_h, fonts, &subtitle, rows);
+                        let content = ui::list_modal_content_rect(card, fonts, &subtitle, rows);
+                        Some(ui::focus_row_rect(content, self.menu_focused))
+                    }
+                    Screen::WakeSettings => {
+                        let subtitle = self.wake_settings_subtitle();
+                        let card = Self::wake_settings_card_rect(screen_w, screen_h, fonts, &subtitle);
+                        let content = ui::list_modal_content_rect(card, fonts, &subtitle, ui::DIAGNOSTICS_ROW_COUNT);
+                        Some(ui::focus_row_rect(content, self.wake_settings_focused))
+                    }
+                    Screen::SpeedTest => matches!(
+                        self.speed_test,
+                        Some(crate::app::state::speedtest::SpeedTestState::Done { .. })
+                            | Some(crate::app::state::speedtest::SpeedTestState::Failed(_))
+                    )
+                    .then(|| {
+                        let card = self.speed_test_card_rect(screen_w, screen_h, fonts);
+                        ui::confirm_button_rect(self.speed_test_buttons_rect(card, fonts), self.speed_test_focused)
+                    }),
+                    Screen::Diagnostics => {
+                        let subtitle = self.diagnostics_subtitle();
+                        let card = Self::diagnostics_card_rect(screen_w, screen_h, fonts, &subtitle);
+                        let content = ui::list_modal_content_rect(card, fonts, &subtitle, ui::DIAGNOSTICS_ROW_COUNT);
+                        Some(ui::focus_row_rect(content, self.diagnostics_focused))
+                    }
+                    Screen::Experimental => {
+                        let subtitle = self.experimental_subtitle();
+                        let card = Self::experimental_card_rect(screen_w, screen_h, fonts, &subtitle);
+                        let content = ui::list_modal_content_rect(card, fonts, &subtitle, ui::EXPERIMENTAL_ROW_COUNT);
+                        Some(ui::focus_row_rect(content, self.experimental_focused))
+                    }
+                    Screen::SendLogs => Some(Self::confirm_focus_button_rect(
                         screen_w,
                         screen_h,
                         fonts,
-                        &Self::forget_host_subtitle(name),
-                        self.host_menu_focused,
-                    ))
+                        Self::SEND_LOGS_SUBTITLE,
+                        self.send_logs_focused,
+                    )),
+                    Screen::Home | Screen::AddHost | Screen::EditHost | Screen::About | Screen::PinLimit => None,
                 }
-                Screen::HostMenu => {
-                    let subtitle = self.host_menu_subtitle();
-                    let rows = self.host_menu_actions().len();
-                    let card = Self::host_menu_card_rect(screen_w, screen_h, fonts, &subtitle, rows);
-                    let content = ui::list_modal_content_rect(card, fonts, &subtitle, rows);
-                    Some(ui::focus_row_rect(content, self.menu_focused))
-                }
-                Screen::WakeSettings => {
-                    let subtitle = self.wake_settings_subtitle();
-                    let card = Self::wake_settings_card_rect(screen_w, screen_h, fonts, &subtitle);
-                    let content = ui::list_modal_content_rect(card, fonts, &subtitle, ui::DIAGNOSTICS_ROW_COUNT);
-                    Some(ui::focus_row_rect(content, self.wake_settings_focused))
-                }
-                Screen::SpeedTest => matches!(
-                    self.speed_test,
-                    Some(crate::app::state::speedtest::SpeedTestState::Done { .. })
-                        | Some(crate::app::state::speedtest::SpeedTestState::Failed(_))
-                )
-                .then(|| {
-                    let card = self.speed_test_card_rect(screen_w, screen_h, fonts);
-                    ui::confirm_button_rect(self.speed_test_buttons_rect(card, fonts), self.speed_test_focused)
-                }),
-                Screen::Diagnostics => {
-                    let subtitle = self.diagnostics_subtitle();
-                    let card = Self::diagnostics_card_rect(screen_w, screen_h, fonts, &subtitle);
-                    let content = ui::list_modal_content_rect(card, fonts, &subtitle, ui::DIAGNOSTICS_ROW_COUNT);
-                    Some(ui::focus_row_rect(content, self.diagnostics_focused))
-                }
-                Screen::Experimental => {
-                    let subtitle = self.experimental_subtitle();
-                    let card = Self::experimental_card_rect(screen_w, screen_h, fonts, &subtitle);
-                    let content = ui::list_modal_content_rect(card, fonts, &subtitle, ui::EXPERIMENTAL_ROW_COUNT);
-                    Some(ui::focus_row_rect(content, self.experimental_focused))
-                }
-                Screen::SendLogs => Some(Self::confirm_focus_button_rect(
-                    screen_w,
-                    screen_h,
-                    fonts,
-                    Self::SEND_LOGS_SUBTITLE,
-                    self.send_logs_focused,
-                )),
-                Screen::Home | Screen::AddHost | Screen::EditHost | Screen::About | Screen::PinLimit => None,
             };
             if let Some(rect) = focus_rect {
                 let pad = ui::ROW_TILE_PAD;

--- a/src/app/view/settings.rs
+++ b/src/app/view/settings.rs
@@ -26,13 +26,10 @@ impl App {
         ((budget.saturating_sub(2 * ui::SETTINGS_PEEK) / stride) as usize).clamp(1, total)
     }
 
-    /// Card space below the list: minimal, unless the high-bitrate caution line needs room.
+    /// Card space below the list. The high-bitrate caution now rides on the Bitrate row
+    /// itself (see `settings_rows`), so no extra chrome is reserved for it.
     pub(crate) fn settings_chrome_bottom(&self) -> u32 {
-        if self.settings.bitrate_kbps > ui::BITRATE_WARN_KBPS {
-            ui::SETTINGS_WARN_CHROME
-        } else {
-            ui::SETTINGS_CHROME_BOTTOM
-        }
+        ui::SETTINGS_CHROME_BOTTOM
     }
 
     /// Height of the scrolling viewport: the fully-visible rows plus a peek strip past each
@@ -77,7 +74,7 @@ impl App {
         screen_w: u32,
         screen_h: u32,
     ) -> Result<()> {
-        let (card, content) = self.settings_layout(screen_w, screen_h);
+        let (card, _content) = self.settings_layout(screen_w, screen_h);
         self.draw_modal_shell(painter, text_cache, fonts.raster, fonts.icon, card)?;
         ui::draw_text(
             painter,
@@ -99,18 +96,6 @@ impl App {
         // The open dropdown's panel is drawn separately too — see `Tile::DropdownOverlay`
         // — so it composites *after* `Tile::ScrollContent` instead of being covered by it.
 
-        if self.settings.bitrate_kbps > ui::BITRATE_WARN_KBPS {
-            ui::draw_text(
-                painter,
-                text_cache,
-                fonts.raster,
-                fonts.value,
-                "May be unstable on Wi-Fi — try Ethernet if streaming drops.",
-                content.x(),
-                content.y() + content.height() as i32 + 16,
-                ui::WARNING,
-            )?;
-        }
         Ok(())
     }
 

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -122,6 +122,10 @@ pub(super) fn run_ui_flow(
     // dialog while streaming — see `DisconnectChord`.
     let mut chord = DisconnectChord::default();
     let mut quit_dialog_was_active = false;
+    // One-shot: warm the modal text/shadow/freetype caches on the first idle tick
+    // (Home already painted by then) so the first Settings/host-menu open doesn't
+    // hitch on cold rasterization. Reset per menu entry — `text_cache` is too.
+    let mut prewarmed = false;
     'ui: loop {
         let tick_start = Instant::now();
         if QUIT_REQUESTED.load(Ordering::Relaxed) {
@@ -292,6 +296,10 @@ pub(super) fn run_ui_flow(
         let log_overlay_due = log_overlay_state() != LogOverlayState::Off
             && log_overlay_last.is_none_or(|t| t.elapsed() >= Duration::from_millis(500));
         if !dirty && !animating && !log_overlay_due {
+            if !prewarmed {
+                prewarmed = true;
+                app.prewarm_modal_caches(&mut text_cache, fonts, display_mode.w as u32, display_mode.h as u32)?;
+            }
             let elapsed = tick_start.elapsed();
             if elapsed < TICK_BUDGET {
                 std::thread::sleep(TICK_BUDGET - elapsed);

--- a/src/ui/painter.rs
+++ b/src/ui/painter.rs
@@ -49,6 +49,14 @@ pub fn rounded_rect_path(x: f32, y: f32, w: f32, h: f32, radius: f32) -> Option<
 /// version did.
 pub struct Painter {
     pixmap: Pixmap,
+    /// Drawing offset: every coordinate a caller passes is shifted by `-origin`
+    /// before it hits the buffer. Lets a painter whose buffer covers only a
+    /// sub-region of the screen still be fed absolute, screen-space geometry — the
+    /// modal tile uses this so it can be sized to just the card's bounding box
+    /// (a fraction of the full-screen raster + GPU upload it used to be) while the
+    /// per-screen render fns keep computing centered, absolute card rects. `(0, 0)`
+    /// for every full-screen painter, so their behaviour is unchanged.
+    origin: (i32, i32),
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -91,7 +99,19 @@ impl Painter {
     pub fn new(width: u32, height: u32) -> Self {
         Self {
             pixmap: Pixmap::new(width.max(1), height.max(1)).expect("nonzero framebuffer size"),
+            origin: (0, 0),
         }
+    }
+
+    /// Shifts all subsequent drawing so `(x, y)` in caller (screen) space maps to
+    /// this buffer's top-left — see the `origin` field. Set once, right after
+    /// `new`, for a sub-region tile.
+    pub fn set_origin(&mut self, x: i32, y: i32) {
+        self.origin = (x, y);
+    }
+
+    fn off(&self, rect: Rect) -> Rect {
+        rect.offset(-self.origin.0, -self.origin.1)
     }
 
     /// Raw premultiplied RGBA8 bytes, row-major, `width() * height() * 4` long —
@@ -109,12 +129,6 @@ impl Painter {
 
     pub fn height(&self) -> u32 {
         self.pixmap.height()
-    }
-
-    /// Zeroes the buffer to fully transparent — tile painters start from this
-    /// (their surroundings must stay see-through for GPU alpha compositing).
-    pub fn clear_transparent(&mut self) {
-        self.pixmap.data_mut().fill(0);
     }
 
     pub fn fill_rect(&mut self, rect: Rect, color: Color) {
@@ -159,6 +173,7 @@ impl Painter {
     }
 
     pub fn fill_rounded_rect(&mut self, rect: Rect, radius: i32, color: Color) {
+        let rect = self.off(rect);
         let (w, h) = (rect.width() as f32, rect.height() as f32);
         if w <= 0.0 || h <= 0.0 {
             return;
@@ -170,6 +185,7 @@ impl Painter {
     }
 
     pub fn stroke_rounded_rect(&mut self, rect: Rect, radius: i32, color: Color, width: f32) {
+        let rect = self.off(rect);
         let (w, h) = (rect.width() as f32, rect.height() as f32);
         if w <= 0.0 || h <= 0.0 {
             return;
@@ -190,6 +206,7 @@ impl Painter {
         if r <= 0.0 {
             return;
         }
+        let (cx, cy) = (cx - self.origin.0 as f32, cy - self.origin.1 as f32);
         let Some(path) = PathBuilder::from_circle(cx, cy, r) else {
             return;
         };
@@ -215,6 +232,7 @@ impl Painter {
             return;
         }
         let pad = blur.ceil().max(0.0) as i32 + 1;
+        let (ox, oy) = self.origin;
         let key = ShadowKey {
             w: rect.width(),
             h: rect.height(),
@@ -235,8 +253,8 @@ impl Painter {
                 }
             };
             self.pixmap.draw_pixmap(
-                rect.x() - pad + dx.round() as i32,
-                rect.y() - pad + dy.round() as i32,
+                rect.x() - pad + dx.round() as i32 - ox,
+                rect.y() - pad + dy.round() as i32 - oy,
                 shape.as_ref(),
                 &PixmapPaint::default(),
                 Transform::identity(),
@@ -253,6 +271,7 @@ impl Painter {
             return;
         }
         let pad = blur.ceil().max(0.0) as i32 + 1;
+        let (ox, oy) = self.origin;
         let key = GlowKey {
             w: rect.width(),
             h: rect.height(),
@@ -272,8 +291,8 @@ impl Painter {
                 }
             };
             self.pixmap.draw_pixmap(
-                rect.x() - pad,
-                rect.y() - pad,
+                rect.x() - pad - ox,
+                rect.y() - pad - oy,
                 shape.as_ref(),
                 &PixmapPaint::default(),
                 Transform::identity(),
@@ -287,6 +306,7 @@ impl Painter {
         if radius == 0 {
             return;
         }
+        let rect = self.off(rect);
         let (pw, ph) = (self.pixmap.width() as i32, self.pixmap.height() as i32);
         let x0 = rect.x().max(0);
         let y0 = rect.y().max(0);
@@ -324,8 +344,14 @@ impl Painter {
     }
 
     pub fn draw_pixmap(&mut self, x: i32, y: i32, src: &Pixmap) {
-        self.pixmap
-            .draw_pixmap(x, y, src.as_ref(), &PixmapPaint::default(), Transform::identity(), None);
+        self.pixmap.draw_pixmap(
+            x - self.origin.0,
+            y - self.origin.1,
+            src.as_ref(),
+            &PixmapPaint::default(),
+            Transform::identity(),
+            None,
+        );
     }
 
     /// Composites `src` scaled to exactly fill `dst` — the one caller is game-art
@@ -336,6 +362,7 @@ impl Painter {
     /// once per card build, not every frame — plain `Nearest` scaling left visible
     /// jaggies on art whose source resolution didn't cleanly divide into the card size.
     pub fn draw_pixmap_scaled(&mut self, dst: Rect, src: &Pixmap) {
+        let dst = self.off(dst);
         let (dw, dh) = (dst.width() as f32, dst.height() as f32);
         let (sw, sh) = (src.width() as f32, src.height() as f32);
         if dw <= 0.0 || dh <= 0.0 || sw <= 0.0 || sh <= 0.0 {

--- a/src/ui/rows.rs
+++ b/src/ui/rows.rs
@@ -43,6 +43,38 @@ pub struct FocusRow {
     /// Confirm can mean, reached with Right, so the row's own action stays a single
     /// press. `None` (the default) draws no button at all.
     pub menu: Option<bool>,
+    /// A small secondary line drawn under the row's label (e.g. the high-bitrate
+    /// "may be unstable on Wi-Fi" caution on the Bitrate row). `None` draws nothing and
+    /// the label stays vertically centred; `Some` centres label + subtext as a block.
+    pub subtext: Option<RowSubtext>,
+}
+
+/// A small caption drawn under a row's label. The color is carried with the text so the
+/// drawing code stays generic — a neutral hint and a caution differ only by which
+/// constructor built them, not by any special-casing in `draw_focus_row`.
+pub struct RowSubtext {
+    pub text: String,
+    pub color: Color,
+}
+
+impl RowSubtext {
+    /// Neutral secondary line (muted grey) — the default for extra context. No caller
+    /// yet; provided alongside `caution` so a future row's plain sub-label reads the same.
+    #[allow(dead_code)]
+    pub fn hint(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            color: MUTED,
+        }
+    }
+
+    /// Dull-orange caution line — a soft warning that isn't a hard error.
+    pub fn caution(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            color: CAUTION,
+        }
+    }
 }
 
 impl FocusRow {
@@ -56,6 +88,7 @@ impl FocusRow {
             fraction: 0.0,
             danger: false,
             menu: None,
+            subtext: None,
         }
     }
 
@@ -208,6 +241,28 @@ pub fn draw_focus_row(
     };
     draw_icon(painter, text_cache, fonts.raster, fonts.icon, icon_rect, row.icon, fg)?;
     let label_x = icon_rect.x() + SETTINGS_ICON_SIZE as i32 + 20;
+    // With a caution caption the label + caption are centred as a block; without one the
+    // label alone stays centred (the common case).
+    let label_h = fonts.raster.height(fonts.label);
+    let label_y = if let Some(subtext) = &row.subtext {
+        let caption_h = fonts.raster.height(fonts.caption);
+        let gap = 4;
+        let block_h = label_h + gap + caption_h;
+        let top = row_rect.y() + (row_rect.height() as i32 - block_h) / 2;
+        draw_text(
+            painter,
+            text_cache,
+            fonts.raster,
+            fonts.caption,
+            &subtext.text,
+            label_x,
+            top + label_h + gap,
+            subtext.color,
+        )?;
+        top
+    } else {
+        row_rect.y() + (row_rect.height() as i32 - label_h) / 2
+    };
     draw_text(
         painter,
         text_cache,
@@ -215,7 +270,7 @@ pub fn draw_focus_row(
         fonts.label,
         &row.label,
         label_x,
-        row_rect.y() + (row_rect.height() as i32 - fonts.raster.height(fonts.label)) / 2,
+        label_y,
         fg,
     )?;
 

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -22,7 +22,7 @@ pub const BITRATE_STEP_KBPS: u32 = 5_000;
 /// or climbing every ~750ms. A fixed Mbps number, however carefully picked, never adapts to a link
 /// that degrades mid-session — this does.
 pub const BITRATE_AUTOMATIC: u32 = 0;
-/// Above this, shown as amber caution (not a hard cap).
+/// Above this, the Bitrate row shows a dull-orange caution caption (not a hard cap).
 pub const BITRATE_WARN_KBPS: u32 = 150_000;
 
 /// Card space above the row list: title, divider, and their padding.
@@ -34,11 +34,6 @@ pub const SETTINGS_CHROME_TOP: u32 = 120;
 /// Anything more shows as a band of flat card background under the fade — the fade already
 /// *is* the bottom edge, so padding beneath it reads as dead space rather than breathing room.
 pub const SETTINGS_CHROME_BOTTOM: u32 = 16;
-
-/// Extra bottom chrome while the high-bitrate caution line is showing, which is the only
-/// thing that ever needs room below the list. Conditional so the other 99% of the time the
-/// card isn't padded out for a line that isn't there.
-pub const SETTINGS_WARN_CHROME: u32 = 52;
 
 /// Minimum gap between the settings card and the screen edges, top and bottom combined.
 ///
@@ -215,6 +210,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
+            subtext: None,
         },
         FocusRow {
             icon: ICON_SCHEDULE,
@@ -224,6 +220,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
+            subtext: None,
         },
         FocusRow {
             icon: ICON_SIGNAL,
@@ -237,6 +234,8 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: bitrate_frac,
             danger: false,
             menu: None,
+            subtext: (settings.bitrate_kbps > BITRATE_WARN_KBPS)
+                .then(|| RowSubtext::caution("May be unstable on Wi-Fi — try Ethernet")),
         },
         FocusRow {
             icon: ICON_MEMORY,
@@ -249,6 +248,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
+            subtext: None,
         },
         FocusRow {
             icon: ICON_PALETTE,
@@ -258,6 +258,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
+            subtext: None,
         },
         FocusRow {
             icon: ICON_MOVIE,
@@ -274,6 +275,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
+            subtext: None,
         },
         FocusRow {
             icon: ICON_SUN,
@@ -287,6 +289,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
+            subtext: None,
         },
         FocusRow {
             icon: ICON_SIGNAL,
@@ -296,6 +299,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
+            subtext: None,
         },
         FocusRow {
             icon: ICON_GAMEPAD,
@@ -305,6 +309,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
+            subtext: None,
         },
         FocusRow {
             icon: ICON_MOUSE,
@@ -318,6 +323,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
+            subtext: None,
         },
         FocusRow::action(ICON_BUG, "Experimental"),
         FocusRow::action(ICON_WRENCH, "Diagnostics"),
@@ -379,6 +385,7 @@ pub fn diagnostics_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
+            subtext: None,
         },
         FocusRow {
             icon: ICON_CHART,
@@ -392,6 +399,7 @@ pub fn diagnostics_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
+            subtext: None,
         },
         FocusRow {
             icon: ICON_VISIBILITY,
@@ -401,6 +409,7 @@ pub fn diagnostics_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
+            subtext: None,
         },
         FocusRow::action(ICON_SEND, "Send logs to developer"),
     ]
@@ -422,6 +431,7 @@ pub fn experimental_rows(settings: &Settings) -> Vec<FocusRow> {
         fraction: 0.0,
         danger: false,
         menu: None,
+        subtext: None,
     }]
 }
 
@@ -435,6 +445,7 @@ pub fn wake_settings_rows(auto_send: bool) -> Vec<FocusRow> {
         fraction: 0.0,
         danger: false,
         menu: None,
+        subtext: None,
     }]
 }
 

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -6,6 +6,9 @@ pub const SURFACE: Color = Color::RGB(0x2b, 0x21, 0x48);
 pub const ACCENT: Color = Color::RGB(0x6c, 0x5b, 0xf3);
 pub const ACCENT_BRIGHT: Color = Color::RGB(0xa7, 0x9f, 0xf8);
 pub const WARNING: Color = Color::RGB(0xff, 0xc1, 0x07);
+/// Muted, desaturated orange for an inline caution caption (e.g. the high-bitrate note on
+/// the Bitrate row) — dimmer than `WARNING` so it reads as a hint, not an alert.
+pub const CAUTION: Color = Color::RGB(0xd1, 0x84, 0x4a);
 pub const ERROR_RED: Color = Color::RGB(0xff, 0x6b, 0x6b);
 /// A desaturated mint rather than a signal green — it sits next to brand purple on every row,
 /// and a pure green fights it.


### PR DESCRIPTION
Settings and host-menu modals opened with a noticeable delay — worst the first time in a session. This cuts both the cold first-open cost and the per-open cost, and fixes a close-fade glitch found along the way.

**What changed**
- **Pre-warm caches on the first idle Home frame** — renders the Settings shell into throwaway painters so the first real modal open doesn't pay a burst of cold `SDL2_ttf` glyph renders. The freetype glyph cache is font-wide, so every modal's first open gets faster, not just Settings.
- **Modal tile sized to the card, not the whole screen** — added a draw-origin offset to `Painter` so the render fns keep their absolute, screen-centered geometry while the tile buffer covers only the card's bounding box. Much less to rasterize and a far smaller GPU upload each open (a small confirm dialog is now ~15% of the old full-screen upload). Full-screen painters are unchanged.
- **Close-fade fix** — the focused-row highlight recomputed its position from live per-screen state that Back had already torn down (e.g. `host_menu_index` cleared), floating the row to screen centre while fading out. The overlay is now dropped during the close fade; the shell/content tiles already show the row.

**Also included** (separate in-progress work that was staged):
- Bitrate 'may be unstable on Wi-Fi' caution now renders as a caption under the row (`RowSubtext` + `CAUTION` color) instead of a separate warning line.
- The finished/failed speed-test row picks up pointer hover.

Typechecks + clippy clean. Best verified on-device: open Settings and a host menu cold, confirm the hitch is gone and the close-fade is clean.