### PR TITLE
Hold the hero loading screen until video actually starts

### DIFF
--- a/src/app/hero.rs
+++ b/src/app/hero.rs
@@ -112,7 +112,17 @@ impl Hero {
 
     /// Whether the loading screen is finished, so the streaming loop can take the screen.
     /// Also what starts the fade-out, once everything else it waits on is satisfied.
-    pub(crate) fn handover_ready(&mut self, launch_elapsed: Duration, connect_done: Option<Instant>) -> bool {
+    ///
+    /// `presenting` is the decoder reporting live frames. The backdrop waits for it, so
+    /// the fade-out is the last thing that happens before the plane is uncovered rather
+    /// than leaving black in between — with no hero this is not consulted at all, and the
+    /// plain fade to black hands over exactly as it always did.
+    pub(crate) fn handover_ready(
+        &mut self,
+        launch_elapsed: Duration,
+        connect_done: Option<Instant>,
+        presenting: bool,
+    ) -> bool {
         if launch_elapsed < ui::LAUNCH_FADE {
             return false;
         }
@@ -127,11 +137,13 @@ impl Hero {
             // still be a fetch away, and would otherwise land just after the hand-off.
             return !self.expected || launch_elapsed >= ui::LAUNCH_FADE + ui::HERO_WAIT;
         }
-        // Held a beat past the handshake rather than cut at it (the stream's own first
-        // second is black anyway), for its own minimum so a late arrival isn't cut
-        // mid-fade-in, and then for the fade-out — so live video arrives out of black.
-        let held_past_connect = connect_done.is_some_and(|done| done.elapsed() >= ui::HERO_LINGER);
-        held_past_connect && self.shown_for(ui::HERO_MIN_SHOW) && self.faded_out()
+        // Held until the stream is genuinely up: a beat past the handshake (the stream's
+        // own first frames are black anyway) and until the decoder presents, so the
+        // fade-out runs straight into live video. Also for its own minimum, so a late
+        // arrival isn't cut mid-fade-in.
+        let Some(done) = connect_done else { return false };
+        let stream_up = presenting || done.elapsed() >= ui::STREAM_REVEAL_WAIT;
+        stream_up && done.elapsed() >= ui::HERO_LINGER && self.shown_for(ui::HERO_MIN_SHOW) && self.faded_out()
     }
 
     /// Whether the backdrop has been up (fade-in included) for at least `least`.

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 use super::*;
 
 /// How long the finished menu frame is held waiting for NDL `PLAYING` before uncovering the
-/// video plane regardless.
-const NDL_REVEAL_TIMEOUT: Duration = Duration::from_millis(1_500);
+/// video plane regardless. Shared with the hero loading screen, which waits on the same
+/// signal for the same reason (`ui::STREAM_REVEAL_WAIT`) — so when a hero held the screen
+/// this wait is already satisfied and returns immediately.
+const NDL_REVEAL_TIMEOUT: Duration = crate::ui::STREAM_REVEAL_WAIT;
 
 pub(super) fn run_inner() -> Result<()> {
     // Stops webOS's launcher intercepting Back/Windows-Meta/Guide as its own Home shortcut

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -203,12 +203,14 @@ pub(super) fn run_ui_flow(
         // Without a hero the screen is handed to the streaming loop at the end of the
         // launch fade, as it always was. With one, this loop keeps animating it as the
         // loading screen until `Hero::handover_ready` is satisfied — the handshake having
-        // landed (`run_inner`'s join then returns immediately) plus its hold and fade-out.
+        // landed (`run_inner`'s join then returns immediately), the decoder presenting (so
+        // its reveal wait is satisfied too), and the hold and fade-out done.
         if let Some(t) = app.launch_anim {
             if connect_done_at.is_none() && connect_handle.as_ref().is_none_or(|(h, _)| h.is_finished()) {
                 connect_done_at = Some(Instant::now());
             }
-            if app.hero.handover_ready(t.elapsed(), connect_done_at) {
+            let presenting = crate::platform::webos::ndl::playing();
+            if app.hero.handover_ready(t.elapsed(), connect_done_at, presenting) {
                 break 'ui;
             }
         }

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -19,7 +19,7 @@ pub const HERO_FADE_OUT: Duration = Duration::from_millis(280);
 
 /// How long past the launch fade a game with wide art waits for a hero that hasn't
 /// arrived yet. Only paid on a cold cache — a prefetched hero is already up by then.
-pub const HERO_WAIT: Duration = Duration::from_millis(1_200);
+pub const HERO_WAIT: Duration = Duration::from_millis(2_200);
 
 /// How long the hero stays up once it appears, fade-in included — long enough to read as
 /// a loading screen with a visible pan, not a flash. A floor, not a cap: a slower

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -21,9 +21,10 @@ pub const HERO_FADE_OUT: Duration = Duration::from_millis(280);
 /// arrived yet. Only paid on a cold cache — a prefetched hero is already up by then.
 pub const HERO_WAIT: Duration = Duration::from_millis(1_200);
 
-/// Least time the hero stays up once it appears, fade-in included, so a late arrival
-/// reads as a loading screen rather than a flash.
-pub const HERO_MIN_SHOW: Duration = Duration::from_millis(1_600);
+/// How long the hero stays up once it appears, fade-in included — long enough to read as
+/// a loading screen with a visible pan, not a flash. A floor, not a cap: a slower
+/// handshake keeps it up longer.
+pub const HERO_MIN_SHOW: Duration = Duration::from_secs(3);
 
 /// How much longer it holds after the handshake lands, before the fade-out starts. That
 /// and the fade-out together are the ~1s of stream that would be black regardless.

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -29,6 +29,11 @@ pub const HERO_MIN_SHOW: Duration = Duration::from_millis(1_600);
 /// and the fade-out together are the ~1s of stream that would be black regardless.
 pub const HERO_LINGER: Duration = Duration::from_millis(700);
 
+/// Longest anything waits for the decoder to report that it is presenting before
+/// uncovering the video plane regardless — both the hero's fade-out (`app::hero`) and, for
+/// the launches that have no hero to hold, `runtime::stream`'s reveal.
+pub const STREAM_REVEAL_WAIT: Duration = Duration::from_millis(1_500);
+
 /// Longest the loading screen runs before handing over regardless of the connect thread.
 /// Only a backstop — `session::connect` has its own timeouts.
 pub const HERO_LOADING_MAX: Duration = Duration::from_secs(30);


### PR DESCRIPTION
Follow-up to #84. Three timing fixes to the hero loading screen; no change to launches without hero art, which still hand over at the end of the 600 ms fade.

- **Wait for the decoder, not just the handshake.** The backdrop faded out when the connect thread finished, but `run_inner` then waits up to 1.5 s for NDL to report `PLAYING` before uncovering the video plane — so the fade-out could land on black and the reveal happen a beat later. It now waits on that signal too, which makes the fade-out the last thing before live video and leaves `run_inner`'s wait already satisfied.
- **Show it for 3 s once it appears**, up from 1.6 s. A floor, not a cap — a slower handshake keeps it up longer.
- **Give art still in flight another second** (2.2 s past the fade, up from 1.2 s). Only paid when the game actually has wide art.

The 1.5 s NDL bound was about to exist in two places, so it's one constant now (`ui::STREAM_REVEAL_WAIT`) that `runtime::stream`'s reveal timeout aliases.

Every hold that got longer sits inside the "hero is on screen" branch, so Desktop, games with no wide art, and launches that don't come from a grid card (host-list connect, `connect.conf` override) are all unaffected.

Not yet tested on the TV.