### PR TITLE
Hero art as the connecting screen

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -252,6 +252,25 @@ pub struct App {
     /// Cover art pixmaps by game id.
     pub art: std::collections::HashMap<String, Pixmap>,
     pub(crate) art_loader: Option<crate::services::art::ArtLoader>,
+    /// The one decoded hero image kept in memory (id + pixels) — several MB each, and
+    /// only the focused card's can ever be needed, so a newer one replaces it.
+    pub(crate) hero: Option<(String, crate::services::art::HeroImage)>,
+    /// Id of the hero last asked for, so a hero that arrives after focus moved on
+    /// (or after a different game was launched) is dropped rather than kept.
+    pub(crate) hero_wanted: Option<String>,
+    /// Game id whose hero belongs on the connecting screen — `None` for Desktop.
+    pub(crate) hero_target: Option<String>,
+    /// Whether the launching game has wide art at all. The menu loop waits a moment for
+    /// one that is still in flight, but must not delay a game that will never have one.
+    pub(crate) hero_expected: bool,
+    /// Id of the hero currently uploaded as `Tile::Hero`, uploaded only once the
+    /// launch starts (browsing must not put a multi-MB texture on the GPU).
+    pub(crate) hero_uploaded: Option<String>,
+    /// When the uploaded hero started fading in. Its own clock, not `launch_anim`'s:
+    /// a hero can land mid-handshake, and then it fades in from there.
+    pub(crate) hero_since: Option<Instant>,
+    /// When the hero started fading back out, i.e. when the stream became ready.
+    pub(crate) hero_fade_out: Option<Instant>,
     pub(crate) launch_ready: Option<ConnectTarget>,
     pub(crate) launch_anim: Option<Instant>,
     pub(crate) launch_anim_idx: Option<usize>,
@@ -495,6 +514,13 @@ impl App {
             home_status: None,
             art: std::collections::HashMap::new(),
             art_loader: None,
+            hero: None,
+            hero_wanted: None,
+            hero_target: None,
+            hero_expected: false,
+            hero_uploaded: None,
+            hero_since: None,
+            hero_fade_out: None,
             launch_ready: None,
             launch_anim: None,
             launch_anim_idx: None,
@@ -672,10 +698,27 @@ impl App {
             return false;
         }
         for item in loaded {
-            // Layout is unchanged by art arriving — queue a repaint of just that
-            // card's tile (see `grid_cards_dirty`) rather than a full layer rebuild.
-            self.grid_cards_dirty.push(item.game_id.clone());
-            self.art.insert(item.game_id, item.pixmap);
+            match item {
+                crate::services::art::ArtLoaded::Card { game_id, pixmap } => {
+                    // Layout is unchanged by art arriving — queue a repaint of just that
+                    // card's tile (see `grid_cards_dirty`) rather than a full layer rebuild.
+                    self.grid_cards_dirty.push(game_id.clone());
+                    self.art.insert(game_id, pixmap);
+                }
+                crate::services::art::ArtLoaded::Hero { game_id, image } => {
+                    // A hero for a card that is no longer focused (and isn't the one being
+                    // launched) is dead weight — it would only evict the one that matters.
+                    if self.hero_wanted.as_deref() == Some(game_id.as_str())
+                        || self.hero_target.as_deref() == Some(game_id.as_str())
+                    {
+                        self.hero = Some((game_id, image));
+                    } else if let Some(loader) = &mut self.art_loader {
+                        // Dropped, so let it be re-requested when focus comes back — it is
+                        // served from the disk cache by then, no round trip.
+                        loader.forget_hero(&game_id);
+                    }
+                }
+            }
         }
         true
     }
@@ -815,7 +858,9 @@ impl App {
         if self.dropdown_fade.tick(DROPDOWN_FADE) {
             animating = true;
         }
-        if self.launch_anim.is_some_and(|t| t.elapsed() < ui::LAUNCH_FADE) {
+        // The hero loading screen keeps panning for as long as the launch is on screen,
+        // which (unlike the fade) is however long the handshake takes.
+        if self.launch_anim.is_some_and(|t| t.elapsed() < ui::LAUNCH_FADE) || self.hero_showing() {
             animating = true;
         }
         if let Some(t) = self.modal_focus_anim {
@@ -1686,6 +1731,24 @@ impl App {
             }
             self.tiles_pending = pending;
 
+            // Prefetch the focused card's hero, so the connecting screen has one ready the
+            // moment OK is pressed. Deduped in the loader, and the fetched bytes are
+            // disk-cached, so hovering back over a card costs no round trip.
+            //
+            // Only once the visible window has settled: the loader serves hero requests
+            // ahead of card art, so queueing one mid-scroll would put the cards the user is
+            // actually looking at behind a full-screen fetch and decode.
+            if self.grid_reveal_ready && !pending {
+                if let HomeFocus::Grid(focus_idx) = self.home_focus {
+                    if let Some(game) = layout.game_at(&self.games, focus_idx) {
+                        if let Some(loader) = &mut self.art_loader {
+                            loader.request_hero(game);
+                        }
+                        self.hero_wanted = Some(game.id.clone());
+                    }
+                }
+            }
+
             // The pinned badge tile — built once, composited over the focused
             // card in `draw_list` rather than baked into individual card tiles.
             if tiles.pin_badge_tile.is_none() {
@@ -1752,6 +1815,30 @@ impl App {
             }
         }
         Ok(())
+    }
+
+    /// Uploads the launching game's hero art as `Tile::Hero`, once, and starts its
+    /// fade-in clock. Gated on the launch having actually started: at ~1600px wide this
+    /// is a multi-MB texture, and putting one on the GPU for every card the user merely
+    /// scrolls past would undo the whole point of the windowed card cache.
+    fn prepare_hero(&mut self, updated: &mut Vec<Tile>) {
+        if self.launch_anim.is_none() {
+            return;
+        }
+        let Some(id) = self.hero_target.clone() else { return };
+        if self.hero_uploaded.as_deref() == Some(id.as_str()) {
+            return;
+        }
+        if !self.hero.as_ref().is_some_and(|(loaded, _)| *loaded == id) {
+            // Still fetching — the fade to black covers this, and the hero joins it
+            // whenever it lands (possibly not at all, on a slow host).
+            return;
+        }
+        if let Some(stale) = self.hero_uploaded.replace(id.clone()) {
+            self.evicted_tiles.push(Tile::Hero(stale));
+        }
+        self.hero_since = Some(Instant::now());
+        updated.push(Tile::Hero(id));
     }
 
     /// Modal family: the open modal's full-screen shell tile (rebuilt only on content
@@ -2371,6 +2458,8 @@ impl App {
             &mut updated,
         )?;
 
+        self.prepare_hero(&mut updated);
+
         // Status line block — built whenever `home_status` is set, independent of
         // whether a host is selected (the "Send logs" result shows here too).
         match &self.home_status {
@@ -2545,11 +2634,12 @@ impl App {
             Tile::ScrollFadeTop => tiles.scroll_fade_top_tile.as_ref(),
             Tile::Status => tiles.status_tile.as_ref().map(|(_, p)| p),
             Tile::NoHost => tiles.nohost_tile.as_ref(),
-            // `SpinnerFrame` is uploaded directly from its raw decoded pixels (see
+            // `SpinnerFrame` and `Hero` are uploaded directly from their raw decoded pixels (see
             // `main.rs`), never rasterized as a `Painter`; the rest are stream-side only
             // (uploaded directly by `run_inner`'s overlay refresh) — never one of App's
             // menu tiles.
             Tile::SpinnerFrame(_)
+            | Tile::Hero(_)
             | Tile::StatsOverlay
             | Tile::Notification
             | Tile::LogOverlay
@@ -3123,8 +3213,50 @@ impl App {
                 rect: Rect::new(0, 0, screen_w, screen_h),
                 color: crate::ui::render::Color::RGBA(0, 0, 0, (255.0 * f) as u8),
             });
+            // With wide art for this game, the loading screen is that art instead of the
+            // bare black: it fades in over the scrim above (so a hero arriving mid-
+            // handshake still eases in rather than snapping), then drifts slowly left to
+            // right for as long as the stream takes to come up.
+            self.compose_hero(screen_w, screen_h, &mut cmds);
         }
         cmds
+    }
+
+    /// Starts the hero's fade-out (idempotent) and reports whether it has finished. The
+    /// menu loop calls this once the stream is ready and hands over on `true`.
+    pub(crate) fn hero_faded_out(&mut self) -> bool {
+        let since = *self.hero_fade_out.get_or_insert_with(Instant::now);
+        since.elapsed() >= ui::HERO_FADE_OUT
+    }
+
+    /// Whether an uploaded hero is currently on screen as the connecting backdrop.
+    pub(crate) fn hero_showing(&self) -> bool {
+        self.launch_anim.is_some() && self.hero_since.is_some() && self.hero_uploaded.is_some()
+    }
+
+    /// The connecting screen's hero backdrop: fade-in, slow pan, and its dimming scrim.
+    fn compose_hero(&self, screen_w: u32, screen_h: u32, cmds: &mut ui::render::DrawList) {
+        let (Some(id), Some(since)) = (self.hero_uploaded.as_ref(), self.hero_since) else {
+            return;
+        };
+        let Some((_, hero)) = self.hero.as_ref().filter(|(loaded, _)| loaded == id) else {
+            return;
+        };
+        // Fades out over the black scrim it faded in over, so the hand-off to live video
+        // goes through black rather than cutting from a lit image.
+        let out = self
+            .hero_fade_out
+            .map_or(0.0, |t| ui::anim_frac(Some(t), ui::HERO_FADE_OUT));
+        let f = ui::anim_frac(Some(since), ui::HERO_FADE) * (1.0 - out);
+        cmds.push(DrawCmd::TexF {
+            tile: Tile::Hero(id.clone()),
+            dst: ui::hero_pan_dst(hero.width, hero.height, screen_w, screen_h, since.elapsed()),
+            alpha: (255.0 * f) as u8,
+        });
+        cmds.push(DrawCmd::Fill {
+            rect: Rect::new(0, 0, screen_w, screen_h),
+            color: crate::ui::render::Color::RGBA(0, 0, 0, (ui::HERO_SCRIM_ALPHA * f) as u8),
+        });
     }
 
     /// Shared modal chrome — dark backdrop, the rounded card, and its close (X)

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -523,6 +523,18 @@ impl App {
             Some(GridCard::Game(game)) => (Some(game.id.clone()), game.title.clone()),
             None => return,
         };
+        // The loading screen's backdrop. Requested here as well as on focus, since a card
+        // can be confirmed before the focus prefetch got round to it; Desktop has no art,
+        // so it keeps the plain fade to black.
+        self.hero_target = launch.clone();
+        self.hero_expected = false;
+        if let Some(game) = launch.as_ref().and_then(|id| self.games.iter().find(|g| &g.id == id)) {
+            let expected = game.art.hero.is_some() || game.art.header.is_some();
+            if let Some(loader) = &mut self.art_loader {
+                loader.request_hero(game);
+            }
+            self.hero_expected = expected;
+        }
         tracing::debug!("launch: connecting to {host}:{port} now, zoom runs in parallel");
         // Stays up through the zoom and the connect; `run_inner` owns the screen from there.
         self.home_status = Some(format!("Starting {title}…"));

--- a/src/platform/webos/compositor.rs
+++ b/src/platform/webos/compositor.rs
@@ -156,6 +156,15 @@ impl Compositor {
                         .copy(tex, Some(to_sdl_rect(*src)), Some(to_sdl_rect(*dst)))
                         .map_err(|e| anyhow::anyhow!("copy cropped {tile:?}: {e}"))?;
                 }
+                DrawCmd::TexF { tile, dst, alpha } => {
+                    let Some(tex) = self.textures.get_mut(tile) else {
+                        continue; // not uploaded yet — skip
+                    };
+                    tex.set_alpha_mod(*alpha);
+                    canvas
+                        .copy_f(tex, None, Some(sdl2::rect::FRect::new(dst.x, dst.y, dst.w, dst.h)))
+                        .map_err(|e| anyhow::anyhow!("copy float {tile:?}: {e}"))?;
+                }
                 DrawCmd::Fill { rect, color } => {
                     canvas.set_blend_mode(BlendMode::Blend);
                     canvas.set_draw_color(to_sdl_color(*color));

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -27,6 +27,15 @@ pub(super) fn run_ui_flow(
     // the loop at a steady ~60Hz regardless of work cost, which comfortably samples
     // every 33ms spinner frame.
     const TICK_BUDGET: Duration = Duration::from_millis(16);
+    // Longest the hero loading screen is animated before handing over regardless of the
+    // connect thread. Only a backstop — `session::connect` has its own timeouts.
+    const HERO_LOADING_MAX: Duration = Duration::from_secs(30);
+    // How long past the fade a game with wide art waits for a hero that hasn't arrived
+    // yet. Only paid on a cold cache — a prefetched hero is already up by then.
+    const HERO_WAIT: Duration = Duration::from_millis(1_200);
+    // How much longer the hero holds after the handshake lands, before its fade-out
+    // starts — the two together are the ~1s of stream that would be black regardless.
+    const HERO_LINGER: Duration = Duration::from_millis(700);
     // Test/dev override: skip the UI entirely if a connect.conf was dropped
     // alongside sideloading (see store.rs docs) — the UI flow is the normal path.
     // Bypasses the library screen too (`launch: None`, a plain desktop session).
@@ -98,6 +107,8 @@ pub(super) fn run_ui_flow(
     // running by then, so this just carries its handle out of the loop for
     // `run_inner` to join once the launch animation finishes.
     let mut connect_handle: Option<ConnectOutcome> = None;
+    // When the connect thread was first seen finished — the hero linger runs off this.
+    let mut connect_done_at: Option<Instant> = None;
     // Yellow button log overlay works here too (see streaming loop).
     let mut yellow_held = false;
     let mut home_held = false;
@@ -198,11 +209,43 @@ pub(super) fn run_ui_flow(
                 connect_handle = Some((handle, settings));
             }
         }
-        if app.launch_anim.is_some_and(|t| t.elapsed() >= crate::ui::LAUNCH_FADE) {
-            break 'ui;
+        // When to hand the screen over to the streaming loop. Without a hero that is the
+        // end of the launch fade, as it always was. With one, this loop keeps animating it
+        // as the loading screen until the handshake lands (`run_inner`'s join then returns
+        // immediately), holds a beat, and fades it out — so live video arrives out of
+        // black rather than cutting from a lit image.
+        if let Some(t) = app.launch_anim.filter(|t| t.elapsed() >= crate::ui::LAUNCH_FADE) {
+            if connect_done_at.is_none() && connect_handle.as_ref().is_none_or(|(h, _)| h.is_finished()) {
+                connect_done_at = Some(Instant::now());
+            }
+            // A game with wide art gets a grace period before giving up on it: on a cold
+            // cache the hero can still be a fetch away, and would otherwise land just
+            // after the hand-off and never be seen.
+            let hero_late = t.elapsed() >= crate::ui::LAUNCH_FADE + HERO_WAIT;
+            let hero_coming = app.hero_expected && !hero_late;
+            let held_past_connect = connect_done_at.is_some_and(|done| done.elapsed() >= HERO_LINGER);
+            let done = if app.hero_showing() {
+                held_past_connect && app.hero_faded_out()
+            } else {
+                !hero_coming
+            };
+            // Capped either way, so a connect that somehow never returns can't strand the
+            // app on a panning image.
+            if done || t.elapsed() >= HERO_LOADING_MAX {
+                break 'ui;
+            }
         }
         for event in events.poll_iter() {
             use sdl2::event::Event;
+            // Launch committed: the menu is behind the loading screen and its input would
+            // move a grid the user can no longer see. Only shutdown still counts.
+            if app.launch_anim.is_some() {
+                if matches!(event, Event::Quit { .. }) {
+                    tracing::info!("quit during launch");
+                    return Ok(None);
+                }
+                continue;
+            }
             // Device-level events, handled before anything screen-specific:
             // shutdown and controller hotplug.
             match event {
@@ -344,6 +387,11 @@ pub(super) fn run_ui_flow(
                 &Tile::SpinnerFrame(idx) => {
                     if let Some(frame) = crate::ui::spinner_frame(idx) {
                         compositor.upload_raw(texture_creator, tile, frame.width, frame.height, &frame.pixels)?;
+                    }
+                }
+                Tile::Hero(id) => {
+                    if let Some((_, hero)) = app.hero.as_ref().filter(|(loaded, _)| loaded == id) {
+                        compositor.upload_raw(texture_creator, tile.clone(), hero.width, hero.height, &hero.pixels)?;
                     }
                 }
                 _ => {

--- a/src/services/art.rs
+++ b/src/services/art.rs
@@ -1,6 +1,6 @@
 //! On-demand cover-art loading with disk cache (not all-at-once, which caused OOM).
 //! Fetches via mTLS, decodes with pure-Rust `image` crate, handed to UI as `Pixmap`.
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 
@@ -9,15 +9,34 @@ use tiny_skia::{FilterQuality, IntSize, Pixmap, PixmapPaint, Transform};
 use crate::services::library::GameEntry;
 use crate::ui::premultiply_rgba;
 
-/// One decoded cover, ready to composite straight into the UI's frame `Painter`.
-pub struct ArtLoaded {
-    pub game_id: String,
-    pub pixmap: Pixmap,
+/// A decoded wide hero image, straight (not premultiplied) RGBA8 — it goes to the
+/// GPU as a raw texture (`Compositor::upload_raw`) rather than through a `Painter`,
+/// since nothing is ever rasterized on top of it.
+pub struct HeroImage {
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Vec<u8>,
 }
 
-/// A cover the UI wants soon.
+/// One decoded image, ready to composite.
+pub enum ArtLoaded {
+    /// Grid cover, stretched to card size.
+    Card { game_id: String, pixmap: Pixmap },
+    /// Wide art for the connecting screen.
+    Hero { game_id: String, image: HeroImage },
+}
+
+/// Which variant of a game's art a request wants.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ArtKind {
+    Card,
+    Hero,
+}
+
+/// An image the UI wants soon.
 struct ArtRequest {
     game_id: String,
+    kind: ArtKind,
     /// Candidate art paths (host-relative or external URL), tried in order — a
     /// host-reported path can 404 even when another variant works fine.
     paths: Vec<String>,
@@ -27,6 +46,13 @@ struct ArtRequest {
 const MAX_ART_DIMENSION: u32 = 480;
 /// Grid card portrait aspect (cropped to avoid distortion).
 const TARGET_ART_ASPECT: f32 = 3.0 / 4.0;
+/// Max decoded hero width. Full-screen art, so far larger than a card — but still
+/// upscaled a little by the GPU on a 4K panel rather than held at panel size, which
+/// would be four times the decode cost and the memory for one transient screen.
+const MAX_HERO_WIDTH: u32 = 1600;
+/// Hero crop aspect. Deliberately wider than any panel (16:9 at its widest), because
+/// the slack between the two is exactly what the connecting screen's pan travels.
+const HERO_ASPECT: f32 = 2.4;
 
 /// Center-crop to aspect ratio (no-op if already close).
 fn crop_to_aspect(img: image::DynamicImage, aspect: f32) -> image::DynamicImage {
@@ -70,8 +96,25 @@ pub fn clear_host_cache(host: &str, port: u16) {
     let _ = std::fs::remove_dir_all(cache_dir(host, port));
 }
 
+/// Decoded-pixel cache path (cards only — see the worker's hero branch).
 fn raw_cache_path(dir: &std::path::Path, game_id: &str) -> PathBuf {
     dir.join(format!("{}.raw", cache_name(game_id)))
+}
+
+/// Encoded-bytes cache path (what the host served, undecoded).
+fn bytes_cache_path(dir: &std::path::Path, game_id: &str, kind: ArtKind) -> PathBuf {
+    match kind {
+        ArtKind::Card => dir.join(cache_name(game_id)),
+        ArtKind::Hero => dir.join(format!("{}.hero", cache_name(game_id))),
+    }
+}
+
+/// Staging name for a write-then-rename. Appends to the whole filename rather than
+/// replacing an extension, which would make `id.raw` and `id` stage to the same path.
+fn tmp_path(path: &std::path::Path) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(".tmp");
+    PathBuf::from(name)
 }
 
 /// Write-then-rename (prevents truncated cache files on kill mid-write).
@@ -81,7 +124,7 @@ fn write_raw_cache(path: &std::path::Path, pixmap: &Pixmap) {
     buf.extend_from_slice(&pixmap.width().to_le_bytes());
     buf.extend_from_slice(&pixmap.height().to_le_bytes());
     buf.extend_from_slice(pixmap.data());
-    let tmp = path.with_extension("raw.tmp");
+    let tmp = tmp_path(path);
     if std::fs::write(&tmp, &buf).is_ok() {
         let _ = std::fs::rename(&tmp, path);
     }
@@ -90,15 +133,15 @@ fn write_raw_cache(path: &std::path::Path, pixmap: &Pixmap) {
 /// Read raw cache, if present and well-formed.
 fn read_raw_cache(path: &std::path::Path) -> Option<Pixmap> {
     let buf = std::fs::read(path).ok()?;
-    let magic = u32::from_le_bytes(buf.get(0..4)?.try_into().ok()?);
-    if magic != RAW_CACHE_MAGIC {
+    if u32::from_le_bytes(buf.get(0..4)?.try_into().ok()?) != RAW_CACHE_MAGIC {
         return None;
     }
     let width = u32::from_le_bytes(buf.get(4..8)?.try_into().ok()?);
     let height = u32::from_le_bytes(buf.get(8..12)?.try_into().ok()?);
-    let size = IntSize::from_wh(width, height)?;
-    let pixels = buf.get(12..)?.to_vec();
-    Pixmap::from_vec(pixels, size)
+    if buf.len() - 12 != width as usize * height as usize * 4 {
+        return None;
+    }
+    Pixmap::from_vec(buf.get(12..)?.to_vec(), IntSize::from_wh(width, height)?)
 }
 
 /// Stretch to card size (done here, not in each card build, to save armv7 cost).
@@ -136,6 +179,9 @@ pub struct ArtLoader {
     /// Ids already handed to the worker, so scrolling over the same card repeatedly
     /// doesn't queue it repeatedly.
     requested: HashSet<String>,
+    /// Same, for hero art — a separate set because focus moving back and forth over a
+    /// card must not re-queue its (much larger) hero either.
+    hero_requested: HashSet<String>,
 }
 
 impl ArtLoader {
@@ -170,6 +216,7 @@ impl ArtLoader {
             tx: tx_req,
             rx: rx_done,
             requested: HashSet::new(),
+            hero_requested: HashSet::new(),
         }
     }
 
@@ -198,8 +245,42 @@ impl ArtLoader {
         // A closed channel means the worker is gone; the card keeps its placeholder.
         let _ = self.tx.send(ArtRequest {
             game_id: game.id.clone(),
+            kind: ArtKind::Card,
             paths,
         });
+    }
+
+    /// Asks for `game`'s wide hero art (the connecting screen's backdrop) if it hasn't
+    /// been asked for already. Called for the focused card, so the image is usually
+    /// decoded and waiting by the time the user actually launches.
+    ///
+    /// Portrait art is deliberately not a fallback here: cropped to a hero's aspect
+    /// there'd be almost nothing left of it, and the connecting screen falls back to
+    /// its plain black fade perfectly well.
+    pub fn request_hero(&mut self, game: &GameEntry) {
+        if !self.hero_requested.insert(game.id.clone()) {
+            return;
+        }
+        let paths: Vec<String> = [game.art.hero.as_deref(), game.art.header.as_deref()]
+            .into_iter()
+            .flatten()
+            .map(str::to_string)
+            .collect();
+        if paths.is_empty() {
+            return;
+        }
+        let _ = self.tx.send(ArtRequest {
+            game_id: game.id.clone(),
+            kind: ArtKind::Hero,
+            paths,
+        });
+    }
+
+    /// Forgets that `game_id`'s hero was requested, so it can be asked for again. Needed
+    /// when a hero arrives too late to be of use and is dropped — without this the game
+    /// would never get another chance at one, even though its bytes are now cached.
+    pub fn forget_hero(&mut self, game_id: &str) {
+        self.hero_requested.remove(game_id);
     }
 
     /// Forgets that `game_id` was requested, so a later scroll back re-requests it. Served
@@ -238,20 +319,42 @@ fn worker(config: &WorkerConfig, rx: &Receiver<ArtRequest>, tx: &Sender<ArtLoade
     // never opens a connection at all.
     let mut agent = None;
 
-    // A closed channel means the host was switched away from; the caller stops draining.
-    let deliver = |tx: &Sender<ArtLoaded>, game_id: String, pixmap: Pixmap| tx.send(ArtLoaded { game_id, pixmap });
-
-    while let Ok(req) = rx.recv() {
-        let raw_cached = raw_cache_path(dir, &req.game_id);
-        if let Some(pixmap) = read_raw_cache(&raw_cached) {
-            let sized = resize_pixmap(&pixmap, card_w, card_h).unwrap_or(pixmap);
-            if deliver(tx, req.game_id, sized).is_err() {
-                return;
+    // Local queue rather than straight `recv()`: a hero request gates the connecting
+    // screen, so it has to jump whatever card-art backlog the grid has just queued. A
+    // closed channel means the host was switched away from, and the worker is done.
+    let mut queue: VecDeque<ArtRequest> = VecDeque::new();
+    loop {
+        if queue.is_empty() {
+            match rx.recv() {
+                Ok(req) => queue.push_back(req),
+                Err(_) => return,
             }
-            continue;
+        }
+        while let Ok(req) = rx.try_recv() {
+            queue.push_back(req);
+        }
+        let at = queue.iter().position(|r| r.kind == ArtKind::Hero).unwrap_or_default();
+        let Some(req) = queue.remove(at) else { continue };
+
+        // Decoded-pixel cache, cards only: a hero's would be ~4MB per game, and one gets
+        // cached for every card the user so much as focuses. The encoded bytes below
+        // already spare the network, and the decode runs here, off the UI thread.
+        let raw_cached = raw_cache_path(dir, &req.game_id);
+        if req.kind == ArtKind::Card {
+            if let Some(pixmap) = read_raw_cache(&raw_cached) {
+                let sized = resize_pixmap(&pixmap, card_w, card_h).unwrap_or(pixmap);
+                let loaded = ArtLoaded::Card {
+                    game_id: req.game_id,
+                    pixmap: sized,
+                };
+                if tx.send(loaded).is_err() {
+                    return;
+                }
+                continue;
+            }
         }
 
-        let cached = dir.join(cache_name(&req.game_id));
+        let cached = bytes_cache_path(dir, &req.game_id, req.kind);
         let bytes = match std::fs::read(&cached) {
             Ok(b) if !b.is_empty() => b,
             _ => {
@@ -281,7 +384,7 @@ fn worker(config: &WorkerConfig, rx: &Receiver<ArtRequest>, tx: &Sender<ArtLoade
                 // Write-then-rename, never truncate-in-place: a kill mid-write would
                 // otherwise leave a truncated file that gets served from cache forever
                 // (same discipline, and the same reason, as `store::write_atomic`).
-                let tmp = cached.with_extension("tmp");
+                let tmp = tmp_path(&cached);
                 if std::fs::write(&tmp, &fetched).is_ok() {
                     let _ = std::fs::rename(&tmp, &cached);
                 }
@@ -299,32 +402,67 @@ fn worker(config: &WorkerConfig, rx: &Receiver<ArtRequest>, tx: &Sender<ArtLoade
                 continue;
             }
         };
-        let decoded = crop_to_aspect(decoded, TARGET_ART_ASPECT);
-        let longer_side = decoded.width().max(decoded.height());
-        let decoded = if longer_side > MAX_ART_DIMENSION {
-            decoded.resize(
-                MAX_ART_DIMENSION,
-                MAX_ART_DIMENSION,
-                image::imageops::FilterType::Triangle,
-            )
-        } else {
-            decoded
+        let decoded = match req.kind {
+            ArtKind::Card => {
+                let cropped = crop_to_aspect(decoded, TARGET_ART_ASPECT);
+                if cropped.width().max(cropped.height()) > MAX_ART_DIMENSION {
+                    cropped.resize(
+                        MAX_ART_DIMENSION,
+                        MAX_ART_DIMENSION,
+                        image::imageops::FilterType::Triangle,
+                    )
+                } else {
+                    cropped
+                }
+            }
+            ArtKind::Hero => {
+                let cropped = crop_to_aspect(decoded, HERO_ASPECT);
+                if cropped.width() > MAX_HERO_WIDTH {
+                    // `u32::MAX` height: `resize` preserves aspect, so width alone bounds it.
+                    cropped.resize(MAX_HERO_WIDTH, u32::MAX, image::imageops::FilterType::Triangle)
+                } else {
+                    cropped
+                }
+            }
         };
         let rgba = decoded.to_rgba8();
         let (width, height) = rgba.dimensions();
-        let Some(size) = IntSize::from_wh(width, height) else {
+        if width == 0 || height == 0 {
             tracing::warn!("art: {} decoded to zero size ({width}x{height})", req.game_id);
             continue;
-        };
+        }
         let mut buf = rgba.into_raw();
-        premultiply_rgba(&mut buf);
-        let Some(pixmap) = Pixmap::from_vec(buf, size) else {
-            tracing::warn!("art: {} Pixmap::from_vec failed ({width}x{height})", req.game_id);
-            continue;
+        let loaded = match req.kind {
+            ArtKind::Hero => {
+                // Left straight-alpha (no `premultiply_rgba`): it is uploaded as a raw
+                // texture, and SDL's blend mode expects straight alpha.
+                ArtLoaded::Hero {
+                    game_id: req.game_id,
+                    image: HeroImage {
+                        width,
+                        height,
+                        pixels: buf,
+                    },
+                }
+            }
+            ArtKind::Card => {
+                premultiply_rgba(&mut buf);
+                let Some(size) = IntSize::from_wh(width, height) else {
+                    continue;
+                };
+                let Some(pixmap) = Pixmap::from_vec(buf, size) else {
+                    tracing::warn!("art: {} Pixmap::from_vec failed ({width}x{height})", req.game_id);
+                    continue;
+                };
+                write_raw_cache(&raw_cached, &pixmap);
+                let sized = resize_pixmap(&pixmap, card_w, card_h).unwrap_or(pixmap);
+                ArtLoaded::Card {
+                    game_id: req.game_id,
+                    pixmap: sized,
+                }
+            }
         };
-        write_raw_cache(&raw_cached, &pixmap);
-        let sized = resize_pixmap(&pixmap, card_w, card_h).unwrap_or(pixmap);
-        if deliver(tx, req.game_id, sized).is_err() {
+        if tx.send(loaded).is_err() {
             return;
         }
     }

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -1,9 +1,55 @@
-use crate::ui::render::Rect;
+use crate::ui::render::{Rect, RectF};
 use std::time::{Duration, Instant};
 
 /// Durations for focus-pop and launch-fade animations.
 pub const FOCUS_POP: Duration = Duration::from_millis(140);
 pub const LAUNCH_FADE: Duration = Duration::from_millis(600);
+
+/// How long the connecting screen's hero pan takes to cross the whole image. Set
+/// well past any plausible handshake so a real load only ever shows a slow drift.
+pub const HERO_PAN: Duration = Duration::from_secs(75);
+
+/// The hero's own fade-in, slower than `LAUNCH_FADE`: the card zoom is a reaction to a
+/// button press and has to feel immediate, while this is a scene settling in.
+pub const HERO_FADE: Duration = Duration::from_millis(1_100);
+
+/// The hero's fade-out, run just before the stream is uncovered. Quick — it is a
+/// hand-off, not a transition, and every frame of it delays live video.
+pub const HERO_FADE_OUT: Duration = Duration::from_millis(280);
+
+/// How much the hero is darkened once fully faded in, so it reads as a backdrop
+/// rather than as content.
+pub const HERO_SCRIM_ALPHA: f32 = 70.0;
+
+/// Destination for the connecting screen's slow left-to-right pan: the hero scaled to
+/// full screen height (so it is wider than the screen, by design — see the art loader's
+/// `HERO_ASPECT`) and slid leftwards across that slack, off the edges of the target.
+///
+/// Subpixel on purpose. At this speed the image travels well under a pixel per frame, so
+/// a whole-pixel destination would hold still for ten-odd frames and then jump; the
+/// fractional offset plus bilinear filtering makes it a continuous drift instead.
+///
+/// Linear rather than eased — a constant drift reads as deliberate motion, while an
+/// ease would visibly stall on a loading screen of unpredictable length.
+pub fn hero_pan_dst(img_w: u32, img_h: u32, screen_w: u32, screen_h: u32, elapsed: Duration) -> RectF {
+    let full = RectF {
+        x: 0.0,
+        y: 0.0,
+        w: screen_w as f32,
+        h: screen_h as f32,
+    };
+    if img_h == 0 || img_w == 0 {
+        return full;
+    }
+    let scaled_w = img_w as f32 * (screen_h as f32 / img_h as f32);
+    let slack = (scaled_w - screen_w as f32).max(0.0);
+    let f = (elapsed.as_secs_f32() / HERO_PAN.as_secs_f32()).clamp(0.0, 1.0);
+    RectF {
+        x: -slack * f,
+        w: scaled_w,
+        ..full
+    }
+}
 
 /// Cubic ease-out function.
 pub fn ease(f: f32) -> f32 {

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -63,6 +63,17 @@ impl Rect {
     }
 }
 
+/// Float rectangle, for the one case where whole-pixel placement is too coarse: a pan
+/// slow enough that an integer destination would advance in visible jumps rather than
+/// drift (see `DrawCmd::TexF`).
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct RectF {
+    pub x: f32,
+    pub y: f32,
+    pub w: f32,
+    pub h: f32,
+}
+
 /// Straight-alpha RGBA8. Mirrors `sdl2::pixels::Color`'s public field layout.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct Color {
@@ -104,6 +115,8 @@ pub enum TileId {
     ScrollFade,
     ScrollFadeTop,
     SpinnerFrame(usize),
+    /// Wide hero art for the connecting screen, keyed by game id.
+    Hero(String),
     StatsOverlay,
     Notification,
     LogOverlay,
@@ -122,6 +135,14 @@ pub enum DrawCmd {
         tile: TileId,
         src: Rect,
         dst: Rect,
+        alpha: u8,
+    },
+    /// Whole texture to a subpixel destination, clipped by the render target. Bilinear
+    /// filtering turns the fractional offset into real subpixel motion, which is what
+    /// makes a very slow pan look continuous instead of stepped.
+    TexF {
+        tile: TileId,
+        dst: RectF,
         alpha: u8,
     },
     Fill {


### PR DESCRIPTION
Launching a game used to fade to a black screen and sit there for the whole handshake. Now, if the game has wide art, the launch fades into that instead and pans slowly across it until the stream is up.

- Prefers `art.hero`, falls back to `art.header`. No wide art (or Desktop) keeps the existing fade to black, same timings as before.
- The card zoom and the black scrim still run at 600 ms; the hero has its own slower 1.1 s fade-in so it settles rather than snaps.
- Pan is subpixel via `SDL_RenderCopyF` — at this speed (75 s across the image) a whole-pixel destination visibly stepped.
- Once the handshake lands the hero holds 700 ms, then fades out over 280 ms, so live video arrives out of black instead of cutting from a lit image. That ~1 s is stream time that's black anyway.
- A game with wide art waits up to 1.2 s past the fade for art that's still in flight, so a cold cache doesn't just miss it.

Loading cost is kept off the critical path: the existing art worker fetches the hero when a card takes focus, only once the visible grid has settled (hero requests jump the card-art queue, so queueing one mid-scroll would starve the cards on screen). Fetched bytes are disk-cached per host like cover art; the decoded pixels deliberately aren't — at ~4 MB a game that would pile up fast. The GPU texture is uploaded only when a launch actually starts, and goes away with the rest at stream handoff.

Not yet tested on the TV.