### PR TITLE
Restore webOS launcher on remote Home button

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -894,8 +894,9 @@ impl App {
         let focus_changed = self.hover_focus_at(x, y, screen_w, screen_h, fonts);
         // Parity with the D-pad: a hover that moves modal focus replays the focus-pop zoom
         // (and shows the new row's caption). Home drives its own `focus_anim` instead, so
-        // it's excluded.
-        if focus_changed && !matches!(self.screen, Screen::Home) {
+        // it's excluded. An open dropdown is excluded too — hover there only moves the
+        // option cursor, so popping the parent row (as the D-pad also declines to) is wrong.
+        if focus_changed && self.dropdown.is_none() && !matches!(self.screen, Screen::Home) {
             self.modal_focus_anim = Some(Instant::now());
         }
         let close_changed = self.hover_close_at(x, y, screen_w, screen_h, fonts);

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -701,11 +701,19 @@ impl App {
     /// button click (`handle_mouse_click`'s `hover_close` branch below).
     pub fn back(&mut self) -> Option<ConnectTarget> {
         match self.screen {
-            // Home has nothing to "back out" of (it's the root screen) — Back is a
-            // no-op. (It used to be a shortcut straight to Settings, but that made
-            // Back in Settings feel broken: close Settings, press Back again, and
-            // Settings popped right back up.)
-            Screen::Home => None,
+            // Back steps focus out of the game grid (and the ⋯ column) back onto the
+            // host sidebar first. Only a Back from the sidebar itself is a no-op here
+            // — the menu loop turns that into the quit dialog.
+            Screen::Home => {
+                match self.home_focus {
+                    HomeFocus::Grid(_) => {
+                        self.home_focus = HomeFocus::Sidebar(self.sidebar_index_for_selected());
+                    }
+                    HomeFocus::SidebarMenu(i) => self.home_focus = HomeFocus::Sidebar(i),
+                    HomeFocus::Sidebar(_) => {}
+                }
+                None
+            }
             Screen::Pairing => {
                 self.handle_pairing_event(MenuEvent::Back);
                 None

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -196,6 +196,8 @@ impl App {
                     }
                 }
             }
+            // Back on Home is owned by `App::back` (grid/⋯ → sidebar), reached via
+            // `dispatch_menu_event` before this handler — never routed here.
             MenuEvent::Back => {}
         }
         None

--- a/src/platform/webos/input.rs
+++ b/src/platform/webos/input.rs
@@ -81,6 +81,10 @@ pub const WEBOS_GREEN_SCANCODE: i32 = 487;
 pub const WEBOS_YELLOW_SCANCODE: i32 = 488;
 pub const WEBOS_BLUE_SCANCODE: i32 = 489;
 
+/// webOS Home key (`SDL_SCANCODE_WEBOS_HOME = 384`, also the keyboard Super key).
+/// Polled to re-open the launcher once `KEYS_HOME` capture stops the OS doing it.
+pub const WEBOS_HOME_SCANCODE: i32 = 384;
+
 /// webOS EXIT key (`SDL_SCANCODE_WEBOS_EXIT`). A held/root-level Back is turned
 /// by the OS into its own EXIT gesture and delivered as this discrete keypress —
 /// *not* as a held [`WEBOS_BACK_KEYCODE`] — so it's the reliable signal for

--- a/src/platform/webos/luna.rs
+++ b/src/platform/webos/luna.rs
@@ -47,6 +47,17 @@ pub fn available() -> bool {
     })
 }
 
+/// Opens the webOS launcher by relaunching the Home app — the stand-in for the OS's
+/// Home shortcut once `KEYS_HOME` capture takes it over (so a keyboard's Windows key
+/// reaches the host). Fire-and-forget: a Home press must not block the input loop.
+pub fn launch_home() {
+    std::thread::spawn(|| {
+        if let Err(e) = call("luna://com.webos.applicationManager/launch", r#"{"id":"com.webos.app.home"}"#) {
+            tracing::warn!("launch webOS home failed: {e:#}");
+        }
+    });
+}
+
 /// Fires one `luna://` call and discards the reply. Blocking (bounded by [`CALL_TIMEOUT`]);
 /// `Err` covers spawn failure, the deadline, and a non-zero exit.
 ///

--- a/src/runtime/input.rs
+++ b/src/runtime/input.rs
@@ -309,14 +309,25 @@ impl ConfirmDialog {
     }
 }
 
