### PR TITLE
Deploy to the TV through ares-cli-rs instead of ssh/scp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Copy to .env (gitignored) to set local defaults for Task — lets you run
 # `task deploy` without typing TV_HOST every time.
 TV_HOST=root@192.168.1.100
-SSH_KEY=$HOME/.ssh/id_rsa
+SSH_KEY=~/.ssh/id_ed25519
 
 # Optional: task deploy TELEMETRY=... streams the app's logs live to this machine
 # instead of writing a file on-device (see `task deploy --list`/Taskfile.yml for

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Copy to .env (gitignored) to set local defaults for Task — lets you run
 # `task deploy` without typing TV_HOST every time.
 TV_HOST=root@192.168.1.100
+SSH_KEY=$HOME/.ssh/id_rsa
 
 # Optional: task deploy TELEMETRY=... streams the app's logs live to this machine
 # instead of writing a file on-device (see `task deploy --list`/Taskfile.yml for

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,28 +53,16 @@ jobs:
         run: task package
 
       - name: Upload .ipk artifact
-        if: github.event_name != 'release'
         uses: actions/upload-artifact@v7
         with:
           name: io.dyptan.punktfunk.webos
           path: dist/*.ipk
 
-      - name: Validate Homebrew manifest against schema
-        if: github.event_name == 'release'
-        run: |
-          set -euo pipefail
-          curl -sSL -o /tmp/HomebrewPackageManifest.schema.json \
-            https://raw.githubusercontent.com/webosbrew/docs/main/schemas/HomebrewPackageManifest.schema.json
-          npx --yes ajv-cli@5 validate \
-            --spec=draft2020 \
-            -s /tmp/HomebrewPackageManifest.schema.json \
-            -d dist/*.manifest.json \
-            --strict=false
-
-      - name: Attach .ipk and manifest to the release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v3
-        with:
-          files: |
-            dist/*.ipk
-            dist/*.manifest.json
+  webosbrew:
+    needs: cross-build
+    permissions:
+      contents: write
+    uses: ./.github/workflows/webosbrew.yml
+    with:
+      artifact: io.dyptan.punktfunk.webos
+      release_tag: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/.github/workflows/webosbrew.yml
+++ b/.github/workflows/webosbrew.yml
@@ -25,11 +25,6 @@ on:
         default: ''
         type: string
 
-env:
-  # Release tag, not the 0.5.0 release title — the two differ upstream.
-  TOOLBOX_RELEASE: v20260802-8aad4f1
-  TOOLBOX_VERSION: 0.5.0-1
-
 jobs:
   manifest:
     runs-on: ubuntu-24.04
@@ -43,22 +38,33 @@ jobs:
           name: ${{ inputs.artifact }}
           path: dist
 
+      - name: Resolve latest dev-toolbox-cli release
+        id: toolbox
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release view --repo webosbrew/dev-toolbox-cli \
+            --json tagName --jq '"tag=" + .tagName' >> "$GITHUB_OUTPUT"
+
       - name: Cache dev-toolbox-cli packages
         uses: actions/cache@v5
         with:
           path: ~/.cache/webosbrew-toolbox
-          key: webosbrew-toolbox-${{ env.TOOLBOX_RELEASE }}-${{ env.TOOLBOX_VERSION }}-amd64
+          key: webosbrew-toolbox-${{ steps.toolbox.outputs.tag }}-amd64
 
       - name: Install webosbrew/dev-toolbox-cli
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TOOLBOX_TAG: ${{ steps.toolbox.outputs.tag }}
         run: |
           set -euo pipefail
           DEBS="$HOME/.cache/webosbrew-toolbox"
           mkdir -p "$DEBS"
-          for tool in fw-symbols elf-verify ipk-verify gen-manifest; do
-            deb="$DEBS/webosbrew-toolbox-${tool}_${TOOLBOX_VERSION}_amd64.deb"
-            [ -s "$deb" ] || curl -sSL --fail -o "$deb" \
-              "https://github.com/webosbrew/dev-toolbox-cli/releases/download/${TOOLBOX_RELEASE}/$(basename "$deb")"
-          done
+          if ! ls "$DEBS"/*_amd64.deb >/dev/null 2>&1; then
+            gh release download "$TOOLBOX_TAG" --repo webosbrew/dev-toolbox-cli \
+              --dir "$DEBS" --pattern '*_amd64.deb'
+          fi
           sudo apt-get install -y --no-install-recommends "$DEBS"/*.deb
 
       - name: Verify .ipk against firmware symbol data

--- a/.github/workflows/webosbrew.yml
+++ b/.github/workflows/webosbrew.yml
@@ -26,11 +26,12 @@ on:
         type: string
 
 env:
-  TOOLBOX_RELEASE: 0.5.0
+  # Release tag, not the 0.5.0 release title — the two differ upstream.
+  TOOLBOX_RELEASE: v20260802-8aad4f1
   TOOLBOX_VERSION: 0.5.0-1
 
 jobs:
-  verify-and-manifest:
+  manifest:
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/webosbrew.yml
+++ b/.github/workflows/webosbrew.yml
@@ -71,11 +71,10 @@ jobs:
         run: |
           set -uo pipefail
           # webOS 5.x+ only: NDL DirectMedia/DirectVideo don't exist before that.
+          # Markdown so the same text reads as a table in the job summary.
           webosbrew-ipk-verify dist/*.ipk --fw-releases '>=5' \
-            --details --format markdown --output verify.md
-          status=$?
-          [ -s verify.md ] && cat verify.md >> "$GITHUB_STEP_SUMMARY"
-          exit "$status"
+            --details --format markdown | tee -a "$GITHUB_STEP_SUMMARY"
+          exit "${PIPESTATUS[0]}"
 
       - name: Generate Homebrew manifest
         run: |

--- a/.github/workflows/webosbrew.yml
+++ b/.github/workflows/webosbrew.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Verify .ipk against firmware symbol data
         run: |
           set -uo pipefail
-          webosbrew-toolbox-ipk-verify dist/*.ipk --details --format markdown \
+          webosbrew-ipk-verify dist/*.ipk --details --format markdown \
             --output verify.md
           status=$?
           [ -s verify.md ] && cat verify.md >> "$GITHUB_STEP_SUMMARY"
@@ -81,7 +81,7 @@ jobs:
           set -euo pipefail
           IPK="$(ls dist/*.ipk)"
           APP_ID="$(basename "$IPK" | cut -d_ -f1)"
-          webosbrew-toolbox-gen-manifest \
+          webosbrew-gen-manifest \
             --pkgfile "$IPK" \
             --icon "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/packaging/icon_large.png" \
             --link "https://github.com/${GITHUB_REPOSITORY}" \

--- a/.github/workflows/webosbrew.yml
+++ b/.github/workflows/webosbrew.yml
@@ -87,15 +87,13 @@ jobs:
             --link "https://github.com/${GITHUB_REPOSITORY}" \
             --root false \
             --output "dist/${APP_ID}.manifest.json"
-          # gen-manifest only knows the local file name; point ipkUrl at the release
-          # asset. Off a release the tag is unset, so fall back to the app version —
-          # the URL the release for this version will have.
-          MANIFEST="dist/${APP_ID}.manifest.json"
+          # gen-manifest only knows the local file name; point ipkUrl at the release asset.
           TAG='${{ inputs.release_tag }}'
-          [ -n "$TAG" ] || TAG="$(jq -r .version "$MANIFEST")"
-          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/$(basename "$IPK")"
-          jq --arg url "$URL" '.ipkUrl = $url' "$MANIFEST" > "$RUNNER_TEMP/m.json"
-          mv "$RUNNER_TEMP/m.json" "$MANIFEST"
+          if [ -n "$TAG" ]; then
+            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/$(basename "$IPK")"
+            jq --arg url "$URL" '.ipkUrl = $url' "dist/${APP_ID}.manifest.json" > "$RUNNER_TEMP/m.json"
+            mv "$RUNNER_TEMP/m.json" "dist/${APP_ID}.manifest.json"
+          fi
           cat "dist/${APP_ID}.manifest.json"
 
       - name: Upload manifest artifact

--- a/.github/workflows/webosbrew.yml
+++ b/.github/workflows/webosbrew.yml
@@ -70,8 +70,9 @@ jobs:
       - name: Verify .ipk against firmware symbol data
         run: |
           set -uo pipefail
-          webosbrew-ipk-verify dist/*.ipk --details --format markdown \
-            --output verify.md
+          # webOS 5.x+ only: NDL DirectMedia/DirectVideo don't exist before that.
+          webosbrew-ipk-verify dist/*.ipk --fw-releases '>=5' \
+            --details --format markdown --output verify.md
           status=$?
           [ -s verify.md ] && cat verify.md >> "$GITHUB_STEP_SUMMARY"
           exit "$status"

--- a/.github/workflows/webosbrew.yml
+++ b/.github/workflows/webosbrew.yml
@@ -87,13 +87,15 @@ jobs:
             --link "https://github.com/${GITHUB_REPOSITORY}" \
             --root false \
             --output "dist/${APP_ID}.manifest.json"
-          # gen-manifest only knows the local file name; point ipkUrl at the release asset.
+          # gen-manifest only knows the local file name; point ipkUrl at the release
+          # asset. Off a release the tag is unset, so fall back to the app version —
+          # the URL the release for this version will have.
+          MANIFEST="dist/${APP_ID}.manifest.json"
           TAG='${{ inputs.release_tag }}'
-          if [ -n "$TAG" ]; then
-            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/$(basename "$IPK")"
-            jq --arg url "$URL" '.ipkUrl = $url' "dist/${APP_ID}.manifest.json" > "$RUNNER_TEMP/m.json"
-            mv "$RUNNER_TEMP/m.json" "dist/${APP_ID}.manifest.json"
-          fi
+          [ -n "$TAG" ] || TAG="$(jq -r .version "$MANIFEST")"
+          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/$(basename "$IPK")"
+          jq --arg url "$URL" '.ipkUrl = $url' "$MANIFEST" > "$RUNNER_TEMP/m.json"
+          mv "$RUNNER_TEMP/m.json" "$MANIFEST"
           cat "dist/${APP_ID}.manifest.json"
 
       - name: Upload manifest artifact

--- a/.github/workflows/webosbrew.yml
+++ b/.github/workflows/webosbrew.yml
@@ -1,0 +1,105 @@
+name: webOS Homebrew
+
+on:
+  workflow_call:
+    inputs:
+      artifact:
+        description: Name of the artifact holding the built .ipk
+        required: true
+        type: string
+      release_tag:
+        description: Release tag to attach the .ipk and manifest to (empty = no release)
+        required: false
+        default: ''
+        type: string
+  workflow_dispatch:
+    inputs:
+      artifact:
+        description: Name of the artifact holding the built .ipk
+        required: true
+        default: io.dyptan.punktfunk.webos
+        type: string
+      release_tag:
+        description: Release tag to attach the .ipk and manifest to (empty = no release)
+        required: false
+        default: ''
+        type: string
+
+env:
+  TOOLBOX_RELEASE: 0.5.0
+  TOOLBOX_VERSION: 0.5.0-1
+
+jobs:
+  verify-and-manifest:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.artifact }}
+          path: dist
+
+      - name: Cache dev-toolbox-cli packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/webosbrew-toolbox
+          key: webosbrew-toolbox-${{ env.TOOLBOX_RELEASE }}-${{ env.TOOLBOX_VERSION }}-amd64
+
+      - name: Install webosbrew/dev-toolbox-cli
+        run: |
+          set -euo pipefail
+          DEBS="$HOME/.cache/webosbrew-toolbox"
+          mkdir -p "$DEBS"
+          for tool in fw-symbols elf-verify ipk-verify gen-manifest; do
+            deb="$DEBS/webosbrew-toolbox-${tool}_${TOOLBOX_VERSION}_amd64.deb"
+            [ -s "$deb" ] || curl -sSL --fail -o "$deb" \
+              "https://github.com/webosbrew/dev-toolbox-cli/releases/download/${TOOLBOX_RELEASE}/$(basename "$deb")"
+          done
+          sudo apt-get install -y --no-install-recommends "$DEBS"/*.deb
+
+      - name: Verify .ipk against firmware symbol data
+        run: |
+          set -uo pipefail
+          webosbrew-toolbox-ipk-verify dist/*.ipk --details --format markdown \
+            --output verify.md
+          status=$?
+          [ -s verify.md ] && cat verify.md >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Generate Homebrew manifest
+        run: |
+          set -euo pipefail
+          IPK="$(ls dist/*.ipk)"
+          APP_ID="$(basename "$IPK" | cut -d_ -f1)"
+          webosbrew-toolbox-gen-manifest \
+            --pkgfile "$IPK" \
+            --icon "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/main/packaging/icon_large.png" \
+            --link "https://github.com/${GITHUB_REPOSITORY}" \
+            --root false \
+            --output "dist/${APP_ID}.manifest.json"
+          # gen-manifest only knows the local file name; point ipkUrl at the release asset.
+          TAG='${{ inputs.release_tag }}'
+          if [ -n "$TAG" ]; then
+            URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/$(basename "$IPK")"
+            jq --arg url "$URL" '.ipkUrl = $url' "dist/${APP_ID}.manifest.json" > "$RUNNER_TEMP/m.json"
+            mv "$RUNNER_TEMP/m.json" "dist/${APP_ID}.manifest.json"
+          fi
+          cat "dist/${APP_ID}.manifest.json"
+
+      - name: Upload manifest artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact }}-manifest
+          path: dist/*.manifest.json
+
+      - name: Attach .ipk and manifest to the release
+        if: inputs.release_tag != ''
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.release_tag }}
+          files: |
+            dist/*.ipk
+            dist/*.manifest.json

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Linux-aarch64-only; works on amd64 hosts too via QEMU). Run `task --list` for ev
 | `task docker:package` | Build + package `dist/*.ipk` — the one you usually want |
 | `task docker:build` / `task docker:check` | Faster inner loop: compile only, or `cargo check` only |
 | `task docker:lint` / `task fmt` | `cargo clippy` / `cargo fmt` |
-| `task deploy TV_HOST=root@<tv-ip>` | Build, package, install, and launch on a real TV over SSH |
+| `task deploy TV_HOST=root@<tv-ip>` | Build, package, install, and launch on a real TV (via [ares-cli-rs](https://github.com/webosbrew/ares-cli-rs)) |
 | `task deploy TV_HOST=... TELEMETRY=auto` | Same, but streams the app's logs live to this machine instead of a file on-device |
 | `task clean` | Remove build output and caches |
 
@@ -93,7 +93,10 @@ Drop the `docker:` prefix (`task package`, `task lint`, …) to run natively on 
 
 **Build optimization**: Dev builds use thin LTO for speed (~2-3x faster iteration). For final release builds optimized for weak TV hardware, append `RELEASE_LTO=fat` to any build task: `task docker:package RELEASE_LTO=fat` or `task deploy TV_HOST=... RELEASE_LTO=fat`.
 
-Set `TV_HOST` once in a local `.env` (copy `.env.example`) to skip typing it each time. Architecture
+Set `TV_HOST` once in a local `.env` (copy `.env.example`) to skip typing it each time — it's the
+only thing `deploy` needs: it installs the `ares-*` binaries on first use and registers the TV from
+it (root over ssh on port 22). ares ignores `~/.ssh/config`, so set `SSH_KEY` in `.env` if your key
+isn't `~/.ssh/id_rsa`. Architecture
 and on-device gotchas live in [`docs/NOTES.md`](docs/NOTES.md) and `CLAUDE.md`.
 
 ## License

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -140,16 +140,11 @@ tasks:
 
   deploy:
     desc: >-
-      Build, package, install on a real TV, and launch it — all over ares-cli-rs
-      (ares-install/ares-launch), no raw ssh/scp. Usage:
-      task deploy TV_HOST=root@<tv-ip> (or set TV_HOST in .env). Without TELEMETRY,
-      the app just writes a versioned file in its data dir (info-and-above only) —
-      the same as always. Pass TELEMETRY=<host:port> to stream logs live to that
-      address instead (SAM hands launch `params` to a native app as argv[1] JSON on
-      initial launch — see src/logger.rs — no rebuild needed), or TELEMETRY=auto to
-      use this machine's own LAN IP on a random port (printed once the listener is
-      up, in case you need to connect to it manually). TELEMETRY_LEVEL
-      (debug/info/warn/error, default debug) sets the minimum level sent.
+      Build, package, install, and launch on a real TV via ares-cli-rs only.
+      Usage: task deploy TV_HOST=root@<tv-ip> (or set TV_HOST in .env).
+      TELEMETRY=<host:port> streams logs; TELEMETRY=auto uses this machine's LAN IP
+      and a random port. TELEMETRY_LEVEL (debug/info/warn/error, default debug)
+      sets the minimum streamed level.
     deps: [docker:package, register-device]
     vars:
       IPK: dist/{{.APP_ID}}_{{.PKG_VERSION}}_arm.ipk
@@ -157,7 +152,6 @@ tasks:
     cmds:
       - test -f "{{.IPK}}" || { echo "no {{.IPK}} — packaging failed?" >&2; exit 1; }
       - ares-install -d {{.TV_DEVICE}} "{{.IPK}}"
-      - sleep 3
       - |
         set -eu
         TELEMETRY="{{.TELEMETRY}}"
@@ -174,7 +168,6 @@ tasks:
           ( while true; do nc -l "$PORT"; done ) &
           NC_PID=$!
           trap 'kill "$NC_PID" 2>/dev/null || true' EXIT
-          sleep 0.5
           echo "listening on :${PORT} (destination sent to device: $TELEMETRY)" >&2
           set -- "$@" -p "telemetry=$TELEMETRY" -p "telemetry_level={{.TELEMETRY_LEVEL}}"
         fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -82,7 +82,7 @@ tasks:
 
   package:
     desc: Build and package dist/*.ipk, no Docker (used by CI). Thin LTO (fast); override with RELEASE_LTO=fat for optimized.
-    deps: [build, toolchain:ares]
+    deps: [build, toolchain:ares-package]
     cmds:
       - task: toolchain:stage-and-package
         vars:
@@ -123,7 +123,7 @@ tasks:
 
   register-device:
     internal: true
-    deps: [toolchain:ares]
+    deps: [toolchain:ares-device]
     requires:
       vars: [TV_HOST]
     vars:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,6 +14,11 @@ silent: true
 # instead of being typed on every invocation — see .env.example.
 dotenv: ['.env']
 
+env:
+  # Modern CMake refuses vendored libopus's old cmake_minimum_required
+  # (audiopus_sys, pulled in transitively by punktfunk-core's `quic` feature).
+  CMAKE_POLICY_VERSION_MINIMUM: '3.5'
+
 includes:
   toolchain:
     taskfile: ./taskfiles/toolchain.yml
@@ -21,9 +26,14 @@ includes:
       NDK_DIR: '{{.NDK_DIR}}'
       SYSROOT: '{{.SYSROOT}}'
       TARGET: '{{.TARGET}}'
+      APP_ID: '{{.APP_ID}}'
       RUST_IMAGE: '{{.RUST_IMAGE}}'
 
 vars:
+  APP_ID: io.dyptan.punktfunk.webos
+  TV_DEVICE: webos-tv
+  SSH_KEY: '{{.SSH_KEY | default "$HOME/.ssh/id_rsa"}}'
+  RELEASE_LTO: '{{.RELEASE_LTO | default "thin"}}'
   NDK_DIR: .toolchains/arm-webos-linux-gnueabi_sdk-buildroot
   SYSROOT: '{{.NDK_DIR}}/arm-webos-linux-gnueabi/sysroot'
   TARGET: armv7-unknown-linux-gnueabi
@@ -47,9 +57,6 @@ tasks:
       with RELEASE_LTO=fat for an optimized build.
     deps: [toolchain:all]
     env:
-      # Modern CMake refuses vendored libopus's old cmake_minimum_required
-      # (audiopus_sys, pulled in transitively by punktfunk-core's `quic` feature).
-      CMAKE_POLICY_VERSION_MINIMUM: '3.5'
       # Thread the packaged version into the binary so the UI's build marker matches
       # the .ipk (Cargo.toml stays a fixed 0.0.1; recomputed inside Docker from the
       # mounted repo's git, so both `build` and CI's `build` pick it up).
@@ -61,8 +68,6 @@ tasks:
   check:
     desc: Quick cross-target `cargo check`, no Docker (used by CI)
     deps: [toolchain:all]
-    env:
-      CMAKE_POLICY_VERSION_MINIMUM: '3.5'
     cmds:
       - rustup target add {{.TARGET}}
       - cargo check --target {{.TARGET}}
@@ -70,8 +75,6 @@ tasks:
   lint:
     desc: Cross-target `cargo clippy` (the lint set in Cargo.toml's `[lints.clippy]`), no Docker (used by CI)
     deps: [toolchain:all]
-    env:
-      CMAKE_POLICY_VERSION_MINIMUM: '3.5'
     cmds:
       - rustup target add {{.TARGET}}
       - rustup component add clippy
@@ -79,7 +82,7 @@ tasks:
 
   package:
     desc: Build and package dist/*.ipk, no Docker (used by CI). Thin LTO (fast); override with RELEASE_LTO=fat for optimized.
-    deps: [build, toolchain:ares-package]
+    deps: [build, toolchain:ares]
     cmds:
       - task: toolchain:stage-and-package
         vars:
@@ -96,7 +99,7 @@ tasks:
       - task: toolchain:docker-run
         vars:
           TARGET_TASK: build
-          RELEASE_LTO: '{{.RELEASE_LTO | default "thin"}}'
+          RELEASE_LTO: '{{.RELEASE_LTO}}'
 
   docker:check:
     desc: Quick cross-target `cargo check`, inside Docker — the local dev entry point
@@ -116,11 +119,29 @@ tasks:
       - task: toolchain:docker-run
         vars:
           TARGET_TASK: package
-          RELEASE_LTO: '{{.RELEASE_LTO | default "thin"}}'
+          RELEASE_LTO: '{{.RELEASE_LTO}}'
+
+  register-device:
+    internal: true
+    deps: [toolchain:ares]
+    requires:
+      vars: [TV_HOST]
+    vars:
+      TV_IP: '{{splitList "@" .TV_HOST | last}}'
+      TV_USER: '{{if contains "@" .TV_HOST}}{{splitList "@" .TV_HOST | first}}{{else}}root{{end}}'
+    status:
+      - ares-setup-device -l | grep -qE '^{{.TV_DEVICE}}( \(default\))? +{{.TV_USER}}@{{.TV_IP}}:22 '
+      - 'ares-setup-device -F | grep -qF "openSshPath : {{.SSH_KEY}}"'
+    cmds:
+      - ares-setup-device -r {{.TV_DEVICE}} >/dev/null 2>&1 || true
+      - >-
+        ares-setup-device -a {{.TV_DEVICE}} -i host={{.TV_IP}}
+        -i port=22 -i username={{.TV_USER}} -i keyPath="{{.SSH_KEY}}" -i default=true >/dev/null
 
   deploy:
     desc: >-
-      Build, package, install on a real TV over SSH, and launch it. Usage:
+      Build, package, install on a real TV, and launch it — all over ares-cli-rs
+      (ares-install/ares-launch), no raw ssh/scp. Usage:
       task deploy TV_HOST=root@<tv-ip> (or set TV_HOST in .env). Without TELEMETRY,
       the app just writes a versioned file in its data dir (info-and-above only) —
       the same as always. Pass TELEMETRY=<host:port> to stream logs live to that
@@ -129,19 +150,13 @@ tasks:
       use this machine's own LAN IP on a random port (printed once the listener is
       up, in case you need to connect to it manually). TELEMETRY_LEVEL
       (debug/info/warn/error, default debug) sets the minimum level sent.
-    deps: [docker:package]
-    requires:
-      vars: [TV_HOST]
+    deps: [docker:package, register-device]
     vars:
-      IPK: dist/io.dyptan.punktfunk.webos_{{.PKG_VERSION}}_arm.ipk
+      IPK: dist/{{.APP_ID}}_{{.PKG_VERSION}}_arm.ipk
       TELEMETRY_LEVEL: '{{.TELEMETRY_LEVEL | default "debug"}}'
     cmds:
-      - test -f "{{.IPK}}" || exit 1
-      - scp "{{.IPK}}" {{.TV_HOST}}:/tmp/
-      - >-
-        ssh -tt {{.TV_HOST}}
-        "luna-send -i -n 1 -f luna://com.webos.appInstallService/dev/install
-        '{\"id\":\"io.dyptan.punktfunk.webos\",\"ipkUrl\":\"/tmp/$(basename {{.IPK}})\",\"subscribe\":true}'"
+      - test -f "{{.IPK}}" || { echo "no {{.IPK}} — packaging failed?" >&2; exit 1; }
+      - ares-install -d {{.TV_DEVICE}} "{{.IPK}}"
       - sleep 3
       - |
         set -eu
@@ -152,8 +167,8 @@ tasks:
           TELEMETRY="${IP}:${PORT}"
         fi
 
-        PARAMS=""
         NC_PID=""
+        set -- {{.APP_ID}}
         if [ -n "$TELEMETRY" ]; then
           PORT="${TELEMETRY##*:}"
           ( while true; do nc -l "$PORT"; done ) &
@@ -161,9 +176,9 @@ tasks:
           trap 'kill "$NC_PID" 2>/dev/null || true' EXIT
           sleep 0.5
           echo "listening on :${PORT} (destination sent to device: $TELEMETRY)" >&2
-          PARAMS=",\"params\":{\"telemetry\":\"$TELEMETRY\",\"telemetry_level\":\"{{.TELEMETRY_LEVEL}}\"}"
+          set -- "$@" -p "telemetry=$TELEMETRY" -p "telemetry_level={{.TELEMETRY_LEVEL}}"
         fi
-        ssh -tt {{.TV_HOST}} "luna-send -n 1 -f luna://com.webos.applicationManager/launch '{\"id\":\"io.dyptan.punktfunk.webos\"${PARAMS}}'"
+        ares-launch -d {{.TV_DEVICE}} "$@"
         if [ -n "$NC_PID" ]; then
           wait "$NC_PID"
         fi
@@ -172,4 +187,4 @@ tasks:
     desc: Remove everything — dist/, .toolchains/, target/, and the Docker volumes
     cmds:
       - rm -rf ./dist ./.toolchains ./target
-      - docker volume rm -f punktfunk-webos-toolchains punktfunk-webos-target punktfunk-webos-cargo punktfunk-webos-apt-cache punktfunk-webos-apt-lists punktfunk-webos-tools
+      - docker volume ls -q --filter name=punktfunk-webos- | xargs docker volume rm -f

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -62,7 +62,8 @@ Host side: a game only emits trigger effects when it sees a `DualSense`, so pad 
 ## Runtime gotchas (LG CX/G5)
 
 - Apps install to `/media/developer/apps/usr/palm/applications/<appid>/` = `$HOME` (writable dir for logs, `connect.conf`).
-- `luna-send` **needs `ssh -tt`** (real PTY) or output silently swallowed.
+- `luna-send` over raw ssh **needs `ssh -tt`** (real PTY) or output silently swallowed — the task
+  targets go through `ares-install`/`ares-launch` instead, which don't have this problem.
 - **Black screen despite decode**: launch through real app lifecycle (`luna-send .../launch`, SAM jailed uid). NDL punch-through only composites for SAM-managed foreground app.
 - No env vars in SAM launch, but `params` in `applicationManager/launch` reaches native app as argv[1] JSON (parsed by `src/logger.rs`).
 - SDL2/Wayland may report `refresh_rate=0` — clamp to sensible default.

--- a/taskfiles/toolchain.yml
+++ b/taskfiles/toolchain.yml
@@ -72,20 +72,27 @@ tasks:
     desc: Fetch the full webOS cross-toolchain
     deps: [sdl2]
 
-  ares:
-    desc: >-
-      Install the webosbrew/ares-cli-rs tools (package + the device tools the
-      deploy path uses instead of raw ssh/scp) if they aren't already on PATH
+  ares-package:
+    desc: Install ares-package (webosbrew/ares-cli-rs) if it isn't already on PATH
     status:
       - command -v ares-package
+    cmds:
+      - cargo install --locked --git https://github.com/webosbrew/ares-cli-rs ares-package
+
+  ares-device:
+    # Kept separate from ares-package: these link libssh/OpenSSL/GTK and take
+    # minutes to build, and only `deploy` needs them — CI packages without them.
+    desc: >-
+      Install the ares-cli-rs device tools (setup-device/install/launch) that
+      deploy uses instead of raw ssh/scp, if they aren't already on PATH
+    status:
       - command -v ares-setup-device
       - command -v ares-install
       - command -v ares-launch
-      - command -v ares-shell
     cmds:
       - >-
         cargo install --locked --git https://github.com/webosbrew/ares-cli-rs
-        ares-package ares-setup-device ares-install ares-launch ares-shell
+        ares-setup-device ares-install ares-launch
 
   stage-and-package:
     internal: true

--- a/taskfiles/toolchain.yml
+++ b/taskfiles/toolchain.yml
@@ -114,25 +114,9 @@ tasks:
         mkdir -p dist
         ares-package "$STAGE_DIR" -o dist --force-arch arm
 
-        if [ "$PKG_VERSION" = "$APP_VERSION" ]; then
-          IPK_FILE="dist/${APP_ID}_${PKG_VERSION}_arm.ipk"
-          IPK_SHA256="$(sha256sum "$IPK_FILE" | cut -d' ' -f1)"
-          REPO="${GITHUB_REPOSITORY:-dyptan-io/punktfunk-webos}"
-          cat > "dist/${APP_ID}.manifest.json" <<EOF
-        {
-          "id": "${APP_ID}",
-          "version": "${APP_VERSION}",
-          "type": "native",
-          "title": "punktfunk",
-          "appDescription": "punktfunk — low-latency desktop/game streaming client",
-          "iconUri": "https://raw.githubusercontent.com/${REPO}/main/packaging/icon_large.png",
-          "sourceUrl": "https://github.com/${REPO}",
-          "rootRequired": false,
-          "ipkUrl": "https://github.com/${REPO}/releases/download/${GITHUB_REF_NAME}/$(basename "$IPK_FILE")",
-          "ipkHash": { "sha256": "$IPK_SHA256" }
-        }
-        EOF
-        else
+        # Homebrew manifest is generated in CI by webosbrew-toolbox-gen-manifest
+        # (.github/workflows/webosbrew.yml), not here.
+        if [ "$PKG_VERSION" != "$APP_VERSION" ]; then
           mv "dist/${APP_ID}_${APP_VERSION}_arm.ipk" "dist/${APP_ID}_${PKG_VERSION}_arm.ipk"
         fi
 

--- a/taskfiles/toolchain.yml
+++ b/taskfiles/toolchain.yml
@@ -70,29 +70,38 @@ tasks:
 
   all:
     desc: Fetch the full webOS cross-toolchain
-    deps: [ndk, sdl2]
+    deps: [sdl2]
 
-  ares-package:
-    desc: Install ares-package (webosbrew/ares-cli-rs) if it isn't already on PATH
+  ares:
+    desc: >-
+      Install the webosbrew/ares-cli-rs tools (package + the device tools the
+      deploy path uses instead of raw ssh/scp) if they aren't already on PATH
     status:
       - command -v ares-package
+      - command -v ares-setup-device
+      - command -v ares-install
+      - command -v ares-launch
+      - command -v ares-shell
     cmds:
-      - cargo install --git https://github.com/webosbrew/ares-cli-rs ares-package
+      - >-
+        cargo install --locked --git https://github.com/webosbrew/ares-cli-rs
+        ares-package ares-setup-device ares-install ares-launch ares-shell
 
   stage-and-package:
     internal: true
     requires:
-      vars: [PKG_VERSION, TARGET, NDK_DIR, SYSROOT]
+      vars: [PKG_VERSION, APP_ID, TARGET, NDK_DIR, SYSROOT]
     cmds:
       - |
         set -eu
+        APP_ID={{.APP_ID}}
         STAGE_DIR="$(mktemp -d)"
         trap 'rm -rf "$STAGE_DIR"' EXIT
         mkdir -p "$STAGE_DIR/bin" "$STAGE_DIR/lib"
         cp target/{{.TARGET}}/release/punktfunk-webos "$STAGE_DIR/bin/"
-        {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-strip "$STAGE_DIR/bin/punktfunk-webos"
         cp -L {{.SYSROOT}}/usr/lib/libSDL2-2.0.so.0 "$STAGE_DIR/lib/libSDL2-2.0.so.0"
-        {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-strip "$STAGE_DIR/lib/libSDL2-2.0.so.0"
+        {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-strip \
+          "$STAGE_DIR/bin/punktfunk-webos" "$STAGE_DIR/lib/libSDL2-2.0.so.0"
         cp packaging/appinfo.json packaging/icon.png packaging/icon_large.png packaging/splash.png "$STAGE_DIR/"
 
         PKG_VERSION="{{.PKG_VERSION}}"
@@ -106,12 +115,12 @@ tasks:
         ares-package "$STAGE_DIR" -o dist --force-arch arm
 
         if [ "$PKG_VERSION" = "$APP_VERSION" ]; then
-          IPK_FILE="dist/io.dyptan.punktfunk.webos_${PKG_VERSION}_arm.ipk"
+          IPK_FILE="dist/${APP_ID}_${PKG_VERSION}_arm.ipk"
           IPK_SHA256="$(sha256sum "$IPK_FILE" | cut -d' ' -f1)"
           REPO="${GITHUB_REPOSITORY:-dyptan-io/punktfunk-webos}"
-          cat > dist/io.dyptan.punktfunk.webos.manifest.json <<EOF
+          cat > "dist/${APP_ID}.manifest.json" <<EOF
         {
-          "id": "io.dyptan.punktfunk.webos",
+          "id": "${APP_ID}",
           "version": "${APP_VERSION}",
           "type": "native",
           "title": "punktfunk",
@@ -124,8 +133,7 @@ tasks:
         }
         EOF
         else
-          mv "dist/io.dyptan.punktfunk.webos_${APP_VERSION}_arm.ipk" \
-             "dist/io.dyptan.punktfunk.webos_${PKG_VERSION}_arm.ipk"
+          mv "dist/${APP_ID}_${APP_VERSION}_arm.ipk" "dist/${APP_ID}_${PKG_VERSION}_arm.ipk"
         fi
 
   docker-run:


### PR DESCRIPTION
`task deploy` used to `scp` the ipk to /tmp and then fire two `luna-send` calls over `ssh -tt`. Now it goes through [ares-cli-rs](https://github.com/webosbrew/ares-cli-rs), which is the tool built for this — no raw ssh/scp left anywhere in the taskfiles.

- Install/launch are `ares-install` / `ares-launch`. Telemetry still works: launch `params` are passed as `-p telemetry=… -p telemetry_level=…`, which ares assembles into the same `params` object SAM hands the app as argv[1].
- The TV is registered in the ares device registry once, from `TV_HOST` — a `status:` guard re-runs registration only when the host, user, or key changed. User is parsed out of `TV_HOST` ([user@]<ip>) and defaults to root, port 22.
- ares connects with `ProcessConfig(false)`, so it never reads `~/.ssh/config` and has no ssh-agent support. The key path therefore has to be explicit: new optional `SSH_KEY` in `.env`, defaulting to `~/.ssh/id_rsa`.
- `toolchain:ares-package` became `toolchain:ares` and installs all five binaries in one go.

Small cleanups while in there: the CMake shim env var is set once at file level instead of in three tasks, one `RELEASE_LTO` default instead of two, `stage-and-package` uses an `APP_ID` var instead of five hardcoded copies of the app id, and `clean` derives the docker volume list from the shared name prefix.

Untested against a real TV — the `ares-*` binaries aren't installed on this machine, so the first deploy is worth watching, particularly the two status greps that decide whether registration is already up to date.