### PR TITLE
Settings caption polish + overlay cleanup

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -884,6 +884,12 @@ impl App {
     /// `true` rather than on every event.
     pub fn handle_mouse_motion(&mut self, x: i32, y: i32, screen_w: u32, screen_h: u32, fonts: &ui::Fonts) -> bool {
         let focus_changed = self.hover_focus_at(x, y, screen_w, screen_h, fonts);
+        // Parity with the D-pad: a hover that moves modal focus replays the focus-pop zoom
+        // (and shows the new row's caption). Home drives its own `focus_anim` instead, so
+        // it's excluded.
+        if focus_changed && !matches!(self.screen, Screen::Home) {
+            self.modal_focus_anim = Some(Instant::now());
+        }
         let close_changed = self.hover_close_at(x, y, screen_w, screen_h, fonts);
         focus_changed || close_changed
     }

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -579,13 +579,12 @@ pub(super) fn run_inner() -> Result<()> {
                     });
                     let mut lines = vec![
                         format!(
-                            "{}x{}@{} {}{} · {}",
+                            "{}x{}@{} {}{}",
                             mode.width,
                             mode.height,
                             mode.refresh_hz,
                             session::codec_name(connected.client.codec),
                             if connected.client.color.is_hdr() { " HDR" } else { "" },
-                            connected.backend_name,
                         ),
                         format!("Video {fps:.1} fps · {frames} frames"),
                         {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -89,10 +89,6 @@ impl VideoPlayer {
     fn render_buffer_length(&self) -> Option<i32> {
         self.0.render_buffer_length()
     }
-
-    fn backend_name(&self) -> &'static str {
-        "NDL"
-    }
 }
 
 pub struct Connected {
@@ -106,8 +102,6 @@ pub struct Connected {
     audio_thread: Option<std::thread::JoinHandle<()>>,
     /// True when NDL accepted Opus config; prevents opening SDL2 audio device.
     pub audio_offloaded: bool,
-    /// Decode backend name for the stats overlay (always "NDL").
-    pub backend_name: &'static str,
     /// Whether HDR mastering metadata is being applied this session (negotiated codec is
     /// HEVC *and* the host signalled HDR). Drives which Game picture mode the runtime asks
     /// the TV for — `game` vs `hdrGame` (see `platform::webos::game_mode`).
@@ -418,7 +412,7 @@ pub fn connect(
     let mut color = client.color;
     color_range_override.apply(&mut color);
     if let Err(e) = player.set_color_info(initial_meta.as_ref(), color) {
-        tracing::warn!("{} colour metadata failed: {e:#}", player.backend_name());
+        tracing::warn!("NDL colour metadata failed: {e:#}");
     }
     tracing::debug!(
         "colour metadata sent: transfer={} primaries={} matrix={} full_range={} (override={color_range_override:?})",
@@ -428,7 +422,6 @@ pub fn connect(
         color.full_range,
     );
 
-    let backend_name = player.backend_name();
     let audio_offloaded = player.audio_offloaded();
     tracing::info!(
         "audio path: {} (host resolved {} channel(s))",
@@ -482,7 +475,6 @@ pub fn connect(
         video_thread,
         audio_thread,
         audio_offloaded,
-        backend_name,
         hdr: is_hdr,
     })
 }
@@ -1011,8 +1003,7 @@ fn video_pump(
 
                     if feed_elapsed >= FEED_BACKPRESSURE_WARN {
                         tracing::warn!(
-                            "{} slow: {:.1}ms (frame {}, pts {:.2}ms)",
-                            player.backend_name(),
+                            "NDL slow: {:.1}ms (frame {}, pts {:.2}ms)",
                             feed_elapsed.as_secs_f32() * 1000.0,
                             frame.frame_index,
                             pts_ns as f64 / 1_000_000.0,
@@ -1033,8 +1024,7 @@ fn video_pump(
                     }
                     if let Err(e) = play_result {
                         tracing::warn!(
-                            "{} error (frame {}, pts {:.2}ms): {e:#}",
-                            player.backend_name(),
+                            "NDL error (frame {}, pts {:.2}ms): {e:#}",
                             frame.frame_index,
                             pts_ns as f64 / 1_000_000.0,
                         );
@@ -1079,7 +1069,7 @@ fn video_pump(
                 let mut color = client.color;
                 color_range_override.apply(&mut color);
                 if let Err(e) = player.set_color_info(Some(&meta), color) {
-                    tracing::warn!("{} set_color_info: {e:#}", player.backend_name());
+                    tracing::warn!("NDL set_color_info: {e:#}");
                 }
             }
         }

--- a/src/ui/rows.rs
+++ b/src/ui/rows.rs
@@ -43,9 +43,10 @@ pub struct FocusRow {
     /// Confirm can mean, reached with Right, so the row's own action stays a single
     /// press. `None` (the default) draws no button at all.
     pub menu: Option<bool>,
-    /// A small secondary line drawn under the row's label (e.g. the high-bitrate
-    /// "may be unstable on Wi-Fi" caution on the Bitrate row). `None` draws nothing and
-    /// the label stays vertically centred; `Some` centres label + subtext as a block.
+    /// A small secondary line drawn under the row's label *only while the row is focused*
+    /// (e.g. the high-bitrate "may be unstable on Wi-Fi" caution on the Bitrate row).
+    /// Unfocused, the label stays vertically centred and nothing is drawn; on focus the
+    /// label + caption centre as a block. `None` never draws anything.
     pub subtext: Option<RowSubtext>,
 }
 
@@ -240,27 +241,28 @@ pub fn draw_focus_row(
     };
     draw_icon(painter, text_cache, fonts.raster, fonts.icon, icon_rect, row.icon, fg)?;
     let label_x = icon_rect.x() + SETTINGS_ICON_SIZE as i32 + 20;
-    // With a caution caption the label + caption are centred as a block; without one the
-    // label alone stays centred (the common case).
+    // A caption belongs to the focused row only: unfocused rows keep the label centred
+    // (the common case), while a focused row with one centres label + caption as a block.
     let label_h = fonts.raster.height(fonts.label);
-    let label_y = if let Some(subtext) = &row.subtext {
-        let caption_h = fonts.raster.height(fonts.caption);
-        let gap = 4;
-        let block_h = label_h + gap + caption_h;
-        let top = row_rect.y() + (row_rect.height() as i32 - block_h) / 2;
-        draw_text(
-            painter,
-            text_cache,
-            fonts.raster,
-            fonts.caption,
-            &subtext.text,
-            label_x,
-            top + label_h + gap,
-            subtext.color,
-        )?;
-        top
-    } else {
-        row_rect.y() + (row_rect.height() as i32 - label_h) / 2
+    let label_y = match &row.subtext {
+        Some(subtext) if focused => {
+            let caption_h = fonts.raster.height(fonts.caption);
+            let gap = 4;
+            let block_h = label_h + gap + caption_h;
+            let top = row_rect.y() + (row_rect.height() as i32 - block_h) / 2;
+            draw_text(
+                painter,
+                text_cache,
+                fonts.raster,
+                fonts.caption,
+                &subtext.text,
+                label_x,
+                top + label_h + gap,
+                subtext.color,
+            )?;
+            top
+        }
+        _ => row_rect.y() + (row_rect.height() as i32 - label_h) / 2,
     };
     draw_text(
         painter,

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -223,7 +223,7 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
-            subtext: None,
+            subtext: (settings.codec == CodecPref::H264).then(|| RowSubtext::hint("HDR is not supported with this codec")),
         },
         FocusRow {
             icon: ICON_SUN,
@@ -375,7 +375,11 @@ pub fn experimental_rows(settings: &Settings, rooted: bool) -> Vec<FocusRow> {
         fraction: 0.0,
         danger: false,
         menu: None,
-        subtext: Some(RowSubtext::hint("Toggles live with the Blue button")),
+        subtext: Some(RowSubtext::hint(if settings.video_pacing {
+            "Toggles live with the Blue button"
+        } else {
+            "May improve framerate smoothness, adds latency"
+        })),
     }];
     // Driving the TV's Game picture/sound modes needs the Homebrew Channel's root helper — the
     // public bus is denied `settingsservice` outright (see `platform::webos::game_mode`). So the


### PR DESCRIPTION
A few small UI tweaks to the settings/experimental modals, plus a stats-overlay cleanup.

- Captions under settings rows now only show for the focused row (were always visible). Same behavior for D-pad and mouse hover — hovering a row now replays the focus-pop the same way arrow keys do.
- Codec row shows "HDR is not supported with this codec" when H.264 is picked.
- Frame pacer row caption is state-aware: "May improve framerate smoothness, adds latency" when off, "Toggles live with the Blue button" when on.
- Dropped the video backend name ("NDL") from the stats overlay header and removed the now-pointless `backend_name` field/method plumbing — there's only one backend, so the warn logs just say "NDL" directly.