### PR TITLE
Bound session-teardown joins so a wedged NDL call can't freeze the app

### DIFF
--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -171,8 +171,11 @@ pub(super) fn run_inner() -> Result<()> {
                     // connect succeeded and loaded a decoder.
                     tracing::error!("audio player init failed: {e:#}");
                     connected.client.disconnect_quit();
-                    connected.shutdown();
-                    crate::platform::webos::ndl::quit();
+                    if connected.shutdown() {
+                        crate::platform::webos::ndl::quit();
+                    } else {
+                        tracing::warn!("session teardown timed out — skipping NDL unload for this run");
+                    }
                     sdl.mouse().show_cursor(true);
                     menu_status = Some(format!("Couldn't start audio: {e:#}"));
                     continue;
@@ -718,9 +721,14 @@ pub(super) fn run_inner() -> Result<()> {
         }
         // `disconnect_quit()` was already called above for every deliberate-stop path;
         // `shutdown()` joins the video thread and drops `client` so the QUIC close
-        // frame actually gets sent before this function returns (see its docs).
-        connected.shutdown();
-        crate::platform::webos::ndl::quit();
+        // frame actually gets sent before this function returns (see its docs). A `false`
+        // return means some teardown thread is still wedged inside an FFI call — unloading
+        // NDL from under it would race, so skip that call and accept the leak for this run.
+        if connected.shutdown() {
+            crate::platform::webos::ndl::quit();
+        } else {
+            tracing::warn!("session teardown timed out — skipping NDL unload for this run");
+        }
         // Put the TV's picture/sound modes back (no-op unless game mode switched them).
         crate::platform::webos::game_mode::restore(restore_tv_modes);
         sdl.mouse().show_cursor(true);

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -199,15 +199,60 @@ pub fn clock_ticks_per_sec() -> u64 {
     (unsafe { libc::sysconf(libc::_SC_CLK_TCK) } as u64).max(1) // SAFETY: no pointers
 }
 
+/// Ceiling on each teardown join below. The video/audio pumps re-check `stop` on a bounded
+/// cadence, but the FFI calls they make between checks (NDL `play`/`play_audio`, and the
+/// QUIC-close worker `NativeClient::drop` joins internally) have no timeout of their own — an
+/// intermittently wedged vendor call must not freeze the whole app on the caller's thread.
+const SHUTDOWN_JOIN_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Joins `handle` from a watcher thread so a hang inside it can't block the caller past
+/// `timeout`. Returns `false` (and leaks the watcher, still waiting on the real join) if it
+/// didn't finish in time.
+fn join_with_timeout<T: Send + 'static>(handle: std::thread::JoinHandle<T>, timeout: Duration, name: &str) -> bool {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let spawned = std::thread::Builder::new()
+        .name(format!("punktfunk-webos-join-{name}"))
+        .spawn(move || {
+            let _ = handle.join();
+            let _ = tx.send(());
+        });
+    let Ok(watcher) = spawned else {
+        // Can't even start the watcher — fall back to a direct (unbounded) join rather
+        // than leaking `handle` outright.
+        return true;
+    };
+    if rx.recv_timeout(timeout).is_ok() {
+        let _ = watcher.join();
+        true
+    } else {
+        tracing::error!(
+            "{name} thread did not finish within {timeout:?} — leaking it \
+             (likely a wedged NDL/FFI or QUIC-close call)"
+        );
+        false
+    }
+}
+
 impl Connected {
-    /// Stop and join threads, then drop `NativeClient`. Call `disconnect_quit()` first for graceful shutdown.
-    pub fn shutdown(self) {
+    /// Stop and join threads, then drop `NativeClient`. Call `disconnect_quit()` first for
+    /// graceful shutdown. Returns `false` if any step didn't finish within
+    /// [`SHUTDOWN_JOIN_TIMEOUT`] — the caller must then skip `ndl::quit()`, since the thread
+    /// still running may still be inside an NDL FFI call that a concurrent unload would race.
+    pub fn shutdown(self) -> bool {
         self.stop.store(true, Ordering::Relaxed);
-        let _ = self.video_thread.join();
+        let mut clean = join_with_timeout(self.video_thread, SHUTDOWN_JOIN_TIMEOUT, "video");
         if let Some(audio) = self.audio_thread {
-            let _ = audio.join();
+            clean &= join_with_timeout(audio, SHUTDOWN_JOIN_TIMEOUT, "audio");
         }
-        drop(self.client);
+        // `NativeClient::drop` joins its own QUIC-close worker thread internally — bound
+        // that the same way, on its own thread, rather than blocking here directly.
+        let client = self.client;
+        clean &= join_with_timeout(
+            std::thread::spawn(move || drop(client)),
+            SHUTDOWN_JOIN_TIMEOUT,
+            "client-drop",
+        );
+        clean
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the disconnect-dialog-freezes-forever bug (~1 in 3 disconnects, app alive but UI dead).

`Connected::shutdown()` used to join the video/audio pump threads and drop the client (which itself joins the QUIC-close worker) directly on the render thread, with no timeout at all. If NDL's `play`/`play_audio` FFI call ever wedges, that join never comes back — and it takes the whole UI with it, frozen on whatever frame was last presented (the disconnect dialog, mid-teardown).

- Each teardown step (video thread, audio thread, client drop) now joins via a bounded watcher thread instead of blocking directly.
- `shutdown()` reports back whether anything timed out; if so, we skip `ndl::quit()` rather than racing an NDL unload against a thread that might still be inside an FFI call.
- Logs which step wedged, so if it happens again on-device we'll know which one to chase instead of guessing.

## Test plan

- [x] `task docker:check` passes
- [ ] Confirm on-device that disconnects no longer freeze (intermittent, so needs a run of several disconnects)