### PR TITLE
Load the hero from cache on launch, and cut the timing constants down

### DIFF
--- a/src/app/hero.rs
+++ b/src/app/hero.rs
@@ -19,8 +19,8 @@ pub(crate) struct Hero {
     wanted: Option<String>,
     /// Id whose hero belongs on the connecting screen. `None` for Desktop.
     target: Option<String>,
-    /// Whether the launching game has wide art at all: the menu loop waits a moment for
-    /// art still in flight, but must not delay a game that will never have any.
+    /// Whether this launch's hero is still in flight: the menu loop waits a moment for art on
+    /// its way, but must not delay a launch with nothing to wait for.
     expected: bool,
     /// Id currently uploaded as `TileId::Hero`. Uploaded only once a launch starts —
     /// browsing must not put a multi-MB texture on the GPU.
@@ -41,11 +41,17 @@ impl Hero {
         }
     }
 
-    /// Arms the loading screen for a launch of `target` (`None` = Desktop), `expected`
-    /// saying whether that game has wide art to wait for.
-    pub(crate) fn arm(&mut self, target: Option<String>, expected: bool) {
+    /// Arms the loading screen for a launch of `target` (`None` = Desktop). Nothing is waited
+    /// for unless [`Self::await_art`] says so.
+    pub(crate) fn arm(&mut self, target: Option<String>) {
         self.target = target;
-        self.expected = expected;
+        self.expected = false;
+    }
+
+    /// Says this launch's hero is still being fetched, so the hand-off gives it a moment to
+    /// land. A game with none, or one whose hero is already in hand, must not spend that moment.
+    pub(crate) fn await_art(&mut self) {
+        self.expected = true;
     }
 
     /// Takes a freshly decoded image, and reports whether it was kept. A `false` means the
@@ -104,7 +110,7 @@ impl Hero {
 
     /// This frame's opacity factor, 0..=1: the fade-in, less the fade-out once that starts.
     pub(crate) fn opacity(&self) -> f32 {
-        let out = self.fade_out.map_or(0.0, |t| ui::anim_frac(Some(t), ui::HERO_FADE_OUT));
+        let out = self.fade_out.map_or(0.0, |t| ui::anim_frac(Some(t), ui::HERO_FADE));
         ui::anim_frac(self.since, ui::HERO_FADE) * (1.0 - out)
     }
 
@@ -117,16 +123,11 @@ impl Hero {
     /// Whether the loading screen is finished, so the streaming loop can take the screen.
     /// Also what starts the fade-out, once everything else it waits on is satisfied.
     ///
-    /// `presenting` is the decoder reporting live frames. The backdrop waits for it, so
-    /// the fade-out is the last thing that happens before the plane is uncovered rather
-    /// than leaving black in between — with no hero this is not consulted at all, and the
-    /// plain fade to black hands over exactly as it always did.
-    pub(crate) fn handover_ready(
-        &mut self,
-        launch_elapsed: Duration,
-        connect_done: Option<Instant>,
-        presenting: bool,
-    ) -> bool {
+    /// `presenting` is the decoder reporting live frames. The backdrop waits for it, so the
+    /// fade-out is the last thing that happens before the plane is uncovered rather than leaving
+    /// black in between — with no hero this is not consulted at all, and the plain fade to black
+    /// hands over exactly as it always did.
+    pub(crate) fn handover_ready(&mut self, launch_elapsed: Duration, connected: bool, presenting: bool) -> bool {
         if launch_elapsed < ui::LAUNCH_FADE {
             return false;
         }
@@ -139,25 +140,19 @@ impl Hero {
             // Nothing on screen: hand over at the end of the fade, as it always did. A game
             // that *has* wide art gets a grace period first — on a cold cache the hero can
             // still be a fetch away, and would otherwise land just after the hand-off.
-            return !self.expected || launch_elapsed >= ui::LAUNCH_FADE + ui::HERO_WAIT;
+            return !self.expected || launch_elapsed >= ui::LAUNCH_FADE + ui::STREAM_REVEAL_WAIT;
         }
-        // Held until the stream is genuinely up: a beat past the handshake (the stream's
-        // own first frames are black anyway) and until the decoder presents, so the
-        // fade-out runs straight into live video. Also for its own minimum, so a late
-        // arrival isn't cut mid-fade-in.
-        let Some(done) = connect_done else { return false };
-        let stream_up = presenting || done.elapsed() >= ui::STREAM_REVEAL_WAIT;
-        stream_up && done.elapsed() >= ui::HERO_LINGER && self.shown_for(ui::HERO_MIN_SHOW) && self.faded_out()
-    }
-
-    /// Whether the backdrop has been up (fade-in included) for at least `least`.
-    fn shown_for(&self, least: Duration) -> bool {
-        self.since.is_some_and(|t| t.elapsed() >= least)
+        // Held until the stream is genuinely up: the handshake landed *and* the decoder is
+        // presenting, so the fade-out runs straight into live video. Deliberately un-timed — a
+        // player that isn't ready yet is what this screen exists for, so it keeps panning rather
+        // than cut to a stream opening on black. Plus its own minimum, so a hero that arrived
+        // late isn't cut mid-fade.
+        connected && presenting && self.since.is_some_and(|t| t.elapsed() >= ui::HERO_MIN_SHOW) && self.faded_out()
     }
 
     /// Starts the fade-out (idempotent) and reports whether it has finished.
     fn faded_out(&mut self) -> bool {
         let since = *self.fade_out.get_or_insert_with(Instant::now);
-        since.elapsed() >= ui::HERO_FADE_OUT
+        since.elapsed() >= ui::HERO_FADE
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3369,9 +3369,9 @@ impl App {
     }
 
     /// The connecting screen's hero backdrop: fade in/out, slow pan, and its dimming
-    /// scrim. Fading rather than cutting at both ends, over the same black the launch
-    /// faded to, so a hero arriving mid-handshake eases in and live video arrives out of
-    /// black rather than from a lit image.
+    /// scrim. Fading rather than cutting at both ends, over the same black the launch faded
+    /// to, so a hero arriving mid-handshake eases in and live video arrives out of black
+    /// rather than from a lit image.
     fn compose_hero(&self, screen_w: u32, screen_h: u32, cmds: &mut ui::render::DrawList) {
         let Some((id, hero)) = self.hero.visible() else { return };
         let f = self.hero.opacity();

--- a/src/app/state/addhost.rs
+++ b/src/app/state/addhost.rs
@@ -5,12 +5,13 @@ use crate::services::store::{self, KnownHost};
 use crate::ui::MenuEvent;
 
 impl App {
-    /// Handles menu event on add-host modal. Left/Right stand in for backspace (no dot
-    /// key on remote); Confirm once four octets typed.
+    /// Handles menu event on add-host modal. Left/Right stand in for backspace and
+    /// "next field" (no dot or colon key on the remote) — Right past the fourth octet
+    /// opens the optional port. Confirm once the address is complete.
     pub fn handle_add_host_event(&mut self, ev: MenuEvent) {
         match ev {
             MenuEvent::Left => self.add_host.backspace(),
-            MenuEvent::Right => self.add_host.advance_octet(),
+            MenuEvent::Right => self.add_host.advance_field(),
             MenuEvent::Up | MenuEvent::Down | MenuEvent::Secondary => {}
             MenuEvent::Confirm => self.confirm_add_host(),
             MenuEvent::Back => self.screen = Screen::Home,
@@ -28,10 +29,16 @@ impl App {
             return;
         }
         let (host, port) = self.add_host.host_and_port();
+        // Non-default port in the name, so two ports on one address stay tellable apart.
+        let name = if port == crate::ui::FIXED_HOST_PORT {
+            host.clone()
+        } else {
+            format!("{host}:{port}")
+        };
         store::upsert_known_host(
             &mut self.known_hosts,
             KnownHost {
-                name: host.clone(),
+                name,
                 host: host.clone(),
                 port,
                 mgmt_port: None,

--- a/src/app/state/edithost.rs
+++ b/src/app/state/edithost.rs
@@ -12,7 +12,7 @@ impl App {
         let Some(HostEntry::Known(h)) = self.entries.get(idx) else {
             return;
         };
-        self.add_host = AddHostState::from_ip(&h.host);
+        self.add_host = AddHostState::from_host_port(&h.host, h.port);
         self.edit_host_index = Some(idx);
         self.host_menu_index = None;
         self.screen = Screen::EditHost;
@@ -22,7 +22,7 @@ impl App {
     pub(crate) fn handle_edit_host_event(&mut self, ev: MenuEvent) {
         match ev {
             MenuEvent::Left => self.add_host.backspace(),
-            MenuEvent::Right => self.add_host.advance_octet(),
+            MenuEvent::Right => self.add_host.advance_field(),
             MenuEvent::Confirm => self.confirm_edit_host(),
             MenuEvent::Back => {
                 self.edit_host_index = None;

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -581,17 +581,27 @@ impl App {
             Some(GridCard::Game(game)) => (Some(game.id.clone()), game.title.clone()),
             None => return,
         };
-        // The loading screen's backdrop. Requested here as well as on focus, since a card
-        // can be confirmed before the focus prefetch got round to it; Desktop has no art,
-        // so it keeps the plain fade to black.
-        let mut expected = false;
-        if let Some(game) = launch.as_ref().and_then(|id| self.games.iter().find(|g| &g.id == id)) {
-            expected = game.art.hero.is_some() || game.art.header.is_some();
-            if let Some(loader) = &mut self.art_loader {
+        // The loading screen's backdrop. Desktop has no art, so it keeps the plain fade to
+        // black — as does a game with none, which hands straight over to the stream. Armed
+        // before the art is handed over, so `Hero::accept` recognises a cache hit as belonging
+        // to this launch even if the focus prefetch never ran.
+        let game = launch.as_ref().and_then(|id| self.games.iter().find(|g| &g.id == id));
+        self.hero.arm(launch.clone());
+        if let (Some(game), Some(loader)) = (game, &mut self.art_loader) {
+            // The disk is only touched when the focus prefetch hasn't already decoded this
+            // hero — re-reading it would be several MB of nothing, and that is the common case.
+            let in_hand = self.hero.image_for(&game.id).is_some()
+                || loader
+                    .cached_hero(&game.id)
+                    .is_some_and(|image| self.hero.accept(game.id.clone(), image));
+            if !in_hand && (game.art.hero.is_some() || game.art.header.is_some()) {
+                // Asked for here as well as on focus, since a card can be confirmed before the
+                // prefetch got round to it. The fetch overlaps the connect, and only *this*
+                // case — art that isn't on this TV yet — is worth holding the hand-off for.
                 loader.request_hero(game);
+                self.hero.await_art();
             }
         }
-        self.hero.arm(launch.clone(), expected);
         tracing::debug!("launch: connecting to {host}:{port} now, zoom runs in parallel");
         // Stays up through the zoom and the connect; `run_inner` owns the screen from there.
         self.home_status = Some(format!("Starting {title}…"));

--- a/src/app/view/addhost.rs
+++ b/src/app/view/addhost.rs
@@ -6,7 +6,7 @@ use crate::ui::render::Rect;
 use crate::ui::{self, Painter};
 use anyhow::Result;
 
-const ADD_HOST_SUBTITLE: &str = "Enter the host's IP address.";
+const ADD_HOST_SUBTITLE: &str = "Enter the host's IP address. Right adds an optional port.";
 
 impl App {
     /// Screen-specific subtitle to avoid layout overflow.

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use super::*;
 
 /// How long the finished menu frame is held waiting for NDL `PLAYING` before uncovering the
-/// video plane regardless. Shared with the hero loading screen, which waits on the same
-/// signal for the same reason (`ui::STREAM_REVEAL_WAIT`) — so when a hero held the screen
-/// this wait is already satisfied and returns immediately.
+/// video plane regardless. The hero loading screen waits on the same signal, and without a
+/// timeout (`app::hero::handover_ready`) — so when a hero held the screen this wait is already
+/// satisfied and returns immediately.
 const NDL_REVEAL_TIMEOUT: Duration = crate::ui::STREAM_REVEAL_WAIT;
 
 pub(super) fn run_inner() -> Result<()> {

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -111,8 +111,9 @@ pub(super) fn run_ui_flow(
     // running by then, so this just carries its handle out of the loop for
     // `run_inner` to join once the launch animation finishes.
     let mut connect_handle: Option<ConnectOutcome> = None;
-    // When the connect thread was first seen finished — the hero linger runs off this.
-    let mut connect_done_at: Option<Instant> = None;
+    // Whether the connect thread has been seen finished. Latched, since `is_finished` is only
+    // polled while the loading screen is up.
+    let mut connect_done = false;
     // Yellow button log overlay works here too (see streaming loop).
     let mut yellow_held = false;
     let mut home_held = false;
@@ -214,11 +215,9 @@ pub(super) fn run_ui_flow(
         // landed (`run_inner`'s join then returns immediately), the decoder presenting (so
         // its reveal wait is satisfied too), and the hold and fade-out done.
         if let Some(t) = app.launch_anim {
-            if connect_done_at.is_none() && connect_handle.as_ref().is_none_or(|(h, _)| h.is_finished()) {
-                connect_done_at = Some(Instant::now());
-            }
+            connect_done |= connect_handle.as_ref().is_none_or(|(h, _)| h.is_finished());
             let presenting = crate::platform::webos::ndl::playing();
-            if app.hero.handover_ready(t.elapsed(), connect_done_at, presenting) {
+            if app.hero.handover_ready(t.elapsed(), connect_done, presenting) {
                 break 'ui;
             }
         }

--- a/src/services/art.rs
+++ b/src/services/art.rs
@@ -90,11 +90,14 @@ const HERO_BYTES_SUFFIX: &str = ".hero";
 /// 200-game library, on a TV with no disk to spare. At this budget roughly 80 covers stay
 /// resident, which is far more than the grid window, and a miss costs one LAN fetch.
 const CARD_CACHE_BUDGET: u64 = 56 * 1024 * 1024;
-/// Per-host disk budget for hero art. ~2.7 MB per decoded hero at [`MAX_HERO_WIDTH`], so this
-/// keeps the last ~8 launched. Its own budget rather than a share of the card one because the
-/// two compete on nothing: a full grid of covers must not evict the hero of the game being
-/// launched, and one launch must not evict the visible grid.
-const HERO_CACHE_BUDGET: u64 = 24 * 1024 * 1024;
+/// Per-host disk budget for hero art. ~3.7 MB per hero (a ~2.7 MB decoded `.hero.raw` at
+/// [`MAX_HERO_WIDTH`] plus the encoded bytes beside it), so this keeps the last dozen or so.
+/// Its own budget rather than a share of the card one because the two compete on nothing: a
+/// full grid of covers must not evict the hero of the game being launched, and one launch
+/// must not evict the visible grid. Sized against *browsing* rather than launching, since a
+/// hero is prefetched for every card the focus settles on: at ~6 entries, scrolling one shelf
+/// evicted the hero of the game the user then launched.
+const HERO_CACHE_BUDGET: u64 = 48 * 1024 * 1024;
 /// Card writes between prunes. Pruning walks the host's directory, so doing it per cover would
 /// put a `read_dir` on every grid fetch; heroes are few and large enough to prune every time.
 const CARD_PRUNE_EVERY: u32 = 24;
@@ -148,20 +151,38 @@ fn write_raw(path: &std::path::Path, magic: u32, width: u32, height: u32, pixels
 /// Read raw cache, if present and written with this magic (and so this pixel convention —
 /// card pixels are premultiplied, hero pixels straight, and the two must never be
 /// mistaken for each other).
+///
+/// Header first, then the payload into its own exactly-sized buffer: the pixels are all but
+/// 12 bytes of the file, so reading the lot and shifting it down over the header would be a
+/// multi-MB memmove — and a hero is read this way on the launch path (`cached_hero`). A
+/// mismatched magic or size costs only the header read.
 fn read_raw(path: &std::path::Path, magic: u32) -> Option<(u32, u32, Vec<u8>)> {
-    let mut buf = std::fs::read(path).ok()?;
-    if u32::from_le_bytes(buf.get(0..4)?.try_into().ok()?) != magic {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut header = [0u8; 12];
+    file.read_exact(&mut header).ok()?;
+    if u32::from_le_bytes(header[0..4].try_into().ok()?) != magic {
         return None;
     }
-    let width = u32::from_le_bytes(buf.get(4..8)?.try_into().ok()?);
-    let height = u32::from_le_bytes(buf.get(8..12)?.try_into().ok()?);
-    if buf.len() - 12 != width as usize * height as usize * 4 {
+    let width = u32::from_le_bytes(header[4..8].try_into().ok()?);
+    let height = u32::from_le_bytes(header[8..12].try_into().ok()?);
+    let len = (width as usize).checked_mul(height as usize)?.checked_mul(4)?;
+    // Against the file's own length, before allocating for it: a truncated (or absurd)
+    // header must not turn into a multi-MB reservation.
+    if file.metadata().ok()?.len() != (len + 12) as u64 {
         return None;
     }
-    // Shift the payload down over the header rather than copying it out: the pixels are the
-    // whole file, and this way the read's allocation is the one handed on.
-    buf.drain(..12);
-    Some((width, height, buf))
+    let mut pixels = Vec::with_capacity(len);
+    file.read_to_end(&mut pixels).ok()?;
+    (pixels.len() == len).then_some((width, height, pixels))
+}
+
+/// A hero straight out of the decoded-pixel cache, or `None` if it isn't cached (or was
+/// written by an older build). One file read, no decode and no fetch, which is what makes it
+/// safe to call on the UI thread.
+fn read_hero_raw(path: &std::path::Path) -> Option<HeroImage> {
+    let (width, height, pixels) = read_raw(path, HERO_CACHE_MAGIC)?;
+    Some(HeroImage { width, height, pixels })
 }
 
 /// Which budget a cached file counts against. Heroes are matched first: `x.hero.raw` ends with
@@ -262,6 +283,9 @@ pub struct ArtLoader {
     /// back and forth over a card must not re-queue its much larger hero either, and the two
     /// are forgotten independently.
     requested: [HashSet<String>; ART_KINDS],
+    /// This host's cache directory, so [`Self::cached_hero`] can read it without going
+    /// through the worker — the worker's own copy is in its `WorkerConfig`.
+    dir: PathBuf,
 }
 
 impl ArtLoader {
@@ -285,7 +309,7 @@ impl ArtLoader {
             query_port,
             identity,
             fingerprint,
-            dir,
+            dir: dir.clone(),
             card_w,
             card_h,
         };
@@ -297,6 +321,7 @@ impl ArtLoader {
             tx: tx_req,
             rx: rx_done,
             requested: Default::default(),
+            dir,
         }
     }
 
@@ -358,6 +383,18 @@ impl ArtLoader {
                 .map(str::to_string)
                 .collect()
         });
+    }
+
+    /// `game_id`'s hero out of the disk cache, on the calling thread. For the launch itself:
+    /// going through the worker for an image that is already decoded on disk would put it
+    /// behind whatever card art that thread is mid-fetch on, which is how a hero that *was*
+    /// cached still managed to arrive after the hand-off.
+    ///
+    /// A hit counts as a request, so nothing queues the same image a second time.
+    pub fn cached_hero(&mut self, game_id: &str) -> Option<HeroImage> {
+        let image = read_hero_raw(&raw_cache_path(&self.dir, game_id, ArtKind::Hero))?;
+        self.requested[ArtKind::Hero as usize].insert(game_id.to_string());
+        Some(image)
     }
 
     /// Forgets that `game_id`'s hero was requested, so it can be asked for again. Needed
@@ -444,9 +481,9 @@ fn worker(config: &WorkerConfig, rx: &Receiver<ArtRequest>, tx: &Sender<ArtLoade
                         pixmap: sized,
                     }
                 }),
-            ArtKind::Hero => read_raw(&raw_cached, HERO_CACHE_MAGIC).map(|(width, height, pixels)| ArtLoaded::Hero {
+            ArtKind::Hero => read_hero_raw(&raw_cached).map(|image| ArtLoaded::Hero {
                 game_id: req.game_id.clone(),
-                image: HeroImage { width, height, pixels },
+                image,
             }),
         };
         if let Some(loaded) = cached_raw {
@@ -594,6 +631,26 @@ mod tests {
         assert_eq!(cache_class(&dir.join("123.raw")), Some(ArtKind::Card));
         assert_eq!(cache_class(&dir.join("123")), Some(ArtKind::Card));
         assert_eq!(cache_class(&dir.join("123.hero.raw.tmp")), None);
+    }
+
+    /// The gate that decides whether a hero is fetched again: the worker (and `cached_hero`)
+    /// only skip the host when this round-trips, so a header written one way and read another
+    /// shows up as re-downloaded art rather than as a failure.
+    #[test]
+    fn a_written_hero_is_read_back_from_cache() {
+        let dir = std::env::temp_dir().join("pf-art-hero-roundtrip");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = raw_cache_path(&dir, "game 1", ArtKind::Hero);
+        let pixels: Vec<u8> = (0..2u32 * 3 * 4).map(|b| b as u8).collect();
+        write_raw(&path, HERO_CACHE_MAGIC, 2, 3, &pixels);
+
+        let image = read_hero_raw(&path).expect("hero cache should read back");
+        assert_eq!((image.width, image.height), (2, 3));
+        assert_eq!(image.pixels, pixels);
+        // A card's magic must not read as a hero: the two disagree on premultiplication.
+        assert!(read_raw(&path, RAW_CACHE_MAGIC).is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Each host gets its own directory, so one host's library can't crowd out another's.

--- a/src/ui/addhost.rs
+++ b/src/ui/addhost.rs
@@ -1,129 +1,111 @@
-//! Manual add-host-by-IP entry state.
+//! Manual add-host-by-address entry state.
 //!
 //! Split out of the former single-file `ui.rs`; see `super`'s module docs.
 
 /// punktfunk's conventional host port (see `store::dev_override_connect`'s
-/// fallback) — fixed and not user-editable, so the add-host screen only ever
-/// has to ask for an IP address.
+/// fallback) — what a bare address means, so the add-host screen only *has* to
+/// ask for an IP; an explicit `:port` suffix overrides it.
 pub const FIXED_HOST_PORT: u16 = 9777;
 
-/// Manual "add host by IP" entry state: a plain, naturally-growing digit
-/// string rather than a fixed-width masked grid — no `_` placeholders, no
-/// per-octet box, no port field (that's always [`FIXED_HOST_PORT`]). Dots are
-/// inserted automatically once an octet is complete (three digits, or a
-/// fourth that would push its value past 255), so the Magic Remote's number
-/// pad (`digit_key_value`) — the only realistic input this screen gets — is
-/// enough on its own, with Left/Right (see `app.rs`'s `handle_add_host_event`)
-/// standing in for backspace/"next octet" on a remote with no dot key.
+/// Manual "add host" entry state: one free-form field holding `ip[:port]`
+/// exactly as typed — no fixed-width mask, no `_` placeholders, no separate
+/// port box. Separators are inserted automatically (a `.` once an octet is
+/// complete — three digits, or a fourth that would push it past 255 — and a `:`
+/// once a fourth octet is), so the Magic Remote's number pad (`digit_key_value`)
+/// is enough on its own, with Left/Right (see `app::state::addhost`) standing in
+/// for the backspace and separator keys it lacks.
 #[derive(Default)]
 pub struct AddHostState {
-    /// Completed octets so far (0-3 of them once a further one is being typed).
-    octets: Vec<u8>,
-    /// Digits typed into the octet currently being entered, not yet finalized
-    /// into `octets` — kept as text (not a parsed `u8`) so it can grow one
-    /// digit at a time and still show a partial value like "2" or "25".
-    current: String,
+    text: String,
 }
 
 impl AddHostState {
-    /// Pre-fills from an existing dotted-quad address, for `Screen::EditHost`. A
-    /// value that isn't four numeric octets comes back empty rather than partially
-    /// parsed — better to retype than to silently edit a mangled address.
-    pub fn from_ip(ip: &str) -> Self {
-        let parts: Vec<&str> = ip.split('.').collect();
-        if parts.len() != 4 {
+    /// Pre-fills from an existing address for `Screen::EditHost`, keeping a
+    /// non-default port visible so re-saving can't silently move the host back
+    /// to [`FIXED_HOST_PORT`]. An address that isn't four numeric octets comes
+    /// back empty rather than partially parsed — better to retype than to
+    /// silently edit a mangled address.
+    pub fn from_host_port(ip: &str, port: u16) -> Self {
+        let mut s = Self { text: ip.to_string() };
+        if !s.is_complete() {
             return Self::default();
         }
-        let mut octets = Vec::with_capacity(4);
-        for p in parts {
-            match p.parse::<u8>() {
-                Ok(v) => octets.push(v),
-                Err(_) => return Self::default(),
-            }
+        if port != FIXED_HOST_PORT {
+            s.text.push(':');
+            s.text.push_str(&port.to_string());
         }
-        Self {
-            octets,
-            current: String::new(),
-        }
+        s
     }
 
     /// Types one character from the webOS on-screen keyboard (`Event::TextInput`,
-    /// see `main.rs`) — digits behave exactly as the remote's number pad does, and a
-    /// literal `.` finishes the current octet, since a real keyboard *does* have the
-    /// dot key the Magic Remote lacks. Anything else is ignored: this field only ever
-    /// holds an IPv4 address.
+    /// see `main.rs`) — digits behave exactly as the remote's number pad does, and
+    /// `.` / `:` finish the current field, since a real keyboard *does* have the
+    /// separator keys the Magic Remote lacks. Anything else is ignored: this field
+    /// only ever holds an IPv4 address and an optional port.
     pub fn enter_char(&mut self, c: char) {
         if let Some(d) = c.to_digit(10) {
             self.enter_digit(d as u8);
-        } else if c == '.' {
-            self.advance_octet();
+        } else if c == '.' || c == ':' {
+            self.advance_field();
         }
     }
 
-    /// Whether exactly four octets' worth of digits have been typed — the
-    /// point at which `host_and_port()` names a real, connectable address.
+    /// Whether the address part names a real, connectable host — the point at
+    /// which `host_and_port()` is meaningful. The port part is optional and, when
+    /// absent or unparseable, falls back to [`FIXED_HOST_PORT`].
     pub fn is_complete(&self) -> bool {
-        (self.octets.len() == 4 && self.current.is_empty()) || (self.octets.len() == 3 && !self.current.is_empty())
+        let addr = self.text.split(':').next().unwrap_or_default();
+        let mut octets = addr.split('.');
+        let ok = (&mut octets).take(4).filter(|o| o.parse::<u8>().is_ok()).count() == 4;
+        ok && octets.next().is_none()
     }
 
     pub fn host_and_port(&self) -> (String, u16) {
-        let mut parts: Vec<String> = self.octets.iter().map(u8::to_string).collect();
-        if !self.current.is_empty() {
-            parts.push(self.current.clone());
-        }
-        (parts.join("."), FIXED_HOST_PORT)
+        let (addr, port) = self.text.split_once(':').unwrap_or((&self.text, ""));
+        let port = port.parse::<u16>().ok().filter(|p| *p > 0).unwrap_or(FIXED_HOST_PORT);
+        (addr.to_string(), port)
     }
 
-    /// What's actually been typed so far, exactly as typed — no mask, no
-    /// placeholders, no port.
+    /// What's actually been typed so far, exactly as typed.
     pub fn display_text(&self) -> String {
-        self.host_and_port().0
+        self.text.clone()
     }
 
-    /// Types one digit (0-9) into the octet currently being entered, finishing
-    /// it automatically (a dot appears) once it hits three digits or a fourth
-    /// digit would push its value past 255 — the same auto-advance idiom as a
-    /// phone's IP-entry field, needed since the remote has no dot key of its own.
+    /// Types one digit (0-9), inserting the separator the remote can't type
+    /// whenever the current field is full: an octet finishes at three digits or
+    /// when a fourth would push its value past 255, and after the fourth octet
+    /// further digits can only mean a port, so a `:` goes in by itself.
     pub fn enter_digit(&mut self, digit: u8) {
-        if self.octets.len() >= 4 {
-            return;
-        }
-        let mut candidate = self.current.clone();
-        candidate.push((b'0' + digit) as char);
-        let value: u32 = candidate.parse().unwrap_or(0);
-        if value > 255 || candidate.len() > 3 {
-            self.advance_octet();
-            if self.octets.len() < 4 {
-                self.current.push((b'0' + digit) as char);
+        let c = (b'0' + digit) as char;
+        if let Some((_, port)) = self.text.split_once(':') {
+            let mut candidate = port.to_string();
+            candidate.push(c);
+            if candidate.parse::<u16>().is_ok() {
+                self.text.push(c);
             }
             return;
         }
-        self.current = candidate;
-        if self.current.len() == 3 {
-            self.advance_octet();
+        let seg = self.text.rsplit('.').next().unwrap_or_default();
+        let full = seg.len() == 3 || format!("{seg}{c}").parse::<u16>().unwrap_or(0) > 255;
+        if full {
+            self.advance_field();
         }
+        self.text.push(c);
     }
 
-    /// Deletes the last typed character — a digit from the in-progress octet,
-    /// or (once that's empty) undoes the last completed octet back into it for
-    /// editing. Left on the d-pad.
+    /// Deletes the last typed character, separators included — Left on the d-pad.
     pub fn backspace(&mut self) {
-        if !self.current.is_empty() {
-            self.current.pop();
-        } else if let Some(last) = self.octets.pop() {
-            self.current = last.to_string();
-        }
+        self.text.pop();
     }
 
-    /// Manually finishes the octet in progress — so e.g. "8" can become
-    /// "8.8.8.8" without waiting for three digits or an overflow. Right on the
-    /// d-pad, standing in for the "." key a real keyboard would have.
-    pub fn advance_octet(&mut self) {
-        if self.current.is_empty() || self.octets.len() >= 4 {
+    /// Manually finishes the field in progress — so e.g. "8" can become "8.8.8.8"
+    /// without waiting for three digits or an overflow, and a complete address can
+    /// grow a port. Right on the d-pad, standing in for the "." and ":" keys a real
+    /// keyboard would have.
+    pub fn advance_field(&mut self) {
+        if self.text.is_empty() || self.text.ends_with(['.', ':']) || self.text.contains(':') {
             return;
         }
-        let value: u8 = self.current.parse().unwrap_or(0);
-        self.octets.push(value);
-        self.current.clear();
+        self.text.push(if self.is_complete() { ':' } else { '.' });
     }
 }

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -9,30 +9,21 @@ pub const LAUNCH_FADE: Duration = Duration::from_millis(600);
 /// well past any plausible handshake so a real load only ever shows a slow drift.
 pub const HERO_PAN: Duration = Duration::from_secs(75);
 
-/// The hero's own fade-in, slower than `LAUNCH_FADE`: the card zoom is a reaction to a
-/// button press and has to feel immediate, while this is a scene settling in.
-pub const HERO_FADE: Duration = Duration::from_millis(1_100);
+/// The hero's fade, in and back out to black again. Slower than `LAUNCH_FADE`: the card zoom is
+/// a reaction to a button press and has to feel immediate, while this is a scene settling in —
+/// and leaving it settles out on the same curve it arrived on.
+pub const HERO_FADE: Duration = Duration::from_millis(1_300);
 
-/// The hero's fade-out, run just before the stream is uncovered. Quick — it is a
-/// hand-off, not a transition, and every frame of it delays live video.
-pub const HERO_FADE_OUT: Duration = Duration::from_millis(280);
+/// How long the hero stays up once it appears, [`HERO_FADE`] included. A floor, not a cap: a
+/// slower handshake keeps it up longer. Long enough to read as a loading screen with a visible
+/// pan rather than a flash. Only ever paid by a game that has wide art — with no hero to hold,
+/// the hand-off is unchanged.
+pub const HERO_MIN_SHOW: Duration = Duration::from_millis(2_700);
 
-/// How long past the launch fade a game with wide art waits for a hero that hasn't
-/// arrived yet. Only paid on a cold cache — a prefetched hero is already up by then.
-pub const HERO_WAIT: Duration = Duration::from_millis(2_200);
-
-/// How long the hero stays up once it appears, fade-in included — long enough to read as
-/// a loading screen with a visible pan, not a flash. A floor, not a cap: a slower
-/// handshake keeps it up longer.
-pub const HERO_MIN_SHOW: Duration = Duration::from_secs(3);
-
-/// How much longer it holds after the handshake lands, before the fade-out starts. That
-/// and the fade-out together are the ~1s of stream that would be black regardless.
-pub const HERO_LINGER: Duration = Duration::from_millis(700);
-
-/// Longest anything waits for the decoder to report that it is presenting before
-/// uncovering the video plane regardless — both the hero's fade-out (`app::hero`) and, for
-/// the launches that have no hero to hold, `runtime::stream`'s reveal.
+/// Longest a launch waits for one thing that may never arrive, spent on a screen the user is
+/// watching. Two of those, on the same budget: the decoder reporting that it presents
+/// (`runtime::stream`'s reveal, for the launches with no hero to hold), and a hero still being
+/// fetched off the host (`app::hero`, before it gives up and hands over without one).
 pub const STREAM_REVEAL_WAIT: Duration = Duration::from_millis(1_500);
 
 /// Longest the loading screen runs before handing over regardless of the connect thread.


### PR DESCRIPTION
The hero loading screen had eight timing constants, several of them within a couple hundred milliseconds of each other, and it still managed to miss its art fairly often. This is mostly a cleanup of both.

**Art gets there in time now**

- A cached hero is read straight off disk on the frame the launch starts (`ArtLoader::cached_hero`), so it's up immediately. Before, even a cached hero went through the art worker's queue — which jumps ahead of *queued* cover art but not the fetch already in flight, so on a cold grid it could land after the hand-off had already happened.
- The disk is only touched when the focus prefetch hasn't already decoded that hero, which is the common case.
- Hero cache budget 24MB -> 48MB. At ~3.7MB per hero that was about six entries, and a hero is prefetched for every card the focus settles on — so scrolling one shelf evicted the hero of the game you then launched.
- `read_raw` reads the header, checks it against the file's own length, then reads the payload into an exactly-sized buffer. Drops a ~2.7MB memmove that now happens on the launch path, and a stale-magic file costs only the header read.
- Test on the cache header round-trip, since that's the gate that decides whether art gets fetched again — when it silently disagrees the symptom is re-downloaded art, not an error.

**Fewer, clearer durations**

`HERO_FADE_OUT`, `HERO_LINGER`, `HERO_WAIT` and `HERO_MIN_SHOW`'s old value are gone. What's left: `HERO_FADE` (1300ms, both directions), `HERO_MIN_SHOW` (2700ms), `STREAM_REVEAL_WAIT` (1500ms, doing double duty as the cold-art grace), `HERO_LOADING_MAX`, `HERO_PAN`. The hero also stays up meaningfully longer than it used to.

**Hand-off waits on the player, not a clock**

`handover_ready` holds until `ndl::playing()` reports the decoder is presenting — no timeout on that condition any more, since a player that isn't ready yet is the whole reason this screen exists. `HERO_LOADING_MAX` (30s) is the only way out if it never comes.

And a launch only pays the cold-art grace period when a hero is genuinely being fetched (`Hero::await_art`). Games with no wide art, and Desktop, hand straight over at the end of the launch fade — previously anything with a `header` field waited up to 1.5s for art that was never going to arrive in time.

**Also in here:** the optional port field in Add/Edit host — Right past the fourth octet opens it, and a non-default port shows up in the host's name so two ports on one address stay tellable apart.

Not yet exercised on the TV.