### PR TITLE
Experimental Game mode (ALLM) for rooted TVs

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -236,6 +236,7 @@ pub(crate) enum ModalShellKey {
     },
     Experimental {
         video_pacing: bool,
+        game_mode: bool,
         hover_close: bool,
     },
     /// Fixed warning copy + two buttons; only the close (X) hover varies.
@@ -442,10 +443,14 @@ pub struct App {
     /// button) since only one is ever open, and focused, at a time.
     pub(crate) modal_focus_anim: Option<Instant>,
     /// In-flight `Toggle` row flip: `(when it started, the value it flipped
-    /// from)` — lets `modal_focus_tile`'s render slide the switch knob from
-    /// its old state to its new one over `ui::FOCUS_POP` instead of snapping.
+    /// from, the focused row it flipped)` — lets `modal_focus_tile`'s render
+    /// slide the switch knob from its old state to its new one over
+    /// `ui::FOCUS_POP` instead of snapping. The row index scopes the slide to
+    /// the row that actually changed: without it, navigating onto a different
+    /// toggle whose state happens to differ from `from` mid-animation would
+    /// make that unrelated switch spuriously slide (see `toggle_frac`).
     /// Shared by Settings' HDR/Stats-overlay toggles and Wake's auto-send one.
-    pub(crate) switch_anim: Option<(Instant, bool)>,
+    pub(crate) switch_anim: Option<(Instant, bool, usize)>,
     /// Last screen `prepare_tiles` saw — a change triggers the modal-open
     /// animation and a modal re-rasterize without every transition site
     /// needing to remember to.
@@ -826,7 +831,7 @@ impl App {
             }
             animating = true;
         }
