### PR TITLE
Warn when the TV can't do DualSense feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ video decode, and webOS packaging.
 - About & licenses screen with the build version and full third-party notices.
 - Hardware H.264/H.265 decode via webOS's NDL DirectMedia API; audio via SDL2/PulseAudio.
 - Gamepad feedback back to the controller — rumble for any pad, plus DualSense adaptive triggers,
-  haptics and lightbar. **Requires webOS 6.0+** (see note below).
+  haptics and lightbar. **Requires a newer webOS version** (see note below).
 - Magic Remote friendly: d-pad navigation, pointer hover/click, number-pad PIN/IP entry, and the
   Red button as a Back/disconnect substitute.
 
-> **Controller feedback needs webOS 6.0+.** Rumble, DualSense triggers, haptics and lightbar all
-> rely on the kernel's `hid-playstation` driver, which LG ships only on webOS 6.0+ (C1 and later).
+> **Controller feedback needs newer webOS version.** Rumble, DualSense triggers, haptics and lightbar all
+> rely on the kernel's `hid-playstation` driver, which LG ships only on latest webOS versions 24+.
 > On webOS 5.x (e.g. the CX) the pad still works as an *input*, but no feedback reaches it.
 
 <details>

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -266,6 +266,11 @@ pub struct App {
     pub settings: Settings,
     /// Persists settings off UI thread to avoid blocking.
     pub(crate) settings_writer: store::SettingsWriter,
+    /// The attached pad's type per `gamepad::detect_type`, refreshed on hotplug in
+    /// `runtime::ui_flow`. `None` with no pad attached or an unrecognized one. Only meaningful
+    /// when `settings.gamepad_type` is `Auto` — an explicit pick doesn't need this to know what
+    /// it's driving, but the Controller row's `DualSense` caption does (see `settings_rows`).
+    pub(crate) detected_gamepad_type: Option<store::GamepadType>,
     pub settings_focused: usize,
     /// Scroll state for overflowing modal content.
     pub(crate) scroll: ui::ScrollWindow,
@@ -517,6 +522,7 @@ impl App {
             launch_anim_idx: None,
             settings,
             settings_writer: store::SettingsWriter::spawn(),
+            detected_gamepad_type: None,
             settings_focused: 0,
             scroll: ui::ScrollWindow::new(),
             settings_scroll: ui::ScrollWindow::new(),
@@ -1244,7 +1250,7 @@ impl App {
         let overlay = Self::dropdown_overlay_rect_at_px(content, dd.row, scroll_px);
         let options_len = match self.screen {
             Screen::Diagnostics => ui::LOG_LEVEL_OPTIONS.len(),
-            _ => ui::dropdown_options(&self.settings, ui::settings_logical_row(&self.settings, dd.row)).len(),
+            _ => ui::dropdown_options(&self.settings, ui::settings_logical_row(&self.settings, dd.row), self.detected_gamepad_type).len(),
         };
         (0..options_len).find(|&i| ui::dropdown_option_rect(overlay, i).contains_point((x, y)))
     }
@@ -2038,7 +2044,11 @@ impl App {
         // (Home, AddHost) or when Wake has nothing to focus (no MAC on record,
         // see `handle_wake_event`'s matching guard).
         let focus_key = match self.screen {
-            Screen::Settings => Some(ModalFocusKey::SettingsRow(self.settings_focused, self.settings)),
+            Screen::Settings => Some(ModalFocusKey::SettingsRow(
+                self.settings_focused,
+                self.settings,
+                self.detected_gamepad_type,
+            )),
             Screen::Wake => self
                 .wake
                 .as_ref()
@@ -2105,7 +2115,7 @@ impl App {
                 let tile = match self.screen {
                     Screen::Settings => {
                         let (_, content) = self.settings_layout(screen_w, screen_h);
-                        let rows = ui::settings_rows(&self.settings);
+                        let rows = self.settings_rows();
                         let dropdown_open = self.dropdown.as_ref().is_some_and(|dd| dd.row == self.settings_focused);
                         let target_on = rows.get(self.settings_focused).is_some_and(|r| r.value == "On");
                         ui::render_focus_row_tile(
@@ -2339,7 +2349,7 @@ impl App {
                 _ => {
                     let (_, content) = self.settings_layout(screen_w, screen_h);
                     let logical = ui::settings_logical_row(&self.settings, dd.row);
-                    (ui::dropdown_options(&self.settings, logical), content.width())
+                    (ui::dropdown_options(&self.settings, logical, self.detected_gamepad_type), content.width())
                 }
             };
 
@@ -2428,11 +2438,11 @@ impl App {
                     let dropdown_row = self.dropdown.as_ref().map(|dd| dd.row);
                     let key = (
                         Screen::Settings,
-                        ScrollContentKey::Settings(self.settings, dropdown_row),
+                        ScrollContentKey::Settings(self.settings, dropdown_row, self.detected_gamepad_type),
                     );
                     let stale = !matches!(&tiles.scroll_content_tile, Some((k, _)) if *k == key);
                     if stale {
-                        let rows = ui::settings_rows(&self.settings);
+                        let rows = self.settings_rows();
                         let tile = ui::render_focus_rows_tile(text_cache, fonts, &rows, content.width(), dropdown_row)?;
                         tiles.scroll_content_tile = Some((key, tile));
                         // Settings' whole row list always fits one tile — no windowing.
@@ -2487,7 +2497,7 @@ impl App {
         let mut scratch = Painter::new(screen_w, screen_h);
         self.render_settings(&mut scratch, text_cache, fonts, screen_w, screen_h)?;
         let (_, content) = self.settings_layout(screen_w, screen_h);
-        let rows = ui::settings_rows(&self.settings);
+        let rows = self.settings_rows();
         let _ = ui::render_focus_rows_tile(text_cache, fonts, &rows, content.width(), None)?;
         let _ = ui::render_focus_row_tile(text_cache, fonts, &rows, content.width(), 0, false, 0.0)?;
         Ok(())
@@ -2835,7 +2845,7 @@ impl App {
                     let overlay_rect = Self::dropdown_overlay_rect_at_px(content, row, scroll_px);
                     let options_len = match screen {
                         Screen::Diagnostics => ui::LOG_LEVEL_OPTIONS.len(),
-                        _ => ui::dropdown_options(&self.settings, ui::settings_logical_row(&self.settings, row)).len(),
+                        _ => ui::dropdown_options(&self.settings, ui::settings_logical_row(&self.settings, row), self.detected_gamepad_type).len(),
                     };
                     cmds.push(DrawCmd::Tex {
                         tile: Tile::DropdownOverlay,

--- a/src/app/state/settings.rs
+++ b/src/app/state/settings.rs
@@ -16,7 +16,7 @@ impl App {
             // `dd.row` is the display position; setting lookups need the logical row.
             let row = dd.row;
             let logical = crate::ui::settings_logical_row(&self.settings, row);
-            let len = crate::ui::dropdown_options(&self.settings, logical).len().max(1);
+            let len = crate::ui::dropdown_options(&self.settings, logical, self.detected_gamepad_type).len().max(1);
             match ev {
                 MenuEvent::Up => dd.focused = if dd.focused == 0 { len - 1 } else { dd.focused - 1 },
                 MenuEvent::Down => dd.focused = (dd.focused + 1) % len,

--- a/src/app/view/settings.rs
+++ b/src/app/view/settings.rs
@@ -3,10 +3,23 @@
 use crate::app::App;
 use crate::app::DROPDOWN_FADE;
 use crate::ui::render::Rect;
-use crate::ui::{self, Painter};
+use crate::ui::{self, FocusRow, Painter};
 use anyhow::Result;
 
 impl App {
+    /// The Controller row's `DualSense` caption needs the *effective* type — the explicit pick,
+    /// or (on `Auto`) whatever's actually plugged in — not the stored preference alone, since
+    /// `Auto` on its own says nothing about what pad the caption should warn about.
+    pub(crate) fn settings_rows(&self) -> Vec<FocusRow> {
+        let effective = if self.settings.gamepad_type == crate::services::store::GamepadType::Auto {
+            self.detected_gamepad_type.unwrap_or_default()
+        } else {
+            self.settings.gamepad_type
+        };
+        let dualsense_limited = effective.is_dualsense() && !crate::platform::webos::dualsense::hid_playstation_bound();
+        ui::settings_rows(&self.settings, dualsense_limited, self.detected_gamepad_type)
+    }
+
     /// How many settings rows are *fully* visible. Capped at the live row count so a hidden
     /// row (HDR on an explicit H.264 pick) leaves no empty slot.
     ///

--- a/src/platform/webos/dualsense.rs
+++ b/src/platform/webos/dualsense.rs
@@ -127,6 +127,37 @@ pub fn find_address() -> Option<String> {
     })
 }
 
+/// Whether an attached `DualSense`/`Edge` is bound to the kernel's `hid-playstation` driver
+/// (registered as `playstation`) rather than falling back to `hid-generic`.
+///
+/// The Bluetooth output report this module builds is a `hid-playstation` behavior, not a
+/// property of the `luna` call: on a TV whose kernel never got that driver backported, the pad
+/// still pairs and shows `connectedProfiles: ["hid"]`, and `hid/internal/sendData` still answers
+/// `returnValue: true` for every report — but nothing reaches the pad, silently. Verified on a
+/// webOS 5/6-class set (kernel 4.4.84): `/sys/bus/hid/devices/0005:054C:0CE6.0002/driver` links to
+/// `hid-generic`, and neither the lightbar nor the player LEDs moved for a report identical to
+/// the one confirmed working on webOS 10.3. This is the caption Settings shows for that case.
+pub fn hid_playstation_bound() -> bool {
+    let devices = std::fs::read_to_string("/proc/bus/input/devices").unwrap_or_default();
+    devices.split("\n\n").any(|block| {
+        let is_dualsense = block
+            .lines()
+            .any(|l| l.starts_with("N: Name=") && l.to_ascii_lowercase().contains("dualsense"));
+        if !is_dualsense {
+            return false;
+        }
+        // The evdev node's `Sysfs=` line points at `<hid-device>/input/inputN`; the driver
+        // binding lives on the HID device itself, one level up.
+        let Some(sysfs) = block.lines().find_map(|l| l.strip_prefix("S: Sysfs=")) else {
+            return false;
+        };
+        let Some(device_dir) = sysfs.split("/input/input").next() else {
+            return false;
+        };
+        std::fs::read_link(format!("/sys{device_dir}/driver")).is_ok_and(|d| d.file_name().is_some_and(|f| f == "playstation"))
+    })
+}
+
 /// Owns the pad's feedback state and the thread that ships it.
 ///
 /// The thread exists because a send is a fork/exec of `luna-send-pub` (see [`crate::platform::webos::luna`]),

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -238,6 +238,7 @@ pub(super) fn run_ui_flow(
                         Ok(c) => {
                             tracing::info!("controller connected: {}", c.name());
                             *controller = Some(c);
+                            app.detected_gamepad_type = gamepad::detect_type(game_controller);
                         }
                         Err(e) => tracing::warn!("controller open failed: {e}"),
                     }
@@ -245,6 +246,7 @@ pub(super) fn run_ui_flow(
                 }
                 Event::ControllerDeviceRemoved { .. } => {
                     *controller = None;
+                    app.detected_gamepad_type = None;
                     // An unplugged pad sends no releases — drop any armed chord.
                     chord.clear();
                     continue;

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -180,7 +180,17 @@ pub fn resolution_label(width: u32, height: u32) -> String {
         .map_or_else(|| format!("{width}x{height}"), |(_, _, s)| s.to_string())
 }
 
-pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
+/// `dualsense_limited`: the effective controller type (explicit pick, or auto-detected pad) is
+/// a `DualSense`/`Edge` and the TV's kernel isn't running `hid-playstation` — see
+/// `platform::webos::dualsense::hid_playstation_bound`. Computed by the caller, not here: this
+/// module stays platform-neutral (see `experimental_rows`'s `rooted` parameter for the same
+/// pattern).
+///
+/// `detected`: the attached pad's type per `gamepad::detect_type`, `None` with nothing
+/// attached or an unrecognized pad. Only changes what "Automatic" reads as (see
+/// `gamepad_auto_label`) — it doesn't affect `dualsense_limited`, which the caller already
+/// folded this into.
+pub fn settings_rows(settings: &Settings, dualsense_limited: bool, detected: Option<GamepadType>) -> Vec<FocusRow> {
     let bitrate_frac = if settings.bitrate_kbps == BITRATE_AUTOMATIC {
         0.0
     } else {
@@ -260,12 +270,16 @@ pub fn settings_rows(settings: &Settings) -> Vec<FocusRow> {
         FocusRow {
             icon: ICON_GAMEPAD,
             label: "Controller".into(),
-            value: gamepad_label(settings.gamepad_type).into(),
+            value: if settings.gamepad_type == GamepadType::Auto {
+                gamepad_auto_label(detected)
+            } else {
+                gamepad_label(settings.gamepad_type).into()
+            },
             kind: RowKind::Dropdown,
             fraction: 0.0,
             danger: false,
             menu: None,
-            subtext: None,
+            subtext: dualsense_limited.then(|| RowSubtext::caution("Limited support by your WebOS version")),
         },
         FocusRow::action(ICON_MOUSE, "Cursor"),
         FocusRow::action(ICON_BUG, "Experimental"),
@@ -484,6 +498,13 @@ pub fn gamepad_label(t: GamepadType) -> &'static str {
     }
 }
 
+/// "Automatic", or "Automatic (`DualSense`)" once a recognized pad is attached — what `Auto`
+/// will actually resolve to for this session (see `gamepad::detect_type`), rather than leaving
+/// the user to guess.
+pub fn gamepad_auto_label(detected: Option<GamepadType>) -> String {
+    detected.map_or_else(|| "Automatic".to_string(), |t| format!("Automatic ({})", gamepad_label(t)))
+}
+
 /// Supported channel counts.
 pub const AUDIO_CHANNELS: [(u8, &str); 3] = [(2, "Stereo"), (6, "5.1 surround"), (8, "7.1 surround")];
 
@@ -495,14 +516,23 @@ fn audio_label(channels: u8) -> String {
 }
 
 /// Dropdown labels for a row.
-pub fn dropdown_options(settings: &Settings, row_index: usize) -> Vec<String> {
+pub fn dropdown_options(settings: &Settings, row_index: usize, detected: Option<GamepadType>) -> Vec<String> {
     let _ = settings;
     match row_index {
         ROW_RESOLUTION => RESOLUTIONS.iter().map(|(w, h, _)| resolution_label(*w, *h)).collect(),
         ROW_FRAMERATE => REFRESH_RATES.iter().map(|hz| format!("{hz} Hz")).collect(),
         ROW_CODEC => codec_options().iter().map(|&p| codec_label(p).to_string()).collect(),
         ROW_AUDIO => AUDIO_CHANNELS.iter().map(|(_, s)| (*s).to_string()).collect(),
-        ROW_GAMEPAD => GAMEPAD_TYPES.iter().map(|&t| gamepad_label(t).to_string()).collect(),
+        ROW_GAMEPAD => GAMEPAD_TYPES
+            .iter()
+            .map(|&t| {
+                if t == GamepadType::Auto {
+                    gamepad_auto_label(detected)
+                } else {
+                    gamepad_label(t).to_string()
+                }
+            })
+            .collect(),
         _ => Vec::new(),
     }
 }

--- a/src/ui/tiles.rs
+++ b/src/ui/tiles.rs
@@ -2,7 +2,7 @@
 //!
 //! Split out of the former single-file `ui.rs`; see `super`'s module docs.
 use super::*;
-use crate::core::model::{LogLevelOverride, Settings};
+use crate::core::model::{GamepadType, LogLevelOverride, Settings};
 use crate::core::screen::Screen;
 use crate::ui::render::Color;
 use crate::ui::render::Rect;
@@ -420,7 +420,9 @@ pub fn render_confirm_dialog_shell(
 /// so value changes (not just focus moves) invalidate the tile.
 #[derive(PartialEq)]
 pub enum ModalFocusKey {
-    SettingsRow(usize, Settings),
+    /// The detected pad type rides along because the Controller row's "Automatic (...)" value
+    /// depends on it, not just on `Settings` — a hotplug alone doesn't touch `Settings` at all.
+    SettingsRow(usize, Settings, Option<GamepadType>),
     WakeToggle(bool),
     WakeButton(usize),
     PairingDigit(usize, u8),
@@ -443,8 +445,8 @@ pub enum ModalFocusKey {
 /// Scrollable modal content keys. Paired with Screen for staleness checks.
 #[derive(Clone, PartialEq)]
 pub enum ScrollContentKey {
-    /// Settings row list + open dropdown row.
-    Settings(Settings, Option<usize>),
+    /// Settings row list + open dropdown row + detected pad type (see `ModalFocusKey::SettingsRow`).
+    Settings(Settings, Option<usize>, Option<GamepadType>),
     /// About window's start line.
     About(usize),
 }


### PR DESCRIPTION
## Summary

Some webOS TVs (older kernels) don't ship the `hid-playstation` driver, so a paired DualSense binds as generic HID. Feedback calls still report success but nothing actually reaches the pad — silently, with no way to tell.

- Detect whether `hid-playstation` is bound to the connected pad (checks the sysfs driver symlink).
- Show a caption on the Controller row when DualSense/Edge is picked (or auto-detected) and the driver isn't there — same warning color as the high-bitrate caption.
- "Automatic" in the dropdown now shows which pad it actually resolved to, e.g. "Automatic (DualSense)".
- Fixed a stale README line that still said webOS 6.0+ when the driver note next to it says 24+.
- Fixed DualShock 4 not being auto-detected at all: over Bluetooth it names itself plain "Wireless Controller", so the old name-matching missed it and it fell back to the host's Xbox default. Detection is now by USB vendor/product id instead, which is stable across the whole pad lineup.
- Folded the id table, Settings labels, and dropdown order into one catalog (`core::model::GAMEPAD_CATALOG`) instead of three separate hand-maintained lists.

## Test plan

- [ ] Deploy to a TV with `hid-playstation` (e.g. G5) — pair a DualSense, confirm no caption shows and feedback still works
- [ ] Deploy to a TV without it (e.g. CX) — confirm the caption shows and updates live on connect/disconnect, without needing to focus the row
- [ ] Check the "Automatic" dropdown option label with a DualSense, DualShock 4, Switch Pro, and Xbox pad attached