### PR TITLE
Audio: a real jitter buffer, off the UI thread, and a measured A/V offset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.24.0#2c03290a5ee3452b0e548b097c10621da4d5aeae"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.26.0#f80636f901820b42d9388ade6fbaf718ba948c7c"
 
 [[package]]
 name = "fiat-crypto"
@@ -1109,8 +1109,8 @@ dependencies = [
 
 [[package]]
 name = "punktfunk-core"
-version = "0.24.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.24.0#2c03290a5ee3452b0e548b097c10621da4d5aeae"
+version = "0.26.0"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.26.0#f80636f901820b42d9388ade6fbaf718ba948c7c"
 dependencies = [
  "aes-gcm",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,12 @@ tracing-appender = "0.2"
 # v0.24.0 brings the ABR sweep (eleven defects: the 20 Mbps pin, throughput measured in media
 # bytes not wire bytes, a decode ceiling that latched at the choke rate) and probe throughput
 # measured over the client's own receive interval — all client-side, so the bump is the fix.
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.24.0", features = ["quic"] }
+# v0.26.0 is the first release carrying the audio latency programme — `JitterPolicy` (the shared
+# de-jitter state machine every other client ring runs), `AvSync`, `AudioSyncCell`,
+# `crossfade_drop`, and the redundant `0xD2` audio plane. At v0.24.0 `punktfunk_core::audio` is
+# 369 lines (layouts + `AudioGapTracker`); at v0.26.0 it is 2301. `connect`'s parameter list is
+# unchanged across the two, so this is a pin-only bump. See `docs/NOTES.md` § Audio.
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.26.0", features = ["quic"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # mDNS LAN discovery; direct dep (not via pf-client-core — see session.rs docs).

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -139,7 +139,7 @@ MANIFEST (crate version — SPDX license — source)
   powerfmt 0.2.0 — MIT OR Apache-2.0 — https://github.com/jhpratt/powerfmt
   ppv-lite86 0.2.21 — MIT OR Apache-2.0 — https://github.com/cryptocorrosion/cryptocorrosion
   proc-macro2 1.0.107 — MIT OR Apache-2.0 — https://github.com/dtolnay/proc-macro2
-  punktfunk-core 0.24.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
+  punktfunk-core 0.26.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
   pxfm 0.1.30 — BSD-3-Clause OR Apache-2.0 — https://github.com/awxkee/pxfm
   quinn 0.11.11 — MIT OR Apache-2.0 — https://github.com/quinn-rs/quinn
   quinn-proto 0.11.16 — MIT OR Apache-2.0 — https://github.com/quinn-rs/quinn
@@ -238,7 +238,7 @@ MANIFEST (crate version — SPDX license — source)
 ----------------------------------------------------------------------------
 Crates whose package did not embed a license file (SPDX + source only)
 ----------------------------------------------------------------------------
-  punktfunk-core 0.24.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
+  punktfunk-core 0.26.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
   sdl2-sys 0.38.0 — MIT AND Zlib — https://github.com/rust-sdl2/rust-sdl2
   yasna 0.5.2 — MIT OR Apache-2.0 — https://github.com/qnighy/yasna.rs
 

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -107,6 +107,8 @@ The host stamps `pts_ns` on every audio datagram; this client decoded it and thr
 
 ## Opus offload to NDL (OFF BY DEFAULT — still freezes 10.3)
 
+⚠ **A second, independent defect on this path, found 2026-08-09 and NOT fixed:** `play_audio` stamps arrival wall-clock while video is stamped host-PTS-anchored + paced, so NDL's own A/V sync regulates two unrelated timelines. Fixing it means both planes sharing one `HostPtsAnchor`, i.e. moving anchor ownership onto the `NdlVideo` handle behind a lock — a change to the working video hot path for a path that is off and broken. Whoever revives offload fixes this first. Symptom would be audio drifting against the picture over a session, not a constant offset.
+
 NDL is the sole video backend. Software Opus→SDL is the audio path; NDL hardware Opus is gated off behind the `NDL_AUDIO_OFFLOAD` const in `session/mod.rs` (flip to `true` to re-test).
 
 The wiring is byte-exact with `mariotaku/ss4s` `ndl/webos5`: `NdlAudioConfig.sample_rate` in **kHz** (`48.0`, not `48000.0`), the stereo `opus_empty_frame_211 = {0xec,0xff,0xfe}` decoder prime fed once right after a successful audio-enabled `NDL_DirectMediaLoad`, combined audio+video in one load, and feed-time PTS (`elapsed since load`, ms) on both audio and video planes — identical to ss4s's `FeedVideo`/`FeedAudio` `GetPts`. Struct layouts (`NDL_DIRECTMEDIA_AUDIO_OPUS_INFO_T`, `..._DATA_INFO_T`) verified field-for-field against the ss4s mock headers.

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -82,9 +82,28 @@ CX/G5 are 32-bit userland on ARMv8-A. RustCrypto's `aes` crate has ARMv8 intrins
 
 ## Audio (software Opus path)
 
-- **Soft ceiling (60 ms) drops one 5 ms packet at a time; hard clear (100 ms) backstops bursts.** Hard clear of entire queue = ~100 ms silence per event. Soft walks queue back down.
-- **Lost packets concealed** with libopus PLC: ask `AudioGapTracker` how many precede current packet, synthesize that many PLC frames first (decode with empty input).
-- Underrun vs overrun logged separately (`Underrun`/`Dropped`/`Resnapped`/`Queued`). Underrun sources: audio feed thread too slow, or main thread stats overlay renders every 500 ms on 2-core device.
+Two threads and a ring: `session::audio_feed_pump` decodes Opus and posts chunks down a bounded channel; SDL's audio callback (`platform::webos::audio::RingCallback`) drains that into a ring it owns and serves the device from it under `punktfunk_core::audio::JitterPolicy` — the same de-jitter state machine every other punktfunk client ring runs.
+
+- **The ring primes to 25 ms before the first sample plays**, grows its target under underrun pressure (+10 ms per 3 underruns in a 5 s window, ceiling 90 ms), relaxes after a quiet spell, and sheds drift as **one crossfaded 5 ms frame** once the depth average has sat 20 ms over target for 2 s of consumed audio. Hard cap 120 ms. Preset is `WEBOS_TUNING`, local to `audio.rs`, seeded from core's `AAUDIO` (closest rationale: we own the buffer, and Wi-Fi power-save bunching lands as underruns).
+- **Lost packets concealed** with libopus PLC: ask `AudioGapTracker` how many precede current packet, synthesize that many PLC frames first (decode with empty input). Since core v0.26.0 a *single* lost datagram is instead **recovered** from the redundant `0xD2` plane, which core advertises and rebuilds on its own demux side — no client code.
+- Depth/target/underruns/sheds are logged from the callback ~every 10 s, and ring depth + A/V offset are on the stats overlay.
+
+**Blind alleys, so they aren't re-tried:**
+- **`sdl2::audio::AudioQueue` cannot carry the shared policy.** It exposes `queue_audio`/`size`/`clear` and nothing else — no partial drop — so `JitterStep`'s crossfaded shed is inexpressible against it. The pull callback is a prerequisite, not a refactor.
+- **Do not put the drain back on the main loop.** It was there because `AudioQueue` is `!Send`, which put the 5 ms audio cadence behind the UI's software rasterizer; the 500 ms stats-overlay raster was a *documented* underrun source on a 2-core panel.
+- **Do not shrink `DEVICE_BUFFER_FRAMES` below 512** to chase latency. The policy owns depth now; a smaller device quantum on this SoC buys more wakeups and more missed callbacks. 512 = 10.67 ms, and `WEBOS_TUNING`'s 25 ms base is sized to clear the `want + 5 ms` device floor it implies.
+
+## A/V sync
+
+The host stamps `pts_ns` on every audio datagram; this client decoded it and threw it away, so the A/V offset was an accident of buffer depths — and it got *worse* every time video got faster (a quicker decode path lowers the video leg and leaves the audio leg alone). `AvSync` now folds it into a measured offset.
+
+**Currently measure-only.** `AvSync::desired_depth` is never called and no target reaches `JitterPolicy`. The blocker is the video reference: NDL is submit-only (`NDL_DirectVideoPlay` reports nothing about presentation), so `session::sink::video_e2e_ns` estimates glass time as *submit instant + render-queue depth × panel interval + a fixed constant*. The first two are measured; the constant — NDL's decode+panel latency after the queue drains — is not observable from the app.
+
+- **Sign, and why it matters:** underestimating that constant by Δ biases the video figure low, the offset high, and aims the ring Δ shallower — i.e. **audio plays Δ early**. A plausible 2-5 frame NDL pipeline is 33-83 ms at 60 Hz, far outside `AvSync`'s 10 ms deadband. Shipping it at 0 and acting on it would be a bigger error than the drift being corrected.
+- **How to calibrate:** put the stats overlay up (Green), let the `A/V` figure converge (needs 100 observations and a frame on the glass), and write the converged value into `$HOME/av-trim-ms.conf`. Raising it tells the loop the picture is later than it looked, so it holds audio back.
+- ⚠ **Measure in Game Optimiser mode AND a processing-heavy picture mode.** If those differ much, the constant has to become a real setting rather than one compiled-in number. Untested.
+- ⚠ **Use `frame.pts_ns`, never the paced value.** Both are in scope at the submit site with near-identical names; the paced one has been mapped into NDL's *player* clock by `HostPtsAnchor`. Using it regulates against a fiction that still looks plausible.
+- The estimator's unit tests ship in-tree but **cannot run off-device**: `cargo test` links the whole binary and `-lNDL_directmedia` exists only in the cross sysroot.
 
 ## Opus offload to NDL (OFF BY DEFAULT — still freezes 10.3)
 

--- a/src/platform/webos/audio.rs
+++ b/src/platform/webos/audio.rs
@@ -15,7 +15,7 @@
 //! crossfaded 5 ms shed was literally inexpressible against it. Its coarse corrections were a
 //! whole-queue `clear()` (~100 ms of silence) and an uncrossfaded 5 ms discard.
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicI64, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, SyncSender};
 use std::sync::Arc;
 
@@ -98,7 +98,15 @@ impl AudioPlayer {
     ///
     /// The two halves are returned separately because they belong on different threads: the device
     /// stays wherever SDL was initialised, and the feed moves to the decode thread.
-    pub fn new(sdl_audio: &sdl2::AudioSubsystem, channels: u8, cells: SyncCells) -> Result<(Self, AudioFeed)> {
+    /// `sync_enabled` arms the A/V sync loop. It is the caller's read of whether the NDL present
+    /// constant has been calibrated — see [`AudioFeed::observe_av`] for why an uncalibrated loop
+    /// is worse than none.
+    pub fn new(
+        sdl_audio: &sdl2::AudioSubsystem,
+        channels: u8,
+        cells: SyncCells,
+        sync_enabled: bool,
+    ) -> Result<(Self, AudioFeed)> {
         let layout = layout_for(channels, false);
         let decoder = opus::MSDecoder::new(SAMPLE_RATE, layout.streams, layout.coupled, layout.mapping)
             .map_err(|e| anyhow::anyhow!("opus MSDecoder::new: {e}"))?;
@@ -111,6 +119,12 @@ impl AudioPlayer {
         let (recycle_tx, recycle_rx) = std::sync::mpsc::sync_channel::<Vec<f32>>(CHUNK_QUEUE);
         let sync: Arc<AudioSyncCell> = Arc::default();
         let sync_cb = sync.clone();
+        // Interleaved samples sitting in the chunk channel — decoded, not yet in the ring. Part of
+        // what a packet queued now must wait behind, so it belongs in the A/V measurement; see
+        // `AudioFeed::observe_av`. Balanced by construction: added once on a successful send,
+        // subtracted once on receipt.
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let in_flight_cb = in_flight.clone();
         let device = sdl_audio
             .open_playback(None, &spec, |obtained| {
                 // Build the policy from what the device ACTUALLY negotiated, not what was asked
@@ -122,6 +136,7 @@ impl AudioPlayer {
                     ring: VecDeque::new(),
                     policy: JitterPolicy::new(WEBOS_TUNING, obtained.channels),
                     sync: sync_cb,
+                    in_flight: in_flight_cb,
                     underruns: 0,
                     sheds: 0,
                     callbacks: 0,
@@ -154,6 +169,8 @@ impl AudioPlayer {
                 av: AvSync::new(layout.channels),
                 cells,
                 sync,
+                sync_enabled,
+                in_flight,
             },
         ))
     }
@@ -181,8 +198,12 @@ pub struct AudioFeed {
     /// A/V synchronisation, **measure-only for now** — see [`AudioFeed::observe_av`].
     av: AvSync,
     cells: SyncCells,
-    /// Depth out of the callback, target in. Only the depth half is used today.
+    /// Depth out of the callback, target in.
     sync: Arc<AudioSyncCell>,
+    /// Whether to post a target back, i.e. whether to steer at all. See [`Self::observe_av`].
+    sync_enabled: bool,
+    /// Decoded samples handed off but not yet in the ring — see its construction site.
+    in_flight: Arc<AtomicUsize>,
 }
 
 impl AudioFeed {
@@ -190,9 +211,7 @@ impl AudioFeed {
     /// to the ring. Returns the peak sample — a diagnostic that separates "the host is sending
     /// silence" from "the speaker is not working".
     pub fn play(&mut self, seq: u32, pts_ns: u64, opus_payload: &[u8]) -> Result<f32> {
-        // The ring depth as the callback last saw it: everything that must still play before the
-        // packet being queued now does.
-        self.observe_av(pts_ns, self.sync.depth());
+        self.observe_av(pts_ns, self.sync.depth(), self.in_flight.load(Ordering::Relaxed));
 
         // Conceal whatever went missing immediately before this packet. libopus PLC (decode with
         // empty input) interpolates a frame; the alternative is a hard gap, i.e. a click.
@@ -225,23 +244,46 @@ impl AudioFeed {
         let mut buf = self.recycle_rx.try_recv().unwrap_or_default();
         buf.clear();
         buf.extend_from_slice(pcm);
-        let _ = self.pcm_tx.try_send(buf);
+        let n = buf.len();
+        // Counted only on a successful send, so a dropped chunk cannot strand samples in the
+        // in-flight tally forever.
+        if self.pcm_tx.try_send(buf).is_ok() {
+            self.in_flight.fetch_add(n, Ordering::Relaxed);
+        }
     }
 
     /// Fold one packet into the A/V offset measurement, and publish both the offset and the ring
     /// depth for the stats overlay.
     ///
-    /// **This measures; it does not steer.** [`AvSync::desired_depth`] is deliberately never
-    /// called, and no target is handed to [`JitterPolicy::set_sync_target`]. The reason is the one
-    /// term this platform cannot observe: NDL reports nothing about presentation, so
-    /// `session::sink::video_e2e_ns` carries a *calibrated constant* for the decode+panel latency
-    /// after its render queue drains. Until that constant has been read off real hardware it is
-    /// `0`, which biases the offset high — and acting on a biased offset would place audio early
-    /// by exactly the bias, a worse fault than the drift being corrected. Publishing it on the HUD
-    /// first is what turns that constant from a guess into a measurement.
-    fn observe_av(&mut self, pts_ns: u64, buffered_ahead: usize) {
-        // Published unconditionally — the ring's depth is worth seeing whether or not the loop is
-        // acting, and it is what makes an "audio is late" report triageable at all.
+    /// **Measuring is unconditional; steering is not.** The offset and the ring depth are always
+    /// published — they are the instrument, and a latency report with no instrument behind it is
+    /// what this whole programme exists to end. Whether a *target* is posted back depends on
+    /// [`Self::sync_enabled`].
+    ///
+    /// The gate is there because of the one term this platform cannot observe: NDL reports nothing
+    /// about presentation, so `session::sink::video_e2e_ns` carries a calibrated constant for the
+    /// decode+panel latency after its render queue drains. Uncalibrated it is `0`, which biases
+    /// the measured offset high, and steering on a biased offset places audio early by exactly the
+    /// bias — a plausible 33-83 ms against a 10 ms deadband, i.e. a bigger fault than the drift
+    /// being corrected. So the loop arms only once someone has written the measurement to
+    /// `$HOME/av-trim-ms.conf`; that file's presence IS the calibration, and removing it is the
+    /// bisect escape hatch. A settings toggle would need the same evidence to be worth offering.
+    ///
+    /// Note what is NOT gated: the proposal is only ever a request. [`JitterPolicy`] clamps it
+    /// between its own underrun-driven floor and its hard cap, so continuity outranks sync — a link
+    /// whose jitter genuinely needs more buffer than the picture is away keeps its buffer, and the
+    /// residual shows up on the HUD instead of as a dropout.
+    /// **Two depths, and they are not interchangeable.** `ring_depth` is what the audio callback
+    /// owns and the only thing [`JitterPolicy`] can actually move. `in_flight` is decoded PCM
+    /// already handed off but still in the chunk channel — invisible to the policy, but just as
+    /// real to a listener, since it must play before anything queued now does. The *measurement*
+    /// uses the sum (that is the packet's true wait); the *correction* is expressed against the
+    /// ring alone, because the policy interprets its target in ring samples. Handing the sum to
+    /// `desired_depth` would inflate every target by the channel's contents.
+    fn observe_av(&mut self, pts_ns: u64, ring_depth: usize, in_flight: usize) {
+        let buffered_ahead = ring_depth + in_flight;
+        // Published unconditionally — the depth is worth seeing whether or not the loop is acting,
+        // and it is what makes an "audio is late" report triageable at all.
         self.cells
             .buffer_ms
             .store((buffered_ahead / self.per_ms.max(1)) as u32, Ordering::Relaxed);
@@ -257,6 +299,9 @@ impl AudioFeed {
         self.cells
             .av_offset_ms
             .store(i64::from(self.av.offset_ms()), Ordering::Relaxed);
+        if self.sync_enabled {
+            self.sync.set_target(self.av.desired_depth(ring_depth));
+        }
     }
 }
 
@@ -269,8 +314,10 @@ struct RingCallback {
     /// Prime depth in MILLISECONDS, an underrun-driven adaptive floor, and a crossfaded 5 ms drift
     /// shed so latency returns to target instead of ratcheting. See [`WEBOS_TUNING`].
     policy: JitterPolicy,
-    /// Depth out to the decode thread, target in (unused until the sync loop is armed).
+    /// Depth out to the decode thread, target in.
     sync: Arc<AudioSyncCell>,
+    /// Samples still in the chunk channel; decremented as they are drained into the ring.
+    in_flight: Arc<AtomicUsize>,
     underruns: u64,
     sheds: u64,
     callbacks: u64,
@@ -281,6 +328,7 @@ impl sdl2::audio::AudioCallback for RingCallback {
 
     fn callback(&mut self, out: &mut [f32]) {
         while let Ok(mut chunk) = self.rx.try_recv() {
+            self.in_flight.fetch_sub(chunk.len(), Ordering::Relaxed);
             self.ring.extend(chunk.iter().copied());
             // Return the drained Vec to the pool; a full/closed pool just drops it.
             chunk.clear();
@@ -290,6 +338,10 @@ impl sdl2::audio::AudioCallback for RingCallback {
         // `out` is interleaved samples for this callback — exactly the `want` the policy is
         // denominated in.
         let want = out.len();
+        // Take whatever depth the decode thread's sync loop last asked for, and publish where the
+        // ring actually is so it can measure the result. `None` (nothing armed, or inside the
+        // deadband) reproduces the un-synced behaviour exactly.
+        self.policy.set_sync_target(self.sync.target());
         self.sync.publish_depth(self.ring.len());
         let step = self.policy.step(self.ring.len(), want);
         if step.drop_front > 0 {

--- a/src/platform/webos/audio.rs
+++ b/src/platform/webos/audio.rs
@@ -1,8 +1,11 @@
 //! SDL2 audio-queue playback of punktfunk's Opus audio packets. Decode only (Opus →
 //! PCM) happens here — NDL is video-only (see ndl.rs docs), so this is a completely
 //! separate path from the video decode/punch-through plane.
+use std::sync::atomic::{AtomicI64, AtomicU32, AtomicU64, Ordering};
+use std::sync::Arc;
+
 use anyhow::Result;
-use punktfunk_core::audio::{layout_for, AudioGapTracker};
+use punktfunk_core::audio::{layout_for, AudioGapTracker, AvSync, AvSyncObservation};
 
 /// 48 kHz, 5 ms frames — punktfunk's fixed audio framing (see punktfunk-core's
 /// audio.rs doc comments and its `multistream_layout_roundtrips_with_channel_identity`
@@ -38,18 +41,39 @@ pub enum AudioEvent {
     Resnapped,
 }
 
+/// The cells the A/V sync loop trades through, all owned by `NativeClient`: the video plane and
+/// the clock handshake write the first two, this module writes the last two, and the stats overlay
+/// reads them. They live there rather than here because neither plane owns the other — the video
+/// sink cannot see the speaker, and the audio ring cannot see the glass.
+pub struct SyncCells {
+    /// Host-minus-client clock skew, live (re-synced mid-stream).
+    pub clock_offset: Arc<AtomicI64>,
+    /// The video plane's end-to-end latency in ns; `0` = nothing on the glass yet. Written by
+    /// `session::sink`.
+    pub video_e2e: Arc<AtomicU64>,
+    /// Smoothed A/V offset in ms, positive = audio playing LATE. Published for the HUD.
+    pub av_offset_ms: Arc<AtomicI64>,
+    /// Decoded audio queued ahead of the speaker, in ms. Published for the HUD.
+    pub buffer_ms: Arc<AtomicU32>,
+}
+
 pub struct AudioPlayer {
     queue: sdl2::audio::AudioQueue<f32>,
     decoder: opus::MSDecoder,
     channels: usize,
+    /// Interleaved samples per millisecond at the negotiated layout (48 × channels).
+    per_ms: usize,
     /// Detects packets lost on the wire so they can be concealed rather than skipped —
     /// see [`AudioPlayer::play`].
     gaps: AudioGapTracker,
+    /// A/V synchronisation, **measure-only for now** — see [`AudioPlayer::observe_av`].
+    av: AvSync,
+    cells: SyncCells,
 }
 
 impl AudioPlayer {
     /// `channels` is host-resolved (client MUST build decoder from this, not own request).
-    pub fn new(sdl_audio: &sdl2::AudioSubsystem, channels: u8) -> Result<Self> {
+    pub fn new(sdl_audio: &sdl2::AudioSubsystem, channels: u8, cells: SyncCells) -> Result<Self> {
         let layout = layout_for(channels, false);
         let decoder = opus::MSDecoder::new(SAMPLE_RATE, layout.streams, layout.coupled, layout.mapping)
             .map_err(|e| anyhow::anyhow!("opus MSDecoder::new: {e}"))?;
@@ -66,8 +90,45 @@ impl AudioPlayer {
             queue,
             decoder,
             channels: layout.channels as usize,
+            per_ms: (SAMPLE_RATE / 1000) as usize * layout.channels as usize,
             gaps: AudioGapTracker::new(),
+            av: AvSync::new(layout.channels),
+            cells,
         })
+    }
+
+    /// Fold one packet into the A/V offset measurement, and publish both the offset and the ring
+    /// depth for the stats overlay.
+    ///
+    /// **This measures; it does not steer.** [`AvSync::desired_depth`] is deliberately never
+    /// called, and no target is ever handed to a playback policy. The reason is the one term this
+    /// platform cannot observe: NDL reports nothing about presentation, so
+    /// `session::sink::video_e2e_ns` carries a *calibrated constant* for the decode+panel latency
+    /// after its render queue drains. Until that constant has been read off real hardware it is
+    /// `0`, which biases the offset high — and acting on a biased offset would place audio early
+    /// by exactly the amount of the bias, a worse fault than the drift being corrected. Publishing
+    /// it on the HUD first is what turns that constant from a guess into a measurement.
+    ///
+    /// `buffered_ahead` is the device queue as it stands BEFORE this packet is added: everything
+    /// that must still play before it does.
+    fn observe_av(&mut self, pts_ns: u64, buffered_ahead: usize) {
+        // Published unconditionally — the ring's depth is worth seeing whether or not the loop is
+        // acting, and it is what makes an "audio is late" report triageable at all.
+        self.cells
+            .buffer_ms
+            .store((buffered_ahead / self.per_ms.max(1)) as u32, Ordering::Relaxed);
+        let video_e2e = self.cells.video_e2e.load(Ordering::Relaxed);
+        self.av.observe(AvSyncObservation {
+            pts_ns,
+            now_local_ns: punktfunk_core::client::now_realtime_ns(),
+            clock_offset_ns: self.cells.clock_offset.load(Ordering::Relaxed),
+            buffered_ahead,
+            // 0 = nothing on the glass yet; with no reference there is nothing to measure against.
+            video_e2e_ns: (video_e2e > 0).then_some(video_e2e),
+        });
+        self.cells
+            .av_offset_ms
+            .store(i64::from(self.av.offset_ms()), Ordering::Relaxed);
     }
 
     /// The device's actually-negotiated spec — may differ from what was requested if
@@ -78,9 +139,14 @@ impl AudioPlayer {
 
     /// Decodes Opus packet (with PLC for losses) and queues PCM.
     /// Returns peak sample (diagnostic for silent input vs speaker failure) + `AudioEvent`.
-    pub fn play(&mut self, seq: u32, opus_payload: &[u8]) -> Result<(f32, AudioEvent)> {
+    pub fn play(&mut self, seq: u32, pts_ns: u64, opus_payload: &[u8]) -> Result<(f32, AudioEvent)> {
         let bytes_per_ms = SAMPLE_RATE / 1000 * self.channels as u32 * std::mem::size_of::<f32>() as u32;
         let queued = self.queue.size();
+
+        // Measured against the queue as it stands NOW, before this packet joins it, and before the
+        // shed branches below — a packet this call decides to drop still tells the truth about
+        // where the ring sits relative to the picture.
+        self.observe_av(pts_ns, queued as usize / std::mem::size_of::<f32>());
 
         // WHY: empty queue detects stall on feeding thread (opposite remedy from over-full).
         let underrun = queued == 0;

--- a/src/platform/webos/audio.rs
+++ b/src/platform/webos/audio.rs
@@ -1,11 +1,28 @@
-//! SDL2 audio-queue playback of punktfunk's Opus audio packets. Decode only (Opus →
+//! SDL2 callback playback of punktfunk's Opus audio packets. Decode only (Opus →
 //! PCM) happens here — NDL is video-only (see ndl.rs docs), so this is a completely
 //! separate path from the video decode/punch-through plane.
+//!
+//! **Two threads, one ring.** [`AudioFeed`] decodes on a dedicated thread and posts interleaved
+//! f32 chunks down a bounded channel; [`RingCallback`] drains that channel into a ring it owns
+//! outright and serves SDL's audio callback from it. Nothing locks, and nothing allocates in
+//! steady state (drained chunk `Vec`s go back through a recycle channel for the feed to refill).
+//! Same shape as `pf-client-core`'s `PipeWire` ring, for the same reasons.
+//!
+//! This replaced an `sdl2::audio::AudioQueue` pushed from the main loop. Two defects went with it:
+//! the drain shared a thread with the UI's software rasterizer (`docs/NOTES.md` already named the
+//! 500 ms stats-overlay raster as an underrun source on a 2-core panel), and `AudioQueue` offers
+//! only `queue_audio`/`size`/`clear` — no partial drop — so the shared de-jitter policy's
+//! crossfaded 5 ms shed was literally inexpressible against it. Its coarse corrections were a
+//! whole-queue `clear()` (~100 ms of silence) and an uncrossfaded 5 ms discard.
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicI64, AtomicU32, AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender};
 use std::sync::Arc;
 
 use anyhow::Result;
-use punktfunk_core::audio::{layout_for, AudioGapTracker, AvSync, AvSyncObservation};
+use punktfunk_core::audio::{
+    crossfade_drop, layout_for, AudioGapTracker, AudioSyncCell, AvSync, AvSyncObservation, JitterPolicy, JitterTuning,
+};
 
 /// 48 kHz, 5 ms frames — punktfunk's fixed audio framing (see punktfunk-core's
 /// audio.rs doc comments and its `multistream_layout_roundtrips_with_channel_identity`
@@ -15,31 +32,43 @@ const SAMPLES_PER_FRAME: usize = 240;
 /// Max channels punktfunk ever negotiates (7.1) — sizes the scratch decode buffer.
 const MAX_CHANNELS: usize = 8;
 
-/// Device buffer: 512 frames keeps slack vs pump cadence, cuts latency by ~75ms.
-/// Obtained spec logged at session start for on-device verification.
+/// Device buffer: 512 frames (10.67 ms) keeps slack vs callback cadence. Deliberately NOT lowered
+/// further now that a real jitter policy owns the depth: a smaller quantum on a 2-3 core TV `SoC`
+/// buys more wakeups and more missed callbacks, not less latency. [`WEBOS_TUNING`]'s base target is
+/// sized to clear this quantum — see its note on the device floor.
 const DEVICE_BUFFER_FRAMES: u16 = 512;
 
-/// Soft ceiling on SDL-queued audio: above this, drop packets to let queue drain.
-/// WHY: full clear at `MAX_QUEUED_LAG_MS` was audible (100ms silence). Drops are ~5ms.
-pub const SOFT_QUEUED_LAG_MS: u32 = 60;
+/// Chunks in flight between the decode thread and the audio callback. 64 × 5 ms = 320 ms of slack,
+/// matching `pf-client-core`; the ring, not this channel, is what bounds latency.
+const CHUNK_QUEUE: usize = 64;
 
-/// Hard bound: backstop against burst between pump ticks. Clear costs one audible blip.
-pub const MAX_QUEUED_LAG_MS: u32 = 100;
-
-/// What [`AudioPlayer::play`] did with a packet — reported so the caller can log the
-/// cases that are audible, and tell an over-full queue apart from a starved one.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum AudioEvent {
-    Queued,
-    /// The device buffer had run dry before this packet arrived: the main loop didn't
-    /// feed it in time (a stall), and the gap was audible. Distinct from every
-    /// queue-too-full case below — the remedy is the opposite direction.
-    Underrun,
-    /// Dropped above [`SOFT_QUEUED_LAG_MS`] to let the queue drain.
-    Dropped,
-    /// Cleared at [`MAX_QUEUED_LAG_MS`] — the loud one.
-    Resnapped,
-}
+/// The de-jitter preset for this platform. Not one of core's four (`PIPEWIRE`, `WASAPI`,
+/// `COREAUDIO`, `AAUDIO`) — those are named for audio stacks, and this ring is shaped by the
+/// device it runs on: a 2-3 core TV `SoC` whose UI rasterizes in software on the same silicon, over
+/// a TV Wi-Fi radio `docs/NOTES.md` measures at a ~245 Mbps ceiling with 10-29 s black-hole stalls
+/// on new flows.
+///
+/// Seeded from `JitterTuning::AAUDIO`, whose rationale is the closest match — we own the buffer,
+/// and Wi-Fi power-save bunching arrives as underruns, i.e. crackle. Held locally rather than
+/// upstreamed as a fifth preset until on-glass numbers justify specific values; the fields are
+/// public and the struct is not `#[non_exhaustive]`, so this costs core nothing.
+///
+/// Two invariants checked by hand against these numbers, both of which the parent programme
+/// shipped broken once:
+///   * **The smooth shed fires strictly below the hard trim**, or drift correction is dead code and
+///     every correction is the audible drop it was meant to replace. `shed_excess_ms()` is
+///     `max(headroom/2, 2 × FRAME_MS)` = 20 ms, so the shed point is target+20 = 45 ms against a
+///     trim point of `min(target+40, 120)` = 65 ms. 45 < 65.
+///   * **The base target clears the device floor.** `effective_target` floors at `want + FRAME_MS`;
+///     at [`DEVICE_BUFFER_FRAMES`] that is 10.67 + 5 = 15.7 ms, under the 25 ms base — so the ring
+///     cannot oscillate prime → dropout → re-prime.
+const WEBOS_TUNING: JitterTuning = JitterTuning {
+    base_target_ms: 25,
+    max_target_ms: 90,
+    headroom_ms: 40,
+    hard_cap_ms: 120,
+    deprime_after: 5,
+};
 
 /// The cells the A/V sync loop trades through, all owned by `NativeClient`: the video plane and
 /// the clock handshake write the first two, this module writes the last two, and the stats overlay
@@ -57,23 +86,19 @@ pub struct SyncCells {
     pub buffer_ms: Arc<AtomicU32>,
 }
 
+/// The playback device. Holding it alive is the whole job — the ring drains on SDL's own audio
+/// thread from construction until this is dropped.
 pub struct AudioPlayer {
-    queue: sdl2::audio::AudioQueue<f32>,
-    decoder: opus::MSDecoder,
-    channels: usize,
-    /// Interleaved samples per millisecond at the negotiated layout (48 × channels).
-    per_ms: usize,
-    /// Detects packets lost on the wire so they can be concealed rather than skipped —
-    /// see [`AudioPlayer::play`].
-    gaps: AudioGapTracker,
-    /// A/V synchronisation, **measure-only for now** — see [`AudioPlayer::observe_av`].
-    av: AvSync,
-    cells: SyncCells,
+    device: sdl2::audio::AudioDevice<RingCallback>,
 }
 
 impl AudioPlayer {
-    /// `channels` is host-resolved (client MUST build decoder from this, not own request).
-    pub fn new(sdl_audio: &sdl2::AudioSubsystem, channels: u8, cells: SyncCells) -> Result<Self> {
+    /// Opens the device and returns it alongside the [`AudioFeed`] that fills it. `channels` is
+    /// host-resolved (the client MUST build its decoder from this, never from its own request).
+    ///
+    /// The two halves are returned separately because they belong on different threads: the device
+    /// stays wherever SDL was initialised, and the feed moves to the decode thread.
+    pub fn new(sdl_audio: &sdl2::AudioSubsystem, channels: u8, cells: SyncCells) -> Result<(Self, AudioFeed)> {
         let layout = layout_for(channels, false);
         let decoder = opus::MSDecoder::new(SAMPLE_RATE, layout.streams, layout.coupled, layout.mapping)
             .map_err(|e| anyhow::anyhow!("opus MSDecoder::new: {e}"))?;
@@ -82,35 +107,138 @@ impl AudioPlayer {
             channels: Some(layout.channels),
             samples: Some(DEVICE_BUFFER_FRAMES),
         };
-        let queue = sdl_audio
-            .open_queue::<f32, _>(None, &spec)
-            .map_err(|e| anyhow::anyhow!("SDL open_queue: {e}"))?;
-        queue.resume();
-        Ok(Self {
-            queue,
-            decoder,
-            channels: layout.channels as usize,
-            per_ms: (SAMPLE_RATE / 1000) as usize * layout.channels as usize,
-            gaps: AudioGapTracker::new(),
-            av: AvSync::new(layout.channels),
-            cells,
-        })
+        let (pcm_tx, pcm_rx) = std::sync::mpsc::sync_channel::<Vec<f32>>(CHUNK_QUEUE);
+        let (recycle_tx, recycle_rx) = std::sync::mpsc::sync_channel::<Vec<f32>>(CHUNK_QUEUE);
+        let sync: Arc<AudioSyncCell> = Arc::default();
+        let sync_cb = sync.clone();
+        let device = sdl_audio
+            .open_playback(None, &spec, |obtained| {
+                // Build the policy from what the device ACTUALLY negotiated, not what was asked
+                // for: the policy's depths are denominated in interleaved samples, so a channel
+                // count that differs here would silently scale every threshold.
+                RingCallback {
+                    rx: pcm_rx,
+                    recycle: recycle_tx,
+                    ring: VecDeque::new(),
+                    policy: JitterPolicy::new(WEBOS_TUNING, obtained.channels),
+                    sync: sync_cb,
+                    underruns: 0,
+                    sheds: 0,
+                    callbacks: 0,
+                }
+            })
+            .map_err(|e| anyhow::anyhow!("SDL open_playback: {e}"))?;
+        let obtained = *device.spec();
+        if obtained.channels != layout.channels || obtained.freq != SAMPLE_RATE as i32 {
+            // Not fatal — SDL converts — but it means the decoder and the device disagree about
+            // the frame shape, which is worth seeing in a log before it is heard.
+            tracing::warn!(
+                "audio device negotiated {}ch @{}Hz, stream is {}ch @{}Hz",
+                obtained.channels,
+                obtained.freq,
+                layout.channels,
+                SAMPLE_RATE,
+            );
+        }
+        device.resume();
+        let channels = layout.channels as usize;
+        Ok((
+            Self { device },
+            AudioFeed {
+                pcm_tx,
+                recycle_rx,
+                decoder,
+                channels,
+                per_ms: (SAMPLE_RATE / 1000) as usize * channels,
+                gaps: AudioGapTracker::new(),
+                av: AvSync::new(layout.channels),
+                cells,
+                sync,
+            },
+        ))
+    }
+
+    /// The device's actually-negotiated spec — may differ from what was requested if
+    /// the device doesn't support it exactly.
+    pub fn spec(&self) -> &sdl2::audio::AudioSpec {
+        self.device.spec()
+    }
+}
+
+/// The decode half: Opus → PCM, loss concealment, the A/V measurement, and the hand-off to the
+/// ring. Lives on its own thread (`session::audio_feed_pump`).
+pub struct AudioFeed {
+    pcm_tx: SyncSender<Vec<f32>>,
+    /// Drained chunk `Vec`s coming back from the callback for reuse — the pool half of the chunk
+    /// channel, so steady-state playback stops allocating (~200 chunks/s otherwise).
+    recycle_rx: Receiver<Vec<f32>>,
+    decoder: opus::MSDecoder,
+    channels: usize,
+    /// Interleaved samples per millisecond at the negotiated layout (48 × channels).
+    per_ms: usize,
+    /// Detects packets lost on the wire so they can be concealed rather than skipped.
+    gaps: AudioGapTracker,
+    /// A/V synchronisation, **measure-only for now** — see [`AudioFeed::observe_av`].
+    av: AvSync,
+    cells: SyncCells,
+    /// Depth out of the callback, target in. Only the depth half is used today.
+    sync: Arc<AudioSyncCell>,
+}
+
+impl AudioFeed {
+    /// Decodes one Opus packet (concealing anything lost immediately before it) and hands the PCM
+    /// to the ring. Returns the peak sample — a diagnostic that separates "the host is sending
+    /// silence" from "the speaker is not working".
+    pub fn play(&mut self, seq: u32, pts_ns: u64, opus_payload: &[u8]) -> Result<f32> {
+        // The ring depth as the callback last saw it: everything that must still play before the
+        // packet being queued now does.
+        self.observe_av(pts_ns, self.sync.depth());
+
+        // Conceal whatever went missing immediately before this packet. libopus PLC (decode with
+        // empty input) interpolates a frame; the alternative is a hard gap, i.e. a click.
+        for _ in 0..self.gaps.missing_before(seq) {
+            let mut pcm = [0f32; SAMPLES_PER_FRAME * MAX_CHANNELS];
+            let n = self
+                .decoder
+                .decode_float(&[], &mut pcm, false)
+                .map_err(|e| anyhow::anyhow!("opus PLC decode: {e}"))?;
+            self.push(&pcm[..n * self.channels]);
+        }
+
+        let mut pcm = [0f32; SAMPLES_PER_FRAME * MAX_CHANNELS];
+        let samples_per_channel = self
+            .decoder
+            .decode_float(opus_payload, &mut pcm, false)
+            .map_err(|e| anyhow::anyhow!("opus decode_float: {e}"))?;
+        let decoded = &pcm[..samples_per_channel * self.channels];
+        let peak = decoded.iter().fold(0f32, |m, &s| m.max(s.abs()));
+        self.push(decoded);
+        Ok(peak)
+    }
+
+    /// Hands one decoded chunk to the ring, reusing a pooled `Vec` where one is available.
+    ///
+    /// A full channel drops the chunk rather than blocking: this runs on the decode thread, and
+    /// blocking it would back pressure into the transport. A wedged callback is already a fault
+    /// the ring's own underrun path reports.
+    fn push(&mut self, pcm: &[f32]) {
+        let mut buf = self.recycle_rx.try_recv().unwrap_or_default();
+        buf.clear();
+        buf.extend_from_slice(pcm);
+        let _ = self.pcm_tx.try_send(buf);
     }
 
     /// Fold one packet into the A/V offset measurement, and publish both the offset and the ring
     /// depth for the stats overlay.
     ///
     /// **This measures; it does not steer.** [`AvSync::desired_depth`] is deliberately never
-    /// called, and no target is ever handed to a playback policy. The reason is the one term this
-    /// platform cannot observe: NDL reports nothing about presentation, so
+    /// called, and no target is handed to [`JitterPolicy::set_sync_target`]. The reason is the one
+    /// term this platform cannot observe: NDL reports nothing about presentation, so
     /// `session::sink::video_e2e_ns` carries a *calibrated constant* for the decode+panel latency
     /// after its render queue drains. Until that constant has been read off real hardware it is
     /// `0`, which biases the offset high — and acting on a biased offset would place audio early
-    /// by exactly the amount of the bias, a worse fault than the drift being corrected. Publishing
-    /// it on the HUD first is what turns that constant from a guess into a measurement.
-    ///
-    /// `buffered_ahead` is the device queue as it stands BEFORE this packet is added: everything
-    /// that must still play before it does.
+    /// by exactly the bias, a worse fault than the drift being corrected. Publishing it on the HUD
+    /// first is what turns that constant from a guess into a measurement.
     fn observe_av(&mut self, pts_ns: u64, buffered_ahead: usize) {
         // Published unconditionally — the ring's depth is worth seeing whether or not the loop is
         // acting, and it is what makes an "audio is late" report triageable at all.
@@ -130,75 +258,73 @@ impl AudioPlayer {
             .av_offset_ms
             .store(i64::from(self.av.offset_ms()), Ordering::Relaxed);
     }
+}
 
-    /// The device's actually-negotiated spec — may differ from what was requested if
-    /// the device doesn't support it exactly.
-    pub fn spec(&self) -> &sdl2::audio::AudioSpec {
-        self.queue.spec()
-    }
+/// The playback half, owned by SDL's audio thread. Drains the chunk channel into a ring it owns
+/// outright, then serves the callback from it under the shared de-jitter policy.
+struct RingCallback {
+    rx: Receiver<Vec<f32>>,
+    recycle: SyncSender<Vec<f32>>,
+    ring: VecDeque<f32>,
+    /// Prime depth in MILLISECONDS, an underrun-driven adaptive floor, and a crossfaded 5 ms drift
+    /// shed so latency returns to target instead of ratcheting. See [`WEBOS_TUNING`].
+    policy: JitterPolicy,
+    /// Depth out to the decode thread, target in (unused until the sync loop is armed).
+    sync: Arc<AudioSyncCell>,
+    underruns: u64,
+    sheds: u64,
+    callbacks: u64,
+}
 
-    /// Decodes Opus packet (with PLC for losses) and queues PCM.
-    /// Returns peak sample (diagnostic for silent input vs speaker failure) + `AudioEvent`.
-    pub fn play(&mut self, seq: u32, pts_ns: u64, opus_payload: &[u8]) -> Result<(f32, AudioEvent)> {
-        let bytes_per_ms = SAMPLE_RATE / 1000 * self.channels as u32 * std::mem::size_of::<f32>() as u32;
-        let queued = self.queue.size();
+impl sdl2::audio::AudioCallback for RingCallback {
+    type Channel = f32;
 
-        // Measured against the queue as it stands NOW, before this packet joins it, and before the
-        // shed branches below — a packet this call decides to drop still tells the truth about
-        // where the ring sits relative to the picture.
-        self.observe_av(pts_ns, queued as usize / std::mem::size_of::<f32>());
-
-        // WHY: empty queue detects stall on feeding thread (opposite remedy from over-full).
-        let underrun = queued == 0;
-
-        if queued > bytes_per_ms * MAX_QUEUED_LAG_MS {
-            self.queue.clear();
-            self.queue_packet(opus_payload)?;
-            return Ok((0.0, AudioEvent::Resnapped));
-        }
-        if queued > bytes_per_ms * SOFT_QUEUED_LAG_MS {
-            // WHY: decode anyway (stateful codec); skip would corrupt state and follow-up.
-            let _ = self.gaps.missing_before(seq);
-            let mut pcm = [0f32; SAMPLES_PER_FRAME * MAX_CHANNELS];
-            let _ = self.decoder.decode_float(opus_payload, &mut pcm, false);
-            return Ok((0.0, AudioEvent::Dropped));
+    fn callback(&mut self, out: &mut [f32]) {
+        while let Ok(mut chunk) = self.rx.try_recv() {
+            self.ring.extend(chunk.iter().copied());
+            // Return the drained Vec to the pool; a full/closed pool just drops it.
+            chunk.clear();
+            let _ = self.recycle.try_send(chunk);
         }
 
-        // Conceal whatever went missing immediately before this packet.
-        for _ in 0..self.gaps.missing_before(seq) {
-            let mut pcm = [0f32; SAMPLES_PER_FRAME * MAX_CHANNELS];
-            let n = self
-                .decoder
-                .decode_float(&[], &mut pcm, false)
-                .map_err(|e| anyhow::anyhow!("opus PLC decode: {e}"))?;
-            self.queue
-                .queue_audio(&pcm[..n * self.channels])
-                .map_err(|e| anyhow::anyhow!("SDL queue_audio (PLC): {e}"))?;
+        // `out` is interleaved samples for this callback — exactly the `want` the policy is
+        // denominated in.
+        let want = out.len();
+        self.sync.publish_depth(self.ring.len());
+        let step = self.policy.step(self.ring.len(), want);
+        if step.drop_front > 0 {
+            self.sheds += 1;
+            crossfade_drop(&mut self.ring, step.drop_front, step.crossfade);
         }
 
-        let peak = self.queue_packet(opus_payload)?;
-        Ok((
-            peak,
-            if underrun {
-                AudioEvent::Underrun
+        let mut ran_short = false;
+        for slot in out.iter_mut() {
+            *slot = if step.silence {
+                0.0
             } else {
-                AudioEvent::Queued
-            },
-        ))
-    }
-
-    /// Decodes one real packet into the device queue, returning its peak sample.
-    fn queue_packet(&mut self, opus_payload: &[u8]) -> Result<f32> {
-        let mut pcm = [0f32; SAMPLES_PER_FRAME * MAX_CHANNELS];
-        let samples_per_channel = self
-            .decoder
-            .decode_float(opus_payload, &mut pcm, false)
-            .map_err(|e| anyhow::anyhow!("opus decode_float: {e}"))?;
-        let decoded = &pcm[..samples_per_channel * self.channels];
-        let peak = decoded.iter().fold(0f32, |m, &s| m.max(s.abs()));
-        self.queue
-            .queue_audio(decoded)
-            .map_err(|e| anyhow::anyhow!("SDL queue_audio: {e}"))?;
-        Ok(peak)
+                self.ring.pop_front().unwrap_or_else(|| {
+                    ran_short = true;
+                    0.0
+                })
+            };
+        }
+        // No-op while un-primed (the policy ignores it), so a deliberate priming silence is never
+        // miscounted as an underrun.
+        self.policy.note_read(ran_short);
+        self.underruns += u64::from(ran_short);
+        self.callbacks += 1;
+        // ~10 s at this device quantum. The exact cadence does not matter; that the plane stops
+        // being invisible does — before this, the only audio signal in a log was a per-packet
+        // "underrun" line from the feed side, which said the queue was empty without saying how
+        // deep it was supposed to be.
+        if self.callbacks % 1_000 == 0 {
+            tracing::debug!(
+                buffer_ms = self.policy.avg_depth_ms(),
+                target_ms = self.policy.target_ms(),
+                underruns = self.underruns,
+                drift_sheds = self.sheds,
+                "audio playback"
+            );
+        }
     }
 }

--- a/src/platform/webos/audio.rs
+++ b/src/platform/webos/audio.rs
@@ -273,6 +273,7 @@ impl AudioFeed {
     /// between its own underrun-driven floor and its hard cap, so continuity outranks sync — a link
     /// whose jitter genuinely needs more buffer than the picture is away keeps its buffer, and the
     /// residual shows up on the HUD instead of as a dropout.
+    ///
     /// **Two depths, and they are not interchangeable.** `ring_depth` is what the audio callback
     /// owns and the only thing [`JitterPolicy`] can actually move. `in_flight` is decoded PCM
     /// already handed off but still in the chunk channel — invisible to the policy, but just as

--- a/src/platform/webos/dualsense.rs
+++ b/src/platform/webos/dualsense.rs
@@ -166,10 +166,13 @@ impl Feedback {
 
     /// Folds one host feedback event into the pad state and queues a send.
     ///
-    /// Variants this pad has no hardware for are dropped: `TrackpadHaptic` is a Steam
+    /// Variants this pad has no route for are dropped: `TrackpadHaptic` is a Steam
     /// Controller voice-coil buzz, and `HidRaw` is a passthrough report for a device the host
     /// mirrors as-is — replaying either on a `DualSense` would mean writing arbitrary bytes in
-    /// the wrong protocol.
+    /// the wrong protocol. `AudioCtl` is the routing/volume half of pad audio, which this client
+    /// never asks for (it advertises no `CLIENT_CAP_PAD_AUDIO`, so no host sends it) and could
+    /// not honour anyway: the feedback path here is the Bluetooth service's state model, not a
+    /// hidraw node, so there is nothing to write a DS5 output report to.
     pub fn apply(&mut self, event: &HidOutput) {
         match event {
             HidOutput::Led { r, g, b, .. } => self.state.lightbar = Some((*r, *g, *b)),
@@ -186,7 +189,7 @@ impl Feedback {
                 }
                 self.state.triggers_owned = true;
             }
-            HidOutput::TrackpadHaptic { .. } | HidOutput::HidRaw { .. } => return,
+            HidOutput::TrackpadHaptic { .. } | HidOutput::HidRaw { .. } | HidOutput::AudioCtl { .. } => return,
         }
         // Dropping on a full queue *is* the coalescing: the waiting value is strictly older.
         if let Some(tx) = &self.tx {

--- a/src/platform/webos/ndl.rs
+++ b/src/platform/webos/ndl.rs
@@ -323,7 +323,20 @@ impl NdlVideo {
     }
 
     /// Feed one Opus packet to NDL (only when `audio_offloaded`).
-    /// PTS is ms since load, synced with video `play()` calls.
+    ///
+    /// ⚠ **The two planes are stamped in unrelated time bases, and NDL syncs them against each
+    /// other.** This stamps arrival wall-clock (`load_instant.elapsed()`), while video is stamped
+    /// with a host-PTS value mapped onto NDL's player clock by `HostPtsAnchor` and then smoothed by
+    /// `PtsPacer` (`session::sink`). NDL's own A/V synchronisation therefore regulates against a
+    /// fiction: the audio timeline drifts with delivery jitter while the video timeline tracks host
+    /// capture cadence.
+    ///
+    /// Left as-is deliberately. Fixing it properly means both planes sharing ONE anchor, which
+    /// means moving anchor ownership out of the sink and onto this handle behind a lock — a change
+    /// to the *working* video hot path, made for a path that is off by default (see
+    /// `NDL_AUDIO_OFFLOAD`) and that `docs/NOTES.md` records as freezing video outright on webOS
+    /// 10.3. Anyone reviving audio offload must fix this first; the symptom would be audio that
+    /// drifts against the picture over a session rather than sitting at a constant offset.
     pub fn play_audio(&self, packet: &[u8]) -> Result<()> {
         let pts_ms = self.load_instant.elapsed().as_millis() as c_longlong;
         let _ffi = self.ffi.lock().expect("NDL FFI mutex poisoned");

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -152,8 +152,16 @@ pub(super) fn run_inner() -> Result<()> {
         let audio = match connected.audio_channels() {
             None => None,
             Some(channels) => {
-                match crate::platform::webos::audio::AudioPlayer::new(&sdl_audio, channels, connected.sync_cells())
-                    .and_then(|(player, feed)| Ok((player, connected.spawn_audio_feed(feed)?)))
+                // The A/V loop arms only once the NDL present constant has been calibrated — the
+                // trim file's presence is that calibration. See `audio::AudioFeed::observe_av`.
+                let av_calibrated = store::dev_override_av_trim_ms().is_some();
+                match crate::platform::webos::audio::AudioPlayer::new(
+                    &sdl_audio,
+                    channels,
+                    connected.sync_cells(),
+                    av_calibrated,
+                )
+                .and_then(|(player, feed)| Ok((player, connected.spawn_audio_feed(feed)?)))
                 {
                     Ok(pair) => Some(pair),
                     Err(e) => {
@@ -174,10 +182,17 @@ pub(super) fn run_inner() -> Result<()> {
             }
         };
         if let Some((player, _)) = &audio {
+            // Whether the sync loop is armed belongs in the session log, not only in a source
+            // comment: "audio sounds late" and "audio sounds early" are the same report from a
+            // user, and which one is possible depends entirely on this line.
             tracing::info!(
-                "SDL audio driver: {}, spec: {:?}",
+                "SDL audio driver: {}, spec: {:?}, A/V sync: {}",
                 sdl_audio.current_audio_driver(),
-                player.spec()
+                player.spec(),
+                match store::dev_override_av_trim_ms() {
+                    Some(ms) => format!("armed (trim {ms} ms)"),
+                    None => "measuring only (no av-trim-ms.conf)".to_string(),
+                },
             );
         }
 

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -147,11 +147,15 @@ pub(super) fn run_inner() -> Result<()> {
 
         // `None` when the session decodes audio somewhere other than here (punktfunk's NDL Opus
         // offload) — a second unfed audio device would still claim a PulseAudio sink.
-        let mut audio_player = match connected.audio_channels() {
+        // The device is held here for the length of the stream — dropping it stops playback — while
+        // the feed half moves to its own decode thread.
+        let audio = match connected.audio_channels() {
             None => None,
             Some(channels) => {
-                match crate::platform::webos::audio::AudioPlayer::new(&sdl_audio, channels, connected.sync_cells()) {
-                    Ok(p) => Some(p),
+                match crate::platform::webos::audio::AudioPlayer::new(&sdl_audio, channels, connected.sync_cells())
+                    .and_then(|(player, feed)| Ok((player, connected.spawn_audio_feed(feed)?)))
+                {
+                    Ok(pair) => Some(pair),
                     Err(e) => {
                         // Same no-crash policy as the connect above, plus the video teardown a
                         // loaded decoder now needs.
@@ -169,7 +173,7 @@ pub(super) fn run_inner() -> Result<()> {
                 }
             }
         };
-        if let Some(player) = &audio_player {
+        if let Some((player, _)) = &audio {
             tracing::info!(
                 "SDL audio driver: {}, spec: {:?}",
                 sdl_audio.current_audio_driver(),
@@ -539,10 +543,10 @@ pub(super) fn run_inner() -> Result<()> {
                 canvas.clear();
                 canvas.present();
             }
-            // Offloaded audio drains on its own dedicated thread instead (`session::ndl_audio_pump`).
-            if let Some(player) = &mut audio_player {
-                connected.pump_audio_once(player);
-            }
+            // Audio drains on its own threads either way now — the software path on
+            // `session::audio_feed_pump` into SDL's audio callback, the offloaded path on
+            // `session::ndl_audio_pump`. Nothing for this loop to do.
+            //
             // Unconditional so both feedback planes keep draining with no pad attached.
             connected.pump_feedback_once(controller.as_mut(), ds_feedback.as_mut());
             // Skipped while the dialog owns the canvas. Stats/log share one clear/execute/present
@@ -757,6 +761,13 @@ pub(super) fn run_inner() -> Result<()> {
         // Rumble is likewise pad state, not stream state.
         if let Some(pad) = controller.as_mut() {
             let _ = pad.set_rumble(0, 0, 0);
+        }
+        // Stop feeding before the transport goes away, and drop the device with it. Ordered ahead
+        // of `shutdown()` only for tidiness — the feed thread also exits on the session's stop flag
+        // and on the audio plane closing, and a late `try_send` into a dropped ring is a no-op.
+        if let Some((player, feed_thread)) = audio {
+            connected.stop_audio_feed(feed_thread);
+            drop(player);
         }
         // `shutdown()` joins the video thread and drops `client` so the QUIC close frame
         // actually sends. `false` means a teardown thread is wedged in FFI — skip the NDL

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -149,23 +149,25 @@ pub(super) fn run_inner() -> Result<()> {
         // offload) — a second unfed audio device would still claim a PulseAudio sink.
         let mut audio_player = match connected.audio_channels() {
             None => None,
-            Some(channels) => match crate::platform::webos::audio::AudioPlayer::new(&sdl_audio, channels) {
-                Ok(p) => Some(p),
-                Err(e) => {
-                    // Same no-crash policy as the connect above, plus the video teardown a
-                    // loaded decoder now needs.
-                    tracing::error!("audio player init failed: {e:#}");
-                    connected.disconnect_quit();
-                    if connected.shutdown() {
-                        crate::platform::webos::ndl::quit();
-                    } else {
-                        tracing::warn!("session teardown timed out — skipping NDL unload for this run");
+            Some(channels) => {
+                match crate::platform::webos::audio::AudioPlayer::new(&sdl_audio, channels, connected.sync_cells()) {
+                    Ok(p) => Some(p),
+                    Err(e) => {
+                        // Same no-crash policy as the connect above, plus the video teardown a
+                        // loaded decoder now needs.
+                        tracing::error!("audio player init failed: {e:#}");
+                        connected.disconnect_quit();
+                        if connected.shutdown() {
+                            crate::platform::webos::ndl::quit();
+                        } else {
+                            tracing::warn!("session teardown timed out — skipping NDL unload for this run");
+                        }
+                        cursor.set_captured(false);
+                        menu_status = Some(format!("Couldn't start audio: {e:#}"));
+                        continue;
                     }
-                    cursor.set_captured(false);
-                    menu_status = Some(format!("Couldn't start audio: {e:#}"));
-                    continue;
                 }
-            },
+            }
         };
         if let Some(player) = &audio_player {
             tracing::info!(
@@ -643,6 +645,16 @@ pub(super) fn run_inner() -> Result<()> {
                             info.target_kbps / 1000,
                         ),
                     ];
+                    // Audio's own line. Before this the plane published nothing a surface could
+                    // render, so "the audio is late" had no instrument behind it at all — and on
+                    // this client the A/V offset is the number that says whether the sync loop is
+                    // working. `buf` is what is queued ahead of the speaker; `A/V` is positive when
+                    // audio plays BEHIND the picture. Both read 0 until the loop has evidence
+                    // (100 observations, and a frame on the glass to compare against).
+                    {
+                        let (buf_ms, av_ms) = connected.audio_stats();
+                        lines.push(format!("Audio buf {buf_ms} ms · A/V {av_ms:+} ms"));
+                    }
                     if let Some(line) = cpu_mem_line {
                         lines.push(line);
                     }

--- a/src/runtime/stream_handle.rs
+++ b/src/runtime/stream_handle.rs
@@ -52,6 +52,22 @@ impl StreamHandle {
         }
     }
 
+    /// The cells the A/V sync loop trades through — handed to the audio player at construction.
+    pub(crate) fn sync_cells(&self) -> crate::platform::webos::audio::SyncCells {
+        crate::platform::webos::audio::SyncCells {
+            clock_offset: self.0.client.clock_offset_shared(),
+            video_e2e: self.0.client.video_e2e_shared(),
+            av_offset_ms: self.0.client.audio_av_offset_shared(),
+            buffer_ms: self.0.client.audio_buffer_ms_shared(),
+        }
+    }
+
+    /// Audio's two HUD figures: ring depth in ms, and the smoothed A/V offset in ms (positive =
+    /// audio playing behind the picture). Both are `0` until the sync loop has evidence.
+    pub(crate) fn audio_stats(&self) -> (u32, i64) {
+        (self.0.client.audio_buffer_ms(), self.0.client.audio_av_offset_ms())
+    }
+
     /// Drains decoded audio into the device. Call once per tick.
     pub(crate) fn pump_audio_once(&self, audio: &mut AudioPlayer) {
         session::pump_audio_once(&self.0.client, audio);

--- a/src/runtime/stream_handle.rs
+++ b/src/runtime/stream_handle.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use punktfunk_core::input::InputEvent;
 
-use crate::platform::webos::audio::AudioPlayer;
+use crate::platform::webos::audio::AudioFeed;
 use crate::session::{self, Connected, StreamStats};
 
 pub(crate) struct StreamHandle(pub(crate) Connected);
@@ -68,9 +68,18 @@ impl StreamHandle {
         (self.0.client.audio_buffer_ms(), self.0.client.audio_av_offset_ms())
     }
 
-    /// Drains decoded audio into the device. Call once per tick.
-    pub(crate) fn pump_audio_once(&self, audio: &mut AudioPlayer) {
-        session::pump_audio_once(&self.0.client, audio);
+    /// Starts the audio decode/feed thread. It exits on the session's stop flag, or when the
+    /// transport's audio plane closes.
+    pub(crate) fn spawn_audio_feed(&self, feed: AudioFeed) -> anyhow::Result<std::thread::JoinHandle<()>> {
+        session::spawn_audio_feed(self.0.client.clone(), feed, self.0.stop.clone())
+    }
+
+    /// Signals the audio feed thread to stop and joins it, bounded. Sets the session's stop flag,
+    /// which `shutdown()` sets moments later anyway — doing it here just means the ring stops being
+    /// fed before its device is dropped.
+    pub(crate) fn stop_audio_feed(&self, handle: std::thread::JoinHandle<()>) {
+        self.0.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        session::join_audio_feed(handle);
     }
 
     /// Drains the host→client pad feedback planes.

--- a/src/services/store.rs
+++ b/src/services/store.rs
@@ -223,6 +223,24 @@ pub fn dev_override_ndl_drop_threshold() -> Option<i32> {
     std::fs::read_to_string(path).ok()?.trim().parse().ok()
 }
 
+/// A/V sync trim, in milliseconds: `$HOME/av-trim-ms.conf`, absent (⇒ 0) by default.
+///
+/// This is NDL's decode + panel latency *after* its render queue drains — the one term of
+/// `session::sink::video_e2e_ns` the app cannot observe, because `NDL_DirectVideoPlay` reports
+/// nothing about presentation. It is a sweep knob for exactly the reason
+/// [`dev_override_ndl_drop_threshold`] is one: the value is unmeasurable from inside, so it has to
+/// be read off real playback, and a rebuild per candidate makes that impractical. Deliberately NOT
+/// a Settings row yet — what the default should be, and whether it even needs to be user-visible,
+/// is what the observe-only measurement decides (LG panels plausibly differ between Game Optimiser
+/// and the processing-heavy picture modes, which no single compiled-in constant would cover).
+///
+/// Sign: this value is ADDED to the video leg, so raising it tells the sync loop the picture is
+/// later than it looked, and the loop answers by holding audio back. If audio runs early, raise it.
+pub fn dev_override_av_trim_ms() -> Option<u32> {
+    let path = Path::new(&app_dir()).join("av-trim-ms.conf");
+    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
 /// Test/dev override: a config file dropped alongside sideloading skips straight to
 /// a connect target — predates the finding (see `docs/NOTES.md`) that SAM launch
 /// `params` reach a native app as `argv[1]` JSON on initial launch, which

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -400,6 +400,9 @@ pub fn connect(
         stream_hz: resolved_mode.refresh_hz,
         report_decode_latency: client.wants_decode_latency(),
         keyframe_min_interval: KEYFRAME_REQUEST_MIN_INTERVAL,
+        clock_offset: client.clock_offset_shared(),
+        video_e2e: client.video_e2e_shared(),
+        present_fixed_ns: u64::from(crate::services::store::dev_override_av_trim_ms().unwrap_or(0)) * 1_000_000,
     };
     let video_stats = stats.clone();
     let video_thread = std::thread::Builder::new()
@@ -970,7 +973,7 @@ pub fn pump_audio_once(client: &NativeClient, audio: &mut crate::platform::webos
     // Logged roughly once/sec (200 packets @ 5ms/frame).
     static PACKET_COUNT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
     while let Ok(packet) = client.next_audio(Duration::ZERO) {
-        match audio.play(packet.seq, &packet.data) {
+        match audio.play(packet.seq, packet.pts_ns, &packet.data) {
             Ok((peak, event)) => {
                 match event {
                     // The two queue-too-full cases and the starved case are each audible

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -4,10 +4,10 @@
 //! transport and hands them to a [`sink::NdlSink`] — everything from PTS pacing down to
 //! the NDL `DirectMedia` backend (the sole video backend) lives behind that seam.
 //!
-//! Audio takes one of two paths: software-decoded audio is drained from the main
-//! thread ([`pump_audio_once`]) because `sdl2::audio::AudioQueue` is `!Send`; the
-//! NDL-offloaded path has its own drain thread ([`ndl_audio_pump`]), decoupled from
-//! both the main loop and the video pump.
+//! Audio takes one of two paths, and each has a thread of its own: software-decoded audio is
+//! decoded by [`audio_feed_pump`] into the playback ring SDL's audio callback drains
+//! (`platform::webos::audio`), and the NDL-offloaded path hands raw Opus straight to NDL from
+//! [`ndl_audio_pump`]. Neither shares the main loop, which carries the UI's software rasterizer.
 pub mod pacing;
 pub mod sink;
 
@@ -966,45 +966,56 @@ fn ndl_audio_pump(client: &NativeClient, ndl: &NdlVideo, stop: &AtomicBool) {
     }
 }
 
-/// Drains and plays all pending audio packets (non-blocking). Call once per main-loop
-/// tick; runs on the main thread because `sdl2::audio::AudioQueue` is `!Send`.
-pub fn pump_audio_once(client: &NativeClient, audio: &mut crate::platform::webos::audio::AudioPlayer) {
-    use crate::platform::webos::audio::AudioEvent;
+/// Spawns the dedicated audio decode/feed thread and returns its handle.
+///
+/// A thread of its own, not a drain bolted onto the main loop. That is where this lived, forced by
+/// `sdl2::audio::AudioQueue` being `!Send` — which put the session's 5 ms audio cadence behind the
+/// UI's software rasterizer on a 2-3 core panel, and `docs/NOTES.md` already named the 500 ms
+/// stats-overlay raster as an underrun source because of it. The offloaded path
+/// ([`ndl_audio_pump`]) worked this way for the same reason, and core's `next_audio` docs ask for
+/// exactly this thread ("packets arrive every 5 ms").
+pub fn spawn_audio_feed(
+    client: Arc<NativeClient>,
+    mut feed: crate::platform::webos::audio::AudioFeed,
+    stop: Arc<AtomicBool>,
+) -> Result<std::thread::JoinHandle<()>> {
+    std::thread::Builder::new()
+        .name("punktfunk-webos-audio".into())
+        .spawn(move || audio_feed_pump(&client, &mut feed, &stop))
+        .context("spawn audio feed thread")
+}
+
+/// Joins the audio feed thread, bounded by the same timeout every other teardown join uses — a
+/// thread wedged in an Opus decode must not hold the whole app on the way back to the menu.
+pub fn join_audio_feed(handle: std::thread::JoinHandle<()>) -> bool {
+    join_with_timeout(handle, SHUTDOWN_JOIN_TIMEOUT, "audio-feed")
+}
+
+/// Pulls Opus packets off the transport, decodes them, and hands the PCM to the playback ring.
+fn audio_feed_pump(client: &NativeClient, feed: &mut crate::platform::webos::audio::AudioFeed, stop: &AtomicBool) {
+    // Same boost the video pump requests for itself — 5 ms packets are the most latency-sensitive
+    // cadence in the session. Best-effort, like every renice here.
+    // SAFETY: plain syscall — tid 0 (self) and priority value only, no pointers.
+    let _ = unsafe { libc::setpriority(libc::PRIO_PROCESS, 0, -10) };
     // Logged roughly once/sec (200 packets @ 5ms/frame).
-    static PACKET_COUNT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
-    while let Ok(packet) = client.next_audio(Duration::ZERO) {
-        match audio.play(packet.seq, packet.pts_ns, &packet.data) {
-            Ok((peak, event)) => {
-                match event {
-                    // The two queue-too-full cases and the starved case are each audible
-                    // and have different causes, so they are never collapsed into one
-                    // message: `Underrun` means this thread was too slow, `Dropped`/
-                    // `Resnapped` mean audio arrived faster than realtime.
-                    AudioEvent::Underrun => {
-                        tracing::debug!("audio underrun (device queue ran dry before this packet)");
-                    }
-                    AudioEvent::Resnapped => {
-                        tracing::debug!(
-                            "audio resnapped (queue was >{}ms behind)",
-                            crate::platform::webos::audio::MAX_QUEUED_LAG_MS
-                        );
-                    }
-                    AudioEvent::Dropped => {
-                        tracing::debug!(
-                            "audio packet dropped (queue >{}ms, draining)",
-                            crate::platform::webos::audio::SOFT_QUEUED_LAG_MS
-                        );
-                    }
-                    AudioEvent::Queued => {
-                        let n = PACKET_COUNT.fetch_add(1, Ordering::Relaxed);
-                        if n % 200 == 0 {
-                            tracing::debug!("audio peak: {peak:.4}");
-                        }
+    let mut packets: u32 = 0;
+    while !stop.load(Ordering::Relaxed) {
+        match client.next_audio(Duration::from_millis(100)) {
+            Ok(packet) => match feed.play(packet.seq, packet.pts_ns, &packet.data) {
+                Ok(peak) => {
+                    packets = packets.wrapping_add(1);
+                    if packets % 200 == 0 {
+                        tracing::debug!("audio peak: {peak:.4}");
                     }
                 }
-            }
+                // Underruns and drift sheds are reported by the ring itself, which is the only
+                // side that knows the depth — see `platform::webos::audio`'s callback.
+                Err(e) => tracing::warn!("audio error (seq {}): {e:#}", packet.seq),
+            },
+            Err(punktfunk_core::PunktfunkError::NoFrame) => {}
             Err(e) => {
-                tracing::warn!("audio error (seq {}): {e:#}", packet.seq);
+                tracing::info!("audio feed ending: {e:#}");
+                break;
             }
         }
     }
@@ -1023,7 +1034,7 @@ pub fn send_input(client: &NativeClient, ev: &InputEvent) -> Result<()> {
 const FEEDBACK_DRAIN_BUDGET: usize = 32;
 
 /// Drains the host→client gamepad feedback planes (non-blocking) and applies them to the
-/// physical pad. Call once per main-loop tick, like [`pump_audio_once`].
+/// physical pad. Call once per main-loop tick.
 ///
 /// The two planes go to different places, because each has one route that works for every
 /// controller rather than only one:

--- a/src/session/sink.rs
+++ b/src/session/sink.rs
@@ -6,7 +6,7 @@
 //! parts that are wire-shaped — pulling frames, and *how* a keyframe is asked for, which it
 //! answers to [`SinkResult::NeedKeyframe`] with `NativeClient::request_keyframe`.
 
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -23,6 +23,47 @@ const FEED_BACKPRESSURE_WARN: Duration = Duration::from_millis(20);
 /// How often the sink refreshes NDL's render-buffer depth for the decode-latency signal —
 /// three samples per 750 ms ABR report window; see [`NdlSink::decode_us`].
 const BACKLOG_POLL: Duration = Duration::from_millis(250);
+
+/// This frame's video end-to-end latency, in the shape [`punktfunk_core::audio::AvSync`] compares
+/// against: the instant it reaches the glass expressed in the HOST capture clock, minus its host
+/// PTS. Published for the audio plane, which steers its ring depth to land audio WITH the picture.
+///
+/// **Why an estimate at all.** NDL is submit-only — `NDL_DirectVideoPlay` returns nothing about
+/// presentation and there is no glass callback — so the true stamp the Vulkan/Android/Apple
+/// presenters publish does not exist here. This is the fallback core's own `video_e2e_ns` field
+/// docs already sanction ("a TRUE on-glass stamp where `VK_KHR_present_wait` is available, and the
+/// submit instant otherwise"), plus the one further term this platform *can* observe: NDL's
+/// standing render queue. That middle term is the one that MOVES — a decoder falling behind
+/// buffers deeper — and it is precisely the ratchet the sync loop exists to cancel.
+///
+/// **`present_fixed_ns` is a calibration, not a guess.** It is NDL's decode + panel latency after
+/// the queue drains, which the app cannot observe at all. Underestimating it by Δ biases this
+/// figure low, biases the measured A/V offset high, and so aims the audio ring Δ *shallower* —
+/// i.e. **audio plays Δ early**. At 60 Hz a plausible 2–5 frame pipeline is 33–83 ms, far outside
+/// `AvSync`'s 10 ms deadband, so shipping it at 0 is not a conservative default but a systematic
+/// error larger than the thing being corrected. It is measured observe-only first; see
+/// `docs/NOTES.md` § "A/V sync".
+///
+/// `None` when the arithmetic would place the frame on the glass *before* its own capture — a
+/// wall-clock step, a stale PTS, or a host clock that has not settled. The caller then publishes
+/// nothing, core reads the untouched cell as "nothing presented yet", and the loop stays inert
+/// rather than steering on a figure it cannot believe.
+fn video_e2e_ns(
+    submit_realtime_ns: i128,
+    clock_offset_ns: i64,
+    frame_pts_ns: u64,
+    backlog_frames: u64,
+    frame_interval_ns: u64,
+    present_fixed_ns: u64,
+) -> Option<u64> {
+    let pipeline_ns = backlog_frames
+        .saturating_mul(frame_interval_ns)
+        .saturating_add(present_fixed_ns);
+    let glass_host_ns = submit_realtime_ns
+        .checked_add(i128::from(pipeline_ns))?
+        .checked_add(i128::from(clock_offset_ns))?;
+    u64::try_from(glass_host_ns.checked_sub(i128::from(frame_pts_ns))?).ok()
+}
 
 /// What the pump knows about a frame that the sink can't work out for itself.
 pub struct FrameFlags {
@@ -112,6 +153,15 @@ pub struct SinkConfig {
     /// Minimum spacing between [`SinkResult::NeedKeyframe`] results — see
     /// each protocol's own constant for why this is per-protocol.
     pub keyframe_min_interval: Duration,
+    /// Host-minus-client clock skew, live (`NativeClient::clock_offset_shared`). Read per
+    /// published frame, never cached — the handshake re-syncs it mid-stream.
+    pub clock_offset: Arc<AtomicI64>,
+    /// Where [`video_e2e_ns`] is published for the audio plane
+    /// (`NativeClient::video_e2e_shared`). `0` = nothing on the glass yet.
+    pub video_e2e: Arc<AtomicU64>,
+    /// NDL's decode + panel latency after its render queue drains — the calibrated constant in
+    /// [`video_e2e_ns`], from the user's A/V trim setting.
+    pub present_fixed_ns: u64,
 }
 
 /// The NDL implementation: [`VideoPlayer`] + [`PtsPacer`] + [`StreamStats`].
@@ -120,6 +170,10 @@ pub struct NdlSink {
     stats: Arc<StreamStats>,
     cfg: SinkConfig,
     frame_period_us: u64,
+    /// The panel's actual drain cadence, reconciled against the stream rate — the same interval
+    /// the pacer runs on. NDL drains at panel cadence whether or not pacing is enabled, so this,
+    /// not the stream rate, is what converts a render-queue depth into time in [`video_e2e_ns`].
+    frame_interval_ns: u64,
     /// Always instantiated — the Blue button can flip pacing on mid-stream, so the state
     /// must exist even when it starts off. Pacer interval reconciles against the panel's
     /// measured refresh; the backlog fold stays on the stream rate (host's actual cadence).
@@ -143,11 +197,13 @@ impl NdlSink {
     pub fn new(player: VideoPlayer, stats: Arc<StreamStats>, cfg: SinkConfig) -> Self {
         let stream_hz = cfg.stream_hz.max(1);
         let pacing_was_on = stats.pacing_enabled.load(Ordering::Relaxed);
+        let frame_interval_ns = reconciled_pace_interval_ns(stream_hz);
         Self {
             player,
             stats,
             frame_period_us: 1_000_000 / u64::from(stream_hz),
-            pacer: PtsPacer::new(reconciled_pace_interval_ns(stream_hz)),
+            frame_interval_ns,
+            pacer: PtsPacer::new(frame_interval_ns),
             host_anchor: HostPtsAnchor::new(),
             pacing_was_on,
             cfg,
@@ -188,7 +244,23 @@ impl NdlSink {
     /// frame — three samples per 750 ms ABR report window is plenty, and assuming an NDL
     /// query is cheap enough for per-frame use is exactly the mistake docs/NOTES.md warns
     /// against; between polls the cached depth is reused.
-    fn decode_us(&mut self, feed_elapsed: Duration) -> u32 {
+    fn decode_us(&mut self, feed_elapsed: Duration, backlog: u64) -> u32 {
+        let decode_us = u64::try_from(feed_elapsed.as_micros())
+            .unwrap_or(u64::MAX)
+            .saturating_add(backlog.saturating_mul(self.frame_period_us));
+        u32::try_from(decode_us).unwrap_or(u32::MAX)
+    }
+
+    /// NDL's render-queue depth, refreshed on [`BACKLOG_POLL`]'s cadence and cached between polls.
+    ///
+    /// Called unconditionally, because it now has TWO consumers: the ABR decode figure
+    /// ([`Self::decode_us`]) and the A/V sync loop's video reference ([`video_e2e_ns`]). It used to
+    /// live inside `decode_us`, which runs only when the host asked for decode latency — so against
+    /// any host that did not, the cached depth stayed pinned at `0` for the entire session. That
+    /// would have silently zeroed the queue term in the video reference, i.e. deleted the one part
+    /// of the estimate that actually tracks the decoder falling behind, while every number involved
+    /// still looked plausible.
+    fn poll_backlog(&mut self) -> u64 {
         if self.last_backlog_poll.is_none_or(|t| t.elapsed() >= BACKLOG_POLL) {
             self.last_backlog_poll = Some(Instant::now());
             self.backlog_cached = self
@@ -197,10 +269,26 @@ impl NdlSink {
                 .and_then(|b| u64::try_from(b).ok())
                 .unwrap_or(0);
         }
-        let decode_us = u64::try_from(feed_elapsed.as_micros())
-            .unwrap_or(u64::MAX)
-            .saturating_add(self.backlog_cached.saturating_mul(self.frame_period_us));
-        u32::try_from(decode_us).unwrap_or(u32::MAX)
+        self.backlog_cached
+    }
+
+    /// Publish this frame's video end-to-end figure for the audio plane's sync loop.
+    ///
+    /// Nothing is published when [`video_e2e_ns`] cannot believe its own arithmetic — the cell
+    /// keeps its previous value and `AvSync` simply makes no observation, which is the same inert
+    /// path as a session where no frame has been presented yet.
+    fn publish_video_e2e(&self, submit_realtime_ns: i128, frame_pts_ns: u64, backlog: u64) {
+        let e2e = video_e2e_ns(
+            submit_realtime_ns,
+            self.cfg.clock_offset.load(Ordering::Relaxed),
+            frame_pts_ns,
+            backlog,
+            self.frame_interval_ns,
+            self.cfg.present_fixed_ns,
+        );
+        if let Some(ns) = e2e {
+            self.cfg.video_e2e.store(ns, Ordering::Relaxed);
+        }
     }
 
     /// Whether a freeze-until-reanchor hold is currently active (stats/logging).
@@ -269,6 +357,11 @@ impl NdlSink {
             base_ns
         };
 
+        // The submit instant, on CLOCK_REALTIME — the same basis the host stamps `pts_ns` with and
+        // the skew handshake compares, so the two are directly subtractable. Taken BEFORE the feed
+        // call: `play` blocks for its submission time, and the frame enters NDL's pipeline behind
+        // exactly the frames the backlog below counts.
+        let submit_realtime_ns = punktfunk_core::client::now_realtime_ns();
         let (play_result, feed_elapsed) = self.player.play(au, paced_ns);
         self.stats.feed_us.store(
             u32::try_from(feed_elapsed.as_micros()).unwrap_or(u32::MAX),
@@ -283,7 +376,14 @@ impl NdlSink {
             );
         }
 
-        let decode_us = (self.cfg.report_decode_latency && play_result.is_ok()).then(|| self.decode_us(feed_elapsed));
+        let backlog = self.poll_backlog();
+        if play_result.is_ok() {
+            // Only a frame NDL actually accepted is on its way to the glass. A failed feed is
+            // followed by a flush and a hold below, where the reference would be meaningless.
+            self.publish_video_e2e(submit_realtime_ns, pts_ns, backlog);
+        }
+        let decode_us =
+            (self.cfg.report_decode_latency && play_result.is_ok()).then(|| self.decode_us(feed_elapsed, backlog));
 
         if let Err(e) = play_result {
             tracing::warn!(
@@ -303,5 +403,80 @@ impl NdlSink {
         } else {
             SinkResult::Presented { decode_us }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::video_e2e_ns;
+
+    /// 60 Hz, the cadence the pacing grid reconciles to on most panels.
+    const HZ60_NS: u64 = 16_666_666;
+    /// A frame submitted 30 ms after the host captured it, with clocks aligned and nothing queued.
+    const SUBMIT: i128 = 2_000_000_000;
+    const PTS: u64 = 1_970_000_000;
+
+    fn base() -> Option<u64> {
+        video_e2e_ns(SUBMIT, 0, PTS, 0, HZ60_NS, 0)
+    }
+
+    #[test]
+    fn e2e_is_the_glass_instant_minus_the_capture_instant() {
+        assert_eq!(base(), Some(30_000_000));
+    }
+
+    /// The term that makes this better than a bare submit stamp: frames already queued in NDL must
+    /// drain before this one is seen, so each adds one panel interval. Deleting the backlog term
+    /// collapses this onto the base case.
+    #[test]
+    fn the_render_queue_adds_its_own_drain_time() {
+        assert_eq!(
+            video_e2e_ns(SUBMIT, 0, PTS, 3, HZ60_NS, 0),
+            Some(30_000_000 + 3 * HZ60_NS)
+        );
+        // And a deeper queue is strictly later — the ratchet the sync loop exists to cancel.
+        let shallow = video_e2e_ns(SUBMIT, 0, PTS, 1, HZ60_NS, 0).unwrap();
+        let deep = video_e2e_ns(SUBMIT, 0, PTS, 6, HZ60_NS, 0).unwrap();
+        assert!(deep > shallow, "{deep} !> {shallow}");
+    }
+
+    /// The calibrated constant. At 0 the estimate is biased LOW by NDL's whole decode+panel
+    /// pipeline, which is the systematic error the observe-only pass exists to measure.
+    #[test]
+    fn the_fixed_present_latency_is_added() {
+        assert_eq!(video_e2e_ns(SUBMIT, 0, PTS, 0, HZ60_NS, 50_000_000), Some(80_000_000));
+    }
+
+    /// The glass instant is expressed in the HOST clock, so the skew term shifts it directly. A
+    /// host running ahead of the client makes the same frame land later in host terms.
+    #[test]
+    fn clock_skew_moves_the_glass_instant() {
+        assert_eq!(video_e2e_ns(SUBMIT, 7_000_000, PTS, 0, HZ60_NS, 0), Some(37_000_000));
+        assert_eq!(video_e2e_ns(SUBMIT, -7_000_000, PTS, 0, HZ60_NS, 0), Some(23_000_000));
+    }
+
+    /// A frame cannot reach the glass before it was captured. A wall-clock step or an unsettled
+    /// skew estimate produces exactly this, and steering a playback ring by it would empty or
+    /// overfill the ring outright — so it is rejected, not clamped.
+    #[test]
+    fn a_frame_landing_before_its_own_capture_is_rejected() {
+        assert_eq!(video_e2e_ns(1_000_000_000, 0, 2_000_000_000, 0, HZ60_NS, 0), None);
+    }
+
+    /// This runs on the video thread for every presented frame, so the failure mode it guards is a
+    /// **panic**: plain `+` here aborts the stream on overflow in a debug build. Proven by planting
+    /// exactly that — swapping the `checked_add`s for `+` fails this test with an overflow panic.
+    ///
+    /// What it deliberately does NOT claim: that `checked_add` beats `wrapping_add`. With real
+    /// inputs the i128 accumulator cannot overflow at all (a realtime stamp is ~1.7e18 ns and the
+    /// whole pipeline term is bounded by `u64::MAX` ~1.8e19, against an i128 range of ~1.7e38), and
+    /// a wrapped value would be caught by the `u64::try_from` below anyway. The `checked_add`s are
+    /// belt-and-braces against garbage arguments, and this gate is about the panic.
+    #[test]
+    fn implausible_inputs_return_none_rather_than_panicking() {
+        assert_eq!(video_e2e_ns(i128::MAX, i64::MAX, 0, u64::MAX, u64::MAX, u64::MAX), None);
+        assert_eq!(video_e2e_ns(i128::MIN, i64::MIN, u64::MAX, 0, 0, 0), None);
+        // A saturating queue term must not wrap into a small, believable-looking number.
+        assert_eq!(video_e2e_ns(SUBMIT, 0, PTS, u64::MAX, HZ60_NS, 0), None);
     }
 }


### PR DESCRIPTION
punktfunk-webos is the fifth client audio ring, and it received none of the audio latency programme that shipped a shared de-jitter policy and A/V sync to the other four (Linux/PipeWire, Windows/WASAPI, Android/AAudio, Apple/CoreAudio).

The reason was the pin. At core **v0.24.0** `punktfunk_core::audio` is 369 lines — layouts and `AudioGapTracker`. At **v0.26.0** it is 2301, with `JitterPolicy`, `AvSync`, `AudioSyncCell`, `crossfade_drop` and the redundant `0xD2` audio plane. None of it was reachable from here.

## What was wrong

**No jitter buffer at all.** No priming, so ring depth was whatever arrival lead the network happened to give and every jitter event was an underrun. No adaptive floor, so an underrun was logged and forgotten. Corrections were a 5 ms uncrossfaded discard at 60 ms and a whole-queue `clear()` at 100 ms — about 100 ms of silence per event, as `docs/NOTES.md` said in as many words. This is the client on the worst link in the fleet (NOTES measures a ~245 Mbps airlink ceiling with 10–29 s black-hole stalls on new flows) and it had the least machinery to survive it.

**The audio timestamp was discarded.** The host stamps `pts_ns` on every audio datagram; this client decoded it and threw it away, so the A/V offset was an accident of buffer depths — and it got *worse* every time video got faster, because a quicker decode path lowers the video leg and leaves the audio leg alone. This client has been actively lowering its video leg (`PtsPacer`, the panel-refresh reconciliation, the renice work).

## What this does

- **Core to v0.26.0.** `connect`'s parameter list is identical across the two tags, so this is a pin-only bump with one break: `HidOutput` gained an `AudioCtl` variant, which joins `TrackpadHaptic`/`HidRaw` as a variant this pad has no route for. The bump also brings the redundant audio plane **for free** — core advertises `CLIENT_CAP_AUDIO_RED` itself and rebuilds on its own demux side, so a single lost datagram is now recovered rather than concealed, with no client code.
- **A real ring.** A dedicated decode thread posts chunks down a bounded channel; SDL's audio callback drains them into a ring it owns outright, served under `JitterPolicy`. Prime to a target in milliseconds, an adaptive floor that grows only on devices that actually underrun, and drift shed as one crossfaded 5 ms frame.
- **Off the UI thread.** The drain was on the main loop because `AudioQueue` is `!Send`, which put the 5 ms audio cadence behind the UI's software rasterizer on a 3-core panel — NOTES already named the 500 ms stats-overlay raster as an underrun source.
- **A video reference, and an instrument.** `session::sink` publishes an end-to-end video figure; the stats overlay gains `Audio buf <n> ms · A/V <±n> ms`.

## Things worth reviewing carefully

**`AudioQueue` could not carry the policy.** It exposes `queue_audio`/`size`/`clear` and nothing else — no partial drop — so `JitterStep`'s crossfaded shed is not merely awkward against it but inexpressible. The pull-callback move is a prerequisite, not a refactor that could follow. That is why the ring and the policy land in one commit: a ring with no policy has no bound at all, which is strictly worse than the thresholds it replaces.

**NDL has no presentation timestamp**, so the video reference is an estimate: submit instant + NDL's render-queue depth × panel interval + a constant for decode+panel latency after the queue drains. The first two are measured; the constant is not observable from the app. Underestimating it by Δ biases the offset high and would aim the ring Δ shallower — i.e. **audio plays Δ early** — and a plausible 2–5 frame NDL pipeline is 33–83 ms at 60 Hz against `AvSync`'s 10 ms deadband.

**So the sync loop ships armed but gated.** It activates only when `$HOME/av-trim-ms.conf` exists. That file's presence *is* the calibration, and removing it is the bisect switch. The session log states which mode it is in, because "audio is late" and "audio is early" are the same sentence from a user.

`WEBOS_TUNING` is local rather than a fifth core preset until on-glass numbers justify specific values. Two invariants checked by hand, both of which the parent programme shipped broken once: the smooth shed fires at target+20 against a hard trim at target+40, so drift correction is reachable rather than dead code; and the 25 ms base clears the 15.7 ms floor implied by the 512-frame device quantum, so the ring cannot oscillate prime → dropout → re-prime.

## Deliberately not done

The NDL **audio-offload** path stamps its two planes in unrelated time bases — arrival wall-clock for audio, host-PTS-anchored and paced for video — while NDL syncs them against each other. Documented at the site and in NOTES, **not fixed**: the correct fix moves `HostPtsAnchor` ownership onto the working video hot path behind a lock, for a path that is off by default and that NOTES records as freezing video outright on webOS 10.3.

The A/V trim is a dev-override file rather than a Settings row. What the default should be — and whether it must be user-visible at all, since LG picture modes plausibly move it — is what the field decides.

## Verification

`task check`, `task lint`, `task build` and `cargo fmt --check` on the armv7 cross target, all clean.

Six unit tests on the video-reference estimator, each proven non-vacuous by planting the defect it claims to catch (drop the queue term, drop the trim, drop the skew, clamp the negative case, plain `+` for the checked adds). They ship in-tree but **cannot run off-device**: `cargo test` links the whole binary and `-lNDL_directmedia` exists only in the cross sysroot.

**On hardware:** installed and running on an OLED65G58LW (webOS 10) — launches clean, discovers hosts, telemetry healthy. **The A/V calibration itself has not been done**, so the sync loop has not yet been exercised in its armed state. That is the remaining step: read the converged `A/V` figure off the overlay, write it to `av-trim-ms.conf`, and confirm it holds while video latency changes underneath it.

⚠ Note for anyone deploying to a TV that was previously rooted: `ares-install` fails if `/media/developer/temp` is left owned by `root` and the device is no longer rooted — removing a directory needs write on the parent, which `prisoner` does not have.
