### PR TITLE
Seed detected gamepad type on menu re-entry, not just on hotplug

### DIFF
--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -48,6 +48,12 @@ pub(super) fn run_ui_flow(
 
     canvas.window_mut().show();
     let mut app = App::new(identity.clone());
+    // `App` is fresh every menu entry, but the pad isn't: a controller attached before a
+    // stream stays attached across it (no `ControllerDeviceAdded`/`Removed` fires on return,
+    // since nothing about the device changed), so without this seed the Controller row's
+    // "Automatic (...)" label would go blank on every return from streaming until the pad was
+    // physically unplugged and replugged.
+    app.detected_gamepad_type = gamepad::detect_type(game_controller);
     // The GPU tile cache is the render loop's, not App's — App holds only screen state
     // (see docs/REMAINING_IMPROVEMENTS.md A2). Recreated per menu entry, same as `app`.
     let mut tiles = crate::ui::TileCache::new();


### PR DESCRIPTION
## Summary

Follow-up to #96: the Controller row's "Automatic (...)" label was going blank after a stream ended, until the pad was physically unplugged and replugged.

- `App` is recreated fresh every time the menu is re-entered (streaming and menu are two alternating runtime phases), which reset `detected_gamepad_type` to `None`.
- A controller attached before the stream stays attached across it, so no `ControllerDeviceAdded` fires on return — nothing repopulated the field.
- Fix: seed `detected_gamepad_type` from the already-attached controller right when `App` is constructed in `run_ui_flow`, same call the hotplug handler already uses.

## Test plan

- [ ] Connect a DualSense/DualShock, start a stream, disconnect from the host, confirm the Controller row still shows "Automatic (DualSense)"/"Automatic (DualShock 4)" back on the menu without needing to unplug/replug