### PR TITLE
Stop automatic bitrate collapsing to its floor on NDL's present cushion

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,9 +48,8 @@ const ABR_PROBE_KBPS: &str = "300000";
 fn main() -> anyhow::Result<()> {
     // Set before anything spawns a thread: `set_var` is not thread-safe, and core reads this
     // while building its data-plane pump during `connect`. An older core simply ignores it.
-    //
-    // No `PUNKTFUNK_ABR_MAX_MBPS` alongside it: the probe above already measures this link's
-    // ceiling, and a second, compiled-in cap would override a measurement with a guess.
+    // Deliberately no `PUNKTFUNK_ABR_MAX_MBPS` alongside it — the probe measures this link's
+    // ceiling, and a compiled-in cap would override that measurement with a guess.
     std::env::set_var("PUNKTFUNK_ABR_PROBE_KBPS", ABR_PROBE_KBPS);
     runtime::run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,9 @@ const ABR_PROBE_KBPS: &str = "300000";
 fn main() -> anyhow::Result<()> {
     // Set before anything spawns a thread: `set_var` is not thread-safe, and core reads this
     // while building its data-plane pump during `connect`. An older core simply ignores it.
+    //
+    // No `PUNKTFUNK_ABR_MAX_MBPS` alongside it: the probe above already measures this link's
+    // ceiling, and a second, compiled-in cap would override a measurement with a guess.
     std::env::set_var("PUNKTFUNK_ABR_PROBE_KBPS", ABR_PROBE_KBPS);
     runtime::run()
 }

--- a/src/platform/webos/ndl.rs
+++ b/src/platform/webos/ndl.rs
@@ -230,16 +230,17 @@ static LEAKED_THREADS: AtomicUsize = AtomicUsize::new(0);
 
 /// One leaked NDL-touching thread, for as long as this value lives (see [`LEAKED_THREADS`]).
 ///
-/// A guard rather than a `poison`/`recovered` pair of calls, because the counter has exactly two
-/// failure modes and both are silent: a missed decrement refuses streaming until the app restarts,
-/// and an extra one re-permits it while a thread is still inside NDL — the race this exists to
-/// prevent. Ownership makes the pairing structural, so neither can be written by accident.
+/// A guard rather than a `poison`/`recovered` pair of calls: both ways of mispairing them are
+/// silent — a missed decrement refuses streaming until restart, an extra one re-permits it while a
+/// thread is still inside NDL. Ownership makes the pairing structural.
 pub struct LeakGuard(());
 
 impl Drop for LeakGuard {
     fn drop(&mut self) {
         if LEAKED_THREADS.fetch_sub(1, Ordering::SeqCst) == 1 {
-            tracing::info!("NDL recovered: the wedged decode thread finished and unloaded cleanly — streaming re-enabled");
+            tracing::info!(
+                "NDL recovered: the wedged decode thread finished and unloaded cleanly — streaming re-enabled"
+            );
         }
     }
 }
@@ -258,16 +259,11 @@ pub fn poison() -> LeakGuard {
     LeakGuard(())
 }
 
-/// Whether any leaked thread might still be live — see [`LEAKED_THREADS`].
-pub fn is_poisoned() -> bool {
-    LEAKED_THREADS.load(Ordering::SeqCst) > 0
-}
-
-/// `Err` while [`is_poisoned`], with the message the user sees. One gate, one wording: `load()`
-/// enforces it and `session::connect` checks it early to avoid holding a host session slot for a
-/// connect that can only end here.
+/// `Err` while any leaked thread might still be live (see [`LEAKED_THREADS`]). One gate, one
+/// wording: `load()` enforces it and `session::connect` checks it early to avoid holding a host
+/// session slot for a connect that can only end here.
 pub fn ensure_not_poisoned() -> Result<()> {
-    if is_poisoned() {
+    if LEAKED_THREADS.load(Ordering::SeqCst) > 0 {
         bail!("NDL is still tearing down a wedged decode thread from the previous session — try reconnecting shortly");
     }
     Ok(())

--- a/src/platform/webos/ndl.rs
+++ b/src/platform/webos/ndl.rs
@@ -224,28 +224,38 @@ static INIT_DONE: AtomicBool = AtomicBool::new(false);
 ///
 /// No way to force this: an OS thread can't be safely cancelled mid-FFI-call, and racing
 /// `NDL_DirectMediaUnload` against it is the exact hazard this guards against. So `load()`
-/// refuses while nonzero, and [`thread_recovered`] clears it in-process (no restart) once the
+/// refuses while nonzero, and dropping the [`LeakGuard`] clears it in-process (no restart) once the
 /// leaked thread actually returns — its `NdlVideo::drop` has run the real unload by then.
 static LEAKED_THREADS: AtomicUsize = AtomicUsize::new(0);
 
-/// Marks one NDL-touching thread as leaked (see [`LEAKED_THREADS`]). Pair with exactly one
-/// later [`thread_recovered`] call once that same thread actually joins.
-pub fn poison() {
+/// One leaked NDL-touching thread, for as long as this value lives (see [`LEAKED_THREADS`]).
+///
+/// A guard rather than a `poison`/`recovered` pair of calls, because the counter has exactly two
+/// failure modes and both are silent: a missed decrement refuses streaming until the app restarts,
+/// and an extra one re-permits it while a thread is still inside NDL — the race this exists to
+/// prevent. Ownership makes the pairing structural, so neither can be written by accident.
+pub struct LeakGuard(());
+
+impl Drop for LeakGuard {
+    fn drop(&mut self) {
+        if LEAKED_THREADS.fetch_sub(1, Ordering::SeqCst) == 1 {
+            tracing::info!("NDL recovered: the wedged decode thread finished and unloaded cleanly — streaming re-enabled");
+        }
+    }
+}
+
+/// Marks one NDL-touching thread as leaked until the returned guard drops — which the caller must
+/// arrange to happen when that same thread actually finishes, however late. Leaking the guard
+/// (`mem::forget`) is the deliberate "nothing will ever tell us it recovered" case.
+#[must_use = "NDL stays poisoned until this guard drops — hold it until the wedged thread returns"]
+pub fn poison() -> LeakGuard {
     if LEAKED_THREADS.fetch_add(1, Ordering::SeqCst) == 0 {
         tracing::error!(
             "NDL poisoned: a decode thread is wedged past its join deadline — streaming \
              refused until it actually finishes (no safe way to force it sooner)"
         );
     }
-}
-
-/// Call once the thread that triggered a matching [`poison`] actually finishes, however late —
-/// its `Arc<NdlVideo>` has dropped by then, which already ran the real `NDL_DirectMediaUnload`,
-/// so a fresh `load()` is safe again as soon as every leaked thread has cleared.
-pub fn thread_recovered() {
-    if LEAKED_THREADS.fetch_sub(1, Ordering::SeqCst) == 1 {
-        tracing::info!("NDL recovered: the wedged decode thread finished and unloaded cleanly — streaming re-enabled");
-    }
+    LeakGuard(())
 }
 
 /// Whether any leaked thread might still be live — see [`LEAKED_THREADS`].

--- a/src/platform/webos/ndl.rs
+++ b/src/platform/webos/ndl.rs
@@ -1,7 +1,7 @@
 //! Safe wrapper over webOS's NDL `DirectMedia` v2 API (`NDL_Direct*`, webOS 5+).
 //! Video only; audio via SDL2. Never calls `NDL_DirectVideoSetArea` (causes stutter above 1080p).
 use std::ffi::{c_char, c_int, c_longlong, c_uint, c_void, CStr, CString};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Instant;
 
 use anyhow::{bail, Result};
@@ -216,6 +216,53 @@ fn last_error() -> String {
 
 static INIT_DONE: AtomicBool = AtomicBool::new(false);
 
+/// Count of video/audio pump threads leaked past `SHUTDOWN_JOIN_TIMEOUT` (see
+/// `session::join_with_timeout`), not yet confirmed exited. A leaked thread may still be
+/// inside an `NDL_Direct*` call and still holds a live `NdlVideo` with its own unsynchronized
+/// `ffi` mutex — a second `NDL_DirectMediaLoad` on top of that races it instead of starting
+/// clean, reproducing as an undecodable stream rather than a clean failure.
+///
+/// No way to force this: an OS thread can't be safely cancelled mid-FFI-call, and racing
+/// `NDL_DirectMediaUnload` against it is the exact hazard this guards against. So `load()`
+/// refuses while nonzero, and [`thread_recovered`] clears it in-process (no restart) once the
+/// leaked thread actually returns — its `NdlVideo::drop` has run the real unload by then.
+static LEAKED_THREADS: AtomicUsize = AtomicUsize::new(0);
+
+/// Marks one NDL-touching thread as leaked (see [`LEAKED_THREADS`]). Pair with exactly one
+/// later [`thread_recovered`] call once that same thread actually joins.
+pub fn poison() {
+    if LEAKED_THREADS.fetch_add(1, Ordering::SeqCst) == 0 {
+        tracing::error!(
+            "NDL poisoned: a decode thread is wedged past its join deadline — streaming \
+             refused until it actually finishes (no safe way to force it sooner)"
+        );
+    }
+}
+
+/// Call once the thread that triggered a matching [`poison`] actually finishes, however late —
+/// its `Arc<NdlVideo>` has dropped by then, which already ran the real `NDL_DirectMediaUnload`,
+/// so a fresh `load()` is safe again as soon as every leaked thread has cleared.
+pub fn thread_recovered() {
+    if LEAKED_THREADS.fetch_sub(1, Ordering::SeqCst) == 1 {
+        tracing::info!("NDL recovered: the wedged decode thread finished and unloaded cleanly — streaming re-enabled");
+    }
+}
+
+/// Whether any leaked thread might still be live — see [`LEAKED_THREADS`].
+pub fn is_poisoned() -> bool {
+    LEAKED_THREADS.load(Ordering::SeqCst) > 0
+}
+
+/// `Err` while [`is_poisoned`], with the message the user sees. One gate, one wording: `load()`
+/// enforces it and `session::connect` checks it early to avoid holding a host session slot for a
+/// connect that can only end here.
+pub fn ensure_not_poisoned() -> Result<()> {
+    if is_poisoned() {
+        bail!("NDL is still tearing down a wedged decode thread from the previous session — try reconnecting shortly");
+    }
+    Ok(())
+}
+
 /// Calls `NDL_DirectMediaInit` once (process-global, idempotent-guarded).
 fn ensure_init(app_id: &str) -> Result<()> {
     if INIT_DONE.swap(true, Ordering::SeqCst) {
@@ -250,6 +297,7 @@ impl NdlVideo {
     /// Load NDL video stream. Calls `NDL_DirectMediaInit` on first use.
     /// Audio request is a probe: fails silently on unsupported models, retries video-only.
     pub fn load(app_id: &str, width: i32, height: i32, codec: NdlCodec, audio: Option<NdlAudioConfig>) -> Result<Self> {
+        ensure_not_poisoned()?;
         ensure_init(app_id)?;
         let video = NdlVideoInfo {
             width,

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -147,12 +147,13 @@ pub(super) fn run_inner() -> Result<()> {
         // offload) — a second unfed audio device would still claim a PulseAudio sink.
         // The device is held here for the length of the stream — dropping it stops playback — while
         // the feed half moves to its own decode thread.
+        // The A/V loop arms only once the NDL present constant has been calibrated — the trim
+        // file's presence is that calibration. See `audio::AudioFeed::observe_av`.
+        let av_trim_ms = store::dev_override_av_trim_ms();
         let audio = match connected.audio_channels() {
             None => None,
             Some(channels) => {
-                // The A/V loop arms only once the NDL present constant has been calibrated — the
-                // trim file's presence is that calibration. See `audio::AudioFeed::observe_av`.
-                let av_calibrated = store::dev_override_av_trim_ms().is_some();
+                let av_calibrated = av_trim_ms.is_some();
                 match crate::platform::webos::audio::AudioPlayer::new(
                     &sdl_audio,
                     channels,
@@ -187,7 +188,7 @@ pub(super) fn run_inner() -> Result<()> {
                 "SDL audio driver: {}, spec: {:?}, A/V sync: {}",
                 sdl_audio.current_audio_driver(),
                 player.spec(),
-                match store::dev_override_av_trim_ms() {
+                match av_trim_ms {
                     Some(ms) => format!("armed (trim {ms} ms)"),
                     None => "measuring only (no av-trim-ms.conf)".to_string(),
                 },

--- a/src/services/store.rs
+++ b/src/services/store.rs
@@ -211,34 +211,37 @@ impl Drop for SettingsWriter {
     }
 }
 
-/// Test/dev override for NDL's undocumented frame-drop threshold: a single integer in
-/// `$HOME/ndl-drop-threshold.conf`, absent by default.
+/// One value, one file in `$HOME`, absent by default — the sweep-knob mechanism every
+/// `dev_override_*` below shares. Absent file, unreadable file and unparseable contents are all
+/// the same answer: `None`, i.e. use the compiled-in behaviour.
 ///
-/// Exists because the value's units aren't documented anywhere (the SDK header declares
-/// `NDL_DirectVideoSetFrameDropThreshold` and stops), so it has to be swept against real
-/// playback — and a full rebuild/redeploy per candidate value makes that impractical.
-/// Same reasoning, and the same mechanism, as `dev_override_connect` below.
-pub fn dev_override_ndl_drop_threshold() -> Option<i32> {
-    let path = Path::new(&app_dir()).join("ndl-drop-threshold.conf");
+/// These exist because their values cannot be derived from inside the app (undocumented SDK
+/// units, panel latency NDL never reports, a link that has to be measured), so they have to be
+/// swept against real playback — and a rebuild/redeploy per candidate makes that impractical.
+fn dev_override<T: std::str::FromStr>(file: &str) -> Option<T> {
+    let path = Path::new(&app_dir()).join(file);
     std::fs::read_to_string(path).ok()?.trim().parse().ok()
+}
+
+/// NDL's undocumented frame-drop threshold: `$HOME/ndl-drop-threshold.conf`. The SDK header
+/// declares `NDL_DirectVideoSetFrameDropThreshold` and says nothing about its units.
+pub fn dev_override_ndl_drop_threshold() -> Option<i32> {
+    dev_override("ndl-drop-threshold.conf")
 }
 
 /// A/V sync trim, in milliseconds: `$HOME/av-trim-ms.conf`, absent (⇒ 0) by default.
 ///
 /// This is NDL's decode + panel latency *after* its render queue drains — the one term of
 /// `session::sink::video_e2e_ns` the app cannot observe, because `NDL_DirectVideoPlay` reports
-/// nothing about presentation. It is a sweep knob for exactly the reason
-/// [`dev_override_ndl_drop_threshold`] is one: the value is unmeasurable from inside, so it has to
-/// be read off real playback, and a rebuild per candidate makes that impractical. Deliberately NOT
-/// a Settings row yet — what the default should be, and whether it even needs to be user-visible,
-/// is what the observe-only measurement decides (LG panels plausibly differ between Game Optimiser
-/// and the processing-heavy picture modes, which no single compiled-in constant would cover).
+/// nothing about presentation. Deliberately NOT a Settings row yet — what the default should be,
+/// and whether it even needs to be user-visible, is what the observe-only measurement decides (LG
+/// panels plausibly differ between Game Optimiser and the processing-heavy picture modes, which no
+/// single compiled-in constant would cover).
 ///
 /// Sign: this value is ADDED to the video leg, so raising it tells the sync loop the picture is
 /// later than it looked, and the loop answers by holding audio back. If audio runs early, raise it.
 pub fn dev_override_av_trim_ms() -> Option<u32> {
-    let path = Path::new(&app_dir()).join("av-trim-ms.conf");
-    std::fs::read_to_string(path).ok()?.trim().parse().ok()
+    dev_override("av-trim-ms.conf")
 }
 
 /// Test/dev override: a config file dropped alongside sideloading skips straight to

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -121,15 +121,14 @@ pub const SHUTDOWN_JOIN_TIMEOUT: Duration = Duration::from_secs(2);
 /// `timeout`. Returns `false` (and leaks the watcher, still waiting on the real join) if it
 /// didn't finish in time.
 ///
-/// `ndl_related` marks a thread that may still be calling into NDL (video/audio pumps, not the
-/// QUIC client-drop) — on timeout it poisons NDL (`ndl::poison`) and spawns a second, detached
-/// watcher that waits unboundedly for the real join, calling `ndl::thread_recovered()` to clear
-/// the poison once it lands. No faster recovery exists — see `ndl::LEAKED_THREADS`.
+/// `on_wedged` is handed the channel the (still-running) watcher reports the real join on, so a
+/// caller whose thread holds something the rest of the app must wait for can keep watching it —
+/// see [`ndl_leak_watch`]. Not called at all when the join lands in time.
 fn join_with_timeout<T: Send + 'static>(
     handle: std::thread::JoinHandle<T>,
     timeout: Duration,
     name: &str,
-    ndl_related: bool,
+    on_wedged: impl FnOnce(std::sync::mpsc::Receiver<()>),
 ) -> bool {
     let (tx, rx) = std::sync::mpsc::channel();
     let spawned = std::thread::Builder::new()
@@ -151,16 +150,32 @@ fn join_with_timeout<T: Send + 'static>(
             "{name} thread did not finish within {timeout:?} — leaking it \
              (likely a wedged NDL/FFI or QUIC-close call)"
         );
-        if ndl_related {
-            crate::platform::webos::ndl::poison();
-            // `watcher` keeps running `handle.join()` on its own; this just waits on its
-            // `tx` to notice when that finally lands, instead of leaving the leak permanent.
-            std::thread::spawn(move || {
-                let _ = rx.recv();
-                crate::platform::webos::ndl::thread_recovered();
-            });
-        }
+        on_wedged(rx);
         false
+    }
+}
+
+/// Refuses NDL until a wedged pump thread actually returns. `joined` is the leaked watcher's
+/// channel — it keeps running `handle.join()` regardless, so this only has to notice when that
+/// finally lands, instead of leaving the refusal permanent. No faster recovery exists: see
+/// `ndl::LEAKED_THREADS`.
+///
+/// Only for threads that may still be inside an `NDL_Direct*` call (the video/audio pumps). The
+/// QUIC client-drop wedges the same way but touches no NDL, so it passes `|_| {}`.
+fn ndl_leak_watch(joined: std::sync::mpsc::Receiver<()>) {
+    let guard = crate::platform::webos::ndl::poison();
+    let watching = std::thread::Builder::new()
+        .name("punktfunk-webos-ndl-leak".into())
+        .spawn(move || {
+            let _ = joined.recv();
+            drop(guard);
+        });
+    if watching.is_err() {
+        // The failed spawn dropped the guard with its closure, un-refusing NDL while the thread is
+        // still wedged. Nothing is left to observe the recovery, so refuse for the rest of the
+        // process — a restart is the only way back, which beats racing a live FFI call.
+        std::mem::forget(crate::platform::webos::ndl::poison());
+        tracing::error!("could not watch the wedged NDL thread — streaming refused until restart");
     }
 }
 
@@ -168,25 +183,24 @@ impl Connected {
     /// Stop and join threads, then drop `NativeClient`. Call `disconnect_quit()` first for
     /// graceful shutdown. Returns `false` if any step didn't finish within
     /// [`SHUTDOWN_JOIN_TIMEOUT`] — the caller must then skip `ndl::quit()`, since the thread
-    /// still running may still be inside an NDL FFI call that a concurrent unload would race.
-    /// A wedged video/audio join also poisons NDL until it actually finishes (see
-    /// `join_with_timeout`) — otherwise a later `NdlVideo::load()` would race whatever that
-    /// leaked thread is still doing.
+    /// still running may still be inside an NDL FFI call that a concurrent unload would race. A
+    /// wedged video/audio join additionally refuses new loads until it finishes — see
+    /// [`ndl_leak_watch`].
     pub fn shutdown(self) -> bool {
         self.stop.store(true, Ordering::Relaxed);
-        let mut clean = join_with_timeout(self.video_thread, SHUTDOWN_JOIN_TIMEOUT, "video", true);
+        let mut clean = join_with_timeout(self.video_thread, SHUTDOWN_JOIN_TIMEOUT, "video", ndl_leak_watch);
         if let Some(audio) = self.audio_thread {
-            clean &= join_with_timeout(audio, SHUTDOWN_JOIN_TIMEOUT, "audio", true);
+            clean &= join_with_timeout(audio, SHUTDOWN_JOIN_TIMEOUT, "audio", ndl_leak_watch);
         }
         // `NativeClient::drop` joins its own QUIC-close worker thread internally — bound
         // that the same way, on its own thread, rather than blocking here directly. Doesn't
-        // touch NDL, so a wedge here doesn't poison it, only skips `ndl::quit()` this run.
+        // touch NDL, so a wedge here doesn't refuse it, only skips `ndl::quit()` this run.
         let client = self.client;
         clean &= join_with_timeout(
             std::thread::spawn(move || drop(client)),
             SHUTDOWN_JOIN_TIMEOUT,
             "client-drop",
-            false,
+            |_| {},
         );
         clean
     }
@@ -1008,9 +1022,9 @@ pub fn spawn_audio_feed(
 
 /// Joins the audio feed thread, bounded by the same timeout every other teardown join uses — a
 /// thread wedged in an Opus decode must not hold the whole app on the way back to the menu.
-/// Software Opus → SDL2, not NDL, so a wedge here doesn't poison NDL.
+/// Software Opus → SDL2, not NDL, so a wedge here needs no [`ndl_leak_watch`].
 pub fn join_audio_feed(handle: std::thread::JoinHandle<()>) -> bool {
-    join_with_timeout(handle, SHUTDOWN_JOIN_TIMEOUT, "audio-feed", false)
+    join_with_timeout(handle, SHUTDOWN_JOIN_TIMEOUT, "audio-feed", |_| {})
 }
 
 /// Pulls Opus packets off the transport, decodes them, and hands the PCM to the playback ring.

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -121,21 +121,30 @@ pub const SHUTDOWN_JOIN_TIMEOUT: Duration = Duration::from_secs(2);
 /// `timeout`. Returns `false` (and leaks the watcher, still waiting on the real join) if it
 /// didn't finish in time.
 ///
-/// `on_wedged` is handed the channel the (still-running) watcher reports the real join on, so a
-/// caller whose thread holds something the rest of the app must wait for can keep watching it —
-/// see [`ndl_leak_watch`]. Not called at all when the join lands in time.
-fn join_with_timeout<T: Send + 'static>(
+/// On timeout, `on_wedged` returns a value the leaked watcher then holds until the real join lands
+/// and drops on its way out — how the video/audio pumps keep NDL refused for exactly as long as a
+/// wedged thread might still be inside it (`|| ndl::poison()`). The watcher already outlives the
+/// timeout, so this needs no second thread; threads with nothing to hold pass `|| ()`. Not called
+/// at all when the join lands in time.
+fn join_with_timeout<T: Send + 'static, G: Send + 'static>(
     handle: std::thread::JoinHandle<T>,
     timeout: Duration,
     name: &str,
-    on_wedged: impl FnOnce(std::sync::mpsc::Receiver<()>),
+    on_wedged: impl FnOnce() -> G,
 ) -> bool {
     let (tx, rx) = std::sync::mpsc::channel();
+    // The watcher blocks on this after joining, so the guard can only be dropped once the wedged
+    // thread has actually returned — and the send below cannot race that, because the watcher is
+    // not listening yet when the timeout fires.
+    let (wedged_tx, wedged_rx) = std::sync::mpsc::channel::<G>();
     let spawned = std::thread::Builder::new()
         .name(format!("punktfunk-webos-join-{name}"))
         .spawn(move || {
             let _ = handle.join();
             let _ = tx.send(());
+            // Either a guard to release (we were declared wedged) or a dropped sender (joined in
+            // time, nothing was ever taken out).
+            drop(wedged_rx.recv());
         });
     let Ok(watcher) = spawned else {
         // Can't even start the watcher — fall back to a direct (unbounded) join rather
@@ -143,6 +152,9 @@ fn join_with_timeout<T: Send + 'static>(
         return true;
     };
     if rx.recv_timeout(timeout).is_ok() {
+        // BEFORE the join: the watcher is parked on `wedged_rx.recv()` and only this sender going
+        // away releases it. Joining first would deadlock the teardown on a thread that finished.
+        drop(wedged_tx);
         let _ = watcher.join();
         true
     } else {
@@ -150,32 +162,11 @@ fn join_with_timeout<T: Send + 'static>(
             "{name} thread did not finish within {timeout:?} — leaking it \
              (likely a wedged NDL/FFI or QUIC-close call)"
         );
-        on_wedged(rx);
+        // Unbounded channel: never blocks, and the value stays queued for however long the wedged
+        // thread takes. A failed send would mean the watcher died with the guard, which drops it —
+        // correct either way, since a dead watcher means the join already returned.
+        let _ = wedged_tx.send(on_wedged());
         false
-    }
-}
-
-/// Refuses NDL until a wedged pump thread actually returns. `joined` is the leaked watcher's
-/// channel — it keeps running `handle.join()` regardless, so this only has to notice when that
-/// finally lands, instead of leaving the refusal permanent. No faster recovery exists: see
-/// `ndl::LEAKED_THREADS`.
-///
-/// Only for threads that may still be inside an `NDL_Direct*` call (the video/audio pumps). The
-/// QUIC client-drop wedges the same way but touches no NDL, so it passes `|_| {}`.
-fn ndl_leak_watch(joined: std::sync::mpsc::Receiver<()>) {
-    let guard = crate::platform::webos::ndl::poison();
-    let watching = std::thread::Builder::new()
-        .name("punktfunk-webos-ndl-leak".into())
-        .spawn(move || {
-            let _ = joined.recv();
-            drop(guard);
-        });
-    if watching.is_err() {
-        // The failed spawn dropped the guard with its closure, un-refusing NDL while the thread is
-        // still wedged. Nothing is left to observe the recovery, so refuse for the rest of the
-        // process — a restart is the only way back, which beats racing a live FFI call.
-        std::mem::forget(crate::platform::webos::ndl::poison());
-        tracing::error!("could not watch the wedged NDL thread — streaming refused until restart");
     }
 }
 
@@ -184,13 +175,14 @@ impl Connected {
     /// graceful shutdown. Returns `false` if any step didn't finish within
     /// [`SHUTDOWN_JOIN_TIMEOUT`] — the caller must then skip `ndl::quit()`, since the thread
     /// still running may still be inside an NDL FFI call that a concurrent unload would race. A
-    /// wedged video/audio join additionally refuses new loads until it finishes — see
-    /// [`ndl_leak_watch`].
+    /// wedged video/audio join additionally refuses new loads until it finishes — those two are the
+    /// threads that touch NDL.
     pub fn shutdown(self) -> bool {
+        use crate::platform::webos::ndl::poison;
         self.stop.store(true, Ordering::Relaxed);
-        let mut clean = join_with_timeout(self.video_thread, SHUTDOWN_JOIN_TIMEOUT, "video", ndl_leak_watch);
+        let mut clean = join_with_timeout(self.video_thread, SHUTDOWN_JOIN_TIMEOUT, "video", poison);
         if let Some(audio) = self.audio_thread {
-            clean &= join_with_timeout(audio, SHUTDOWN_JOIN_TIMEOUT, "audio", ndl_leak_watch);
+            clean &= join_with_timeout(audio, SHUTDOWN_JOIN_TIMEOUT, "audio", poison);
         }
         // `NativeClient::drop` joins its own QUIC-close worker thread internally — bound
         // that the same way, on its own thread, rather than blocking here directly. Doesn't
@@ -200,7 +192,7 @@ impl Connected {
             std::thread::spawn(move || drop(client)),
             SHUTDOWN_JOIN_TIMEOUT,
             "client-drop",
-            |_| {},
+            || (),
         );
         clean
     }
@@ -1022,9 +1014,9 @@ pub fn spawn_audio_feed(
 
 /// Joins the audio feed thread, bounded by the same timeout every other teardown join uses — a
 /// thread wedged in an Opus decode must not hold the whole app on the way back to the menu.
-/// Software Opus → SDL2, not NDL, so a wedge here needs no [`ndl_leak_watch`].
+/// Software Opus → SDL2, not NDL, so a wedge here needs no `ndl::poison()`.
 pub fn join_audio_feed(handle: std::thread::JoinHandle<()>) -> bool {
-    join_with_timeout(handle, SHUTDOWN_JOIN_TIMEOUT, "audio-feed", |_| {})
+    join_with_timeout(handle, SHUTDOWN_JOIN_TIMEOUT, "audio-feed", || ())
 }
 
 /// Pulls Opus packets off the transport, decodes them, and hands the PCM to the playback ring.

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -120,7 +120,17 @@ pub const SHUTDOWN_JOIN_TIMEOUT: Duration = Duration::from_secs(2);
 /// Joins `handle` from a watcher thread so a hang inside it can't block the caller past
 /// `timeout`. Returns `false` (and leaks the watcher, still waiting on the real join) if it
 /// didn't finish in time.
-fn join_with_timeout<T: Send + 'static>(handle: std::thread::JoinHandle<T>, timeout: Duration, name: &str) -> bool {
+///
+/// `ndl_related` marks a thread that may still be calling into NDL (video/audio pumps, not the
+/// QUIC client-drop) — on timeout it poisons NDL (`ndl::poison`) and spawns a second, detached
+/// watcher that waits unboundedly for the real join, calling `ndl::thread_recovered()` to clear
+/// the poison once it lands. No faster recovery exists — see `ndl::LEAKED_THREADS`.
+fn join_with_timeout<T: Send + 'static>(
+    handle: std::thread::JoinHandle<T>,
+    timeout: Duration,
+    name: &str,
+    ndl_related: bool,
+) -> bool {
     let (tx, rx) = std::sync::mpsc::channel();
     let spawned = std::thread::Builder::new()
         .name(format!("punktfunk-webos-join-{name}"))
@@ -141,6 +151,15 @@ fn join_with_timeout<T: Send + 'static>(handle: std::thread::JoinHandle<T>, time
             "{name} thread did not finish within {timeout:?} — leaking it \
              (likely a wedged NDL/FFI or QUIC-close call)"
         );
+        if ndl_related {
+            crate::platform::webos::ndl::poison();
+            // `watcher` keeps running `handle.join()` on its own; this just waits on its
+            // `tx` to notice when that finally lands, instead of leaving the leak permanent.
+            std::thread::spawn(move || {
+                let _ = rx.recv();
+                crate::platform::webos::ndl::thread_recovered();
+            });
+        }
         false
     }
 }
@@ -150,19 +169,24 @@ impl Connected {
     /// graceful shutdown. Returns `false` if any step didn't finish within
     /// [`SHUTDOWN_JOIN_TIMEOUT`] — the caller must then skip `ndl::quit()`, since the thread
     /// still running may still be inside an NDL FFI call that a concurrent unload would race.
+    /// A wedged video/audio join also poisons NDL until it actually finishes (see
+    /// `join_with_timeout`) — otherwise a later `NdlVideo::load()` would race whatever that
+    /// leaked thread is still doing.
     pub fn shutdown(self) -> bool {
         self.stop.store(true, Ordering::Relaxed);
-        let mut clean = join_with_timeout(self.video_thread, SHUTDOWN_JOIN_TIMEOUT, "video");
+        let mut clean = join_with_timeout(self.video_thread, SHUTDOWN_JOIN_TIMEOUT, "video", true);
         if let Some(audio) = self.audio_thread {
-            clean &= join_with_timeout(audio, SHUTDOWN_JOIN_TIMEOUT, "audio");
+            clean &= join_with_timeout(audio, SHUTDOWN_JOIN_TIMEOUT, "audio", true);
         }
         // `NativeClient::drop` joins its own QUIC-close worker thread internally — bound
-        // that the same way, on its own thread, rather than blocking here directly.
+        // that the same way, on its own thread, rather than blocking here directly. Doesn't
+        // touch NDL, so a wedge here doesn't poison it, only skips `ndl::quit()` this run.
         let client = self.client;
         clean &= join_with_timeout(
             std::thread::spawn(move || drop(client)),
             SHUTDOWN_JOIN_TIMEOUT,
             "client-drop",
+            false,
         );
         clean
     }
@@ -230,6 +254,9 @@ pub fn connect(
     gamepad_type: crate::services::store::GamepadType,
     cursor_capture: bool,
 ) -> Result<Connected> {
+    // Fails before touching the network: a full handshake would only end in `NdlVideo::load()`
+    // rejecting the same gate, pointlessly holding the host's pending-session slot for `timeout`.
+    crate::platform::webos::ndl::ensure_not_poisoned()?;
     // HDR only ever applies to HEVC. An explicit H.264 pick disables it end to end
     // (the Settings toggle is hidden too — see `ui::hdr_row_shown`); on Automatic the
     // caps are still advertised and the host resolves the codec, with application gated
@@ -833,7 +860,7 @@ fn video_pump(
                 stats.bytes.fetch_add(frame.data.len() as u64, Ordering::Relaxed);
                 if last_heartbeat.elapsed() >= Duration::from_secs(2) {
                     last_heartbeat = Instant::now();
-                    let backlog = sink.backlog();
+                    let backlog = sink.poll_backlog_depth();
                     stats.render_backlog.store(backlog.unwrap_or(-1), Ordering::Relaxed);
                     // `backlog` separates "the decoder is behind" from "frames are
                     // arriving late" — indistinguishable before this, since play()
@@ -845,7 +872,7 @@ fn video_pump(
                     // exactly the situation it exists for, a freeze reported off a
                     // plain sideloaded run with no telemetry listener. Half a line per
                     // second is affordable; a second round trip to reproduce is not.
-                    tracing::debug!(
+                    tracing::info!(
                         "video: {frames_received} frames, holding={}, dropped={}, backlog={}",
                         sink.holding(),
                         client.frames_dropped(),
@@ -889,7 +916,7 @@ fn video_pump(
                     // INFO for the same reason as the main heartbeat above — and this
                     // arm is the one that says "nothing is arriving at all", which is a
                     // different fault from "arriving but not presenting".
-                    tracing::debug!("video: {frames_received} frames (idle)");
+                    tracing::info!("video: {frames_received} frames (idle)");
                 }
             }
             Err(e) => {
@@ -981,8 +1008,9 @@ pub fn spawn_audio_feed(
 
 /// Joins the audio feed thread, bounded by the same timeout every other teardown join uses — a
 /// thread wedged in an Opus decode must not hold the whole app on the way back to the menu.
+/// Software Opus → SDL2, not NDL, so a wedge here doesn't poison NDL.
 pub fn join_audio_feed(handle: std::thread::JoinHandle<()>) -> bool {
-    join_with_timeout(handle, SHUTDOWN_JOIN_TIMEOUT, "audio-feed")
+    join_with_timeout(handle, SHUTDOWN_JOIN_TIMEOUT, "audio-feed", false)
 }
 
 /// Pulls Opus packets off the transport, decodes them, and hands the PCM to the playback ring.

--- a/src/session/sink.rs
+++ b/src/session/sink.rs
@@ -94,9 +94,7 @@ fn video_e2e_ns(
 /// Split out as a free function purely so it is testable — [`NdlSink`] owns a live NDL handle and
 /// cannot be built off-device.
 fn decode_report_us(feed_elapsed: Duration, backlog: u64, cushion: u64, frame_interval_ns: u64) -> u32 {
-    let queued_ns = backlog
-        .saturating_sub(cushion)
-        .saturating_mul(frame_interval_ns);
+    let queued_ns = backlog.saturating_sub(cushion).saturating_mul(frame_interval_ns);
     let decode_us = u64::try_from(feed_elapsed.as_micros())
         .unwrap_or(u64::MAX)
         .saturating_add(queued_ns / 1_000);
@@ -308,23 +306,19 @@ impl NdlSink {
     /// `None` is a failed query, not an empty queue.
     ///
     /// Called unconditionally, because it has TWO consumers: the ABR decode figure
-    /// ([`Self::decode_us`]) and the A/V sync loop's video reference ([`video_e2e_ns`]). It used to
-    /// live inside `decode_us`, which runs only when the host asked for decode latency — so against
-    /// any host that did not, the cached depth stayed pinned at `0` for the entire session, silently
-    /// zeroing the queue term in the video reference while every number still looked plausible.
+    /// ([`Self::decode_us`]) and the A/V sync loop's video reference ([`video_e2e_ns`]). Polling it
+    /// only when the host asks for decode latency pins the depth at `0` against hosts that never
+    /// do, silently zeroing the queue term in the video reference.
     fn poll_backlog(&mut self) -> Option<u64> {
         if self.last_backlog_poll.is_none_or(|t| t.elapsed() >= BACKLOG_POLL) {
             self.last_backlog_poll = Some(Instant::now());
-            self.backlog_cached = self
-                .player
-                .render_buffer_length()
-                .and_then(|b| u64::try_from(b).ok());
+            self.backlog_cached = self.player.render_buffer_length().and_then(|b| u64::try_from(b).ok());
             // A freeze flushes NDL, so a depth polled while held is an emptied buffer, not this
             // mode's settled lead. Learning from it would clamp the cushion back to the floor for
             // [`CUSHION_MIN_POLLS`] after every loss event — and at 60Hz one unaccounted frame is
             // 16.6ms, straight back over the ABR's decode-rise threshold. The cached depth itself
             // still updates: A/V sync wants the truth, only the learned cushion is held steady.
-            if let (false, Some(depth)) = (self.holding(), self.backlog_cached) {
+            if let Some(depth) = self.backlog_cached.filter(|_| !self.holding()) {
                 if self.backlog_recent.len() == CUSHION_MIN_POLLS {
                     self.backlog_recent.pop_front();
                 }
@@ -365,8 +359,7 @@ impl NdlSink {
     /// is the one the decode figure was computed from — a second, unsynchronized reading can
     /// disagree with it — and every `NDL_DirectVideoGetRenderBufferLength` stays on one cadence.
     pub fn poll_backlog_depth(&mut self) -> Option<i32> {
-        self.poll_backlog()
-            .map(|d| i32::try_from(d).unwrap_or(i32::MAX))
+        self.poll_backlog().map(|d| i32::try_from(d).unwrap_or(i32::MAX))
     }
 
     /// Present one access unit, or decide not to. `pts_ns` is the host's capture-clock

--- a/src/session/sink.rs
+++ b/src/session/sink.rs
@@ -23,6 +23,28 @@ const FEED_BACKPRESSURE_WARN: Duration = Duration::from_millis(20);
 /// How often the sink refreshes NDL's render-buffer depth for the decode-latency signal —
 /// three samples per 750 ms ABR report window; see [`NdlSink::decode_us`].
 const BACKLOG_POLL: Duration = Duration::from_millis(250);
+/// Render-buffer frames NDL holds as a *standing* present cushion, excluded from the ABR decode
+/// figure (see [`NdlSink::decode_us`]). NDL presents off its own clock, so a healthy session
+/// sits at 1-2 frames of depth indefinitely — lead, not backlog. Folded in raw it manufactures a
+/// constant 8-17ms of apparent decode latency, crossing `abr`'s 15ms decode-rise threshold and
+/// backing off bitrate for no real reason (observed on the CX 2026-08-10: 1440p120 driven from
+/// 25 Mbps to the 5 Mbps floor with zero loss and flat OWD). Subtracting it keeps the real
+/// signal — a queue that GROWS past this is genuine falling-behind — while dropping the constant.
+///
+/// Only a floor: the settled depth is NDL's business and one frame is 16.6ms at 60Hz, so a mode
+/// idling at three frames would reproduce the bug against a fixed two. The excluded depth is the
+/// rolling min over [`CUSHION_MIN_POLLS`], clamped into this..=[`CUSHION_MAX_FRAMES`] — this value
+/// covers only the first seconds, before that minimum has seen a settled queue.
+const STANDING_CUSHION_FRAMES: u64 = 2;
+/// Polls whose minimum depth is the self-calibrating cushion (see [`STANDING_CUSHION_FRAMES`]).
+/// 20 × [`BACKLOG_POLL`] = 5s: long enough that `abr`'s two-window (1.5s) decode backoff still
+/// fires on a queue that genuinely grows, short enough to follow a mode or content change.
+const CUSHION_MIN_POLLS: usize = 20;
+/// Ceiling on the self-calibrated cushion. Without it, a decoder that stays overloaded for longer
+/// than [`CUSHION_MIN_POLLS`] teaches the rolling minimum its own backlog and the signal goes
+/// quiet — the same baseline-absorption trap this fix exists to escape, just faster. Lead is a
+/// couple of frames by construction, so anything past this is queue, and queue must stay visible.
+const CUSHION_MAX_FRAMES: u64 = 4;
 
 /// This frame's video end-to-end latency, in the shape [`punktfunk_core::audio::AvSync`] compares
 /// against: the instant it reaches the glass expressed in the HOST capture clock, minus its host
@@ -63,6 +85,33 @@ fn video_e2e_ns(
         .checked_add(i128::from(pipeline_ns))?
         .checked_add(i128::from(clock_offset_ns))?;
     u64::try_from(glass_host_ns.checked_sub(i128::from(frame_pts_ns))?).ok()
+}
+
+/// The decode-stage latency reported to `punktfunk_core::abr`: submission time plus the part of
+/// NDL's render queue that is genuinely backlog. See [`NdlSink::decode_us`] for why the queue
+/// belongs in it at all, and [`STANDING_CUSHION_FRAMES`] for why `cushion` comes out first.
+///
+/// Split out as a free function purely so it is testable — [`NdlSink`] owns a live NDL handle and
+/// cannot be built off-device.
+fn decode_report_us(feed_elapsed: Duration, backlog: u64, cushion: u64, frame_interval_ns: u64) -> u32 {
+    let queued_ns = backlog
+        .saturating_sub(cushion)
+        .saturating_mul(frame_interval_ns);
+    let decode_us = u64::try_from(feed_elapsed.as_micros())
+        .unwrap_or(u64::MAX)
+        .saturating_add(queued_ns / 1_000);
+    u32::try_from(decode_us).unwrap_or(u32::MAX)
+}
+
+/// The depth [`decode_report_us`] treats as present lead rather than backlog: the rolling minimum
+/// of recent poll samples, clamped into [`STANDING_CUSHION_FRAMES`]..=[`CUSHION_MAX_FRAMES`].
+/// Empty (no poll yet) yields the floor, never 0 — a session's first windows are exactly when the
+/// buffer is still filling and a raw fold does its damage.
+fn cushion_frames(samples: impl Iterator<Item = u64>) -> u64 {
+    samples
+        .min()
+        .unwrap_or(0)
+        .clamp(STANDING_CUSHION_FRAMES, CUSHION_MAX_FRAMES)
 }
 
 /// What the pump knows about a frame that the sink can't work out for itself.
@@ -169,20 +218,26 @@ pub struct NdlSink {
     player: VideoPlayer,
     stats: Arc<StreamStats>,
     cfg: SinkConfig,
-    frame_period_us: u64,
     /// The panel's actual drain cadence, reconciled against the stream rate — the same interval
     /// the pacer runs on. NDL drains at panel cadence whether or not pacing is enabled, so this,
-    /// not the stream rate, is what converts a render-queue depth into time in [`video_e2e_ns`].
+    /// not the stream rate, is what converts a render-queue depth into time — for BOTH consumers of
+    /// that conversion ([`video_e2e_ns`] and [`NdlSink::decode_us`]), so one depth cannot mean two
+    /// different latencies.
     frame_interval_ns: u64,
     /// Always instantiated — the Blue button can flip pacing on mid-stream, so the state
-    /// must exist even when it starts off. Pacer interval reconciles against the panel's
-    /// measured refresh; the backlog fold stays on the stream rate (host's actual cadence).
+    /// must exist even when it starts off.
     pacer: PtsPacer,
     /// NDL host-PTS→player-clock mapping, reset in lockstep with the pacer.
     host_anchor: HostPtsAnchor,
     /// Previous-frame pacing state, so an off→on flip can re-anchor cleanly.
     pacing_was_on: bool,
-    backlog_cached: u64,
+    /// Last polled depth, `None` if that query failed — which must not read as an empty queue.
+    backlog_cached: Option<u64>,
+    /// Recent poll depths, newest last — their minimum is the cushion the decode figure excludes
+    /// (see [`STANDING_CUSHION_FRAMES`]). Bounded at [`CUSHION_MIN_POLLS`].
+    backlog_recent: std::collections::VecDeque<u64>,
+    /// Cached [`Self::refresh_cushion`] result — read per presented frame, written per poll.
+    cushion_frames: u64,
     last_backlog_poll: Option<Instant>,
     last_keyframe_request: Option<Instant>,
     /// Freeze-until-reanchor: while holding, frames are skipped rather than fed — the
@@ -201,13 +256,14 @@ impl NdlSink {
         Self {
             player,
             stats,
-            frame_period_us: 1_000_000 / u64::from(stream_hz),
             frame_interval_ns,
             pacer: PtsPacer::new(frame_interval_ns),
             host_anchor: HostPtsAnchor::new(),
             pacing_was_on,
             cfg,
-            backlog_cached: 0,
+            backlog_cached: None,
+            backlog_recent: std::collections::VecDeque::with_capacity(CUSHION_MIN_POLLS),
+            cushion_frames: STANDING_CUSHION_FRAMES,
             last_backlog_poll: None,
             last_keyframe_request: None,
             hold_started: None,
@@ -240,34 +296,41 @@ impl NdlSink {
     /// stays fast, which left the controller's decode-rise signal (`abr::DECODE_RISE_US`,
     /// built precisely for "the decoder saturates before the link does") effectively
     /// blind on this client. The render-buffer backlog IS that standing decode queue, so
-    /// it's folded in as `backlog × frame_period`. Polled on a cadence rather than every
-    /// frame — three samples per 750 ms ABR report window is plenty, and assuming an NDL
-    /// query is cheap enough for per-frame use is exactly the mistake docs/NOTES.md warns
-    /// against; between polls the cached depth is reused.
-    fn decode_us(&mut self, feed_elapsed: Duration, backlog: u64) -> u32 {
-        let decode_us = u64::try_from(feed_elapsed.as_micros())
-            .unwrap_or(u64::MAX)
-            .saturating_add(backlog.saturating_mul(self.frame_period_us));
-        u32::try_from(decode_us).unwrap_or(u32::MAX)
+    /// it's folded in as queue-above-cushion × the drain interval (see [`decode_report_us`]).
+    /// Polled on a cadence rather than every frame — three samples per 750 ms ABR report window is
+    /// plenty, and assuming an NDL query is cheap enough for per-frame use is exactly the mistake
+    /// docs/NOTES.md warns against; between polls the cached depth is reused.
+    fn decode_us(&self, feed_elapsed: Duration, backlog: u64) -> u32 {
+        decode_report_us(feed_elapsed, backlog, self.cushion_frames, self.frame_interval_ns)
     }
 
     /// NDL's render-queue depth, refreshed on [`BACKLOG_POLL`]'s cadence and cached between polls.
+    /// `None` is a failed query, not an empty queue.
     ///
-    /// Called unconditionally, because it now has TWO consumers: the ABR decode figure
+    /// Called unconditionally, because it has TWO consumers: the ABR decode figure
     /// ([`Self::decode_us`]) and the A/V sync loop's video reference ([`video_e2e_ns`]). It used to
     /// live inside `decode_us`, which runs only when the host asked for decode latency — so against
-    /// any host that did not, the cached depth stayed pinned at `0` for the entire session. That
-    /// would have silently zeroed the queue term in the video reference, i.e. deleted the one part
-    /// of the estimate that actually tracks the decoder falling behind, while every number involved
-    /// still looked plausible.
-    fn poll_backlog(&mut self) -> u64 {
+    /// any host that did not, the cached depth stayed pinned at `0` for the entire session, silently
+    /// zeroing the queue term in the video reference while every number still looked plausible.
+    fn poll_backlog(&mut self) -> Option<u64> {
         if self.last_backlog_poll.is_none_or(|t| t.elapsed() >= BACKLOG_POLL) {
             self.last_backlog_poll = Some(Instant::now());
             self.backlog_cached = self
                 .player
                 .render_buffer_length()
-                .and_then(|b| u64::try_from(b).ok())
-                .unwrap_or(0);
+                .and_then(|b| u64::try_from(b).ok());
+            // A freeze flushes NDL, so a depth polled while held is an emptied buffer, not this
+            // mode's settled lead. Learning from it would clamp the cushion back to the floor for
+            // [`CUSHION_MIN_POLLS`] after every loss event — and at 60Hz one unaccounted frame is
+            // 16.6ms, straight back over the ABR's decode-rise threshold. The cached depth itself
+            // still updates: A/V sync wants the truth, only the learned cushion is held steady.
+            if let (false, Some(depth)) = (self.holding(), self.backlog_cached) {
+                if self.backlog_recent.len() == CUSHION_MIN_POLLS {
+                    self.backlog_recent.pop_front();
+                }
+                self.backlog_recent.push_back(depth);
+                self.cushion_frames = cushion_frames(self.backlog_recent.iter().copied());
+            }
         }
         self.backlog_cached
     }
@@ -296,9 +359,14 @@ impl NdlSink {
         self.hold_started.is_some()
     }
 
-    /// Decoder backlog depth, or `None` if the backend can't report one.
-    pub fn backlog(&self) -> Option<i32> {
-        self.player.render_buffer_length()
+    /// Decoder backlog depth for the heartbeat/overlay, or `None` if NDL can't report one.
+    ///
+    /// Polls ([`Self::poll_backlog`]) rather than querying NDL directly, so the depth the log prints
+    /// is the one the decode figure was computed from — a second, unsynchronized reading can
+    /// disagree with it — and every `NDL_DirectVideoGetRenderBufferLength` stays on one cadence.
+    pub fn poll_backlog_depth(&mut self) -> Option<i32> {
+        self.poll_backlog()
+            .map(|d| i32::try_from(d).unwrap_or(i32::MAX))
     }
 
     /// Present one access unit, or decide not to. `pts_ns` is the host's capture-clock
@@ -376,7 +444,9 @@ impl NdlSink {
             );
         }
 
-        let backlog = self.poll_backlog();
+        // A failed query counts as no queue for both consumers below: neither the ABR figure nor the
+        // A/V reference has a better guess, and both already treat 0 as "nothing to add".
+        let backlog = self.poll_backlog().unwrap_or(0);
         if play_result.is_ok() {
             // Only a frame NDL actually accepted is on its way to the glass. A failed feed is
             // followed by a flush and a hold below, where the reference would be meaningless.
@@ -408,7 +478,9 @@ impl NdlSink {
 
 #[cfg(test)]
 mod tests {
-    use super::video_e2e_ns;
+    use std::time::Duration;
+
+    use super::{cushion_frames, decode_report_us, video_e2e_ns, CUSHION_MAX_FRAMES, STANDING_CUSHION_FRAMES};
 
     /// 60 Hz, the cadence the pacing grid reconciles to on most panels.
     const HZ60_NS: u64 = 16_666_666;
@@ -478,5 +550,65 @@ mod tests {
         assert_eq!(video_e2e_ns(i128::MIN, i64::MIN, u64::MAX, 0, 0, 0), None);
         // A saturating queue term must not wrap into a small, believable-looking number.
         assert_eq!(video_e2e_ns(SUBMIT, 0, PTS, u64::MAX, HZ60_NS, 0), None);
+    }
+
+    /// 120 Hz — the mode the ABR collapse was observed at (CX, 2026-08-10).
+    const HZ120_NS: u64 = 8_333_333;
+    const FEED: Duration = Duration::from_micros(400);
+
+    /// The regression the cushion exists for: folded in raw, a standing 2-frame lead reported
+    /// ~16.8 ms of "decode latency" every window and walked the rate to the floor. At the settled
+    /// depth the report must be feed time and nothing else.
+    #[test]
+    fn a_standing_present_cushion_reports_no_decode_latency() {
+        for depth in 0..=STANDING_CUSHION_FRAMES {
+            assert_eq!(
+                decode_report_us(FEED, depth, STANDING_CUSHION_FRAMES, HZ120_NS),
+                400,
+                "depth {depth} should read as lead, not queue"
+            );
+        }
+    }
+
+    /// The signal the fold exists for, still intact: a queue GROWING past the cushion is the
+    /// decoder falling behind, and each extra frame is one drain interval of real latency.
+    #[test]
+    fn queue_above_the_cushion_is_reported() {
+        let two_over = decode_report_us(FEED, STANDING_CUSHION_FRAMES + 2, STANDING_CUSHION_FRAMES, HZ120_NS);
+        assert_eq!(two_over, 400 + 2 * 8_333);
+        // And deeper is strictly worse — monotonic, or the controller can't act on it.
+        let one_over = decode_report_us(FEED, STANDING_CUSHION_FRAMES + 1, STANDING_CUSHION_FRAMES, HZ120_NS);
+        assert!(two_over > one_over, "{two_over} !> {one_over}");
+    }
+
+    /// Runs on the video thread per presented frame, so garbage must saturate rather than panic or
+    /// wrap into a believable figure (`u32::MAX` µs is ~71 min — no threshold mistakes it for calm).
+    #[test]
+    fn an_implausible_queue_saturates_instead_of_wrapping() {
+        assert_eq!(decode_report_us(FEED, u64::MAX, 0, u64::MAX), u32::MAX);
+        assert_eq!(decode_report_us(Duration::MAX, 0, 0, HZ120_NS), u32::MAX);
+    }
+
+    /// No samples yet is exactly when a raw fold does its damage — the buffer is still filling — so
+    /// assume the cushion rather than an empty queue.
+    #[test]
+    fn the_cushion_never_starts_at_zero() {
+        assert_eq!(cushion_frames(std::iter::empty()), STANDING_CUSHION_FRAMES);
+        assert_eq!(cushion_frames([0, 0, 1].into_iter()), STANDING_CUSHION_FRAMES);
+    }
+
+    /// A mode that settles deeper than the floor teaches its own lead — one frame is 16.6 ms at
+    /// 60 Hz, so a fixed floor of two would put such a mode straight back over the threshold.
+    #[test]
+    fn a_deeper_settled_queue_raises_the_cushion() {
+        assert_eq!(cushion_frames([4, 3, 5, 3].into_iter()), 3);
+    }
+
+    /// …but only so far. A decoder that stays overloaded past the sample window would otherwise
+    /// teach the minimum its own backlog and mute the signal — the same baseline-absorption trap
+    /// this fix exists to escape, just faster.
+    #[test]
+    fn a_sustained_overload_cannot_teach_the_cushion_away() {
+        assert_eq!(cushion_frames([40, 38, 44].into_iter()), CUSHION_MAX_FRAMES);
     }
 }


### PR DESCRIPTION
Automatic bitrate was pinned at 5-6 Mbps. Turned out we were lying to core's ABR controller.

The decode latency we report folded NDL's entire render-buffer depth in raw. NDL presents off its own clock and holds a standing 1-2 frames of lead, so every window reported ~16.8 ms of "decode latency" (2 x the 8333 us frame period at 120 Hz) — past `abr::DECODE_RISE_US` (15 ms). Core's decode baseline is a 30 s rolling minimum and it latched low while the buffer was still filling, so the cascade ran 25207 -> 17644 -> 12350 -> 8645 -> 5000 kbps with `loss_ppm=0`, OWD falling and encode flat. Well inside 30 s, so the baseline never caught up.

Fix is to subtract the lead before folding: rolling min over the last 5 s of polls, clamped to 2..=4 frames.

- the floor covers a session's first seconds, before any settled sample exists
- the rolling min follows a mode that settles deeper — one frame is 16.6 ms at 60 Hz, so a fixed floor of two would reproduce this elsewhere
- the ceiling stops a sustained overload teaching the minimum its own backlog and muting the signal
- the cushion doesn't learn while frozen, since a flush empties the buffer

A queue growing past the cushion still reports, which is the whole point of folding it in.

1080p60 now climbs to ~100 Mbps where it was stuck at 5-6. Ceiling still comes from core's startup probe — no compiled-in cap, the probe measures the actual link.

Swept up while in here:

- both consumers of the queue-to-time conversion use the panel-reconciled interval, so one depth can't mean two different latencies
- video heartbeat logs at INFO, as its own comment already argued for: the on-device file sink is INFO-only, so the line that says whether NDL drains what it's fed was invisible without a telemetry listener
- `backlog()` reads the cached poll instead of firing a second unsynchronized NDL query, and a failed query is `None` rather than a fake empty queue
- one `ndl::ensure_not_poisoned()` instead of the same message bail'd in two layers, and the three `$HOME` conf readers collapse onto one generic

Tests: 6 new ones over the extracted cushion/decode helpers (settled cushion reports feed only, growth still reports and is monotonic, garbage saturates, cushion never starts at 0, deeper mode raises it, sustained overload can't erase it).

Verified on the CX at 1080p60. 1440p120 — the mode it was originally reported at — still wants a look.