### PR TITLE
Don't uncover the video plane before a frame has reached the decoder

### DIFF
--- a/src/app/hero.rs
+++ b/src/app/hero.rs
@@ -19,7 +19,7 @@ pub(crate) struct Hero {
     wanted: Option<String>,
     /// Id whose hero belongs on the connecting screen. `None` for Desktop.
     target: Option<String>,
-    /// Whether this launch's hero is still in flight: the menu loop waits a moment for art on
+    /// Whether this launch's hero is still in flight: the loading screen waits a moment for art on
     /// its way, but must not delay a launch with nothing to wait for.
     expected: bool,
     /// Id currently uploaded as `TileId::Hero`. Uploaded only once a launch starts —
@@ -123,10 +123,10 @@ impl Hero {
     /// Whether the loading screen is finished, so the streaming loop can take the screen.
     /// Also what starts the fade-out, once everything else it waits on is satisfied.
     ///
-    /// `presenting` is the decoder reporting live frames. The backdrop waits for it, so the
-    /// fade-out is the last thing that happens before the plane is uncovered rather than leaving
-    /// black in between — with no hero this is not consulted at all, and the plain fade to black
-    /// hands over exactly as it always did.
+    /// `presenting` is a frame having reached the decoder — NOT NDL's `PLAYING`, which lands
+    /// during the load with nothing decoded. With a hero to pan, the screen waits for it so the
+    /// fade-out is the last thing before the plane is uncovered; with none, `runtime::stream` holds
+    /// the finished launch frame instead, on the same [`ui::FIRST_FRAME_WAIT`] budget.
     pub(crate) fn handover_ready(&mut self, launch_elapsed: Duration, connected: bool, presenting: bool) -> bool {
         if launch_elapsed < ui::LAUNCH_FADE {
             return false;
@@ -137,16 +137,15 @@ impl Hero {
             return true;
         }
         if !self.showing() {
-            // Nothing on screen: hand over at the end of the fade, as it always did. A game
-            // that *has* wide art gets a grace period first — on a cold cache the hero can
-            // still be a fetch away, and would otherwise land just after the hand-off.
-            return !self.expected || launch_elapsed >= ui::LAUNCH_FADE + ui::STREAM_REVEAL_WAIT;
+            // No hero to hold the wait: hand over at the end of the fade, and `runtime::stream`
+            // keeps that finished frame up until the first frame arrives. A game that *has* wide
+            // art gets a grace period first — on a cold cache the hero can still be a fetch away,
+            // and would otherwise land just after the hand-off.
+            return !self.expected || launch_elapsed >= ui::LAUNCH_FADE + ui::HERO_ART_GRACE;
         }
-        // Held until the stream is genuinely up: the handshake landed *and* the decoder is
-        // presenting, so the fade-out runs straight into live video. Deliberately un-timed — a
-        // player that isn't ready yet is what this screen exists for, so it keeps panning rather
-        // than cut to a stream opening on black. Plus its own minimum, so a hero that arrived
-        // late isn't cut mid-fade.
+        // Held until the stream is genuinely up: the handshake landed *and* a frame reached the
+        // decoder, so the fade-out runs straight into live video rather than cutting to black. Its
+        // own minimum too, so a hero that arrived late isn't cut mid-fade.
         connected && presenting && self.since.is_some_and(|t| t.elapsed() >= ui::HERO_MIN_SHOW) && self.faded_out()
     }
 

--- a/src/platform/webos/ndl.rs
+++ b/src/platform/webos/ndl.rs
@@ -1,7 +1,7 @@
 //! Safe wrapper over webOS's NDL `DirectMedia` v2 API (`NDL_Direct*`, webOS 5+).
 //! Video only; audio via SDL2. Never calls `NDL_DirectVideoSetArea` (causes stutter above 1080p).
 use std::ffi::{c_char, c_int, c_longlong, c_uint, c_void, CStr, CString};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::Instant;
 
 use anyhow::{bail, Result};
@@ -157,26 +157,49 @@ const OPUS_EMPTY_FRAME: [u8; 3] = [0xec, 0xff, 0xfe];
 /// but a model that never delivers the callback must still stream.
 const LOAD_COMPLETE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(2_000);
 
-/// Process-global like the NDL session itself (one load at a time); cleared right before
-/// each `NDL_DirectMediaLoad`.
-static LOAD_COMPLETED: AtomicBool = AtomicBool::new(false);
-/// The only signal the present pipeline actually started (docs/NDL-FRAMERATE-INVESTIGATION.md).
-/// Arrives only once frames are being fed, so it gates *revealing* the plane, never the feed.
-static PLAYING: AtomicBool = AtomicBool::new(false);
+/// Grace for a rejected load's callbacks to land before the video-only retry arms. The callback
+/// carries nothing identifying its load, so separating the two in TIME is the only way to stop a
+/// stale `LOADCOMPLETED` satisfying the retry's wait — and feeding an unloaded decoder is what
+/// turns a launch black.
+const CALLBACK_SETTLE: std::time::Duration = std::time::Duration::from_millis(400);
 
-/// Records NDL load-state transitions so `load()` and the UI reveal can wait on them.
+/// How long past `load()` [`NdlVideo::ensure_loaded`] holds frames while `LOADCOMPLETED` is
+/// missing. Measured from the load, so it follows [`LOAD_COMPLETE_TIMEOUT`].
+const FEED_ANYWAY_AFTER: std::time::Duration = std::time::Duration::from_millis(1_000);
+
+/// Counters, not flags: a late event still increments, so it stays attributable to the load it
+/// came from — a per-load sticky bool cannot tell "this load completed" from "the previous one's
+/// callback arrived a moment too late". Process-global like the NDL session itself.
+static LOAD_COMPLETED_SEQ: AtomicU64 = AtomicU64::new(0);
+static UNLOAD_COMPLETED_SEQ: AtomicU64 = AtomicU64::new(0);
+/// NDL's own present-pipeline signal (docs/NDL-FRAMERATE-INVESTIGATION.md). Measured on a G5:
+/// it lands during `load()`, BEFORE any frame is fed, so it says nothing about there being a
+/// picture — kept for the log line only, never as a reveal gate (see [`PRESENTED_SEQ`]).
+static PLAYING_SEQ: AtomicU64 = AtomicU64::new(0);
+/// Bumped by the first `play()` NDL accepts for the armed load. This, not `PLAYING`, is what
+/// makes uncovering the punch-through plane safe: before it there is provably nothing on the
+/// plane, and a host that delivers its first frame seconds late (new-flow stall, startup
+/// capacity probe) would otherwise show as seconds of black.
+static PRESENTED_SEQ: AtomicU64 = AtomicU64::new(0);
+/// Counter values as of the current load, stamped by [`arm_load`]. Anything at or below these
+/// belongs to an earlier load.
+static LOAD_COMPLETED_BASE: AtomicU64 = AtomicU64::new(0);
+static PLAYING_BASE: AtomicU64 = AtomicU64::new(0);
+static PRESENTED_BASE: AtomicU64 = AtomicU64::new(0);
+
+/// Records NDL load-state transitions so `load()`, `play()` and the UI reveal can wait on them.
 extern "C" fn on_load_state(state: c_int, _num: c_longlong, _str: *const c_char) {
     let name = match state {
         NDL_STATE_LOADCOMPLETED => {
-            LOAD_COMPLETED.store(true, Ordering::SeqCst);
+            LOAD_COMPLETED_SEQ.fetch_add(1, Ordering::SeqCst);
             "LOADCOMPLETED"
         }
-        // Clears nothing: the audio-offload probe unloads then re-loads video-only, so this
-        // can land AFTER the retry's LOADCOMPLETED. `load()` and `Drop` reset the flags —
-        // they know which load they mean.
-        NDL_STATE_UNLOADCOMPLETED => "UNLOADCOMPLETED",
+        NDL_STATE_UNLOADCOMPLETED => {
+            UNLOAD_COMPLETED_SEQ.fetch_add(1, Ordering::SeqCst);
+            "UNLOADCOMPLETED"
+        }
         NDL_STATE_PLAYING => {
-            PLAYING.store(true, Ordering::SeqCst);
+            PLAYING_SEQ.fetch_add(1, Ordering::SeqCst);
             "PLAYING"
         }
         _ => "other",
@@ -184,15 +207,45 @@ extern "C" fn on_load_state(state: c_int, _num: c_longlong, _str: *const c_char)
     tracing::info!("NDL load state: {name} (0x{state:x})");
 }
 
-/// `PLAYING` for the current load: the plane is presenting and safe to uncover.
-pub fn playing() -> bool {
-    PLAYING.load(Ordering::SeqCst)
+/// Takes the counters as the baseline for the load about to be issued. Call immediately before
+/// every `NDL_DirectMediaLoad`, and after an unload so `playing()` stops reporting a dead load.
+fn arm_load() {
+    LOAD_COMPLETED_BASE.store(LOAD_COMPLETED_SEQ.load(Ordering::SeqCst), Ordering::SeqCst);
+    PLAYING_BASE.store(PLAYING_SEQ.load(Ordering::SeqCst), Ordering::SeqCst);
+    PRESENTED_BASE.store(PRESENTED_SEQ.load(Ordering::SeqCst), Ordering::SeqCst);
 }
 
-/// Blocks until the `LOADCOMPLETED` callback lands. Returns `false` on timeout.
+/// Whether `LOADCOMPLETED` has landed for the armed load.
+fn load_completed() -> bool {
+    LOAD_COMPLETED_SEQ.load(Ordering::SeqCst) > LOAD_COMPLETED_BASE.load(Ordering::SeqCst)
+}
+
+/// `PLAYING` for the current load. Diagnostics only — see [`PLAYING_SEQ`].
+pub fn playing() -> bool {
+    PLAYING_SEQ.load(Ordering::SeqCst) > PLAYING_BASE.load(Ordering::SeqCst)
+}
+
+/// Whether a frame of the current load has reached NDL: the plane has a picture and is safe to
+/// uncover.
+pub fn presenting() -> bool {
+    PRESENTED_SEQ.load(Ordering::SeqCst) > PRESENTED_BASE.load(Ordering::SeqCst)
+}
+
+/// Lets the rejected audio-enabled load's callbacks land before the video-only retry is armed:
+/// waits for its `UNLOADCOMPLETED`, then a fixed settle for anything still in flight behind it.
+fn settle_before_retry() {
+    let unloads = UNLOAD_COMPLETED_SEQ.load(Ordering::SeqCst);
+    let start = Instant::now();
+    while UNLOAD_COMPLETED_SEQ.load(Ordering::SeqCst) == unloads && start.elapsed() < CALLBACK_SETTLE {
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+    std::thread::sleep(CALLBACK_SETTLE);
+}
+
+/// Blocks until the armed load's `LOADCOMPLETED` lands. Returns `false` on timeout.
 fn wait_load_completed() -> bool {
     let start = Instant::now();
-    while !LOAD_COMPLETED.load(Ordering::SeqCst) {
+    while !load_completed() {
         if start.elapsed() >= LOAD_COMPLETE_TIMEOUT {
             return false;
         }
@@ -297,6 +350,10 @@ pub struct NdlVideo {
     audio_offloaded: bool,
     /// Serializes `NDL_Direct*` calls (singleton C API not documented as thread-safe).
     ffi: std::sync::Mutex<()>,
+    /// `false` while `LOADCOMPLETED` still hasn't been seen for this load — [`Self::play`]
+    /// refuses to feed until it lands or [`FEED_ANYWAY_AFTER`] passes. Latched once, so the
+    /// steady-state feed path costs one relaxed load.
+    load_confirmed: AtomicBool,
 }
 
 impl NdlVideo {
@@ -316,15 +373,17 @@ impl NdlVideo {
                 video,
                 audio: audio.to_union(),
             };
-            LOAD_COMPLETED.store(false, Ordering::SeqCst);
-            PLAYING.store(false, Ordering::SeqCst);
+            arm_load();
             // SAFETY: `info` is valid for the duration of this call.
             let ret = unsafe { NDL_DirectMediaLoad(&mut info, Some(on_load_state)) };
             if ret == 0 {
                 // `ret == 0` means the request was accepted, not that the pipeline is ready —
                 // the Opus prime below and the caller's first `play()` both need LOADCOMPLETED.
-                if !wait_load_completed() {
-                    tracing::warn!("NDL load: no LOADCOMPLETED within {LOAD_COMPLETE_TIMEOUT:?} — feeding anyway");
+                let confirmed = wait_load_completed();
+                if !confirmed {
+                    tracing::warn!(
+                        "NDL load: no LOADCOMPLETED within {LOAD_COMPLETE_TIMEOUT:?} — holding the first frames"
+                    );
                 }
                 // Prime the Opus decoder with one silent frame (ss4s does this right after a
                 // successful audio-enabled load). Best-effort — a failure here doesn't
@@ -339,6 +398,7 @@ impl NdlVideo {
                     load_instant: Instant::now(),
                     audio_offloaded: true,
                     ffi: std::sync::Mutex::new(()),
+                    load_confirmed: AtomicBool::new(confirmed),
                 });
             }
             // Fall through to video-only: audio offload is optimization, not critical.
@@ -348,25 +408,29 @@ impl NdlVideo {
                 last_error()
             );
             let _ = unsafe { NDL_DirectMediaUnload() };
+            // The rejected load's callbacks are indistinguishable from the retry's, so let them
+            // land BEFORE arming below rather than racing them.
+            settle_before_retry();
         }
         let mut info = NdlDataInfo {
             video,
             audio: NdlAudioUnion { bytes: [0; 32] },
         };
-        LOAD_COMPLETED.store(false, Ordering::SeqCst);
-        PLAYING.store(false, Ordering::SeqCst);
+        arm_load();
         // SAFETY: `info` is valid for the duration of this call.
         let ret = unsafe { NDL_DirectMediaLoad(&mut info, Some(on_load_state)) };
         if ret != 0 {
             bail!("NDL_DirectMediaLoad failed: ret={ret} error={}", last_error());
         }
-        if !wait_load_completed() {
-            tracing::warn!("NDL load: no LOADCOMPLETED within {LOAD_COMPLETE_TIMEOUT:?} — feeding anyway");
+        let confirmed = wait_load_completed();
+        if !confirmed {
+            tracing::warn!("NDL load: no LOADCOMPLETED within {LOAD_COMPLETE_TIMEOUT:?} — holding the first frames");
         }
         Ok(Self {
             load_instant: Instant::now(),
             audio_offloaded: false,
             ffi: std::sync::Mutex::new(()),
+            load_confirmed: AtomicBool::new(confirmed),
         })
     }
 
@@ -407,9 +471,31 @@ impl NdlVideo {
         self.load_instant.elapsed().as_nanos() as u64
     }
 
+    /// `Err` while this load hasn't reported `LOADCOMPLETED`: the sink then flushes, holds and
+    /// requests a keyframe — exactly what a late load needs, instead of frames into a decoder that
+    /// isn't there. Bounded by [`FEED_ANYWAY_AFTER`], since a model that never delivers the
+    /// callback must still stream.
+    fn ensure_loaded(&self) -> Result<()> {
+        if self.load_confirmed.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        if load_completed() {
+            tracing::info!("NDL LOADCOMPLETED landed {:?} after load", self.load_instant.elapsed());
+            self.load_confirmed.store(true, Ordering::Relaxed);
+            return Ok(());
+        }
+        if self.load_instant.elapsed() >= FEED_ANYWAY_AFTER {
+            tracing::warn!("NDL: still no LOADCOMPLETED after {FEED_ANYWAY_AFTER:?} — feeding anyway");
+            self.load_confirmed.store(true, Ordering::Relaxed);
+            return Ok(());
+        }
+        bail!("NDL pipeline not loaded yet — holding");
+    }
+
     /// Feed one access unit at `pts_ns` (ns since `load()`), truncated to ms for NDL.
     /// Pass a paced value, not raw `elapsed_ns()`, to preserve inter-frame spacing.
     pub fn play(&self, au: &[u8], pts_ns: u64) -> Result<()> {
+        self.ensure_loaded()?;
         let pts_ms = (pts_ns / 1_000_000) as c_longlong;
         let _ffi = self.ffi.lock().expect("NDL FFI mutex poisoned");
         // SAFETY: NDL reads `size` bytes from `buffer` synchronously and does not
@@ -417,6 +503,10 @@ impl NdlVideo {
         let ret = unsafe { NDL_DirectVideoPlay(au.as_ptr() as *mut c_void, au.len() as c_uint, pts_ms) };
         if ret != 0 {
             bail!("NDL_DirectVideoPlay failed: ret={ret} error={}", last_error());
+        }
+        if !presenting() {
+            PRESENTED_SEQ.fetch_add(1, Ordering::SeqCst);
+            tracing::info!("NDL first frame fed {:?} after load", self.load_instant.elapsed());
         }
         Ok(())
     }
@@ -515,8 +605,8 @@ impl NdlVideo {
 
 impl Drop for NdlVideo {
     fn drop(&mut self) {
-        LOAD_COMPLETED.store(false, Ordering::SeqCst);
-        PLAYING.store(false, Ordering::SeqCst);
+        // Re-arm so `playing()` stops reporting the load being torn down here.
+        arm_load();
         // SAFETY: best-effort teardown; error ignored (Drop can't propagate a Result).
         let _ = unsafe { NDL_DirectMediaUnload() };
     }

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -1,10 +1,13 @@
 use super::*;
+use crate::platform::webos::input::{
+    webos_scancode_down as key_down, WEBOS_BLUE_SCANCODE, WEBOS_EXIT_SCANCODE, WEBOS_GREEN_SCANCODE,
+    WEBOS_HOME_SCANCODE, WEBOS_YELLOW_SCANCODE,
+};
 
-/// How long the finished menu frame is held waiting for NDL `PLAYING` before uncovering the
-/// video plane regardless. The hero loading screen waits on the same signal, and without a
-/// timeout (`app::hero::handover_ready`) — so when a hero held the screen this wait is already
-/// satisfied and returns immediately.
-const NDL_REVEAL_TIMEOUT: Duration = crate::ui::STREAM_REVEAL_WAIT;
+/// How long the finished launch frame is held waiting for the first frame to reach the decoder
+/// before uncovering the video plane regardless. The hero loading screen waits on the same signal
+/// (`app::hero::handover_ready`), so when a hero held the screen this wait returns immediately.
+const NDL_REVEAL_TIMEOUT: Duration = crate::ui::FIRST_FRAME_WAIT;
 
 pub(super) fn run_inner() -> Result<()> {
     // Stops webOS's launcher intercepting Back/Windows-Meta/Guide as its own Home shortcut
@@ -116,16 +119,18 @@ pub(super) fn run_inner() -> Result<()> {
             }
         };
         tracing::info!("session connected, entering event loop");
-        // `connect` returns past LOADCOMPLETED with the pump feeding; `PLAYING` is the decoder
-        // confirming it presents, so the reveal swaps the menu straight for live video.
-        // Bounded — never arriving must not leave a stale menu frame up.
+        // `connect` returns past LOADCOMPLETED with the pump feeding; the reveal then waits for a
+        // frame to actually reach NDL, so the menu is swapped straight for live video. NDL's own
+        // `PLAYING` is NOT that signal — it lands during `load()`, before anything is fed.
+        // Bounded — a host that never sends must not leave a stale menu frame up.
         let reveal_wait = Instant::now();
-        while !crate::platform::webos::ndl::playing() && reveal_wait.elapsed() < NDL_REVEAL_TIMEOUT {
+        while !crate::platform::webos::ndl::presenting() && reveal_wait.elapsed() < NDL_REVEAL_TIMEOUT {
             std::thread::sleep(Duration::from_millis(4));
         }
         tracing::info!(
-            "NDL reveal after {:?} (playing={})",
+            "NDL reveal after {:?} (presenting={} playing={})",
             reveal_wait.elapsed(),
+            crate::platform::webos::ndl::presenting(),
             crate::platform::webos::ndl::playing(),
         );
 
@@ -251,11 +256,16 @@ pub(super) fn run_inner() -> Result<()> {
             stats_fade.open();
         }
         let mut log_fade = crate::ui::ModalFade::<()>::new();
-        let mut green_held = false;
-        let mut yellow_held = false;
-        let mut home_held = false;
+        // Seeded from live key state, not `false`: these are rising-edge polls, and the launch
+        // itself is a keypress. A key still down when the stream loop starts (webOS's EXIT
+        // gesture in particular — a synthetic press whose key-up may never arrive) would read as
+        // a fresh press on the first tick and, for EXIT, open the disconnect dialog over the
+        // video the instant the stream began.
+        let mut green_held = key_down(WEBOS_GREEN_SCANCODE);
+        let mut yellow_held = key_down(WEBOS_YELLOW_SCANCODE);
+        let mut home_held = key_down(WEBOS_HOME_SCANCODE);
         // Blue button flips pacing live via `stats.pacing_enabled` (pure PTS math, safe mid-stream).
-        let mut blue_held = false;
+        let mut blue_held = key_down(WEBOS_BLUE_SCANCODE);
         // Transient toasts. `overlay_was_active` catches the fade-out edge so the canvas gets
         // wiped once; `stats_dst`/`log_dst` recomposite each frame at their own slower cadence.
         let mut notif = crate::ui::Notification::new();
@@ -283,7 +293,8 @@ pub(super) fn run_inner() -> Result<()> {
         // Gamepad routes to the disconnect dialog — see `DisconnectChord`.
         let mut chord = DisconnectChord::default();
         // Short Back tap forwards Esc; a held Back becomes webOS's EXIT gesture, polled below.
-        let mut exit_held = false;
+        // Seeded like the colour keys above — see there.
+        let mut exit_held = key_down(WEBOS_EXIT_SCANCODE);
         // Waits for close-fade to finish.
         let mut pending_outcome: Option<StreamOutcome> = None;
         // Set when the user confirms the disconnect dialog — distinguishes that from the

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -210,7 +210,7 @@ pub(super) fn run_ui_flow(
         // its reveal wait is satisfied too), and the hold and fade-out done.
         if let Some(t) = app.launch_anim {
             connect_done |= connect_handle.as_ref().is_none_or(|(h, _)| h.is_finished());
-            let presenting = crate::platform::webos::ndl::playing();
+            let presenting = crate::platform::webos::ndl::presenting();
             if app.hero.handover_ready(t.elapsed(), connect_done, presenting) {
                 break 'ui;
             }

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -20,11 +20,16 @@ pub const HERO_FADE: Duration = Duration::from_millis(1_300);
 /// the hand-off is unchanged.
 pub const HERO_MIN_SHOW: Duration = Duration::from_millis(2_700);
 
-/// Longest a launch waits for one thing that may never arrive, spent on a screen the user is
-/// watching. Two of those, on the same budget: the decoder reporting that it presents
-/// (`runtime::stream`'s reveal, for the launches with no hero to hold), and a hero still being
-/// fetched off the host (`app::hero`, before it gives up and hands over without one).
-pub const STREAM_REVEAL_WAIT: Duration = Duration::from_millis(1_500);
+/// Longest the loading screen waits for a hero still being fetched off the host before handing
+/// over without one (`app::hero`).
+pub const HERO_ART_GRACE: Duration = Duration::from_millis(1_500);
+
+/// Longest a launch waits for the first frame to reach the decoder — the one budget for it,
+/// shared by the loading screen (`app::hero`) and the reveal that follows it
+/// (`runtime::stream`). A host's first delivery can be seconds late (its startup capacity probe,
+/// or a new UDP flow the AP holds — see `session`'s `PROBE_WARMUP_CAP`), and until it lands the
+/// video plane is black, so the loading screen is what the user should be looking at.
+pub const FIRST_FRAME_WAIT: Duration = Duration::from_secs(6);
 
 /// Longest the loading screen runs before handing over regardless of the connect thread.
 /// Only a backstop — `session::connect` has its own timeouts.


### PR DESCRIPTION
Chasing intermittent black screens at stream start. Turned out the reveal was firing far too early.

NDL's `PLAYING` callback lands during `load()`, before anything is decoded, so gating the reveal on it uncovered the punch-through plane while the host still hadn't sent a frame. On a 1440p120 launch that gap measured 3.3s (the host's startup capacity probe), all of it black.

- reveal and the hero loading screen now wait on the first frame NDL actually accepts; `playing()` stays for the log line, documented as useless as a gate
- one budget for that wait, `ui::FIRST_FRAME_WAIT` (6s), shared by both. `STREAM_REVEAL_WAIT` was doing double duty for the art wait, which is now `HERO_ART_GRACE`
- load-state callbacks are counters with a per-load baseline, and the audio-probe retry waits for the abandoned load's `UNLOADCOMPLETED` before arming — a late callback could otherwise satisfy the retry's wait and we'd feed an unloaded decoder
- `play()` holds and requests a keyframe while `LOADCOMPLETED` is missing rather than feeding into nothing, latching off after 1s so a model that never delivers the callback still streams
- the polled key edge-detectors seed from live key state now. Starting them at `false` meant a key still down when the stream loop began read as a fresh press, and for EXIT that dropped the disconnect dialog's near-opaque scrim over the video a few seconds into every launch

New log lines to watch: `NDL first frame fed …s after load` and `NDL reveal after … (presenting=…)`.

Note this doesn't explain every black screen — one session still came up blank with frames flowing at ~1.4 KB/frame, which looks like the host encoding a blank output rather than anything here.