-/// Rising-edge detect on the webOS EXIT gesture (a held Back, delivered as
-/// `WEBOS_EXIT_SCANCODE` — polled since it's outside rust-sdl2's `Scancode` enum).
-/// `prev` carries the last-frame state across calls.
-pub(super) fn exit_gesture_fired(prev: &mut bool) -> bool {
-    let down = crate::platform::webos::input::webos_scancode_down(crate::platform::webos::input::WEBOS_EXIT_SCANCODE);
+/// Rising-edge detect on a raw webOS scancode (polled since these sit outside
+/// rust-sdl2's `Scancode` enum). `prev` carries the last-frame state across calls.
+fn scancode_rising_edge(scancode: i32, prev: &mut bool) -> bool {
+    let down = crate::platform::webos::input::webos_scancode_down(scancode);
     let fired = down && !*prev;
     *prev = down;
     fired
+}
+
+/// The webOS EXIT gesture (a held Back, delivered as `WEBOS_EXIT_SCANCODE`).
+pub(super) fn exit_gesture_fired(prev: &mut bool) -> bool {
+    scancode_rising_edge(crate::platform::webos::input::WEBOS_EXIT_SCANCODE, prev)
+}
+
+/// The webOS Home key (`WEBOS_HOME_SCANCODE`) — captured, so callers re-open the
+/// launcher themselves via `luna::launch_home`. Distinct from EXIT, so a long Back
+/// never trips it.
+pub(super) fn home_key_fired(prev: &mut bool) -> bool {
+    scancode_rising_edge(crate::platform::webos::input::WEBOS_HOME_SCANCODE, prev)
 }
 
 /// webOS ships a real on-screen keyboard, and the SDL fork this app links wires it

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -14,18 +14,17 @@ pub(super) fn run_inner() -> Result<()> {
     // which is what killed the app mid-hold. aurora-tv, moonlight-tv, ihsplay and
     // RetroArch all pair EXIT with BACK for exactly this.
     sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_EXIT", "true");
-    // Left to the OS (=false) so the Magic Remote's physical Home button opens
-    // webOS's launcher, in menu and stream. Gated separately from KEYS_META, so the
-    // keyboard's Windows/Meta key still reaches the app and forwards to the host
-    // (VK_LWIN/VK_RWIN, see `keyboard.rs`) without popping the launcher.
-    sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_HOME", "false");
+    // Captured (=true): webOS classes a USB keyboard's Windows/Super key as a
+    // Home-class key, gated here together with the remote's Home button — there's no
+    // separate policy for them. Capturing is the only way the keyboard key reaches
+    // the app to forward to the host (VK_LWIN/VK_RWIN, see `keyboard.rs`). The cost
+    // is the remote's Home no longer opens the launcher natively, so we detect it in
+    // the input loop (bare keycode, no scancode) and relaunch it via `luna::launch_home`.
+    sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_HOME", "true");
     sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_META", "true");
     sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_GUIDE", "true");
-    // What actually paints the launcher when the OS acts on Home (KEYS_HOME=false);
-    // false suppressed it entirely so Home did nothing. Only OS-intercepted keys
-    // reach the ribbon, and KEYS_META/KEYS_GUIDE keep keyboard/gamepad off it, so
-    // only the remote's Home button pops it.
-    sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_RIBBON", "true");
+    // Suppress webOS's launcher ribbon overlay from popping over the foregrounded app.
+    sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_RIBBON", "false");
     // Linear texture filtering (SDL defaults to nearest) — the focus pop
     // scales card textures slightly, which shimmers without it.
     sdl2::hint::set("SDL_RENDER_SCALE_QUALITY", "1");
@@ -236,6 +235,7 @@ pub(super) fn run_inner() -> Result<()> {
         let mut log_fade = crate::ui::ModalFade::<()>::new();
         let mut green_held = false;
         let mut yellow_held = false;
+        let mut home_held = false;
         // Blue button flips pacing live via `stats.pacing_enabled` (`video_pump` reads it
         // per frame). Pure PTS math, no decoder state — safe to toggle mid-stream.
         let mut blue_held = false;
@@ -408,6 +408,11 @@ pub(super) fn run_inner() -> Result<()> {
             if exit_gesture_fired(&mut exit_held) && !disconnect.is_open() {
                 tracing::info!("EXIT gesture — opening disconnect dialog");
                 disconnect.open(1);
+            }
+            // Home key re-opens the webOS launcher (captured so a keyboard's Super key
+            // can reach the host); a long Back fires EXIT above, never this.
+            if home_key_fired(&mut home_held) {
+                crate::platform::webos::luna::launch_home();
             }
             // Green button: local-only stats-overlay toggle, edge-detected here (raw
             // scancode poll — the safe SDL2 event API can't see this key at all).

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -14,20 +14,17 @@ pub(super) fn run_inner() -> Result<()> {
     // which is what killed the app mid-hold. aurora-tv, moonlight-tv, ihsplay and
     // RetroArch all pair EXIT with BACK for exactly this.
     sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_EXIT", "true");
-    // KEYS_HOME left to the OS (=false): the Magic Remote's physical Home button
-    // opens webOS's own launcher, in the menu and mid-stream. Distinct from
-    // KEYS_META below, which gates a *keyboard's* Windows/Meta key separately — so
-    // that key still reaches the app and is forwarded to the host (VK_LWIN/VK_RWIN,
-    // see `keyboard.rs`), and never pops the TV launcher.
+    // Left to the OS (=false) so the Magic Remote's physical Home button opens
+    // webOS's launcher, in menu and stream. Gated separately from KEYS_META, so the
+    // keyboard's Windows/Meta key still reaches the app and forwards to the host
+    // (VK_LWIN/VK_RWIN, see `keyboard.rs`) without popping the launcher.
     sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_HOME", "false");
     sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_META", "true");
     sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_GUIDE", "true");
-    // Allow webOS's launcher/card-switcher ribbon overlay to appear: this is what
-    // actually paints the launcher when the OS acts on the physical Home button
-    // (KEYS_HOME=false above). Forcing it false suppressed the overlay entirely, so
-    // Home did nothing. Only OS-intercepted keys reach the ribbon — the keyboard
-    // Meta key (KEYS_META) and gamepad Guide (KEYS_GUIDE) are captured by the app
-    // and never trigger it, so only the remote's Home button pops the launcher.
+    // What actually paints the launcher when the OS acts on Home (KEYS_HOME=false);
+    // false suppressed it entirely so Home did nothing. Only OS-intercepted keys
+    // reach the ribbon, and KEYS_META/KEYS_GUIDE keep keyboard/gamepad off it, so
+    // only the remote's Home button pops it.
     sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_RIBBON", "true");
     // Linear texture filtering (SDL defaults to nearest) — the focus pop
     // scales card textures slightly, which shimmers without it.
@@ -365,11 +362,9 @@ pub(super) fn run_inner() -> Result<()> {
                     // to the host as real HID mouse input during a stream instead of
                     // driving local UI focus (see `mouse.rs`).
                     Event::MouseMotion { x, y, .. } => {
-                        // webOS (re)materializes its system cursor on pointer
-                        // activity, which can undo the one-shot hide at stream
-                        // start — most visibly when the app was launched with a
-                        // mouse already moving, leaving the TV cursor overlaid on
-                        // the host's. Re-assert the hide here so capture is sticky.
+                        // webOS re-materializes its system cursor on pointer activity,
+                        // undoing the one-shot hide at stream start (most visibly when
+                        // launched with a mouse in motion) — re-assert so it stays hidden.
                         if settings.cursor_capture && sdl.mouse().is_cursor_showing() {
                             sdl.mouse().show_cursor(false);
                         }

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -7,25 +7,28 @@ pub(super) fn run_inner() -> Result<()> {
     // the app into the launcher — see `keyboard.rs`'s LGui/RGui mapping and
     // `gamepad.rs`'s BTN_GUIDE mapping, which need these to actually reach the app
     // instead). Must be set before window creation — confirmed on-device these
-    // hints only latch at creation time, so there's no way to scope them to just
-    // the stream: the tradeoff is the remote's own physical Home button no longer
-    // opens webOS's launcher either, in the menu or mid-stream (accepted — the
-    // priority is that no keyboard/gamepad input can ever reach the TV OS, only
-    // the Magic Remote can).
+    // hints only latch at creation time.
     sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_BACK", "true");
     // Distinct from KEYS_BACK: without it webOS closes (SIGTERMs) the app on its own
     // Back/exit gesture — a held or root-level Back — before the app can act on the key,
     // which is what killed the app mid-hold. aurora-tv, moonlight-tv, ihsplay and
     // RetroArch all pair EXIT with BACK for exactly this.
     sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_EXIT", "true");
-    sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_HOME", "true");
+    // KEYS_HOME left to the OS (=false): the Magic Remote's physical Home button
+    // opens webOS's own launcher, in the menu and mid-stream. Distinct from
+    // KEYS_META below, which gates a *keyboard's* Windows/Meta key separately — so
+    // that key still reaches the app and is forwarded to the host (VK_LWIN/VK_RWIN,
+    // see `keyboard.rs`), and never pops the TV launcher.
+    sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_HOME", "false");
     sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_META", "true");
     sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_KEYS_GUIDE", "true");
-    // The hints above stop the key itself from backgrounding the app, but webOS's
-    // card-switcher ribbon overlay is gated separately — without this it can still
-    // pop the launcher UI on top even though the app stays foregrounded (confirmed
-    // pairing in aurora-tv's app.c).
-    sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_RIBBON", "false");
+    // Allow webOS's launcher/card-switcher ribbon overlay to appear: this is what
+    // actually paints the launcher when the OS acts on the physical Home button
+    // (KEYS_HOME=false above). Forcing it false suppressed the overlay entirely, so
+    // Home did nothing. Only OS-intercepted keys reach the ribbon — the keyboard
+    // Meta key (KEYS_META) and gamepad Guide (KEYS_GUIDE) are captured by the app
+    // and never trigger it, so only the remote's Home button pops the launcher.
+    sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_RIBBON", "true");
     // Linear texture filtering (SDL defaults to nearest) — the focus pop
     // scales card textures slightly, which shimmers without it.
     sdl2::hint::set("SDL_RENDER_SCALE_QUALITY", "1");

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -365,6 +365,14 @@ pub(super) fn run_inner() -> Result<()> {
                     // to the host as real HID mouse input during a stream instead of
                     // driving local UI focus (see `mouse.rs`).
                     Event::MouseMotion { x, y, .. } => {
+                        // webOS (re)materializes its system cursor on pointer
+                        // activity, which can undo the one-shot hide at stream
+                        // start — most visibly when the app was launched with a
+                        // mouse already moving, leaving the TV cursor overlaid on
+                        // the host's. Re-assert the hide here so capture is sticky.
+                        if settings.cursor_capture && sdl.mouse().is_cursor_showing() {
+                            sdl.mouse().show_cursor(false);
+                        }
                         let ev = mouse::move_event(x, y, display_mode.w as u32, display_mode.h as u32);
                         let _ = session::send_input(&connected.client, &ev);
                     }

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -125,14 +125,14 @@ pub(super) fn run_ui_flow(
             log_overlay_last = None;
         }
         yellow_held = yellow_down;
-        // EXIT gesture opens the quit dialog on Home; a short Back tap still flows
-        // through `handle_ui_event` as normal back-navigation (a no-op on Home).
-        if exit_gesture_fired(&mut exit_held) && !quit_dialog.is_open() && matches!(app.screen, Screen::Home) {
-            tracing::info!("EXIT gesture — opening quit dialog");
-            quit_dialog.open(1);
-            dirty = true;
+        // Long-press Back (root/held Back, surfaced as the EXIT gesture) quits
+        // straight away from any menu state, no confirm — the short Back tap below
+        // opens the dialog instead. Menu loop only; stream is unaffected.
+        if exit_gesture_fired(&mut exit_held) {
+            tracing::info!("EXIT gesture — quitting app");
+            return Ok(None);
         }
-        // Controller quit shortcut, mirroring the EXIT gesture: held long enough on Home,
+        // Controller quit shortcut: held long enough on Home,
         // then forgotten so it fires once per hold rather than repeatedly while held.
         if !quit_dialog.is_open() && matches!(app.screen, Screen::Home) && chord.held_for(EXIT_HOLD) {
             tracing::info!("quit shortcut held — opening quit dialog");
@@ -232,6 +232,19 @@ pub(super) fn run_ui_flow(
                     Some(_) => dirty = true,
                     None => {}
                 }
+                continue;
+            }
+            // Short Back tap on Home with sidebar focus opens the quit dialog. From a
+            // game card / the ⋯ column, Back first steps focus back to the sidebar
+            // (see `App::back`), so it falls through to normal dispatch instead.
+            if matches!(app.screen, Screen::Home)
+                && matches!(app.home_focus, HomeFocus::Sidebar(_))
+                && matches!(&event, Event::KeyDown { keycode: Some(k), repeat: false, .. }
+                    if crate::platform::webos::input::menu_event_for_key(*k) == Some(MenuEvent::Back))
+            {
+                tracing::info!("Back tap on Home sidebar — opening quit dialog");
+                quit_dialog.open(1);
+                dirty = true;
                 continue;
             }
             match handle_ui_event(&mut app, event, &mut input, display_mode, fonts, &mut dirty) {

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -91,6 +91,7 @@ pub(super) fn run_ui_flow(
     let mut connect_handle: Option<ConnectOutcome> = None;
     // Yellow button log overlay works here too (see streaming loop).
     let mut yellow_held = false;
+    let mut home_held = false;
     let mut log_overlay_last: Option<Instant> = None;
     // Cache last overlay tile size for idle frames (no re-render if size stable).
     let mut log_overlay_dims: Option<(u32, u32)> = None;
@@ -125,6 +126,11 @@ pub(super) fn run_ui_flow(
             log_overlay_last = None;
         }
         yellow_held = yellow_down;
+        // Home key re-opens the webOS launcher (captured so a keyboard's Super key can
+        // reach the host); works from any menu state, a long Back never trips it.
+        if home_key_fired(&mut home_held) {
+            crate::platform::webos::luna::launch_home();
+        }
         // Long-press Back (root/held Back, surfaced as the EXIT gesture) quits
         // straight away from any menu state, no confirm — the short Back tap below
         // opens the dialog instead. Menu loop only; stream is unaffected.

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -97,9 +97,9 @@ pub(super) fn run_ui_flow(
     // `quit_dialog_was_active` catches the close-fade's final frame so it gets one last
     // redraw-on-change tick to wipe the dialog off the menu.
     let mut quit_dialog = ConfirmDialog::new(
-        "Quit?",
-        "punktfunk will close and you'll return to the webOS home screen.",
-        crate::ui::confirm_buttons(Some(crate::ui::ICON_CLOSE), "Quit app", crate::ui::ERROR_RED),
+        "Quit app?",
+        "Punktfunk will close and you'll return to the webOS home screen.",
+        crate::ui::confirm_buttons(Some(crate::ui::ICON_CLOSE), "Quit", crate::ui::ERROR_RED),
     );
     let mut exit_held = false;
     // Controller routes to the quit dialog the same way it routes to the disconnect

--- a/src/ui/rows.rs
+++ b/src/ui/rows.rs
@@ -106,6 +106,12 @@ impl FocusRow {
         self
     }
 
+    /// Adds a muted caption line under the label.
+    pub fn with_subtext(mut self, subtext: RowSubtext) -> Self {
+        self.subtext = Some(subtext);
+        self
+    }
+
     /// Adds a ⋯ actions button; `focused` indicates button vs row focus.
     pub fn with_menu(mut self, focused: bool) -> Self {
         self.menu = Some(focused);

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -271,7 +271,11 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
-            subtext: None,
+            subtext: Some(RowSubtext::hint(if settings.cursor_capture {
+                "Capture (games)"
+            } else {
+                "Desktop (absolute)"
+            })),
         },
         FocusRow::action(ICON_BUG, "Experimental"),
         FocusRow::action(ICON_WRENCH, "Diagnostics"),
@@ -343,7 +347,7 @@ pub fn diagnostics_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
-            subtext: None,
+            subtext: settings.stats_overlay.then(|| RowSubtext::hint("Or use the Green button")),
         },
         FocusRow {
             icon: ICON_VISIBILITY,
@@ -353,9 +357,10 @@ pub fn diagnostics_rows(settings: &Settings) -> Vec<FocusRow> {
             fraction: 0.0,
             danger: false,
             menu: None,
-            subtext: None,
+            subtext: settings.show_logs.then(|| RowSubtext::hint("Or use the Yellow button")),
         },
-        FocusRow::action(ICON_SEND, "Send logs to developer"),
+        FocusRow::action(ICON_SEND, "Send logs to developer")
+            .with_subtext(RowSubtext::hint("If a developer asked you to")),
     ]
 }
 


### PR DESCRIPTION
The Magic Remote's physical Home button no longer opened webOS's launcher, in either the menu or mid-stream — the access-policy hints were capturing Home and suppressing the launcher ribbon so no keyboard/gamepad input could reach the TV OS.

This splits that: let the OS handle the remote Home button while still keeping keyboard/gamepad input away from the TV OS.

- `KEYS_HOME` → `false`: the OS acts on the remote's Home button and opens its launcher, in menu and stream.
- `RIBBON` → `true`: allow the launcher/card-switcher overlay to actually paint (forcing it false was suppressing it, so Home did nothing).
- `KEYS_META` / `KEYS_GUIDE` stay captured: a USB keyboard's Windows/Meta key and a gamepad's Guide button still reach the app and are forwarded to the host (`VK_LWIN`/`VK_RWIN`), never popping the TV launcher.

Since only OS-intercepted keys reach the ribbon, and keyboard/gamepad keys are captured by the app, only the remote's Home button triggers the launcher.

Closes https://github.com/dyptan-io/punktfunk-webos/issues/74