-        if let Some((t, _)) = self.switch_anim {
+        if let Some((t, _, _)) = self.switch_anim {
             if t.elapsed() >= ui::FOCUS_POP {
                 self.switch_anim = None;
             }
@@ -1441,11 +1446,13 @@ impl App {
 
     /// The current position (0.0..=1.0, see `ui::draw_switch`) of a `Toggle`
     /// row's switch given its settled state `target_on` — mid-slide while
-    /// `switch_anim` is in flight *for that same transition*, otherwise
-    /// settled at the endpoint.
-    pub(crate) fn toggle_frac(&self, target_on: bool) -> f32 {
+    /// `switch_anim` is in flight *for that same row and transition*, otherwise
+    /// settled at the endpoint. `row` is the focused row being rendered; the
+    /// slide only plays for the row that actually flipped, not a same-valued
+    /// neighbor focused mid-animation.
+    pub(crate) fn toggle_frac(&self, target_on: bool, row: usize) -> f32 {
         match self.switch_anim {
-            Some((t, from_on)) if from_on != target_on => {
+            Some((t, from_on, anim_row)) if anim_row == row && from_on != target_on => {
                 let f = ui::anim_frac(Some(t), ui::FOCUS_POP);
                 if target_on {
                     f
@@ -1820,6 +1827,7 @@ impl App {
             }),
             Screen::Experimental => Some(ModalShellKey::Experimental {
                 video_pacing: self.settings.video_pacing,
+                game_mode: self.settings.game_mode,
                 hover_close: self.hover_close,
             }),
             Screen::SendLogs => Some(ModalShellKey::SendLogs {
@@ -1937,6 +1945,7 @@ impl App {
             Screen::Experimental => Some(ModalFocusKey::ExperimentalRow(
                 self.experimental_focused,
                 self.settings.video_pacing,
+                self.settings.game_mode,
             )),
             Screen::SendLogs => Some(ModalFocusKey::SendLogsButton(self.send_logs_focused)),
             // Neither has a single focused widget: the address form is one always-active
@@ -1963,7 +1972,7 @@ impl App {
                             content.width(),
                             self.settings_focused,
                             dropdown_open,
-                            self.toggle_frac(target_on),
+                            self.toggle_frac(target_on, self.settings_focused),
                         )?
                     }
                     Screen::Wake => {
@@ -2061,7 +2070,7 @@ impl App {
                             content.width(),
                             self.wake_settings_focused,
                             false,
-                            self.toggle_frac(on),
+                            self.toggle_frac(on, self.wake_settings_focused),
                         )?
                     }
                     Screen::SpeedTest => {
@@ -2101,7 +2110,7 @@ impl App {
                             content.width(),
                             self.diagnostics_focused,
                             dropdown_open,
-                            self.toggle_frac(target_on),
+                            self.toggle_frac(target_on, self.diagnostics_focused),
                         )?
                     }
                     Screen::Experimental => {
@@ -2117,7 +2126,7 @@ impl App {
                             content.width(),
                             self.experimental_focused,
                             false,
-                            self.toggle_frac(target_on),
+                            self.toggle_frac(target_on, self.experimental_focused),
                         )?
                     }
                     Screen::SendLogs => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1207,7 +1207,7 @@ impl App {
             }
             Screen::Experimental => {
                 let subtitle = self.experimental_subtitle();
-                Self::experimental_card_rect(screen_w, screen_h, fonts, &subtitle)
+                Self::experimental_card_rect(screen_w, screen_h, fonts, &subtitle, self.experimental_row_count())
             }
             Screen::SendLogs => ui::confirm_dialog_card(screen_w, screen_h, fonts, Self::SEND_LOGS_SUBTITLE),
         })
@@ -1237,7 +1237,7 @@ impl App {
         let (subtitle, rows) = match self.screen {
             Screen::HostMenu => (self.host_menu_subtitle(), self.host_menu_actions().len()),
             Screen::Diagnostics => (self.diagnostics_subtitle(), ui::DIAGNOSTICS_ROW_COUNT),
-            Screen::Experimental => (self.experimental_subtitle(), ui::EXPERIMENTAL_ROW_COUNT),
+            Screen::Experimental => (self.experimental_subtitle(), self.experimental_row_count()),
             _ => return None,
         };
         let content = ui::list_modal_content_rect(card, fonts, &subtitle, rows);
@@ -2107,7 +2107,7 @@ impl App {
                     Screen::Experimental => {
                         let subtitle = self.experimental_subtitle();
                         let rows = self.experimental_rows();
-                        let card = Self::experimental_card_rect(screen_w, screen_h, fonts, &subtitle);
+                        let card = Self::experimental_card_rect(screen_w, screen_h, fonts, &subtitle, rows.len());
                         let content = ui::list_modal_content_rect(card, fonts, &subtitle, rows.len());
                         let target_on = rows.get(self.experimental_focused).is_some_and(|r| r.value == "On");
                         ui::render_focus_row_tile(
@@ -2766,8 +2766,9 @@ impl App {
                     }
                     Screen::Experimental => {
                         let subtitle = self.experimental_subtitle();
-                        let card = Self::experimental_card_rect(screen_w, screen_h, fonts, &subtitle);
-                        let content = ui::list_modal_content_rect(card, fonts, &subtitle, ui::EXPERIMENTAL_ROW_COUNT);
+                        let rows = self.experimental_row_count();
+                        let card = Self::experimental_card_rect(screen_w, screen_h, fonts, &subtitle, rows);
+                        let content = ui::list_modal_content_rect(card, fonts, &subtitle, rows);
                         Some(ui::focus_row_rect(content, self.experimental_focused))
                     }
                     Screen::SendLogs => Some(Self::confirm_focus_button_rect(

--- a/src/app/state/diagnostics.rs
+++ b/src/app/state/diagnostics.rs
@@ -57,13 +57,13 @@ impl App {
             (ui::DIAG_ROW_STATS_OVERLAY, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
                 let from = self.settings.stats_overlay;
                 self.settings.stats_overlay = !from;
-                self.switch_anim = Some((Instant::now(), from));
+                self.switch_anim = Some((Instant::now(), from, self.diagnostics_focused));
             }
             (ui::DIAG_ROW_SHOW_LOGS, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
                 let from = self.settings.show_logs;
                 self.settings.show_logs = !from;
                 crate::runtime::set_log_overlay_enabled(!from);
-                self.switch_anim = Some((Instant::now(), from));
+                self.switch_anim = Some((Instant::now(), from, self.diagnostics_focused));
             }
             (ui::DIAG_ROW_SEND_LOGS, MenuEvent::Confirm) => {
                 // Persist any pending diagnostics changes before leaving the screen —

--- a/src/app/state/experimental.rs
+++ b/src/app/state/experimental.rs
@@ -27,6 +27,11 @@ impl App {
                 self.settings.video_pacing = !from;
                 self.switch_anim = Some((Instant::now(), from));
             }
+            (ui::EXP_ROW_GAME_MODE, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
+                let from = self.settings.game_mode;
+                self.settings.game_mode = !from;
+                self.switch_anim = Some((Instant::now(), from));
+            }
             (_, MenuEvent::Back) => {
                 self.settings_writer.save(self.settings);
                 self.screen = Screen::Settings;

--- a/src/app/state/experimental.rs
+++ b/src/app/state/experimental.rs
@@ -25,12 +25,12 @@ impl App {
             (ui::EXP_ROW_FRAME_PACER, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
                 let from = self.settings.video_pacing;
                 self.settings.video_pacing = !from;
-                self.switch_anim = Some((Instant::now(), from));
+                self.switch_anim = Some((Instant::now(), from, self.experimental_focused));
             }
             (ui::EXP_ROW_GAME_MODE, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
                 let from = self.settings.game_mode;
                 self.settings.game_mode = !from;
-                self.switch_anim = Some((Instant::now(), from));
+                self.switch_anim = Some((Instant::now(), from, self.experimental_focused));
             }
             (_, MenuEvent::Back) => {
                 self.settings_writer.save(self.settings);

--- a/src/app/state/settings.rs
+++ b/src/app/state/settings.rs
@@ -119,7 +119,8 @@ impl App {
         };
         if crate::ui::adjust_setting(&mut self.settings, row, forward) {
             if let Some(from) = toggled_from {
-                self.switch_anim = Some((Instant::now(), from));
+                // Scope the slide to the display row being rendered (see `toggle_frac`).
+                self.switch_anim = Some((Instant::now(), from, display_row));
             }
         }
         // Cycling the codec can hide/show the HDR row above; keep focus on `row`.

--- a/src/app/state/wakesettings.rs
+++ b/src/app/state/wakesettings.rs
@@ -47,6 +47,6 @@ impl App {
         let _ = store::save_known_hosts(&self.known_hosts);
         // Captures the value it's flipping *from*, so the knob slides rather than
         // snapping — same contract as the Settings modal's switch rows.
-        self.switch_anim = Some((Instant::now(), from));
+        self.switch_anim = Some((Instant::now(), from, self.wake_settings_focused));
     }
 }

--- a/src/app/view/experimental.rs
+++ b/src/app/view/experimental.rs
@@ -6,15 +6,28 @@ use anyhow::Result;
 
 impl App {
     pub(crate) fn experimental_rows(&self) -> Vec<FocusRow> {
-        ui::experimental_rows(&self.settings)
+        ui::experimental_rows(&self.settings, crate::platform::webos::game_mode::is_rooted())
+    }
+
+    /// Row count without building the `FocusRow` vec — for card/hit-test sizing.
+    pub(crate) fn experimental_row_count(&self) -> usize {
+        ui::experimental_row_count(crate::platform::webos::game_mode::is_rooted())
     }
 
     pub(crate) fn experimental_subtitle(&self) -> String {
-        "Unstable, off by default. Frame pacer also toggles live with the Blue button.".to_string()
+        "Unstable, off by default.".to_string()
     }
 
-    pub(crate) fn experimental_card_rect(screen_w: u32, screen_h: u32, fonts: &ui::Fonts, subtitle: &str) -> Rect {
-        ui::list_modal_card_rect(screen_w, screen_h, fonts, subtitle, ui::EXPERIMENTAL_ROW_COUNT)
+    /// `rows` is the live experimental-row count (`experimental_row_count`) — one shorter when
+    /// the Game mode row is hidden on a non-rooted TV, so the card sizes to what's shown.
+    pub(crate) fn experimental_card_rect(
+        screen_w: u32,
+        screen_h: u32,
+        fonts: &ui::Fonts,
+        subtitle: &str,
+        rows: usize,
+    ) -> Rect {
+        ui::list_modal_card_rect(screen_w, screen_h, fonts, subtitle, rows)
     }
 
     pub(crate) fn render_experimental(
@@ -26,7 +39,8 @@ impl App {
         screen_h: u32,
     ) -> Result<()> {
         let subtitle = self.experimental_subtitle();
-        let card = Self::experimental_card_rect(screen_w, screen_h, fonts, &subtitle);
+        let rows = self.experimental_rows();
+        let card = Self::experimental_card_rect(screen_w, screen_h, fonts, &subtitle, rows.len());
         self.draw_modal_shell(painter, text_cache, fonts.raster, fonts.icon, card)?;
         ui::render_list_modal(
             painter,
@@ -35,7 +49,7 @@ impl App {
             card,
             "Experimental",
             &subtitle,
-            &self.experimental_rows(),
+            &rows,
         )
     }
 }

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -235,6 +235,13 @@ pub struct Settings {
     /// existing settings.json without the key still loads as `true`.
     #[serde(default = "default_cursor_capture")]
     pub cursor_capture: bool,
+    /// Ask the TV to switch to its Game picture mode for the duration of a stream (the
+    /// app-plane stand-in for HDMI ALLM — see `platform::webos::game_mode`). Off by default;
+    /// unverified on non-rooted installs, so it rides the Experimental screen. Applied at
+    /// stream start (SDR "game" / HDR "hdrGame" per the negotiated colour path) and reverted
+    /// on stream exit. `serde(default)` so an existing settings.json loads as `false`.
+    #[serde(default)]
+    pub game_mode: bool,
 }
 
 fn default_audio_channels() -> u8 {
@@ -267,6 +274,7 @@ impl Default for Settings {
             video_pacing: false,
             gamepad_type: GamepadType::Auto,
             cursor_capture: default_cursor_capture(),
+            game_mode: false,
         }
     }
 }

--- a/src/platform/webos/game_mode.rs
+++ b/src/platform/webos/game_mode.rs
@@ -1,0 +1,159 @@
+//! Best-effort TV tuning for low input latency during a stream.
+//!
+//! webOS's own ALLM is an HDMI-plane feature — it never reaches a native app painting the
+//! app/video plane, so the app-side equivalent is to drive the same TV settings ALLM would:
+//! the Game *picture* mode (LG's "Game Optimizer", the real latency win), the Game *sound*
+//! mode, and — for HDR — max Peak Brightness so an HDR game isn't dimmed.
+//!
+//! **Why via the Homebrew Channel and not `settingsservice` directly.** `com.webos.settingsservice`
+//! grants the public bus NO access at all — `luna-send-pub` gets `Access denied` on both get
+//! and set, and an app-identity call is "not privileged" (verified on-device, webOS 10.3). Only
+//! a root private-bus caller may write these. So on a webosbrew-rooted set we hand the privileged
+//! `luna-send` to `org.webosbrew.hbchannel.service`'s `exec` method, which runs it as root and
+//! returns its stdout — reachable from the public bus. On a TV without the Homebrew Channel this
+//! simply fails and is logged; the feature stays behind the Experimental toggle for that reason.
+use serde_json::Value;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+const URI_EXEC: &str = "luna://org.webosbrew.hbchannel.service/exec";
+/// The Homebrew Channel's elevated helper — its presence is our proxy for "this TV is rooted",
+/// since [`enter`] can only reach `settingsservice` by having this service run `luna-send` as
+/// root (see the module docs). No service dir → not rooted → the feature can't work.
+const HBCHANNEL_SERVICE: &str = "/media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service";
+
+/// Whether this TV can drive picture/sound settings — i.e. it's webosbrew-rooted (the Homebrew
+/// Channel elevated service is installed) and `luna-send-pub` exists to reach it. Probed once;
+/// gates whether the Experimental "Game mode" row is offered at all.
+pub fn is_rooted() -> bool {
+    static ROOTED: OnceLock<bool> = OnceLock::new();
+    *ROOTED.get_or_init(|| {
+        crate::platform::webos::luna::available() && std::path::Path::new(HBCHANNEL_SERVICE).is_dir()
+    })
+}
+/// Generous: the outer call forks `luna-send` as root on the TV, which itself round-trips to
+/// `settingsservice`. Passed through as `luna-send-pub -w` and the process kill deadline.
+const EXEC_TIMEOUT: Duration = Duration::from_millis(4000);
+
+/// One setting we changed, plus the value to put back on exit (`None` = nothing to restore:
+/// couldn't read the prior value, or it already equalled what we set).
+pub struct Applied {
+    category: &'static str,
+    key: &'static str,
+    restore_to: Option<String>,
+}
+
+/// SDR vs HDR have distinct picture-mode namespaces on LG panels — "game" is the SDR Game
+/// preset, "hdrGame" the HDR one. Picking the wrong one leaves the panel in a non-game mode
+/// once HDR engages, so this mirrors the *negotiated* HDR state (`session`'s `is_hdr`).
+fn picture_mode(hdr: bool) -> &'static str {
+    if hdr {
+        "hdrGame"
+    } else {
+        "game"
+    }
+}
+
+/// Runs `luna-send-cmd` as root through the Homebrew Channel's `exec` and returns the wrapped
+/// command's stdout (the inner `luna-send`'s reply JSON). Errors if the exec service is absent
+/// (non-rooted TV) or itself reports failure.
+fn exec_root(luna_send_cmd: &str) -> anyhow::Result<String> {
+    // serde_json builds the outer payload so `luna_send_cmd` (which contains quotes) is escaped
+    // correctly regardless of the inner JSON.
+    let payload = serde_json::json!({ "command": luna_send_cmd }).to_string();
+    let reply = crate::platform::webos::luna::call_capture(URI_EXEC, &payload, EXEC_TIMEOUT)?;
+    let parsed: Value = serde_json::from_str(&reply).map_err(|e| anyhow::anyhow!("exec reply parse: {e}"))?;
+    if parsed.get("returnValue").and_then(Value::as_bool) != Some(true) {
+        anyhow::bail!("hbchannel exec failed: {reply}");
+    }
+    Ok(parsed
+        .get("stdoutString")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned())
+}
+
+/// The privileged `luna-send` for one settingsservice method, as a shell string for `exec_root`.
+/// `body` is serialized by `serde_json` (like the outer payload) then single-quoted for the
+/// shell; its own double quotes sit inside untouched.
+fn luna_send(method: &str, body: &Value) -> String {
+    format!("luna-send -n 1 luna://com.webos.settingsservice/{method} '{body}'")
+}
+
+/// Reads one setting's current string value so it can be put back on stream exit.
+fn get_setting(category: &str, key: &str) -> Option<String> {
+    let body = serde_json::json!({ "category": category, "keys": [key] });
+    let out = exec_root(&luna_send("getSystemSettings", &body))
+        .map_err(|e| tracing::warn!("game mode: read {category}.{key} failed: {e:#}"))
+        .ok()?;
+    serde_json::from_str::<Value>(&out)
+        .ok()?
+        .get("settings")?
+        .get(key)?
+        .as_str()
+        .map(str::to_owned)
+}
+
+/// Sets one setting for the current source. No `dimension` — a native app is not an HDMI input,
+/// so this targets the app/current context rather than a specific `hdmiN`. Confirms the inner
+/// call's own `returnValue`, which `exec_root`'s success does not imply.
+fn set_setting(category: &str, key: &str, value: &str) -> anyhow::Result<()> {
+    let body = serde_json::json!({ "category": category, "settings": { key: value } });
+    let out = exec_root(&luna_send("setSystemSettings", &body))?;
+    let ok = serde_json::from_str::<Value>(&out)
+        .ok()
+        .and_then(|v| v.get("returnValue").and_then(Value::as_bool))
+        == Some(true);
+    if !ok {
+        anyhow::bail!("setSystemSettings rejected: {out}");
+    }
+    Ok(())
+}
+
+/// Reads the prior value, applies `value`, and returns an [`Applied`] carrying what to restore.
+/// A failed set is logged and yields nothing to restore (the setting is unchanged).
+fn apply(category: &'static str, key: &'static str, value: &str) -> Option<Applied> {
+    let previous = get_setting(category, key);
+    match set_setting(category, key, value) {
+        Ok(()) => {
+            tracing::info!("game mode: {category}.{key} -> {value} (was {previous:?})");
+            Some(Applied {
+                category,
+                key,
+                // A prior value equal to what we just set needs no restore write.
+                restore_to: previous.filter(|p| p != value),
+            })
+        }
+        Err(e) => {
+            tracing::warn!("game mode: setting {category}.{key}={value} failed: {e:#}");
+            None
+        }
+    }
+}
+
+/// Switches the TV into Game picture + sound mode for the stream (and, on HDR, max Peak
+/// Brightness). Returns the changes to hand back to [`restore`]; empty if nothing applied.
+pub fn enter(hdr: bool) -> Vec<Applied> {
+    let mut applied = Vec::new();
+    applied.extend(apply("picture", "pictureMode", picture_mode(hdr)));
+    applied.extend(apply("sound", "soundMode", "game"));
+    // Peak Brightness only matters for HDR here — it lifts an HDR game's highlights that the
+    // panel would otherwise tone-map down; on SDR it's left as the user has it.
+    if hdr {
+        applied.extend(apply("picture", "peakBrightness", "high"));
+    }
+    applied
+}
+
+/// Restores every setting [`enter`] changed. No-op for entries with nothing to restore.
+pub fn restore(applied: Vec<Applied>) {
+    for a in applied {
+        let Some(value) = a.restore_to else {
+            continue;
+        };
+        match set_setting(a.category, a.key, &value) {
+            Ok(()) => tracing::info!("game mode: {}.{} restored to {value}", a.category, a.key),
+            Err(e) => tracing::warn!("game mode: restoring {}.{}={value} failed: {e:#}", a.category, a.key),
+        }
+    }
+}

--- a/src/platform/webos/luna.rs
+++ b/src/platform/webos/luna.rs
@@ -55,27 +55,57 @@ pub fn available() -> bool {
 /// fix during bring-up, not a runtime condition to branch on. Feedback is idempotent — the
 /// next state update re-sends everything — so a dropped call needs no recovery path.
 pub fn call(uri: &str, payload: &str) -> anyhow::Result<()> {
+    run_bounded(&["-n", "1", uri, payload], CALL_TIMEOUT, false).map(|_| ())
+}
+
+/// Like [`call`] but waits for and returns the reply JSON on stdout — for the callers that
+/// must read a value back (e.g. `getSystemSettings`, or an `exec` service that returns command
+/// output). Non-interactive `luna-send-pub` only waits for the reply when given `-w` (without
+/// it, it fires and exits before the reply arrives — verified on-device, webOS 10.3), so the
+/// caller's `timeout` is passed through as `-w` AND, plus a margin, as the kill deadline.
+pub fn call_capture(uri: &str, payload: &str, timeout: Duration) -> anyhow::Result<String> {
+    let wait_ms = timeout.as_millis().to_string();
+    // Own deadline sits past `-w` so `luna-send-pub` exits on its own timeout first.
+    run_bounded(
+        &["-n", "1", "-w", &wait_ms, uri, payload],
+        timeout + Duration::from_millis(500),
+        true,
+    )
+}
+
+/// Spawns `luna-send-pub` with `args`, polling until it exits or `timeout` elapses (killing and
+/// reaping on timeout so no zombie is left). Returns its stdout when `capture` is set, else an
+/// empty string. Shared by [`call`] and [`call_capture`] — the only differences between them are
+/// the args, `capture`, and the deadline.
+fn run_bounded(args: &[&str], timeout: Duration, capture: bool) -> anyhow::Result<String> {
     if !available() {
         anyhow::bail!("luna-send-pub unavailable");
     }
     let mut child = Command::new(LUNA_SEND_PUB)
-        .args(["-n", "1", uri, payload])
+        .args(args)
         .stdin(Stdio::null())
-        .stdout(Stdio::null())
+        .stdout(if capture { Stdio::piped() } else { Stdio::null() })
         .stderr(Stdio::null())
         .spawn()?;
 
-    let deadline = Instant::now() + CALL_TIMEOUT;
+    let deadline = Instant::now() + timeout;
     loop {
         match child.try_wait()? {
-            Some(status) if status.success() => return Ok(()),
+            Some(status) if status.success() => {
+                let out = if capture {
+                    String::from_utf8_lossy(&child.wait_with_output()?.stdout).into_owned()
+                } else {
+                    String::new()
+                };
+                return Ok(out);
+            }
             Some(status) => anyhow::bail!("luna-send-pub exited {status}"),
             None if Instant::now() >= deadline => {
                 // Kill AND reap: an unreaped child becomes a zombie held for the life of
                 // the app, and this path repeats for every send once a call starts hanging.
                 let _ = child.kill();
                 let _ = child.wait();
-                anyhow::bail!("luna-send-pub timed out after {CALL_TIMEOUT:?}");
+                anyhow::bail!("luna-send-pub timed out after {timeout:?}");
             }
             None => std::thread::sleep(Duration::from_millis(10)),
         }

--- a/src/platform/webos/mod.rs
+++ b/src/platform/webos/mod.rs
@@ -2,6 +2,7 @@ pub mod audio;
 pub mod compositor;
 pub mod device;
 pub mod dualsense;
+pub mod game_mode;
 pub mod gamepad;
 pub mod input;
 pub mod keyboard;

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -187,6 +187,15 @@ pub(super) fn run_inner() -> Result<()> {
             );
         }
 
+        // Experimental: drive the TV into Game picture + sound mode (app-plane stand-in for
+        // HDMI ALLM), plus max Peak Brightness on HDR, matched to the negotiated SDR/HDR path.
+        // Best-effort; the returned changes are reverted on stream exit. See `game_mode`.
+        let restore_tv_modes = if settings.game_mode {
+            crate::platform::webos::game_mode::enter(connected.hdr)
+        } else {
+            Vec::new()
+        };
+
         // DualSense HID feedback (adaptive triggers, lightbar), only when the host is
         // actually presenting a DualSense — anything else never emits these events, so
         // starting the sender thread would be pure overhead. Absent for any other reason
@@ -712,6 +721,8 @@ pub(super) fn run_inner() -> Result<()> {
         // frame actually gets sent before this function returns (see its docs).
         connected.shutdown();
         crate::platform::webos::ndl::quit();
+        // Put the TV's picture/sound modes back (no-op unless game mode switched them).
+        crate::platform::webos::game_mode::restore(restore_tv_modes);
         sdl.mouse().show_cursor(true);
         match outcome {
             StreamOutcome::Quit => {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -141,6 +141,10 @@ pub struct Connected {
     /// Resolved decode backend name for the stats overlay — the *actual* player,
     /// which can differ from the requested `VideoBackend` (Starfish falls back to NDL).
     pub backend_name: &'static str,
+    /// Whether HDR mastering metadata is being applied this session (negotiated codec is
+    /// HEVC *and* the host signalled HDR). Drives which Game picture mode the runtime asks
+    /// the TV for — `game` vs `hdrGame` (see `platform::webos::game_mode`).
+    pub hdr: bool,
 }
 
 /// Live video-pump counters for stats overlay (read at ~2Hz); relaxed atomics written per frame.
@@ -567,6 +571,7 @@ pub fn connect(
         audio_thread,
         audio_offloaded,
         backend_name,
+        hdr: is_hdr,
     })
 }
 

--- a/src/ui/rows.rs
+++ b/src/ui/rows.rs
@@ -58,9 +58,8 @@ pub struct RowSubtext {
 }
 
 impl RowSubtext {
-    /// Neutral secondary line (muted grey) — the default for extra context. No caller
-    /// yet; provided alongside `caution` so a future row's plain sub-label reads the same.
-    #[allow(dead_code)]
+    /// Neutral secondary line (muted grey) — the default for extra context (e.g. the
+    /// rooted-TV note on the experimental Game mode row).
     pub fn hint(text: impl Into<String>) -> Self {
         Self {
             text: text.into(),

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -101,7 +101,15 @@ pub const SETTINGS_ROW_COUNT: usize = 13;
 
 /// Experimental modal row indices (see `experimental_rows`).
 pub const EXP_ROW_FRAME_PACER: usize = 0;
-pub const EXPERIMENTAL_ROW_COUNT: usize = 1;
+/// Only present on rooted TVs (see `experimental_rows`), so it's the last row when shown.
+pub const EXP_ROW_GAME_MODE: usize = 1;
+
+/// Live experimental-row count without building the rows — the Game mode row is only offered on
+/// a rooted TV (see `experimental_rows`), so the screen is one row shorter otherwise. Used by the
+/// card/hit-test sizing paths that need the count but not the `FocusRow` allocations.
+pub fn experimental_row_count(rooted: bool) -> usize {
+    1 + usize::from(rooted)
+}
 
 /// Diagnostics modal row indices (see `diagnostics_rows`). Log level keeps index
 /// 0 so its dropdown's `(Screen, row)` tile key stays stable.
@@ -418,8 +426,8 @@ pub fn diagnostics_rows(settings: &Settings) -> Vec<FocusRow> {
 /// Experimental modal rows: the frame pacer toggle (`session::PtsPacer`). Off by default,
 /// untested on hardware, live-toggleable mid-stream with the Blue button. Order must match
 /// `EXP_ROW_*`.
-pub fn experimental_rows(settings: &Settings) -> Vec<FocusRow> {
-    vec![FocusRow {
+pub fn experimental_rows(settings: &Settings, rooted: bool) -> Vec<FocusRow> {
+    let mut rows = vec![FocusRow {
         icon: ICON_SCHEDULE,
         label: "Frame pacer".into(),
         value: if settings.video_pacing {
@@ -431,8 +439,24 @@ pub fn experimental_rows(settings: &Settings) -> Vec<FocusRow> {
         fraction: 0.0,
         danger: false,
         menu: None,
-        subtext: None,
-    }]
+        subtext: Some(RowSubtext::hint("Toggles live with the Blue button")),
+    }];
+    // Driving the TV's Game picture/sound modes needs the Homebrew Channel's root helper — the
+    // public bus is denied `settingsservice` outright (see `platform::webos::game_mode`). So the
+    // row only exists on a rooted set, where it's known to work.
+    if rooted {
+        rows.push(FocusRow {
+            icon: ICON_GAMEPAD,
+            label: "Game mode".into(),
+            value: if settings.game_mode { "On".into() } else { "Off".into() },
+            kind: RowKind::Toggle,
+            fraction: 0.0,
+            danger: false,
+            menu: None,
+            subtext: Some(RowSubtext::hint("Your TV is rooted, you can use ALLM")),
+        });
+    }
+    rows
 }
 
 /// Wake settings modal rows.

--- a/src/ui/tiles.rs
+++ b/src/ui/tiles.rs
@@ -432,8 +432,8 @@ pub enum ModalFocusKey {
     MenuRow(usize, String, bool),
     /// (focused row, log level, stats-overlay on, show-logs on) — any change invalidates the tile.
     DiagnosticsRow(usize, LogLevelOverride, bool, bool),
-    /// (focused row, frame-pacing on) — any change invalidates the tile.
-    ExperimentalRow(usize, bool),
+    /// (focused row, frame-pacing on, game-mode on) — any change invalidates the tile.
+    ExperimentalRow(usize, bool, bool),
     /// Which `Screen::SendLogs` button is focused (0 = Cancel, 1 = Send).
     SendLogsButton(usize),
 }


### PR DESCRIPTION
Adds an experimental **Game mode** toggle that asks the TV to switch into its Game picture/sound presets for the duration of a stream — the app-plane stand-in for HDMI ALLM, which never reaches a native app painting the video plane.

### What it does (on stream start, reverted on exit)
- `pictureMode` → `game` (SDR) / `hdrGame` (HDR), matched to the negotiated colour path (`session`'s `is_hdr`, now on `Connected.hdr`)
- `soundMode` → `game`
- `peakBrightness` → `high`, **HDR only** (lifts highlights the panel would otherwise tone-map down)

Each setting's prior value is read first and restored when the stream ends.

### Why the Homebrew Channel
The public bus is denied `settingsservice` outright (`Access denied` on both get and set; app-identity calls are "not privileged" — verified on-device). Only a root private-bus caller can write these. So on a webosbrew-rooted set the privileged `luna-send` is routed through `org.webosbrew.hbchannel.service`'s root `exec`, which is reachable from the public bus. Also had to add `-w` to the capture path — non-interactive `luna-send-pub` fires and exits before the reply otherwise, so the set silently no-ops.

### Gating
Rooted-only: the row only appears when the Homebrew Channel helper is present (`game_mode::is_rooted()`), with caption "Your TV is rooted, you can use ALLM". Off by default; lives behind the Experimental screen.

Verified on-device that all three settings apply and revert; not yet exercised through a full deployed stream.