### PR TITLE
Show a toast when the host closes the session

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -180,6 +180,49 @@ fn log_overlay_lines() -> Option<Vec<String>> {
     }
 }
 
+/// Renders a toast (`ui::Notification::frame()`'s output) and appends its `DrawCmd` — shared by
+/// the streaming loop and the menu loop so the two toasts stay pixel-identical.
+///
+/// `cache` holds the last rendered `(text, w, h)`. The tile is alpha-independent (the fade is
+/// applied at draw time via `DrawCmd`'s `alpha`), so only a *text* change needs a re-raster and
+/// re-upload — without this the identical tile would be rasterized and uploaded on every one of
+/// the ~120 frames a single toast lives for.
+fn push_notification_cmd(
+    compositor: &mut Compositor,
+    texture_creator: &sdl2::render::TextureCreator<sdl2::video::WindowContext>,
+    fonts: &crate::ui::Fonts,
+    frame: &Option<(String, f32)>,
+    display_w: i32,
+    cache: &mut Option<(String, u32, u32)>,
+    cmds: &mut Vec<DrawCmd>,
+) -> Result<()> {
+    let Some((text, alpha)) = frame else {
+        return Ok(());
+    };
+    let (tw, th) = match cache {
+        Some((cached, w, h)) if cached == text => (*w, *h),
+        _ => match crate::ui::render_notification_tile(fonts.raster, fonts.value, text) {
+            Ok(tile) => {
+                let (tw, th) = (tile.width(), tile.height());
+                compositor.upload(texture_creator, Tile::Notification, &tile)?;
+                *cache = Some((text.clone(), tw, th));
+                (tw, th)
+            }
+            Err(e) => {
+                tracing::warn!("toast render failed: {e:#}");
+                return Ok(());
+            }
+        },
+    };
+    // Top-centre: never overlaps the top-right stats or bottom log overlay.
+    cmds.push(DrawCmd::Tex {
+        tile: Tile::Notification,
+        dst: crate::ui::render::Rect::new((display_w - tw as i32) / 2, 24, tw, th),
+        alpha: (alpha * 255.0) as u8,
+    });
+    Ok(())
+}
+
 pub fn run() -> Result<()> {
     install_signal_handlers();
     // Streams to a dev machine when `task deploy TELEMETRY=...` passed a

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -75,6 +75,9 @@ pub(super) fn run_inner() -> Result<()> {
     let mut controller: Option<GameController> = None;
     // Why the *last* stream attempt bounced to the menu, shown on the fresh Home screen.
     let mut menu_status: Option<String> = None;
+    // Same, but for a toast popup (e.g. the host closed the session) instead of the
+    // bottom status line — shown on the Home screen right after re-entering the menu.
+    let mut menu_toast: Option<String> = None;
 
     loop {
         let Some((connect_thread, settings)) = run_ui_flow(
@@ -88,6 +91,7 @@ pub(super) fn run_inner() -> Result<()> {
             display_mode,
             &fonts,
             menu_status.take(),
+            menu_toast.take(),
         )?
         else {
             tracing::info!("punktfunk-webos exiting cleanly");
@@ -219,6 +223,12 @@ pub(super) fn run_inner() -> Result<()> {
         // Transient toasts. `overlay_was_active` catches the fade-out edge so the canvas gets
         // wiped once; `stats_dst`/`log_dst` recomposite each frame at their own slower cadence.
         let mut notif = crate::ui::Notification::new();
+        // Last (text, w, h) uploaded for the toast tile — see `push_notification_cmd`.
+        let mut notif_tile: Option<(String, u32, u32)> = None;
+        // Edge-detects `stats.holding` (freeze-until-reanchor — see `session::video_pump`) so a
+        // packet-loss stall surfaces as a toast even with the stats overlay off, same signal the
+        // overlay's "Beat" line already reads.
+        let mut was_holding = false;
         let mut overlay_was_active = false;
         let mut stats_dst: Option<crate::ui::render::Rect> = None;
         let mut log_dst: Option<crate::ui::render::Rect> = None;
@@ -240,6 +250,11 @@ pub(super) fn run_inner() -> Result<()> {
         let mut exit_held = false;
         // Waits for close-fade to finish.
         let mut pending_outcome: Option<StreamOutcome> = None;
+        // Set when the user confirms the disconnect dialog — distinguishes that from the
+        // host ending the session or the network dropping out, so the toast below only
+        // fires for the latter. (SIGTERM/window-close also call `disconnect_quit()`, but
+        // those break with `StreamOutcome::Quit` and never reach the check below.)
+        let mut client_initiated_disconnect = false;
         let outcome = 'running: loop {
             if QUIT_REQUESTED.load(Ordering::Relaxed) {
                 tracing::warn!("SIGTERM/SIGINT received — disconnecting before exit");
@@ -288,6 +303,7 @@ pub(super) fn run_inner() -> Result<()> {
                         match disconnect.handle_event(&event, display_mode.w as u32, display_mode.h as u32, &fonts) {
                             Some(ConfirmAction::Confirmed) => {
                                 tracing::info!("disconnecting to menu");
+                                client_initiated_disconnect = true;
                                 connected.client.disconnect_quit();
                                 disconnect.dismiss();
                                 pending_outcome = Some(StreamOutcome::ReturnToMenu);
@@ -451,6 +467,18 @@ pub(super) fn run_inner() -> Result<()> {
                 overlay_last = None;
             }
             blue_held = blue_down;
+            // Connection-issue toast: fires on the rising edge of a freeze-until-reanchor hold
+            // (dropped/gapped frames — see `session::video_pump`), which is the same "network
+            // trouble" signal the stats overlay's "Beat" line reads, just edge-triggered here so
+            // it's visible without the overlay open. No matching "recovered" toast — the video
+            // itself resuming is the recovery signal.
+            let holding_now = connected.stats.holding.load(Ordering::Relaxed);
+            if holding_now && !was_holding {
+                tracing::warn!("connection issues detected (freeze-until-reanchor)");
+                notif.show("Connection issues — recovering...");
+                overlay_last = None;
+            }
+            was_holding = holding_now;
             // The dialog is navigated with the Magic Remote's pointer, so a captured stream
             // must hand the pointer back while it's up — hidden/relative there'd be nothing
             // to aim with. Recaptured on dismiss.
@@ -653,21 +681,7 @@ pub(super) fn run_inner() -> Result<()> {
                         });
                     }
                 }
-                if let Some((text, alpha)) = &notif_frame {
-                    match crate::ui::render_notification_tile(fonts.raster, fonts.value, text) {
-                        Ok(tile) => {
-                            let (tw, th) = (tile.width(), tile.height());
-                            compositor.upload(&texture_creator, Tile::Notification, &tile)?;
-                            // Top-centre: never overlaps the top-right stats or bottom log overlay.
-                            cmds.push(DrawCmd::Tex {
-                                tile: Tile::Notification,
-                                dst: crate::ui::render::Rect::new((display_mode.w - tw as i32) / 2, 24, tw, th),
-                                alpha: (alpha * 255.0) as u8,
-                            });
-                        }
-                        Err(e) => tracing::warn!("toast render failed: {e:#}"),
-                    }
-                }
+                push_notification_cmd(&mut compositor, &texture_creator, &fonts, &notif_frame, display_mode.w, &mut notif_tile, &mut cmds)?;
                 if !cmds.is_empty() {
                     canvas.set_blend_mode(sdl2::render::BlendMode::None);
                     canvas.set_draw_color(sdl2::pixels::Color::RGBA(0, 0, 0, 0));
@@ -678,6 +692,15 @@ pub(super) fn run_inner() -> Result<()> {
             }
             if connected.client.is_session_ended() {
                 tracing::info!("host ended the session");
+                // `is_session_ended` covers both a graceful host close and a network
+                // drop/idle-timeout (see `NativeClient::is_session_ended`'s doc) — no
+                // signal distinguishes them, so one message covers both. But it also
+                // flips true right after *our own* `disconnect_quit()` calls above
+                // (Back/dialog, SIGTERM) — skip the toast for those, it's not news to
+                // the user who just asked to disconnect.
+                if !client_initiated_disconnect {
+                    menu_toast = Some("The host closed the connection".to_string());
+                }
                 break 'running StreamOutcome::ReturnToMenu;
             }
 

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -17,6 +17,7 @@ pub(super) fn run_ui_flow(
     display_mode: sdl2::video::DisplayMode,
     fonts: &crate::ui::Fonts,
     initial_status: Option<String>,
+    initial_toast: Option<String>,
 ) -> Result<Option<ConnectOutcome>> {
     // Target period for this loop's render ticks, animating or not. Each active
     // (render) iteration used to sleep a flat 16ms *on top of* whatever the tick's own
@@ -62,6 +63,14 @@ pub(super) fn run_ui_flow(
     // connect-error path).
     if initial_status.is_some() {
         app.home_status = initial_status;
+    }
+    // Same toast widget as the streaming loop's frame-pacer toggle (`ui::Notification`);
+    // shown once, right as the Home screen re-appears.
+    let mut notif = crate::ui::Notification::new();
+    // Last (text, w, h) uploaded for the toast tile — see `push_notification_cmd`.
+    let mut notif_tile: Option<(String, u32, u32)> = None;
+    if let Some(msg) = initial_toast {
+        notif.show(msg);
     }
     // Rasterized-text cache (see `ui::TextCache` docs) — created once here and
     // threaded down through every render call for the rest of this UI-flow's
@@ -293,7 +302,14 @@ pub(super) fn run_ui_flow(
             dirty = true;
         }
         quit_dialog_was_active = quit_dialog_active;
-        let animating = app.tick_animations() || app.tiles_pending || !app.grid_reveal_ready || quit_dialog_active;
+        // Polled every tick like the streaming loop's toast, not gated behind
+        // `content_dirty` — its own fade needs frames regardless of anything else.
+        let notif_frame = notif.frame();
+        let animating = app.tick_animations()
+            || app.tiles_pending
+            || !app.grid_reveal_ready
+            || quit_dialog_active
+            || notif_frame.is_some();
         let log_overlay_due = log_overlay_state() != LogOverlayState::Off
             && log_overlay_last.is_none_or(|t| t.elapsed() >= Duration::from_millis(500));
         if !dirty && !animating && !log_overlay_due {
@@ -368,6 +384,7 @@ pub(super) fn run_ui_flow(
                 });
             }
         }
+        push_notification_cmd(compositor, texture_creator, fonts, &notif_frame, display_mode.w, &mut notif_tile, &mut cmds)?;
         // Quit dialog overlay, appended to this loop's single command list rather than
         // getting its own present (unlike the stream, which draws over the video plane).
         quit_dialog.draw(

--- a/src/ui/notification.rs
+++ b/src/ui/notification.rs
@@ -57,7 +57,12 @@ pub fn render_notification_tile(raster: &dyn TextRaster, font: FontId, text: &st
     let h = (raster.height(font) + 2 * pad) as u32;
     let mut p = Painter::new(w.max(1), h.max(1));
     let mut tc = TextCache::new();
-    p.fill_rounded_rect(Rect::new(0, 0, w, h), 14, Color::RGBA(0x14, 0x10, 0x1f, 0x90));
+    let rect = Rect::new(0, 0, w, h);
+    p.fill_rounded_rect(rect, 14, Color::RGBA(0x14, 0x10, 0x1f, 0x90));
+    // The fill is the same near-black hue as the menu's own background (`ui::BG`), so over
+    // that screen it's a same-color-on-same-color box — a light stroke keeps the panel
+    // legible there, not just over the stream's video content.
+    p.stroke_rounded_rect(rect, 14, Color::RGBA(0xff, 0xff, 0xff, 0x40), 1.5);
     draw_text(&mut p, &mut tc, raster, font, text, pad, pad, WHITE)?;
     Ok(p)
 }


### PR DESCRIPTION
## Summary
- Toast pops up on the Home screen right after the host closes the session or the connection drops out — reuses the same widget as the stream's frame-pacer toggle notification
- Skipped when you disconnect yourself (Back/dialog) — only fires when it's news to you
- Added a similar toast mid-stream for connection hiccups (freeze-until-reanchor)
- Fixed the toast's background box being invisible on the menu (same color as the menu background) — added a subtle border so it's visible on both the menu and over video

## Test plan
- [ ] Disconnect via the in-stream dialog — confirm no toast on return to menu
- [ ] Force the host to close/crash mid-session — confirm toast shows on return to menu
- [ ] Trigger a network freeze mid-stream — confirm the connection-issues toast appears
- [ ] Check toast is legible both on the Home screen and over video