### PR TITLE
Start presenting only once NDL reports LOADCOMPLETED

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.22.3#1c836afc02374d00657f26ee03a4854102c70390"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.24.0#2c03290a5ee3452b0e548b097c10621da4d5aeae"
 
 [[package]]
 name = "fiat-crypto"
@@ -1109,8 +1109,8 @@ dependencies = [
 
 [[package]]
 name = "punktfunk-core"
-version = "0.22.3"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.22.3#1c836afc02374d00657f26ee03a4854102c70390"
+version = "0.24.0"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.24.0#2c03290a5ee3452b0e548b097c10621da4d5aeae"
 dependencies = [
  "aes-gcm",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,10 @@ tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 # v0.22.3 is the first release carrying core's `PUNKTFUNK_ABR_PROBE_KBPS` cap, which `main.rs`
 # sets — before it, the startup probe bursts at a fixed 2 Gbps (see docs/NOTES.md).
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.22.3", features = ["quic"] }
+# v0.24.0 brings the ABR sweep (eleven defects: the 20 Mbps pin, throughput measured in media
+# bytes not wire bytes, a decode ceiling that latched at the choke rate) and probe throughput
+# measured over the client's own receive interval — all client-side, so the bump is the fix.
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.24.0", features = ["quic"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # mDNS LAN discovery; direct dep (not via pf-client-core — see session.rs docs).

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -139,7 +139,7 @@ MANIFEST (crate version — SPDX license — source)
   powerfmt 0.2.0 — MIT OR Apache-2.0 — https://github.com/jhpratt/powerfmt
   ppv-lite86 0.2.21 — MIT OR Apache-2.0 — https://github.com/cryptocorrosion/cryptocorrosion
   proc-macro2 1.0.107 — MIT OR Apache-2.0 — https://github.com/dtolnay/proc-macro2
-  punktfunk-core 0.22.3 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
+  punktfunk-core 0.24.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
   pxfm 0.1.30 — BSD-3-Clause OR Apache-2.0 — https://github.com/awxkee/pxfm
   quinn 0.11.11 — MIT OR Apache-2.0 — https://github.com/quinn-rs/quinn
   quinn-proto 0.11.16 — MIT OR Apache-2.0 — https://github.com/quinn-rs/quinn
@@ -238,7 +238,7 @@ MANIFEST (crate version — SPDX license — source)
 ----------------------------------------------------------------------------
 Crates whose package did not embed a license file (SPDX + source only)
 ----------------------------------------------------------------------------
-  punktfunk-core 0.22.3 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
+  punktfunk-core 0.24.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
   sdl2-sys 0.38.0 — MIT AND Zlib — https://github.com/rust-sdl2/rust-sdl2
   yasna 0.5.2 — MIT OR Apache-2.0 — https://github.com/qnighy/yasna.rs
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -165,18 +165,6 @@ impl GridLayout {
     }
 }
 
-/// Pending launch awaiting pre-flight reachability check.
-pub(crate) struct PendingLaunch {
-    pub(crate) host: String,
-    pub(crate) port: u16,
-    pub(crate) fingerprint: [u8; 32],
-    pub(crate) launch: Option<String>,
-    pub(crate) title: String,
-    pub(crate) rx: std::sync::mpsc::Receiver<crate::services::library::GamesLoaded>,
-    /// Card index for `launch_anim`.
-    pub(crate) idx: usize,
-}
-
 /// Open dropdown on settings modal.
 pub struct DropdownState {
     pub row: usize,
@@ -264,7 +252,6 @@ pub struct App {
     /// Cover art pixmaps by game id.
     pub art: std::collections::HashMap<String, Pixmap>,
     pub(crate) art_loader: Option<crate::services::art::ArtLoader>,
-    pub(crate) pending_launch: Option<PendingLaunch>,
     pub(crate) launch_ready: Option<ConnectTarget>,
     pub(crate) launch_anim: Option<Instant>,
     pub(crate) launch_anim_idx: Option<usize>,
@@ -508,7 +495,6 @@ impl App {
             home_status: None,
             art: std::collections::HashMap::new(),
             art_loader: None,
-            pending_launch: None,
             launch_ready: None,
             launch_anim: None,
             launch_anim_idx: None,

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -1,7 +1,7 @@
 //! Home screen logic: sidebar/grid navigation, host selection, game library fetch,
 //! launching. Grid pixel geometry (rect helpers) lives in `app::view::home`.
 use crate::app::App;
-use crate::app::{ConnectTarget, GridCard, GridLayout, PendingLaunch};
+use crate::app::{ConnectTarget, GridCard, GridLayout};
 use crate::core::screen::{HomeFocus, Screen};
 use crate::services::store::{self};
 use crate::ui::{self, AddHostState, HostEntry, MenuEvent};
@@ -503,9 +503,13 @@ impl App {
             self.home_status = Some(reason);
         }
     }
-    /// Confirms grid card; runs reachability check first (library-fetch alone may be stale).
+    /// Confirms grid card: arms the launch straight away so the runtime's connect thread
+    /// starts on the click and overlaps the launch zoom. There is deliberately no pre-flight
+    /// reachability probe — it cost a whole mTLS round trip before the handshake could even
+    /// begin, and the connect attempt itself reports an unreachable host anyway (the host list
+    /// already probes reachability on selection, which is where the Wake dialog comes from).
     pub(crate) fn confirm_grid_card(&mut self, idx: usize, columns: usize) {
-        if self.pending_launch.is_some() {
+        if self.launch_ready.is_some() || self.launch_anim.is_some() {
             return;
         }
         let Some((host, port)) = self.selected_host.clone() else {
@@ -520,77 +524,24 @@ impl App {
             Some(GridCard::Game(game)) => (Some(game.id.clone()), game.title.clone()),
             None => return,
         };
-        let mgmt_port = known.mgmt_port.unwrap_or(crate::services::library::DEFAULT_MGMT_PORT);
-        let identity = (self.identity.0.clone(), self.identity.1.clone());
-        tracing::debug!("launch: checking {host}:{port} is still reachable before connecting…");
-        self.home_status = Some(format!("Checking the host is still reachable before starting {title}…"));
-        let rx = crate::services::library::load_games_async(host.clone(), port, mgmt_port, identity, Some(fingerprint));
-        self.pending_launch = Some(PendingLaunch {
+        tracing::debug!("launch: connecting to {host}:{port} now, zoom runs in parallel");
+        // Stays up through the launch zoom and the connect that follows it —
+        // `run_inner` puts its own UI on screen from there.
+        self.home_status = Some(format!("Starting {title}…"));
+        self.launch_anim_idx = Some(idx);
+        self.launch_ready = Some(ConnectTarget {
             host,
             port,
             fingerprint,
             launch,
-            title,
-            rx,
-            idx,
         });
-    }
-
-    /// Drains `confirm_grid_card`'s pre-flight reachability check, if it's finished. On
-    /// success, stashes the result in `launch_ready` for `main.rs` to pick up via
-    /// `take_ready_launch` (dropped instead if the selection has since moved to a
-    /// different host). On failure, defers to `handle_library_error`.
-    pub fn drain_launch_check(&mut self) -> bool {
-        let Some(pending) = &self.pending_launch else {
-            return false;
-        };
-        let Ok(loaded) = pending.rx.try_recv() else {
-            return false;
-        };
-        let PendingLaunch {
-            host,
-            port,
-            fingerprint,
-            launch,
-            title,
-            idx,
-            ..
-        } = self.pending_launch.take().expect("just matched Some above");
-        match loaded.result {
-            Ok(_) => {
-                if self
-                    .selected_host
-                    .as_ref()
-                    .is_some_and(|(h, p)| *h == host && *p == port)
-                {
-                    // Stays up through the launch zoom and the connect that follows it —
-                    // `run_inner` puts its own UI on screen from there.
-                    self.home_status = Some(format!("Starting {title}…"));
-                    self.launch_anim_idx = Some(idx);
-                    self.launch_ready = Some(ConnectTarget {
-                        host,
-                        port,
-                        fingerprint,
-                        launch,
-                    });
-                }
-            }
-            Err(e) => {
-                tracing::warn!("launch check failed ({host}:{port}): {e}");
-                self.handle_library_error(host, port, e);
-            }
-        }
-        // Not `grid_dirty`: this is a reachability probe only (`loaded.games` is
-        // discarded), so the grid's contents haven't changed — marking it dirty
-        // would rebuild every card tile and re-arm the loading spinner right as
-        // the launch zoom is about to start.
+        // Not `grid_dirty`: the grid's contents haven't changed, and marking it dirty would
+        // rebuild every card tile and re-arm the loading spinner right as the zoom starts.
         self.sidebar_dirty = true;
-        true
     }
 
-    /// Takes the `ConnectTarget` a finished `drain_launch_check` produced, if any —
-    /// `main.rs`'s tick loop calls this right after `drain_launch_check` and breaks its
-    /// event loop with it to actually start the stream.
+    /// Takes the `ConnectTarget` `confirm_grid_card` armed, if any — the runtime's tick loop
+    /// calls this and breaks its event loop with it to actually start the stream.
     pub fn take_ready_launch(&mut self) -> Option<ConnectTarget> {
         self.launch_ready.take()
     }

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -503,11 +503,10 @@ impl App {
             self.home_status = Some(reason);
         }
     }
-    /// Confirms grid card: arms the launch straight away so the runtime's connect thread
-    /// starts on the click and overlaps the launch zoom. There is deliberately no pre-flight
-    /// reachability probe — it cost a whole mTLS round trip before the handshake could even
-    /// begin, and the connect attempt itself reports an unreachable host anyway (the host list
-    /// already probes reachability on selection, which is where the Wake dialog comes from).
+    /// Confirms grid card, arming the launch straight away so the connect thread starts on the
+    /// click and overlaps the zoom. No pre-flight reachability probe: it cost a whole mTLS
+    /// round trip before the handshake, and connect reports an unreachable host itself (the
+    /// host list probes on selection, which is where the Wake dialog comes from).
     pub(crate) fn confirm_grid_card(&mut self, idx: usize, columns: usize) {
         if self.launch_ready.is_some() || self.launch_anim.is_some() {
             return;
@@ -525,8 +524,7 @@ impl App {
             None => return,
         };
         tracing::debug!("launch: connecting to {host}:{port} now, zoom runs in parallel");
-        // Stays up through the launch zoom and the connect that follows it —
-        // `run_inner` puts its own UI on screen from there.
+        // Stays up through the zoom and the connect; `run_inner` owns the screen from there.
         self.home_status = Some(format!("Starting {title}…"));
         self.launch_anim_idx = Some(idx);
         self.launch_ready = Some(ConnectTarget {
@@ -535,8 +533,8 @@ impl App {
             fingerprint,
             launch,
         });
-        // Not `grid_dirty`: the grid's contents haven't changed, and marking it dirty would
-        // rebuild every card tile and re-arm the loading spinner right as the zoom starts.
+        // Not `grid_dirty`: contents are unchanged, and dirtying rebuilds every card tile and
+        // re-arms the loading spinner right as the zoom starts.
         self.sidebar_dirty = true;
     }
 

--- a/src/app/view/speedtest.rs
+++ b/src/app/view/speedtest.rs
@@ -36,9 +36,10 @@ impl App {
                 format!("Connecting to {}…", self.speed_test_name)
             }
             Some(SpeedTestState::Measuring { partial }) => {
-                // Deliberately bytes, not Mbps: `throughput_kbps` divides by the HOST's
-                // reported burst duration, which stays 0 until the end-of-burst report
-                // lands — so a "Mbps so far" reading here could never show anything.
+                // Deliberately bytes, not Mbps: `throughput_kbps`'s denominator (since core
+                // 0.24, the client-measured receive interval, falling back to the host's
+                // burst duration) is frozen only when the end-of-burst report lands — so a
+                // "Mbps so far" reading here could never show anything.
                 // `recv_bytes` is live throughout.
                 let so_far = partial
                     .filter(|p| p.recv_bytes > 0)

--- a/src/bin/pfprobe.rs
+++ b/src/bin/pfprobe.rs
@@ -69,10 +69,11 @@ mod real {
             2,
             quic::CODEC_HEVC | quic::CODEC_H264,
             0,
-            None, // no HDR display metadata
-            0,    // client_caps
-            None, // no launch
-            None, // name: keep the host's fingerprint-derived label
+            None,  // no HDR display metadata
+            0,     // client_caps
+            false, // frame_parts
+            None,  // no launch
+            None,  // name: keep the host's fingerprint-derived label
             Some(pin),
             Some((cert, key)),
             Duration::from_secs(10),

--- a/src/platform/webos/ndl.rs
+++ b/src/platform/webos/ndl.rs
@@ -153,17 +153,58 @@ const NDL_STATE_PLAYING: c_int = 0x1a;
 /// sure the NDL Opus decoder is ready before real audio arrives.
 const OPUS_EMPTY_FRAME: [u8; 3] = [0xec, 0xff, 0xfe];
 
-/// Logs NDL load-state transitions. `PLAYING` is the only signal the present pipeline
-/// actually started — the reference point for the framerate diagnosis
-/// (docs/NDL-FRAMERATE-INVESTIGATION.md). Best-effort logging only, no state kept.
+/// How long `load()` waits for the `LOADCOMPLETED` callback before giving up and feeding
+/// anyway. Feeding an access unit into a decoder that hasn't finished loading is what the
+/// first-frames-black/late-start behaviour traced back to, but a model that never delivers
+/// the callback must still stream — so this is a bound, not a hard requirement.
+const LOAD_COMPLETE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(2_000);
+
+/// Set by the media-load callback. Process-global like the NDL session itself (one
+/// load at a time), cleared right before each `NDL_DirectMediaLoad`.
+static LOAD_COMPLETED: AtomicBool = AtomicBool::new(false);
+/// `PLAYING` — the only signal the present pipeline actually started (the reference point
+/// for docs/NDL-FRAMERATE-INVESTIGATION.md). Arrives only after frames are being fed, so
+/// it gates *revealing* the plane, never the feed itself.
+static PLAYING: AtomicBool = AtomicBool::new(false);
+
+/// Records NDL load-state transitions so `load()` and the UI reveal can wait on them.
 extern "C" fn on_load_state(state: c_int, _num: c_longlong, _str: *const c_char) {
     let name = match state {
-        NDL_STATE_LOADCOMPLETED => "LOADCOMPLETED",
+        NDL_STATE_LOADCOMPLETED => {
+            LOAD_COMPLETED.store(true, Ordering::SeqCst);
+            "LOADCOMPLETED"
+        }
+        // Deliberately clears nothing: the audio-offload probe unloads and immediately
+        // re-loads video-only, so this callback can land AFTER the retry's LOADCOMPLETED and
+        // would clear the live load's flags. Both `load()` paths reset them before the load,
+        // and `Drop` resets them on teardown — those are the points that know which load
+        // they mean.
         NDL_STATE_UNLOADCOMPLETED => "UNLOADCOMPLETED",
-        NDL_STATE_PLAYING => "PLAYING",
+        NDL_STATE_PLAYING => {
+            PLAYING.store(true, Ordering::SeqCst);
+            "PLAYING"
+        }
         _ => "other",
     };
     tracing::info!("NDL load state: {name} (0x{state:x})");
+}
+
+/// Whether NDL has reported `PLAYING` for the current load, i.e. the plane is presenting
+/// real frames and is safe to uncover.
+pub fn playing() -> bool {
+    PLAYING.load(Ordering::SeqCst)
+}
+
+/// Blocks until the `LOADCOMPLETED` callback lands. Returns `false` on timeout.
+fn wait_load_completed() -> bool {
+    let start = Instant::now();
+    while !LOAD_COMPLETED.load(Ordering::SeqCst) {
+        if start.elapsed() >= LOAD_COMPLETE_TIMEOUT {
+            return false;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+    true
 }
 
 /// Reads NDL's last error string (set on the most recent failing call).
@@ -221,9 +262,17 @@ impl NdlVideo {
                 video,
                 audio: audio.to_union(),
             };
+            LOAD_COMPLETED.store(false, Ordering::SeqCst);
+            PLAYING.store(false, Ordering::SeqCst);
             // SAFETY: `info` is valid for the duration of this call.
             let ret = unsafe { NDL_DirectMediaLoad(&mut info, Some(on_load_state)) };
             if ret == 0 {
+                // `NDL_DirectMediaLoad` returning 0 only means the request was accepted; the
+                // pipeline is ready at `LOADCOMPLETED`. Both the Opus prime below and the
+                // caller's first `play()` must wait for it.
+                if !wait_load_completed() {
+                    tracing::warn!("NDL load: no LOADCOMPLETED within {LOAD_COMPLETE_TIMEOUT:?} — feeding anyway");
+                }
                 // Prime the Opus decoder with one silent frame (ss4s does this right after a
                 // successful audio-enabled load). Best-effort — a failure here doesn't
                 // invalidate the load, so it's logged but not propagated.
@@ -251,10 +300,15 @@ impl NdlVideo {
             video,
             audio: NdlAudioUnion { bytes: [0; 32] },
         };
+        LOAD_COMPLETED.store(false, Ordering::SeqCst);
+        PLAYING.store(false, Ordering::SeqCst);
         // SAFETY: `info` is valid for the duration of this call.
         let ret = unsafe { NDL_DirectMediaLoad(&mut info, Some(on_load_state)) };
         if ret != 0 {
             bail!("NDL_DirectMediaLoad failed: ret={ret} error={}", last_error());
+        }
+        if !wait_load_completed() {
+            tracing::warn!("NDL load: no LOADCOMPLETED within {LOAD_COMPLETE_TIMEOUT:?} — feeding anyway");
         }
         Ok(Self {
             load_instant: Instant::now(),
@@ -395,6 +449,8 @@ impl NdlVideo {
 
 impl Drop for NdlVideo {
     fn drop(&mut self) {
+        LOAD_COMPLETED.store(false, Ordering::SeqCst);
+        PLAYING.store(false, Ordering::SeqCst);
         // SAFETY: best-effort teardown; error ignored (Drop can't propagate a Result).
         let _ = unsafe { NDL_DirectMediaUnload() };
     }

--- a/src/platform/webos/ndl.rs
+++ b/src/platform/webos/ndl.rs
@@ -153,18 +153,15 @@ const NDL_STATE_PLAYING: c_int = 0x1a;
 /// sure the NDL Opus decoder is ready before real audio arrives.
 const OPUS_EMPTY_FRAME: [u8; 3] = [0xec, 0xff, 0xfe];
 
-/// How long `load()` waits for the `LOADCOMPLETED` callback before giving up and feeding
-/// anyway. Feeding an access unit into a decoder that hasn't finished loading is what the
-/// first-frames-black/late-start behaviour traced back to, but a model that never delivers
-/// the callback must still stream — so this is a bound, not a hard requirement.
+/// Bound, not a requirement: feeding an unloaded decoder is the first-frames-black cause,
+/// but a model that never delivers the callback must still stream.
 const LOAD_COMPLETE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(2_000);
 
-/// Set by the media-load callback. Process-global like the NDL session itself (one
-/// load at a time), cleared right before each `NDL_DirectMediaLoad`.
+/// Process-global like the NDL session itself (one load at a time); cleared right before
+/// each `NDL_DirectMediaLoad`.
 static LOAD_COMPLETED: AtomicBool = AtomicBool::new(false);
-/// `PLAYING` — the only signal the present pipeline actually started (the reference point
-/// for docs/NDL-FRAMERATE-INVESTIGATION.md). Arrives only after frames are being fed, so
-/// it gates *revealing* the plane, never the feed itself.
+/// The only signal the present pipeline actually started (docs/NDL-FRAMERATE-INVESTIGATION.md).
+/// Arrives only once frames are being fed, so it gates *revealing* the plane, never the feed.
 static PLAYING: AtomicBool = AtomicBool::new(false);
 
 /// Records NDL load-state transitions so `load()` and the UI reveal can wait on them.
@@ -174,11 +171,9 @@ extern "C" fn on_load_state(state: c_int, _num: c_longlong, _str: *const c_char)
             LOAD_COMPLETED.store(true, Ordering::SeqCst);
             "LOADCOMPLETED"
         }
-        // Deliberately clears nothing: the audio-offload probe unloads and immediately
-        // re-loads video-only, so this callback can land AFTER the retry's LOADCOMPLETED and
-        // would clear the live load's flags. Both `load()` paths reset them before the load,
-        // and `Drop` resets them on teardown — those are the points that know which load
-        // they mean.
+        // Clears nothing: the audio-offload probe unloads then re-loads video-only, so this
+        // can land AFTER the retry's LOADCOMPLETED. `load()` and `Drop` reset the flags —
+        // they know which load they mean.
         NDL_STATE_UNLOADCOMPLETED => "UNLOADCOMPLETED",
         NDL_STATE_PLAYING => {
             PLAYING.store(true, Ordering::SeqCst);
@@ -189,8 +184,7 @@ extern "C" fn on_load_state(state: c_int, _num: c_longlong, _str: *const c_char)
     tracing::info!("NDL load state: {name} (0x{state:x})");
 }
 
-/// Whether NDL has reported `PLAYING` for the current load, i.e. the plane is presenting
-/// real frames and is safe to uncover.
+/// `PLAYING` for the current load: the plane is presenting and safe to uncover.
 pub fn playing() -> bool {
     PLAYING.load(Ordering::SeqCst)
 }
@@ -267,9 +261,8 @@ impl NdlVideo {
             // SAFETY: `info` is valid for the duration of this call.
             let ret = unsafe { NDL_DirectMediaLoad(&mut info, Some(on_load_state)) };
             if ret == 0 {
-                // `NDL_DirectMediaLoad` returning 0 only means the request was accepted; the
-                // pipeline is ready at `LOADCOMPLETED`. Both the Opus prime below and the
-                // caller's first `play()` must wait for it.
+                // `ret == 0` means the request was accepted, not that the pipeline is ready —
+                // the Opus prime below and the caller's first `play()` both need LOADCOMPLETED.
                 if !wait_load_completed() {
                     tracing::warn!("NDL load: no LOADCOMPLETED within {LOAD_COMPLETE_TIMEOUT:?} — feeding anyway");
                 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -77,8 +77,15 @@ fn spawn_connect(
                 identity,
                 fp,
                 launch,
-                // 185s: host parks unpinned/TOFU until approval (15s handhake budget too short)
-                Duration::from_secs(185),
+                // 185s only for a host that isn't pinned yet: it parks the TOFU connection until
+                // its operator approves, and a 15s handshake budget can't outlast that. A pinned
+                // host has nothing to approve, so waiting three minutes there just means a
+                // powered-off TV sits on the launch scrim — fail fast and say so instead.
+                if fp.is_some() {
+                    Duration::from_secs(15)
+                } else {
+                    Duration::from_secs(185)
+                },
                 settings.codec,
                 settings.color_range_override,
                 settings.video_pacing,

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -77,12 +77,12 @@ fn spawn_connect(
                 identity,
                 fp,
                 launch,
-                // 185s only for a host that isn't pinned yet: it parks the TOFU connection until
-                // its operator approves, and a 15s handshake budget can't outlast that. A pinned
-                // host has nothing to approve, so waiting three minutes there just means a
-                // powered-off TV sits on the launch scrim — fail fast and say so instead.
+                // 185s applies only to a host that isn't pinned yet: it parks the TOFU
+                // connection until its operator approves. A pinned host has nothing to
+                // approve, so a long budget there just means an unreachable/powered-off TV
+                // sits on the black launch scrim — fail fast and report it instead.
                 if fp.is_some() {
-                    Duration::from_secs(15)
+                    Duration::from_secs(5)
                 } else {
                     Duration::from_secs(185)
                 },

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use super::*;
 
-/// How long the finished menu frame is held while waiting for NDL's `PLAYING` state before
-/// uncovering the video plane regardless — see the reveal in `run_inner`.
+/// How long the finished menu frame is held waiting for NDL `PLAYING` before uncovering the
+/// video plane regardless.
 const NDL_REVEAL_TIMEOUT: Duration = Duration::from_millis(1_500);
 
 pub(super) fn run_inner() -> Result<()> {
@@ -103,10 +103,9 @@ pub(super) fn run_inner() -> Result<()> {
         };
         tracing::debug!("settings: {settings:?}");
 
-        // Joined BEFORE the window is cleared transparent: the menu's last frame (the
-        // finished launch zoom) stays on screen for the rest of the handshake and the NDL
-        // load, so a slow connect shows the app, not a black punch-through hole. A failed
-        // connect never uncovers the plane at all.
+        // Joined BEFORE the window is cleared transparent, so the finished launch zoom stays
+        // on screen across the handshake and NDL load instead of a black punch-through hole,
+        // and a failed connect never uncovers the plane at all.
         let connected = match connect_thread.join().expect("connect thread panicked") {
             Ok(c) => c,
             Err(e) => {
@@ -117,10 +116,9 @@ pub(super) fn run_inner() -> Result<()> {
             }
         };
         tracing::info!("session connected, entering event loop");
-        // `connect` returns with NDL past LOADCOMPLETED and the video pump feeding; `PLAYING`
-        // is the decoder confirming it is actually presenting. Waiting for it here means the
-        // reveal below swaps the menu straight for live video instead of for an empty plane.
-        // Bounded: if it never arrives, uncover anyway rather than sit on a stale menu frame.
+        // `connect` returns past LOADCOMPLETED with the pump feeding; `PLAYING` is the decoder
+        // confirming it presents, so the reveal swaps the menu straight for live video.
+        // Bounded — never arriving must not leave a stale menu frame up.
         let reveal_wait = Instant::now();
         while !crate::platform::webos::ndl::playing() && reveal_wait.elapsed() < NDL_REVEAL_TIMEOUT {
             std::thread::sleep(Duration::from_millis(4));

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -2,6 +2,10 @@ use std::sync::Arc;
 
 use super::*;
 
+/// How long the finished menu frame is held while waiting for NDL's `PLAYING` state before
+/// uncovering the video plane regardless — see the reveal in `run_inner`.
+const NDL_REVEAL_TIMEOUT: Duration = Duration::from_millis(1_500);
+
 pub(super) fn run_inner() -> Result<()> {
     // Stops webOS's launcher intercepting Back/Windows-Meta/Guide as its own Home shortcut
     // (see `keyboard.rs`'s LGui/RGui and `gamepad.rs`'s BTN_GUIDE mapping). Must be set before
@@ -99,6 +103,34 @@ pub(super) fn run_inner() -> Result<()> {
         };
         tracing::debug!("settings: {settings:?}");
 
+        // Joined BEFORE the window is cleared transparent: the menu's last frame (the
+        // finished launch zoom) stays on screen for the rest of the handshake and the NDL
+        // load, so a slow connect shows the app, not a black punch-through hole. A failed
+        // connect never uncovers the plane at all.
+        let connected = match connect_thread.join().expect("connect thread panicked") {
+            Ok(c) => c,
+            Err(e) => {
+                // Return to the menu with the reason on screen instead of `?`-ing the app down.
+                tracing::error!("session connect failed: {e:#}");
+                menu_status = Some(format!("Couldn't connect: {}", crate::errors::friendly(&e)));
+                continue;
+            }
+        };
+        tracing::info!("session connected, entering event loop");
+        // `connect` returns with NDL past LOADCOMPLETED and the video pump feeding; `PLAYING`
+        // is the decoder confirming it is actually presenting. Waiting for it here means the
+        // reveal below swaps the menu straight for live video instead of for an empty plane.
+        // Bounded: if it never arrives, uncover anyway rather than sit on a stale menu frame.
+        let reveal_wait = Instant::now();
+        while !crate::platform::webos::ndl::playing() && reveal_wait.elapsed() < NDL_REVEAL_TIMEOUT {
+            std::thread::sleep(Duration::from_millis(4));
+        }
+        tracing::info!(
+            "NDL reveal after {:?} (playing={})",
+            reveal_wait.elapsed(),
+            crate::platform::webos::ndl::playing(),
+        );
+
         // `hide()` unmaps the surface entirely, silently breaking the Magic Remote's pointer
         // forwarding since Wayland has nowhere left to route motion. aurora-tv never hides its
         // window either — stays mapped, cleared fully transparent so the video shows through.
@@ -112,20 +144,6 @@ pub(super) fn run_inner() -> Result<()> {
         // forwarded-position cursor read as "the pointer doesn't match the mouse".
         let mut cursor = cursor::Cursor::new(sdl.mouse());
         cursor.set_captured(settings.cursor_capture);
-
-        // Already running (started in `run_ui_flow`, overlapping the launch zoom/fade) — joining
-        // just waits out whatever handshake is left.
-        let connected = match connect_thread.join().expect("connect thread panicked") {
-            Ok(c) => c,
-            Err(e) => {
-                // Return to the menu with the reason on screen instead of `?`-ing the app down.
-                tracing::error!("session connect failed: {e:#}");
-                cursor.set_captured(false);
-                menu_status = Some(format!("Couldn't connect: {}", crate::errors::friendly(&e)));
-                continue;
-            }
-        };
-        tracing::info!("session connected, entering event loop");
 
         // Skipped when NDL took the Opus stream — a second unfed audio device would still
         // claim a PulseAudio sink.
@@ -617,11 +635,21 @@ pub(super) fn run_inner() -> Result<()> {
                                 if holding { "yes" } else { "no" },
                             )
                         },
-                        format!(
-                            "Feed {feed_ms:.1} ms · {:.0}/{} Mbps",
-                            actual_kbps / 1000.0,
-                            connected.client.resolved_bitrate_kbps / 1000,
-                        ),
+                        {
+                            // The encoder's CURRENT target, not the session-start negotiation:
+                            // on Automatic the ABR re-targets mid-session (and the host can
+                            // re-pick on a pipeline rebuild), which is exactly what you watch
+                            // when the picture is soft. `0` = a host too old to report one.
+                            let target_kbps = match connected.client.current_bitrate_kbps() {
+                                0 => connected.client.resolved_bitrate_kbps,
+                                live => live,
+                            };
+                            format!(
+                                "Feed {feed_ms:.1} ms · {:.0}/{} Mbps",
+                                actual_kbps / 1000.0,
+                                target_kbps / 1000,
+                            )
+                        },
                     ];
                     if let Some(line) = cpu_mem_line {
                         lines.push(line);
@@ -681,7 +709,15 @@ pub(super) fn run_inner() -> Result<()> {
                         });
                     }
                 }
-                push_notification_cmd(&mut compositor, &texture_creator, &fonts, &notif_frame, display_mode.w, &mut notif_tile, &mut cmds)?;
+                push_notification_cmd(
+                    &mut compositor,
+                    &texture_creator,
+                    &fonts,
+                    &notif_frame,
+                    display_mode.w,
+                    &mut notif_tile,
+                    &mut cmds,
+                )?;
                 if !cmds.is_empty() {
                     canvas.set_blend_mode(sdl2::render::BlendMode::None);
                     canvas.set_draw_color(sdl2::pixels::Color::RGBA(0, 0, 0, 0));

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -164,7 +164,6 @@ pub(super) fn run_ui_flow(
         app.tick_reachability();
         dirty |= app.drain_reachability();
         dirty |= app.tick_wake();
-        dirty |= app.drain_launch_check();
         // Fire on hold elapsed, not release, so user sees it before letting go.
         if let Some(hold) = input
             .pin_held
@@ -384,7 +383,15 @@ pub(super) fn run_ui_flow(
                 });
             }
         }
-        push_notification_cmd(compositor, texture_creator, fonts, &notif_frame, display_mode.w, &mut notif_tile, &mut cmds)?;
+        push_notification_cmd(
+            compositor,
+            texture_creator,
+            fonts,
+            &notif_frame,
+            display_mode.w,
+            &mut notif_tile,
+            &mut cmds,
+        )?;
         // Quit dialog overlay, appended to this loop's single command list rather than
         // getting its own present (unlike the stream, which draws over the video plane).
         quit_dialog.draw(

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -198,14 +198,7 @@ pub(super) fn run_ui_flow(
                 connect_handle = Some((handle, settings));
             }
         }
-        // The launch scrim ends fully black, so leaving the loop while the handshake is
-        // still running would hand the stream loop a black screen for however long the
-        // connect takes (a whole connect timeout, if the host is powered off). Stay here
-        // instead, spinner on the scrim, and leave only once the connect thread is done —
-        // `run_inner`'s join is then immediate, success or failure.
-        let launch_faded = app.launch_anim.is_some_and(|t| t.elapsed() >= crate::ui::LAUNCH_FADE);
-        let awaiting_connect = launch_faded && connect_handle.as_ref().is_some_and(|(handle, _)| !handle.is_finished());
-        if launch_faded && !awaiting_connect {
+        if app.launch_anim.is_some_and(|t| t.elapsed() >= crate::ui::LAUNCH_FADE) {
             break 'ui;
         }
         for event in events.poll_iter() {
@@ -311,8 +304,7 @@ pub(super) fn run_ui_flow(
         // Polled every tick like the streaming loop's toast, not gated behind
         // `content_dirty` — its own fade needs frames regardless of anything else.
         let notif_frame = notif.frame();
-        let animating = awaiting_connect
-            || app.tick_animations()
+        let animating = app.tick_animations()
             || app.tiles_pending
             || !app.grid_reveal_ready
             || quit_dialog_active
@@ -362,22 +354,6 @@ pub(super) fn run_ui_flow(
             }
         }
         let mut cmds = app.draw_list(&tiles, display_mode.w as u32, display_mode.h as u32, fonts);
-        // Centred spinner over the finished launch scrim — the only thing on screen while a
-        // slow handshake finishes, so the wait doesn't read as a hang.
-        if awaiting_connect {
-            let phase = app.launch_anim.map_or(0.0, |t| t.elapsed().as_secs_f32());
-            let (idx, frame) = crate::ui::spinner_frame_at(phase);
-            cmds.push(DrawCmd::Tex {
-                tile: Tile::SpinnerFrame(idx),
-                dst: crate::ui::render::Rect::new(
-                    (display_mode.w - frame.width as i32) / 2,
-                    (display_mode.h - frame.height as i32) / 2,
-                    frame.width,
-                    frame.height,
-                ),
-                alpha: 0xff,
-            });
-        }
         // Appended into the same single draw list/present as the rest of the
         // screen — this loop has no separate overlay pass (see the streaming
         // loop's `Tile::LogOverlay` handling for why that one differs).

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -198,7 +198,14 @@ pub(super) fn run_ui_flow(
                 connect_handle = Some((handle, settings));
             }
         }
-        if app.launch_anim.is_some_and(|t| t.elapsed() >= crate::ui::LAUNCH_FADE) {
+        // The launch scrim ends fully black, so leaving the loop while the handshake is
+        // still running would hand the stream loop a black screen for however long the
+        // connect takes (a whole connect timeout, if the host is powered off). Stay here
+        // instead, spinner on the scrim, and leave only once the connect thread is done —
+        // `run_inner`'s join is then immediate, success or failure.
+        let launch_faded = app.launch_anim.is_some_and(|t| t.elapsed() >= crate::ui::LAUNCH_FADE);
+        let awaiting_connect = launch_faded && connect_handle.as_ref().is_some_and(|(handle, _)| !handle.is_finished());
+        if launch_faded && !awaiting_connect {
             break 'ui;
         }
         for event in events.poll_iter() {
@@ -304,7 +311,8 @@ pub(super) fn run_ui_flow(
         // Polled every tick like the streaming loop's toast, not gated behind
         // `content_dirty` — its own fade needs frames regardless of anything else.
         let notif_frame = notif.frame();
-        let animating = app.tick_animations()
+        let animating = awaiting_connect
+            || app.tick_animations()
             || app.tiles_pending
             || !app.grid_reveal_ready
             || quit_dialog_active
@@ -354,6 +362,22 @@ pub(super) fn run_ui_flow(
             }
         }
         let mut cmds = app.draw_list(&tiles, display_mode.w as u32, display_mode.h as u32, fonts);
+        // Centred spinner over the finished launch scrim — the only thing on screen while a
+        // slow handshake finishes, so the wait doesn't read as a hang.
+        if awaiting_connect {
+            let phase = app.launch_anim.map_or(0.0, |t| t.elapsed().as_secs_f32());
+            let (idx, frame) = crate::ui::spinner_frame_at(phase);
+            cmds.push(DrawCmd::Tex {
+                tile: Tile::SpinnerFrame(idx),
+                dst: crate::ui::render::Rect::new(
+                    (display_mode.w - frame.width as i32) / 2,
+                    (display_mode.h - frame.height as i32) / 2,
+                    frame.width,
+                    frame.height,
+                ),
+                alpha: 0xff,
+            });
+        }
         // Appended into the same single draw list/present as the rest of the
         // screen — this loop has no separate overlay pass (see the streaming
         // loop's `Tile::LogOverlay` handling for why that one differs).

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -325,6 +325,9 @@ pub fn connect(
         display_hdr,
         // client_caps: see `store::Settings::cursor_capture` for the on/off split.
         if cursor_capture { 0 } else { quic::CLIENT_CAP_CURSOR },
+        // frame_parts: NDL DirectMedia takes whole access units only — it has no
+        // `PARTIAL_FRAME` equivalent, so slice-progressive prefixes would have nowhere to go.
+        false,
         launch,
         // Device name for the host's pending-approval list. `None` keeps the host's
         // fingerprint-derived label ("device abcd1234"), i.e. exactly the behaviour before
@@ -507,11 +510,12 @@ pub fn request_access(host: &str, port: u16, identity: (String, String), timeout
         2,
         quic::CODEC_H264,
         0,
-        None, // no HDR display metadata
-        0,    // client_caps: no local cursor rendering
-        None, // no launch
-        None, // name: keep the host's fingerprint-derived label (see `connect`)
-        None, // pin = None → trust-on-first-use, host parks until operator approval
+        None,  // no HDR display metadata
+        0,     // client_caps: no local cursor rendering
+        false, // frame_parts: whole AUs (see `connect`)
+        None,  // no launch
+        None,  // name: keep the host's fingerprint-derived label (see `connect`)
+        None,  // pin = None → trust-on-first-use, host parks until operator approval
         Some(identity),
         timeout,
     )
@@ -624,11 +628,12 @@ pub fn run_speed_probe(
         quic::VIDEO_CAP_CHACHA20,
         2, // stereo baseline
         quic::CODEC_HEVC | quic::CODEC_H264,
-        0,    // no preferred codec
-        None, // no HDR display metadata: nothing presents
-        0,    // client_caps: nothing renders a cursor
-        None, // no launch
-        None, // name: keep the host's fingerprint-derived label (see `connect`)
+        0,     // no preferred codec
+        None,  // no HDR display metadata: nothing presents
+        0,     // client_caps: nothing renders a cursor
+        false, // frame_parts: whole AUs (see `connect`)
+        None,  // no launch
+        None,  // name: keep the host's fingerprint-derived label (see `connect`)
         pin,
         Some(identity),
         timeout,


### PR DESCRIPTION
## What

Three ordering fixes on the launch path, plus the punktfunk-core 0.24 bump they were built against.

**Feed only a loaded decoder.** NDL's media-load callback was log-only, so `NDL_DirectMediaLoad` returning `0` — which means only "request accepted" — was treated as "the pipeline is ready". The callback now records `LOADCOMPLETED`/`PLAYING`, and `load()` waits for `LOADCOMPLETED` (bounded at 2s; warn and proceed if it never arrives) before priming the Opus decoder and before returning. The video pump's first `play()` and the NDL audio pump therefore both start on a loaded pipeline, and the PTS base (`load_instant`) is stamped after the wait.

`UNLOADCOMPLETED` deliberately clears nothing: the audio-offload probe unloads and immediately re-loads video-only, so that callback can land *after* the retry's `LOADCOMPLETED` and would clear the live load's flags. Both `load()` paths reset the flags before their load, and `Drop` resets them on teardown.

**Uncover the plane only when it is presenting.** The connect thread is now joined *before* the window is cleared transparent, and the reveal additionally waits for `PLAYING` (bounded at 1.5s). The finished launch-zoom frame stays on screen across the handshake and the NDL load, so a slow connect shows the app rather than an empty punch-through plane — and a failed connect never uncovers the plane at all.

**Connect on the click.** `confirm_grid_card` arms the launch immediately instead of first running a pre-flight mTLS library fetch, so the connect thread starts on the click and overlaps the zoom rather than following a full extra round trip. `PendingLaunch`/`drain_launch_check` are removed with it.

## Behaviour change

An unreachable host clicked from the grid now reports through the connect failure's status line instead of opening the Wake dialog. The host list still probes reachability on selection, which is where that dialog comes from.

## Verification

`task docker:check` and `task docker:lint` are clean. **Not yet verified on a device:** whether `LOADCOMPLETED` is delivered without an application main loop pumping NDL's callbacks. On-device, watch for the `no LOADCOMPLETED within 2s` warning and the `NDL reveal after …` line.