### PR TITLE
Clean up what the GameStream removal left behind

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -248,9 +248,6 @@ pub struct App {
     pub(crate) pinned_count: usize,
     /// Host answered library fetch (gates Desktop card).
     pub(crate) games_loaded: bool,
-    /// Cached `games` position of the host's own desktop entry — recomputed with the
-    /// library and its pin order, since `grid_layout` needs it several times per redraw.
-    pub(crate) desktop_pos: Option<usize>,
     pub(crate) games_rx: Option<std::sync::mpsc::Receiver<crate::services::library::GamesLoaded>>,
     pub home_status: Option<String>,
     /// Cover art pixmaps by game id.
@@ -503,7 +500,6 @@ impl App {
             games: Vec::new(),
             pinned_count: 0,
             games_loaded: false,
-            desktop_pos: None,
             games_rx: None,
             home_status: None,
             art: std::collections::HashMap::new(),
@@ -1082,9 +1078,8 @@ impl App {
                 *focused = row;
                 changed
             }
-            // Nothing on the display-PIN layout is focusable, so there is no hover target.
             Screen::Pairing => {
-                let card = self.pairing_card_rect(screen_w, screen_h, fonts);
+                let card = Self::pairing_card_rect(screen_w, screen_h, fonts);
                 if Self::pairing_request_button_rect(card, fonts).contains_point((x, y)) {
                     let changed = self.pairing_focus != PairingFocus::RequestAccess;
                     self.pairing_focus = PairingFocus::RequestAccess;
@@ -1260,7 +1255,7 @@ impl App {
         Some(match self.screen {
             Screen::Home => return None,
             Screen::Settings => self.settings_layout(screen_w, screen_h).0,
-            Screen::Pairing => self.pairing_card_rect(screen_w, screen_h, fonts),
+            Screen::Pairing => Self::pairing_card_rect(screen_w, screen_h, fonts),
             Screen::AddHost => self.address_card_rect(screen_w, screen_h, fonts),
             Screen::Wake => Self::wake_card_rect(screen_w, screen_h, self.wake.as_ref()?, fonts),
             Screen::ForgetHost => {
@@ -1413,11 +1408,10 @@ impl App {
                 self.handle_settings_event(MenuEvent::Confirm, screen_h);
                 None
             }
-            // The display-PIN layout has no button to click.
             Screen::Pairing => {
                 // The Magic Remote pointer is the most reliable input on this TV, so the
                 // "Request access" button is clickable directly: focus it and confirm.
-                let card = self.pairing_card_rect(screen_w, screen_h, fonts);
+                let card = Self::pairing_card_rect(screen_w, screen_h, fonts);
                 if Self::pairing_request_button_rect(card, fonts).contains_point((x, y)) {
                     self.pairing_focus = PairingFocus::RequestAccess;
                     self.handle_pairing_event(MenuEvent::Confirm);
@@ -2017,8 +2011,6 @@ impl App {
                 .as_ref()
                 .filter(|w| !w.mac.is_empty())
                 .map(|w| ModalFocusKey::WakeButton(w.focused)),
-            // The display-PIN layout draws everything into the shell — nothing is focusable, so
-            // it has no focus tile at all.
             Screen::Pairing => Some(match self.pairing_focus {
                 PairingFocus::Pin => {
                     ModalFocusKey::PairingDigit(self.pin_digit_index, self.pin_digits[self.pin_digit_index])
@@ -2118,7 +2110,7 @@ impl App {
                             self.pin_digits[self.pin_digit_index],
                         )?,
                         PairingFocus::RequestAccess => {
-                            let card = self.pairing_card_rect(screen_w, screen_h, fonts);
+                            let card = Self::pairing_card_rect(screen_w, screen_h, fonts);
                             let btn = Self::pairing_request_button_rect(card, fonts);
                             ui::render_pairing_button_tile(
                                 text_cache,
@@ -2838,7 +2830,7 @@ impl App {
                         )
                     }),
                     Screen::Pairing => {
-                        let card = self.pairing_card_rect(screen_w, screen_h, fonts);
+                        let card = Self::pairing_card_rect(screen_w, screen_h, fonts);
                         Some(match self.pairing_focus {
                             PairingFocus::Pin => {
                                 let digit_y = Self::pairing_pin_row_y(card, fonts);

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -13,23 +13,9 @@ impl App {
         self.entries.len() + 2
     }
 
-    /// Position of the host's own desktop entry in `games`, if its library lists one.
-    ///
-    /// A host that already lists its desktop as an ordinary app gives it real box art and a real
-    /// id. Where one exists it *is* the desktop card — the synthetic one below would be a second
-    /// card launching the same thing.
-    fn find_desktop_game_pos(&self) -> Option<usize> {
-        self.games
-            .iter()
-            .position(|g| crate::core::model::is_desktop_title(&g.title))
-    }
-
     /// Grid shape at `columns` columns; scans for pinned pins, so build once and reuse.
     pub(crate) fn grid_layout(&self, columns: usize) -> GridLayout {
-        // With a real desktop entry in the library there is no synthetic card at all: it is an
-        // ordinary game, pinned (or not) through the same machinery as any other.
-        let synthetic_desktop = self.games_loaded && self.desktop_pos.is_none();
-        let desktop_pinned = synthetic_desktop
+        let desktop_pinned = self.games_loaded
             && self
                 .selected_known_host()
                 .is_some_and(|h| h.is_pinned(store::DESKTOP_PIN_ID));
@@ -42,7 +28,7 @@ impl App {
         GridLayout {
             pinned_count: self.pinned_count,
             desktop_pinned,
-            desktop_in_rest: synthetic_desktop && !desktop_pinned,
+            desktop_in_rest: self.games_loaded && !desktop_pinned,
             front_count,
             pinned_rows,
             unpinned_start: pinned_rows * columns.max(1),
@@ -288,13 +274,6 @@ impl App {
     /// `known_hosts`' persisted pins for games the host no longer lists — otherwise
     /// a removed game keeps counting toward `MAX_PINNED_GAMES` forever.
     pub(crate) fn reorder_games_by_pin(&mut self) {
-        self.reorder_games_by_pin_inner();
-        // Reordering moves the desktop entry, so the cache is refreshed here — the only
-        // place `games`' order changes after a fetch.
-        self.desktop_pos = self.find_desktop_game_pos();
-    }
-
-    fn reorder_games_by_pin_inner(&mut self) {
         let Some(known_idx) = self
             .selected_host
             .as_ref()
@@ -308,17 +287,8 @@ impl App {
         let mut still_pinned = Vec::new();
         for id in &pinned_ids {
             if id == store::DESKTOP_PIN_ID {
-                // A host that lists its own desktop app: rewrite the pin to that entry's id, so
-                // the card pins and unpins like any other. Done once, here, rather than special-
-                // cased at every pin site — and the rewrite is saved below.
-                // Live scan, not `desktop_pos`: the loop above is removing entries as it goes.
-                if let Some(pos) = self.find_desktop_game_pos() {
-                    still_pinned.push(self.games[pos].id.clone());
-                    pinned.push(self.games.remove(pos));
-                } else {
-                    // The synthetic card isn't in `self.games`, so it's never "missing".
-                    still_pinned.push(id.clone());
-                }
+                // Desktop isn't in `self.games`, so it's never "missing".
+                still_pinned.push(id.clone());
             } else if let Some(pos) = self.games.iter().position(|g| &g.id == id) {
                 pinned.push(self.games.remove(pos));
                 still_pinned.push(id.clone());
@@ -328,7 +298,6 @@ impl App {
         pinned.append(&mut self.games);
         self.games = pinned;
 
-        // Not just a length check: the desktop rewrite above substitutes an id without dropping one.
         if still_pinned != pinned_ids {
             self.known_hosts[known_idx].pinned = still_pinned;
             let _ = store::save_known_hosts(&self.known_hosts);
@@ -427,7 +396,6 @@ impl App {
         self.selected_host = None;
         self.games = Vec::new();
         self.games_loaded = false;
-        self.desktop_pos = None;
         self.pinned_count = 0;
         self.art.clear();
         self.art_loader = None;
@@ -450,7 +418,6 @@ impl App {
         self.games = Vec::new();
         self.pinned_count = 0;
         self.games_loaded = false;
-        self.desktop_pos = None;
         self.art.clear();
         // Dropping the loader stops its worker (its request channel closes), so a host
         // switch abandons in-flight fetches for the previous library.
@@ -463,7 +430,7 @@ impl App {
 
         let identity = (self.identity.0.clone(), self.identity.1.clone());
         let known = self.known_hosts.iter().find(|h| h.host == host && h.port == port);
-        let fingerprint = known.and_then(store::KnownHost::pin);
+        let fingerprint = known.and_then(|k| k.fingerprint);
         let mgmt_port = mgmt_port.unwrap_or(crate::services::library::DEFAULT_MGMT_PORT);
         tracing::debug!("library: fetching from {host}:{mgmt_port}…");
         self.games_rx = Some(crate::services::library::load_games_async(
@@ -497,7 +464,7 @@ impl App {
                 tracing::info!("library: {} games from {host}:{mgmt_port}", games.len());
                 let identity = (self.identity.0.clone(), self.identity.1.clone());
                 let known = self.known_hosts.iter().find(|h| h.host == host && h.port == port);
-                let fingerprint = known.and_then(store::KnownHost::pin);
+                let fingerprint = known.and_then(|k| k.fingerprint);
                 // Covers are requested per card as the grid window reaches them (see
                 // `App::prepare_tiles`), not fetched for the whole library up front.
                 self.art_loader = Some(crate::services::art::ArtLoader::spawn(
@@ -560,7 +527,7 @@ impl App {
         };
         // The pin is also the pair state: no pin means the host was never paired, so there is
         // nothing to connect with.
-        let fingerprint = known.pin();
+        let fingerprint = known.fingerprint;
         if fingerprint.is_none() {
             return;
         }

--- a/src/app/state/hostmenu.rs
+++ b/src/app/state/hostmenu.rs
@@ -110,7 +110,7 @@ impl App {
             })
     }
 
-    /// Handles host menu events; may return `ConnectTarget` (currently never does).
+    /// Handles host menu events.
     pub(crate) fn handle_host_menu_event(&mut self, ev: MenuEvent) {
         let len = self.host_menu_actions().len();
         if crate::ui::list_nav(&mut self.menu_focused, len, ev) {

--- a/src/app/state/speedtest.rs
+++ b/src/app/state/speedtest.rs
@@ -62,7 +62,7 @@ impl App {
             .known_hosts
             .iter()
             .find(|h| h.host == host && h.port == port)
-            .and_then(crate::services::store::KnownHost::pin);
+            .and_then(|k| k.fingerprint);
 
         self.speed_test_name = name;
         self.speed_test = Some(SpeedTestState::Connecting);

--- a/src/app/state/wake.rs
+++ b/src/app/state/wake.rs
@@ -132,7 +132,7 @@ impl App {
         port: u16,
     ) -> std::sync::mpsc::Receiver<crate::services::library::GamesLoaded> {
         let known = known_hosts.iter().find(|h| h.host == host && h.port == port);
-        let fingerprint = known.and_then(crate::services::store::KnownHost::pin);
+        let fingerprint = known.and_then(|k| k.fingerprint);
         let mgmt_port = known
             .and_then(|h| h.mgmt_port)
             .unwrap_or(crate::services::library::DEFAULT_MGMT_PORT);

--- a/src/app/view/pairing.rs
+++ b/src/app/view/pairing.rs
@@ -56,9 +56,9 @@ impl App {
         }
     }
 
-    /// The active pairing card, sized from the layout plus room for an up-to-two-line status.
-    /// Every geometry caller goes through this, so the sizing is done in exactly one place.
-    pub(crate) fn pairing_card_rect(&self, screen_w: u32, screen_h: u32, fonts: &ui::Fonts) -> Rect {
+    /// The pairing card, sized from the layout plus room for an up-to-two-line status. Every
+    /// geometry caller goes through this, so the sizing is done in exactly one place.
+    pub(crate) fn pairing_card_rect(screen_w: u32, screen_h: u32, fonts: &ui::Fonts) -> Rect {
         Self::simple_modal_card(screen_w, screen_h, |probe| {
             let status_room = 2 * (fonts.raster.height(fonts.value) + 6);
             let status_y = Self::pairing_layout(probe, fonts).status_y;
@@ -84,7 +84,7 @@ impl App {
         screen_w: u32,
         screen_h: u32,
     ) -> Result<()> {
-        let card = self.pairing_card_rect(screen_w, screen_h, fonts);
+        let card = Self::pairing_card_rect(screen_w, screen_h, fonts);
         let l = Self::pairing_layout(card, fonts);
         self.draw_modal_shell(painter, text_cache, fonts.raster, fonts.icon, card)?;
 

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -42,21 +42,7 @@ pub const MAX_PINNED_GAMES: usize = 5;
 /// Pin ID for "Desktop" card (stored in pinned like games; counts toward `MAX_PINNED_GAMES`).
 pub const DESKTOP_PIN_ID: &str = "__desktop__";
 
-/// Whether a host-supplied app title names that host's own desktop. A host that already lists
-/// its desktop as an ordinary library entry should use that one rather than the synthetic card,
-/// and its title is all that identifies it — one predicate so the grid and the launch path
-/// can't disagree about which entry that is.
-pub fn is_desktop_title(title: &str) -> bool {
-    title.eq_ignore_ascii_case("desktop")
-}
-
 impl KnownHost {
-    /// The mTLS pin, or `None` for an unpaired host — what every `services::library` /
-    /// `services::art` / `session::connect` caller actually wants.
-    pub fn pin(&self) -> Option<[u8; 32]> {
-        self.fingerprint
-    }
-
     pub fn is_paired(&self) -> bool {
         self.fingerprint.is_some()
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -18,7 +18,7 @@ use crate::ui::render::{DrawCmd, TileId as Tile};
 use crate::ui::MenuEvent;
 
 /// `ConnectOutcome`: connect thread (started early to overlap animation) + settings.
-type ConnectOutcome = (std::thread::JoinHandle<Result<StreamHandle>>, store::Settings);
+type ConnectOutcome = (std::thread::JoinHandle<Result<session::Connected>>, store::Settings);
 
 /// Resolves a `GamepadType::Auto` preference against the attached controller, for this
 /// session only.
@@ -47,7 +47,7 @@ fn spawn_connect(
     identity: (String, String),
     target: crate::app::ConnectTarget,
     settings: store::Settings,
-) -> Result<std::thread::JoinHandle<Result<StreamHandle>>> {
+) -> Result<std::thread::JoinHandle<Result<session::Connected>>> {
     let (host, port, fp, launch) = (target.host, target.port, target.fingerprint, target.launch);
     std::thread::Builder::new()
         .name("punktfunk-webos-connect".into())
@@ -74,8 +74,9 @@ fn spawn_connect(
                 identity,
                 fp,
                 launch,
-                // Only an unpinned host parks (until its operator approves); a pinned one is either
-                // reachable now or off, and a long budget there just holds the black launch scrim.
+                // An unpinned host waits on its operator approving this client; a pinned one is
+                // either reachable now or off, and a long budget there just holds the black
+                // launch scrim.
                 if fp.is_some() {
                     crate::services::budget::HANDSHAKE
                 } else {
@@ -87,7 +88,6 @@ fn spawn_connect(
                 settings.gamepad_type,
                 settings.cursor_capture,
             )
-            .map(StreamHandle)
         })
         .context("spawn connect thread")
 }
@@ -282,10 +282,9 @@ enum StreamOutcome {
 }
 
 mod input;
+mod session_ext;
 mod stream;
-mod stream_handle;
 mod ui_flow;
 use input::*;
 use stream::run_inner;
-use stream_handle::StreamHandle;
 use ui_flow::run_ui_flow;

--- a/src/runtime/session_ext.rs
+++ b/src/runtime/session_ext.rs
@@ -1,9 +1,8 @@
-//! One live stream.
+//! The streaming loop's view of a live session.
 //!
-//! A wrapper around [`Connected`] rather than the session type itself, so the streaming loop has
-//! one place to reach for the handful of figures it needs (stats, overlay, teardown) instead of
-//! peering into the session's internals at each site. Verbs are named after the punktfunk ones
-//! the loop already called (`disconnect_quit`, `is_session_ended`, `shutdown`).
+//! Inherent methods on [`Connected`] for the handful of figures the loop needs (stats, overlay,
+//! teardown), kept here rather than in `session` because every one of them is shaped by what the
+//! loop asks for, not by how the session works.
 
 use std::sync::Arc;
 
@@ -11,8 +10,6 @@ use punktfunk_core::input::InputEvent;
 
 use crate::platform::webos::audio::AudioFeed;
 use crate::session::{self, Connected, StreamStats};
-
-pub(crate) struct StreamHandle(pub(crate) Connected);
 
 /// The input path, cloned for a thread that sends off the main loop (the HID-mouse reader).
 #[derive(Clone)]
@@ -24,61 +21,61 @@ impl InputSender {
     }
 }
 
-impl StreamHandle {
+impl Connected {
     pub(crate) fn input(&self) -> InputSender {
-        InputSender(self.0.client.clone())
+        InputSender(self.client.clone())
     }
 
     pub(crate) fn send_input(&self, ev: &InputEvent) {
-        let _ = session::send_input(&self.0.client, ev);
+        let _ = session::send_input(&self.client, ev);
     }
 
     pub(crate) fn stats(&self) -> &Arc<StreamStats> {
-        &self.0.stats
+        &self.stats
     }
 
     /// Whether HDR is being applied, for the Game-mode picture pick.
     pub(crate) fn hdr(&self) -> bool {
-        self.0.hdr
+        self.hdr
     }
 
     /// Channels to open the SDL audio device with, or `None` when the session needs no local
     /// device (NDL audio offload took the stream).
     pub(crate) fn audio_channels(&self) -> Option<u8> {
-        if self.0.audio_offloaded {
+        if self.audio_offloaded {
             None
         } else {
-            Some(self.0.client.audio_channels)
+            Some(self.client.audio_channels)
         }
     }
 
     /// The cells the A/V sync loop trades through — handed to the audio player at construction.
     pub(crate) fn sync_cells(&self) -> crate::platform::webos::audio::SyncCells {
         crate::platform::webos::audio::SyncCells {
-            clock_offset: self.0.client.clock_offset_shared(),
-            video_e2e: self.0.client.video_e2e_shared(),
-            av_offset_ms: self.0.client.audio_av_offset_shared(),
-            buffer_ms: self.0.client.audio_buffer_ms_shared(),
+            clock_offset: self.client.clock_offset_shared(),
+            video_e2e: self.client.video_e2e_shared(),
+            av_offset_ms: self.client.audio_av_offset_shared(),
+            buffer_ms: self.client.audio_buffer_ms_shared(),
         }
     }
 
     /// Audio's two HUD figures: ring depth in ms, and the smoothed A/V offset in ms (positive =
     /// audio playing behind the picture). Both are `0` until the sync loop has evidence.
     pub(crate) fn audio_stats(&self) -> (u32, i64) {
-        (self.0.client.audio_buffer_ms(), self.0.client.audio_av_offset_ms())
+        (self.client.audio_buffer_ms(), self.client.audio_av_offset_ms())
     }
 
     /// Starts the audio decode/feed thread. It exits on the session's stop flag, or when the
     /// transport's audio plane closes.
     pub(crate) fn spawn_audio_feed(&self, feed: AudioFeed) -> anyhow::Result<std::thread::JoinHandle<()>> {
-        session::spawn_audio_feed(self.0.client.clone(), feed, self.0.stop.clone())
+        session::spawn_audio_feed(self.client.clone(), feed, self.stop.clone())
     }
 
     /// Signals the audio feed thread to stop and joins it, bounded. Sets the session's stop flag,
     /// which `shutdown()` sets moments later anyway — doing it here just means the ring stops being
     /// fed before its device is dropped.
     pub(crate) fn stop_audio_feed(&self, handle: std::thread::JoinHandle<()>) {
-        self.0.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
         session::join_audio_feed(handle);
     }
 
@@ -88,11 +85,11 @@ impl StreamHandle {
         controller: Option<&mut sdl2::controller::GameController>,
         feedback: Option<&mut crate::platform::webos::dualsense::Feedback>,
     ) {
-        session::pump_feedback_once(&self.0.client, controller, feedback);
+        session::pump_feedback_once(&self.client, controller, feedback);
     }
 
     pub(crate) fn is_session_ended(&self) -> bool {
-        self.0.client.is_session_ended()
+        self.client.is_session_ended()
     }
 
     /// The sentence for the menu toast when the session ended on its own. Nothing here separates
@@ -102,18 +99,13 @@ impl StreamHandle {
     }
 
     pub(crate) fn disconnect_quit(&self) {
-        self.0.client.disconnect_quit();
-    }
-
-    /// `false` = teardown timed out, so the caller must skip `ndl::quit()`.
-    pub(crate) fn shutdown(self) -> bool {
-        self.0.shutdown()
+        self.client.disconnect_quit();
     }
 
     /// The stats overlay's figures. Grouped into one call so the overlay block has one lookup
     /// rather than six.
     pub(crate) fn overlay_info(&self) -> OverlayInfo {
-        let client = &self.0.client;
+        let client = &self.client;
         let mode = client.mode();
         OverlayInfo {
             width: mode.width,
@@ -133,7 +125,7 @@ impl StreamHandle {
     }
 }
 
-/// See [`StreamHandle::overlay_info`].
+/// See [`Connected::overlay_info`].
 pub(crate) struct OverlayInfo {
     pub width: u32,
     pub height: u32,

--- a/src/services/budget.rs
+++ b/src/services/budget.rs
@@ -6,12 +6,13 @@ use std::time::Duration;
 /// and a long wait on a black launch scrim buys nothing. Also the per-request TCP connect budget.
 pub const HANDSHAKE: Duration = Duration::from_secs(5);
 
-/// A host that answered but isn't ready to stream yet: the park-until-approved TOFU connection,
-/// and a PIN handshake waiting on someone to walk to their PC. A shorter budget sent the user
+/// A host that answered but isn't ready to stream yet: an unpinned connection waiting on the
+/// host's operator to approve this client, and a PIN handshake waiting on someone to walk to
+/// their PC. A shorter budget sent the user
 /// back to the menu with "couldn't connect" against a host that was merely still starting.
 pub const HOST_WAIT: Duration = Duration::from_secs(185);
 
-/// The ambient reachability dot's per-host budget, for every protocol. Short on purpose: an
+/// The ambient reachability dot's per-host budget. Short on purpose: an
 /// unreachable host on a LAN fails fast (no route / refused), and one slow enough to miss this is
 /// not meaningfully "available". Not [`HANDSHAKE`] — nobody is waiting on this answer, so it is
 /// allowed to be wrong about a sluggish host rather than hold the sweep open.

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -117,10 +117,6 @@ pub fn clock_ticks_per_sec() -> u64 {
 /// Also the ceiling the stream teardown waits on (a different mechanism, same rationale).
 pub const SHUTDOWN_JOIN_TIMEOUT: Duration = Duration::from_secs(2);
 
-/// The keyframe-request throttle: the request travels on its own QUIC control stream, so a
-/// tight interval costs nothing but the request itself.
-const KEYFRAME_REQUEST_MIN_INTERVAL: Duration = Duration::from_millis(100);
-
 /// Joins `handle` from a watcher thread so a hang inside it can't block the caller past
 /// `timeout`. Returns `false` (and leaks the watcher, still waiting on the real join) if it
 /// didn't finish in time.
@@ -399,7 +395,6 @@ pub fn connect(
     let sink_cfg = SinkConfig {
         stream_hz: resolved_mode.refresh_hz,
         report_decode_latency: client.wants_decode_latency(),
-        keyframe_min_interval: KEYFRAME_REQUEST_MIN_INTERVAL,
         clock_offset: client.clock_offset_shared(),
         video_e2e: client.video_e2e_shared(),
         present_fixed_ns: u64::from(crate::services::store::dev_override_av_trim_ms().unwrap_or(0)) * 1_000_000,
@@ -865,9 +860,8 @@ fn video_pump(
                     last_dropped_seen = dropped_now;
                 }
                 if (gap || dropped) && !sink.holding() {
-                    // Which of the two fired is the protocol-specific half of the freeze
-                    // the sink logs next — a sequence hole vs. a frame the transport itself
-                    // gave up on point at different faults.
+                    // Logged alongside the freeze the sink reports next: a sequence hole and a
+                    // frame the transport itself gave up on point at different faults.
                     tracing::warn!("loss: gap={gap} dropped={dropped} (frame {})", frame.frame_index);
                 }
                 let flags = FrameFlags {

--- a/src/session/sink.rs
+++ b/src/session/sink.rs
@@ -84,7 +84,6 @@ pub enum SinkResult {
     /// Skipped — still frozen, waiting for a re-anchor.
     Held,
     /// Skipped or failed, and the throttle allows asking the host for a keyframe now.
-    /// The caller sends it however its protocol does.
     NeedKeyframe,
 }
 
@@ -144,15 +143,12 @@ impl VideoPlayer {
     }
 }
 
-/// Everything protocol-specific the sink needs to know up front.
+/// Everything the sink needs to know up front.
 pub struct SinkConfig {
     /// The host's frame cadence. Drives both the pacing grid and the backlog→latency fold.
     pub stream_hz: u32,
     /// Whether the host asked for decode-latency reports (its ABR controller).
     pub report_decode_latency: bool,
-    /// Minimum spacing between [`SinkResult::NeedKeyframe`] results — see
-    /// each protocol's own constant for why this is per-protocol.
-    pub keyframe_min_interval: Duration,
     /// Host-minus-client clock skew, live (`NativeClient::clock_offset_shared`). Read per
     /// published frame, never cached — the handshake re-syncs it mid-stream.
     pub clock_offset: Arc<AtomicI64>,
@@ -163,6 +159,10 @@ pub struct SinkConfig {
     /// [`video_e2e_ns`], from the user's A/V trim setting.
     pub present_fixed_ns: u64,
 }
+
+/// Minimum spacing between [`SinkResult::NeedKeyframe`] results: the request travels on its own
+/// QUIC control stream, so a tight interval costs nothing but the request itself.
+const KEYFRAME_REQUEST_MIN_INTERVAL: Duration = Duration::from_millis(100);
 
 /// The NDL implementation: [`VideoPlayer`] + [`PtsPacer`] + [`StreamStats`].
 pub struct NdlSink {
@@ -222,7 +222,7 @@ impl NdlSink {
     fn take_keyframe_slot(&mut self) -> bool {
         let ready = self
             .last_keyframe_request
-            .is_none_or(|t| t.elapsed() >= self.cfg.keyframe_min_interval);
+            .is_none_or(|t| t.elapsed() >= KEYFRAME_REQUEST_MIN_INTERVAL);
         if ready {
             self.last_keyframe_request = Some(Instant::now());
         }


### PR DESCRIPTION
#90 backed out GameStream but left behind the shapes it needed. I found these by diffing what #86 actually added (`46d9729^..46d9729`) and checking which of those lines still survive on main — grepping for "gamestream" finds nothing by construction, since the removal already took every line that said so.

**Desktop-as-library-entry machinery.** `is_desktop_title`, `App::desktop_pos`, `find_desktop_game_pos` and the `__desktop__`-to-real-id pin rewrite existed because GameStream hosts serve the desktop as an ordinary app. punktfunk hosts don't — the client synthesizes that card — so `grid_layout` is back to its pre-#86 form, line for line. This is the only behavior change here, and both consequences are restorations:

- a punktfunk host whose library does contain an entry titled "Desktop" shows two cards again (synthetic + real)
- a `known-hosts.json` written by a build off main since 05-08, against such a host, may hold a real game id where `__desktop__` used to be. It resolves as an ordinary pin if the host still lists that game, and is pruned if not; the synthetic Desktop card returns unpinned either way. No migration.

**Abstractions with one implementation left.**

- `runtime/stream_handle.rs` was the protocol seam's newtype over `Connected`. Now inherent methods on `Connected` (`runtime/session_ext.rs`) — all 39 call sites read unchanged, and its `shutdown` forwarder was shadowing the real one.
- `SinkConfig::keyframe_min_interval` was a field because the two protocols wanted different throttles. One caller, one constant, so it moved into `sink.rs`.
- `pairing_card_rect` took `&self` only to branch between the entry layout and the deleted display-PIN one.
- `KnownHost::pin()` returns `self.fingerprint` verbatim now that `HostTrust` is gone.

**Comments that outlived their code.** Three describing the display-PIN ceremony, each contradicting the code directly beneath it — "nothing on this layout is focusable" sat above a hit-test that focuses the request-access button. Plus the two-protocol vocabulary in `sink`, `session` and `budget` ("per-protocol", "for every protocol", host "parking").

**Left alone:** `mouse.rs`'s two GameStream references predate #86 (they came in with #69) and describe the button/wheel numbering `punktfunk-host`'s injectors actually implement. `session::sink`, `services::art`, `pinned_tls`, `budget`, `paths` and the sidebar focus re-anchoring are all #86-era but protocol-neutral, as #90 said.

`task docker:check`, `task docker:lint` and `cargo fmt` clean. Not run on hardware — the grid and pin paths are what to exercise there.