### PR TITLE
Make the hero loading screen show up in time

### DIFF
--- a/src/app/hero.rs
+++ b/src/app/hero.rs
@@ -1,0 +1,147 @@
+//! The connecting screen's backdrop: which game's wide art it wants, the one decoded
+//! image kept for it, and the clocks that fade that image in, pan it, and fade it out
+//! again once the stream is ready.
+//!
+//! One struct rather than seven `App` fields, because none of them mean anything on their
+//! own — every launch moves all of them together.
+use std::time::{Duration, Instant};
+
+use crate::services::art::HeroImage;
+use crate::ui;
+
+#[derive(Default)]
+pub(crate) struct Hero {
+    /// The decoded image and the game id it belongs to. Several MB, and only one can ever
+    /// be on screen, so a newer one simply replaces it.
+    image: Option<(String, HeroImage)>,
+    /// Last id asked for (the focused card), so an image that arrives after focus has
+    /// moved on can be recognised as no longer useful.
+    wanted: Option<String>,
+    /// Id whose hero belongs on the connecting screen. `None` for Desktop.
+    target: Option<String>,
+    /// Whether the launching game has wide art at all: the menu loop waits a moment for
+    /// art still in flight, but must not delay a game that will never have any.
+    expected: bool,
+    /// Id currently uploaded as `TileId::Hero`. Uploaded only once a launch starts —
+    /// browsing must not put a multi-MB texture on the GPU.
+    uploaded: Option<String>,
+    /// When the uploaded image started fading in. Its own clock, not the launch fade's: a
+    /// hero can land mid-handshake, and then it fades in from there.
+    since: Option<Instant>,
+    /// When it started fading back out, i.e. when the stream became ready.
+    fade_out: Option<Instant>,
+}
+
+impl Hero {
+    /// Notes whose hero is worth keeping — the focused card, whose art is prefetched.
+    pub(crate) fn want(&mut self, game_id: &str) {
+        self.wanted = Some(game_id.to_string());
+    }
+
+    /// Arms the loading screen for a launch of `target` (`None` = Desktop), `expected`
+    /// saying whether that game has wide art to wait for.
+    pub(crate) fn arm(&mut self, target: Option<String>, expected: bool) {
+        self.target = target;
+        self.expected = expected;
+    }
+
+    /// Takes a freshly decoded image, and reports whether it was kept. A `false` means the
+    /// caller should let the loader forget it, so focusing that card again re-requests it
+    /// (from the disk cache by then) rather than never asking a second time.
+    pub(crate) fn accept(&mut self, game_id: String, image: HeroImage) -> bool {
+        let useful =
+            self.wanted.as_deref() == Some(game_id.as_str()) || self.target.as_deref() == Some(game_id.as_str());
+        if useful {
+            self.image = Some((game_id, image));
+        }
+        useful
+    }
+
+    /// The id whose texture the launch needs but doesn't have yet, if any.
+    pub(crate) fn pending_upload(&self) -> Option<String> {
+        let target = self.target.as_deref()?;
+        if self.uploaded.as_deref() == Some(target) {
+            return None;
+        }
+        // Still fetching — the fade to black covers this, and the hero joins it whenever
+        // it lands (possibly not at all, on a slow host).
+        self.image
+            .as_ref()
+            .filter(|(loaded, _)| loaded == target)
+            .map(|(loaded, _)| loaded.clone())
+    }
+
+    /// Records that `id`'s texture is now uploaded and starts its fade-in, returning any
+    /// texture the caller should drop in exchange.
+    pub(crate) fn mark_uploaded(&mut self, id: String) -> Option<String> {
+        let stale = self.uploaded.replace(id);
+        self.since = Some(Instant::now());
+        stale
+    }
+
+    /// `id`'s decoded pixels, for the upload itself.
+    pub(crate) fn image_for(&self, id: &str) -> Option<&HeroImage> {
+        self.image.as_ref().filter(|(loaded, _)| loaded == id).map(|(_, im)| im)
+    }
+
+    /// The uploaded tile's id and pixels, once there is one to draw.
+    pub(crate) fn visible(&self) -> Option<(&String, &HeroImage)> {
+        let id = self.uploaded.as_ref()?;
+        self.since?;
+        self.image
+            .as_ref()
+            .filter(|(loaded, _)| loaded == id)
+            .map(|(id, im)| (id, im))
+    }
+
+    /// How far into the pan the backdrop is.
+    pub(crate) fn panned_for(&self) -> Duration {
+        self.since.map(|t| t.elapsed()).unwrap_or_default()
+    }
+
+    /// This frame's opacity factor, 0..=1: the fade-in, less the fade-out once that starts.
+    pub(crate) fn opacity(&self) -> f32 {
+        let out = self.fade_out.map_or(0.0, |t| ui::anim_frac(Some(t), ui::HERO_FADE_OUT));
+        ui::anim_frac(self.since, ui::HERO_FADE) * (1.0 - out)
+    }
+
+    /// Whether an uploaded hero is on screen as the connecting backdrop.
+    pub(crate) fn showing(&self) -> bool {
+        self.since.is_some() && self.uploaded.is_some()
+    }
+
+    /// Whether the loading screen is finished, so the streaming loop can take the screen.
+    /// Also what starts the fade-out, once everything else it waits on is satisfied.
+    pub(crate) fn handover_ready(&mut self, launch_elapsed: Duration, connect_done: Option<Instant>) -> bool {
+        if launch_elapsed < ui::LAUNCH_FADE {
+            return false;
+        }
+        // Capped whatever else is going on, so a connect that never returns can't strand
+        // the app on a panning image.
+        if launch_elapsed >= ui::HERO_LOADING_MAX {
+            return true;
+        }
+        if !self.showing() {
+            // Nothing on screen: hand over at the end of the fade, as it always did. A game
+            // that *has* wide art gets a grace period first — on a cold cache the hero can
+            // still be a fetch away, and would otherwise land just after the hand-off.
+            return !self.expected || launch_elapsed >= ui::LAUNCH_FADE + ui::HERO_WAIT;
+        }
+        // Held a beat past the handshake rather than cut at it (the stream's own first
+        // second is black anyway), for its own minimum so a late arrival isn't cut
+        // mid-fade-in, and then for the fade-out — so live video arrives out of black.
+        let held_past_connect = connect_done.is_some_and(|done| done.elapsed() >= ui::HERO_LINGER);
+        held_past_connect && self.shown_for(ui::HERO_MIN_SHOW) && self.faded_out()
+    }
+
+    /// Whether the backdrop has been up (fade-in included) for at least `least`.
+    fn shown_for(&self, least: Duration) -> bool {
+        self.since.is_some_and(|t| t.elapsed() >= least)
+    }
+
+    /// Starts the fade-out (idempotent) and reports whether it has finished.
+    fn faded_out(&mut self) -> bool {
+        let since = *self.fade_out.get_or_insert_with(Instant::now);
+        since.elapsed() >= ui::HERO_FADE_OUT
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3229,6 +3229,11 @@ impl App {
         since.elapsed() >= ui::HERO_FADE_OUT
     }
 
+    /// Whether the hero has been on screen (fade-in included) for at least `least`.
+    pub(crate) fn hero_shown_for(&self, least: Duration) -> bool {
+        self.hero_since.is_some_and(|t| t.elapsed() >= least)
+    }
+
     /// Whether an uploaded hero is currently on screen as the connecting backdrop.
     pub(crate) fn hero_showing(&self) -> bool {
         self.launch_anim.is_some() && self.hero_since.is_some() && self.hero_uploaded.is_some()

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,6 +4,7 @@
 //! Per-screen `impl App` blocks are split by concern: `state` (event handling, transitions)
 //! and `view` (geometry + draw-list building). Keeping them under `app` lets `ui`/`core`
 //! stay dependency leaves — neither reaches back into `App`.
+pub(crate) mod hero;
 pub(crate) mod state;
 pub(crate) mod view;
 
@@ -252,25 +253,8 @@ pub struct App {
     /// Cover art pixmaps by game id.
     pub art: std::collections::HashMap<String, Pixmap>,
     pub(crate) art_loader: Option<crate::services::art::ArtLoader>,
-    /// The one decoded hero image kept in memory (id + pixels) — several MB each, and
-    /// only the focused card's can ever be needed, so a newer one replaces it.
-    pub(crate) hero: Option<(String, crate::services::art::HeroImage)>,
-    /// Id of the hero last asked for, so a hero that arrives after focus moved on
-    /// (or after a different game was launched) is dropped rather than kept.
-    pub(crate) hero_wanted: Option<String>,
-    /// Game id whose hero belongs on the connecting screen — `None` for Desktop.
-    pub(crate) hero_target: Option<String>,
-    /// Whether the launching game has wide art at all. The menu loop waits a moment for
-    /// one that is still in flight, but must not delay a game that will never have one.
-    pub(crate) hero_expected: bool,
-    /// Id of the hero currently uploaded as `Tile::Hero`, uploaded only once the
-    /// launch starts (browsing must not put a multi-MB texture on the GPU).
-    pub(crate) hero_uploaded: Option<String>,
-    /// When the uploaded hero started fading in. Its own clock, not `launch_anim`'s:
-    /// a hero can land mid-handshake, and then it fades in from there.
-    pub(crate) hero_since: Option<Instant>,
-    /// When the hero started fading back out, i.e. when the stream became ready.
-    pub(crate) hero_fade_out: Option<Instant>,
+    /// The connecting screen's backdrop, and every clock it runs on.
+    pub(crate) hero: hero::Hero,
     pub(crate) launch_ready: Option<ConnectTarget>,
     pub(crate) launch_anim: Option<Instant>,
     pub(crate) launch_anim_idx: Option<usize>,
@@ -514,13 +498,7 @@ impl App {
             home_status: None,
             art: std::collections::HashMap::new(),
             art_loader: None,
-            hero: None,
-            hero_wanted: None,
-            hero_target: None,
-            hero_expected: false,
-            hero_uploaded: None,
-            hero_since: None,
-            hero_fade_out: None,
+            hero: hero::Hero::default(),
             launch_ready: None,
             launch_anim: None,
             launch_anim_idx: None,
@@ -706,16 +684,13 @@ impl App {
                     self.art.insert(game_id, pixmap);
                 }
                 crate::services::art::ArtLoaded::Hero { game_id, image } => {
-                    // A hero for a card that is no longer focused (and isn't the one being
-                    // launched) is dead weight — it would only evict the one that matters.
-                    if self.hero_wanted.as_deref() == Some(game_id.as_str())
-                        || self.hero_target.as_deref() == Some(game_id.as_str())
-                    {
-                        self.hero = Some((game_id, image));
-                    } else if let Some(loader) = &mut self.art_loader {
-                        // Dropped, so let it be re-requested when focus comes back — it is
-                        // served from the disk cache by then, no round trip.
-                        loader.forget_hero(&game_id);
+                    // One that's no longer of use (focus moved on) is let go of in the
+                    // loader too, so coming back to that card asks again — served from the
+                    // disk cache by then, no round trip.
+                    if !self.hero.accept(game_id.clone(), image) {
+                        if let Some(loader) = &mut self.art_loader {
+                            loader.forget_hero(&game_id);
+                        }
                     }
                 }
             }
@@ -860,7 +835,10 @@ impl App {
         }
         // The hero loading screen keeps panning for as long as the launch is on screen,
         // which (unlike the fade) is however long the handshake takes.
-        if self.launch_anim.is_some_and(|t| t.elapsed() < ui::LAUNCH_FADE) || self.hero_showing() {
+        if self
+            .launch_anim
+            .is_some_and(|t| t.elapsed() < ui::LAUNCH_FADE || self.hero.showing())
+        {
             animating = true;
         }
         if let Some(t) = self.modal_focus_anim {
@@ -1744,7 +1722,7 @@ impl App {
                         if let Some(loader) = &mut self.art_loader {
                             loader.request_hero(game);
                         }
-                        self.hero_wanted = Some(game.id.clone());
+                        self.hero.want(&game.id);
                     }
                 }
             }
@@ -1825,19 +1803,10 @@ impl App {
         if self.launch_anim.is_none() {
             return;
         }
-        let Some(id) = self.hero_target.clone() else { return };
-        if self.hero_uploaded.as_deref() == Some(id.as_str()) {
-            return;
-        }
-        if !self.hero.as_ref().is_some_and(|(loaded, _)| *loaded == id) {
-            // Still fetching — the fade to black covers this, and the hero joins it
-            // whenever it lands (possibly not at all, on a slow host).
-            return;
-        }
-        if let Some(stale) = self.hero_uploaded.replace(id.clone()) {
+        let Some(id) = self.hero.pending_upload() else { return };
+        if let Some(stale) = self.hero.mark_uploaded(id.clone()) {
             self.evicted_tiles.push(Tile::Hero(stale));
         }
-        self.hero_since = Some(Instant::now());
         updated.push(Tile::Hero(id));
     }
 
@@ -3222,40 +3191,16 @@ impl App {
         cmds
     }
 
-    /// Starts the hero's fade-out (idempotent) and reports whether it has finished. The
-    /// menu loop calls this once the stream is ready and hands over on `true`.
-    pub(crate) fn hero_faded_out(&mut self) -> bool {
-        let since = *self.hero_fade_out.get_or_insert_with(Instant::now);
-        since.elapsed() >= ui::HERO_FADE_OUT
-    }
-
-    /// Whether the hero has been on screen (fade-in included) for at least `least`.
-    pub(crate) fn hero_shown_for(&self, least: Duration) -> bool {
-        self.hero_since.is_some_and(|t| t.elapsed() >= least)
-    }
-
-    /// Whether an uploaded hero is currently on screen as the connecting backdrop.
-    pub(crate) fn hero_showing(&self) -> bool {
-        self.launch_anim.is_some() && self.hero_since.is_some() && self.hero_uploaded.is_some()
-    }
-
-    /// The connecting screen's hero backdrop: fade-in, slow pan, and its dimming scrim.
+    /// The connecting screen's hero backdrop: fade in/out, slow pan, and its dimming
+    /// scrim. Fading rather than cutting at both ends, over the same black the launch
+    /// faded to, so a hero arriving mid-handshake eases in and live video arrives out of
+    /// black rather than from a lit image.
     fn compose_hero(&self, screen_w: u32, screen_h: u32, cmds: &mut ui::render::DrawList) {
-        let (Some(id), Some(since)) = (self.hero_uploaded.as_ref(), self.hero_since) else {
-            return;
-        };
-        let Some((_, hero)) = self.hero.as_ref().filter(|(loaded, _)| loaded == id) else {
-            return;
-        };
-        // Fades out over the black scrim it faded in over, so the hand-off to live video
-        // goes through black rather than cutting from a lit image.
-        let out = self
-            .hero_fade_out
-            .map_or(0.0, |t| ui::anim_frac(Some(t), ui::HERO_FADE_OUT));
-        let f = ui::anim_frac(Some(since), ui::HERO_FADE) * (1.0 - out);
+        let Some((id, hero)) = self.hero.visible() else { return };
+        let f = self.hero.opacity();
         cmds.push(DrawCmd::TexF {
             tile: Tile::Hero(id.clone()),
-            dst: ui::hero_pan_dst(hero.width, hero.height, screen_w, screen_h, since.elapsed()),
+            dst: ui::hero_pan_dst(hero.width, hero.height, screen_w, screen_h, self.hero.panned_for()),
             alpha: (255.0 * f) as u8,
         });
         cmds.push(DrawCmd::Fill {

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -526,15 +526,14 @@ impl App {
         // The loading screen's backdrop. Requested here as well as on focus, since a card
         // can be confirmed before the focus prefetch got round to it; Desktop has no art,
         // so it keeps the plain fade to black.
-        self.hero_target = launch.clone();
-        self.hero_expected = false;
+        let mut expected = false;
         if let Some(game) = launch.as_ref().and_then(|id| self.games.iter().find(|g| &g.id == id)) {
-            let expected = game.art.hero.is_some() || game.art.header.is_some();
+            expected = game.art.hero.is_some() || game.art.header.is_some();
             if let Some(loader) = &mut self.art_loader {
                 loader.request_hero(game);
             }
-            self.hero_expected = expected;
         }
+        self.hero.arm(launch.clone(), expected);
         tracing::debug!("launch: connecting to {host}:{port} now, zoom runs in parallel");
         // Stays up through the zoom and the connect; `run_inner` owns the screen from there.
         self.home_status = Some(format!("Starting {title}…"));

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -33,6 +33,8 @@ pub(super) fn run_ui_flow(
     // How long past the fade a game with wide art waits for a hero that hasn't arrived
     // yet. Only paid on a cold cache — a prefetched hero is already up by then.
     const HERO_WAIT: Duration = Duration::from_millis(1_200);
+    // Least time a hero stays up once it appears, fade-in included.
+    const HERO_MIN_SHOW: Duration = Duration::from_millis(1_600);
     // How much longer the hero holds after the handshake lands, before its fade-out
     // starts — the two together are the ~1s of stream that would be black regardless.
     const HERO_LINGER: Duration = Duration::from_millis(700);
@@ -225,7 +227,10 @@ pub(super) fn run_ui_flow(
             let hero_coming = app.hero_expected && !hero_late;
             let held_past_connect = connect_done_at.is_some_and(|done| done.elapsed() >= HERO_LINGER);
             let done = if app.hero_showing() {
-                held_past_connect && app.hero_faded_out()
+                // Also held for its own minimum: a hero that only arrived near the end of
+                // the grace period would otherwise be cut mid-fade-in, which reads as a
+                // flash rather than a loading screen.
+                held_past_connect && app.hero_shown_for(HERO_MIN_SHOW) && app.hero_faded_out()
             } else {
                 !hero_coming
             };

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -27,17 +27,6 @@ pub(super) fn run_ui_flow(
     // the loop at a steady ~60Hz regardless of work cost, which comfortably samples
     // every 33ms spinner frame.
     const TICK_BUDGET: Duration = Duration::from_millis(16);
-    // Longest the hero loading screen is animated before handing over regardless of the
-    // connect thread. Only a backstop — `session::connect` has its own timeouts.
-    const HERO_LOADING_MAX: Duration = Duration::from_secs(30);
-    // How long past the fade a game with wide art waits for a hero that hasn't arrived
-    // yet. Only paid on a cold cache — a prefetched hero is already up by then.
-    const HERO_WAIT: Duration = Duration::from_millis(1_200);
-    // Least time a hero stays up once it appears, fade-in included.
-    const HERO_MIN_SHOW: Duration = Duration::from_millis(1_600);
-    // How much longer the hero holds after the handshake lands, before its fade-out
-    // starts — the two together are the ~1s of stream that would be black regardless.
-    const HERO_LINGER: Duration = Duration::from_millis(700);
     // Test/dev override: skip the UI entirely if a connect.conf was dropped
     // alongside sideloading (see store.rs docs) — the UI flow is the normal path.
     // Bypasses the library screen too (`launch: None`, a plain desktop session).
@@ -211,32 +200,15 @@ pub(super) fn run_ui_flow(
                 connect_handle = Some((handle, settings));
             }
         }
-        // When to hand the screen over to the streaming loop. Without a hero that is the
-        // end of the launch fade, as it always was. With one, this loop keeps animating it
-        // as the loading screen until the handshake lands (`run_inner`'s join then returns
-        // immediately), holds a beat, and fades it out — so live video arrives out of
-        // black rather than cutting from a lit image.
-        if let Some(t) = app.launch_anim.filter(|t| t.elapsed() >= crate::ui::LAUNCH_FADE) {
+        // Without a hero the screen is handed to the streaming loop at the end of the
+        // launch fade, as it always was. With one, this loop keeps animating it as the
+        // loading screen until `Hero::handover_ready` is satisfied — the handshake having
+        // landed (`run_inner`'s join then returns immediately) plus its hold and fade-out.
+        if let Some(t) = app.launch_anim {
             if connect_done_at.is_none() && connect_handle.as_ref().is_none_or(|(h, _)| h.is_finished()) {
                 connect_done_at = Some(Instant::now());
             }
-            // A game with wide art gets a grace period before giving up on it: on a cold
-            // cache the hero can still be a fetch away, and would otherwise land just
-            // after the hand-off and never be seen.
-            let hero_late = t.elapsed() >= crate::ui::LAUNCH_FADE + HERO_WAIT;
-            let hero_coming = app.hero_expected && !hero_late;
-            let held_past_connect = connect_done_at.is_some_and(|done| done.elapsed() >= HERO_LINGER);
-            let done = if app.hero_showing() {
-                // Also held for its own minimum: a hero that only arrived near the end of
-                // the grace period would otherwise be cut mid-fade-in, which reads as a
-                // flash rather than a loading screen.
-                held_past_connect && app.hero_shown_for(HERO_MIN_SHOW) && app.hero_faded_out()
-            } else {
-                !hero_coming
-            };
-            // Capped either way, so a connect that somehow never returns can't strand the
-            // app on a panning image.
-            if done || t.elapsed() >= HERO_LOADING_MAX {
+            if app.hero.handover_ready(t.elapsed(), connect_done_at) {
                 break 'ui;
             }
         }
@@ -395,7 +367,7 @@ pub(super) fn run_ui_flow(
                     }
                 }
                 Tile::Hero(id) => {
-                    if let Some((_, hero)) = app.hero.as_ref().filter(|(loaded, _)| loaded == id) {
+                    if let Some(hero) = app.hero.image_for(id) {
                         compositor.upload_raw(texture_creator, tile.clone(), hero.width, hero.height, &hero.pixels)?;
                     }
                 }

--- a/src/services/art.rs
+++ b/src/services/art.rs
@@ -46,10 +46,11 @@ struct ArtRequest {
 const MAX_ART_DIMENSION: u32 = 480;
 /// Grid card portrait aspect (cropped to avoid distortion).
 const TARGET_ART_ASPECT: f32 = 3.0 / 4.0;
-/// Max decoded hero width. Full-screen art, so far larger than a card — but still
-/// upscaled a little by the GPU on a 4K panel rather than held at panel size, which
-/// would be four times the decode cost and the memory for one transient screen.
-const MAX_HERO_WIDTH: u32 = 1600;
+/// Max decoded hero width. Full-screen art, so far larger than a card — but deliberately
+/// under 1080p width and left for the GPU to upscale: it is a dimmed, moving backdrop, and
+/// every extra pixel is resize time on the launch path plus memory for one transient
+/// screen. Source heroes are often 3840 wide, so this is where most of the cost is.
+const MAX_HERO_WIDTH: u32 = 1280;
 /// Hero crop aspect. Deliberately wider than any panel (16:9 at its widest), because
 /// the slack between the two is exactly what the connecting screen's pan travels.
 const HERO_ASPECT: f32 = 2.4;
@@ -75,6 +76,13 @@ fn crop_to_aspect(img: image::DynamicImage, aspect: f32) -> image::DynamicImage 
 
 /// Cache version magic ("PFR2" — bumped for center-cropped art).
 const RAW_CACHE_MAGIC: u32 = 0x50465232;
+/// Hero decoded-pixel cache magic ("PFH1").
+const HERO_CACHE_MAGIC: u32 = 0x50464831;
+/// Filename suffix for a decoded hero, also what `prune_hero_cache` matches on.
+const HERO_RAW_SUFFIX: &str = ".hero.raw";
+/// How many decoded heroes are kept on disk. At a few MB each this bounds the cache at
+/// tens of MB while still covering everything recently launched.
+const HERO_RAW_CACHE_KEEP: usize = 8;
 
 fn cache_root() -> PathBuf {
     let home = std::env::var("HOME").map_or_else(|_| PathBuf::from("/tmp"), PathBuf::from);
@@ -96,9 +104,12 @@ pub fn clear_host_cache(host: &str, port: u16) {
     let _ = std::fs::remove_dir_all(cache_dir(host, port));
 }
 
-/// Decoded-pixel cache path (cards only — see the worker's hero branch).
-fn raw_cache_path(dir: &std::path::Path, game_id: &str) -> PathBuf {
-    dir.join(format!("{}.raw", cache_name(game_id)))
+/// Decoded-pixel cache path. Heroes get their own name so a game can cache both.
+fn raw_cache_path(dir: &std::path::Path, game_id: &str, kind: ArtKind) -> PathBuf {
+    match kind {
+        ArtKind::Card => dir.join(format!("{}.raw", cache_name(game_id))),
+        ArtKind::Hero => dir.join(format!("{}{HERO_RAW_SUFFIX}", cache_name(game_id))),
+    }
 }
 
 /// Encoded-bytes cache path (what the host served, undecoded).
@@ -118,22 +129,24 @@ fn tmp_path(path: &std::path::Path) -> PathBuf {
 }
 
 /// Write-then-rename (prevents truncated cache files on kill mid-write).
-fn write_raw_cache(path: &std::path::Path, pixmap: &Pixmap) {
-    let mut buf = Vec::with_capacity(12 + pixmap.data().len());
-    buf.extend_from_slice(&RAW_CACHE_MAGIC.to_le_bytes());
-    buf.extend_from_slice(&pixmap.width().to_le_bytes());
-    buf.extend_from_slice(&pixmap.height().to_le_bytes());
-    buf.extend_from_slice(pixmap.data());
+fn write_raw(path: &std::path::Path, magic: u32, width: u32, height: u32, pixels: &[u8]) {
+    let mut buf = Vec::with_capacity(12 + pixels.len());
+    buf.extend_from_slice(&magic.to_le_bytes());
+    buf.extend_from_slice(&width.to_le_bytes());
+    buf.extend_from_slice(&height.to_le_bytes());
+    buf.extend_from_slice(pixels);
     let tmp = tmp_path(path);
     if std::fs::write(&tmp, &buf).is_ok() {
         let _ = std::fs::rename(&tmp, path);
     }
 }
 
-/// Read raw cache, if present and well-formed.
-fn read_raw_cache(path: &std::path::Path) -> Option<Pixmap> {
+/// Read raw cache, if present and written with this magic (and so this pixel convention —
+/// card pixels are premultiplied, hero pixels straight, and the two must never be
+/// mistaken for each other).
+fn read_raw(path: &std::path::Path, magic: u32) -> Option<(u32, u32, Vec<u8>)> {
     let buf = std::fs::read(path).ok()?;
-    if u32::from_le_bytes(buf.get(0..4)?.try_into().ok()?) != RAW_CACHE_MAGIC {
+    if u32::from_le_bytes(buf.get(0..4)?.try_into().ok()?) != magic {
         return None;
     }
     let width = u32::from_le_bytes(buf.get(4..8)?.try_into().ok()?);
@@ -141,7 +154,39 @@ fn read_raw_cache(path: &std::path::Path) -> Option<Pixmap> {
     if buf.len() - 12 != width as usize * height as usize * 4 {
         return None;
     }
-    Pixmap::from_vec(buf.get(12..)?.to_vec(), IntSize::from_wh(width, height)?)
+    Some((width, height, buf.get(12..)?.to_vec()))
+}
+
+fn write_card_cache(path: &std::path::Path, pixmap: &Pixmap) {
+    write_raw(path, RAW_CACHE_MAGIC, pixmap.width(), pixmap.height(), pixmap.data());
+}
+
+fn read_card_cache(path: &std::path::Path) -> Option<Pixmap> {
+    let (width, height, pixels) = read_raw(path, RAW_CACHE_MAGIC)?;
+    Pixmap::from_vec(pixels, IntSize::from_wh(width, height)?)
+}
+
+/// Keeps the newest `HERO_RAW_CACHE_KEEP` decoded heroes and deletes the rest. They are
+/// megabytes each, so unlike card art they can't all be kept — but a decode is far too
+/// slow here to redo on the launch path, so the recently played ones stay resident.
+fn prune_hero_cache(dir: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    let mut heroes: Vec<(std::time::SystemTime, PathBuf)> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.to_string_lossy().ends_with(HERO_RAW_SUFFIX))
+        .filter_map(|p| {
+            let modified = p.metadata().and_then(|m| m.modified()).ok()?;
+            Some((modified, p))
+        })
+        .collect();
+    if heroes.len() <= HERO_RAW_CACHE_KEEP {
+        return;
+    }
+    heroes.sort_by_key(|(modified, _)| *modified);
+    for (_, path) in heroes.iter().take(heroes.len() - HERO_RAW_CACHE_KEEP) {
+        let _ = std::fs::remove_file(path);
+    }
 }
 
 /// Stretch to card size (done here, not in each card build, to save armv7 cost).
@@ -336,22 +381,28 @@ fn worker(config: &WorkerConfig, rx: &Receiver<ArtRequest>, tx: &Sender<ArtLoade
         let at = queue.iter().position(|r| r.kind == ArtKind::Hero).unwrap_or_default();
         let Some(req) = queue.remove(at) else { continue };
 
-        // Decoded-pixel cache, cards only: a hero's would be ~4MB per game, and one gets
-        // cached for every card the user so much as focuses. The encoded bytes below
-        // already spare the network, and the decode runs here, off the UI thread.
-        let raw_cached = raw_cache_path(dir, &req.game_id);
-        if req.kind == ArtKind::Card {
-            if let Some(pixmap) = read_raw_cache(&raw_cached) {
+        // Decoded-pixel cache. Worth far more for a hero than for a card: decoding a
+        // full-size hero JPEG on this SoC takes long enough to miss the launch it was
+        // fetched for, so the encoded-bytes layer below is not enough on its own.
+        let raw_cached = raw_cache_path(dir, &req.game_id, req.kind);
+        let cached_raw = match req.kind {
+            ArtKind::Card => read_card_cache(&raw_cached).map(|pixmap| {
                 let sized = resize_pixmap(&pixmap, card_w, card_h).unwrap_or(pixmap);
-                let loaded = ArtLoaded::Card {
-                    game_id: req.game_id,
+                ArtLoaded::Card {
+                    game_id: req.game_id.clone(),
                     pixmap: sized,
-                };
-                if tx.send(loaded).is_err() {
-                    return;
                 }
-                continue;
+            }),
+            ArtKind::Hero => read_raw(&raw_cached, HERO_CACHE_MAGIC).map(|(width, height, pixels)| ArtLoaded::Hero {
+                game_id: req.game_id.clone(),
+                image: HeroImage { width, height, pixels },
+            }),
+        };
+        if let Some(loaded) = cached_raw {
+            if tx.send(loaded).is_err() {
+                return;
             }
+            continue;
         }
 
         let cached = bytes_cache_path(dir, &req.game_id, req.kind);
@@ -436,6 +487,8 @@ fn worker(config: &WorkerConfig, rx: &Receiver<ArtRequest>, tx: &Sender<ArtLoade
             ArtKind::Hero => {
                 // Left straight-alpha (no `premultiply_rgba`): it is uploaded as a raw
                 // texture, and SDL's blend mode expects straight alpha.
+                write_raw(&raw_cached, HERO_CACHE_MAGIC, width, height, &buf);
+                prune_hero_cache(dir);
                 ArtLoaded::Hero {
                     game_id: req.game_id,
                     image: HeroImage {
@@ -454,7 +507,7 @@ fn worker(config: &WorkerConfig, rx: &Receiver<ArtRequest>, tx: &Sender<ArtLoade
                     tracing::warn!("art: {} Pixmap::from_vec failed ({width}x{height})", req.game_id);
                     continue;
                 };
-                write_raw_cache(&raw_cached, &pixmap);
+                write_card_cache(&raw_cached, &pixmap);
                 let sized = resize_pixmap(&pixmap, card_w, card_h).unwrap_or(pixmap);
                 ArtLoaded::Card {
                     game_id: req.game_id,

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -17,6 +17,22 @@ pub const HERO_FADE: Duration = Duration::from_millis(1_100);
 /// hand-off, not a transition, and every frame of it delays live video.
 pub const HERO_FADE_OUT: Duration = Duration::from_millis(280);
 
+/// How long past the launch fade a game with wide art waits for a hero that hasn't
+/// arrived yet. Only paid on a cold cache — a prefetched hero is already up by then.
+pub const HERO_WAIT: Duration = Duration::from_millis(1_200);
+
+/// Least time the hero stays up once it appears, fade-in included, so a late arrival
+/// reads as a loading screen rather than a flash.
+pub const HERO_MIN_SHOW: Duration = Duration::from_millis(1_600);
+
+/// How much longer it holds after the handshake lands, before the fade-out starts. That
+/// and the fade-out together are the ~1s of stream that would be black regardless.
+pub const HERO_LINGER: Duration = Duration::from_millis(700);
+
+/// Longest the loading screen runs before handing over regardless of the connect thread.
+/// Only a backstop — `session::connect` has its own timeouts.
+pub const HERO_LOADING_MAX: Duration = Duration::from_secs(30);
+
 /// How much the hero is darkened once fully faded in, so it reads as a backdrop
 /// rather than as content.
 pub const HERO_SCRIM_ALPHA: f32 = 70.0;


### PR DESCRIPTION
Follow-up to #83. The hero was often just a black screen for games that have art, or it flashed on for a moment right before the video kicked in. Three reasons, all fixed here.

- **Decoded heroes weren't cached.** #83 kept only the encoded bytes, so every app run paid a full-size JPEG decode on the launch path — long enough on this SoC to miss the launch it was fetched for. They're cached as pixels again, pruned to the 8 newest, so the cache sits at tens of MB instead of growing with the library.
- **Decode was scaled to 1280 wide instead of 1600.** Source heroes are often 3840 wide and the resize down is where most of the time goes. It's a dimmed, slowly moving backdrop, so letting the GPU upscale it costs nothing visible and shaves the cached file to ~2.7 MB.
- **A late hero got cut mid-fade-in.** It now stays up at least 1.6 s once it appears, so it reads as a loading screen rather than a flash.

Still not covered: focusing a card and hitting OK immediately on a cold cache, where the fetch and decode can't finish inside the 1.2 s grace window. That launch stays black and the art is cached for every one after. Prefetching a focused card's neighbours would close it, at the cost of fetching art nobody launches.

Not yet tested on the TV.