### PR TITLE
Render the impulse-trigger motors a pad actually has

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What this is
 
-Native LG webOS TV client for [punktfunk](https://git.unom.io/unom/punktfunk) — low-latency desktop/game streaming. Targets webOS 5.x+. Built on `punktfunk-core` (pinned git dep), not upstream `pf-client-core` (drags FFmpeg/PipeWire/SDL3).
+Native LG webOS TV client for [punktfunk](https://git.unom.io/unom/punktfunk) — low-latency desktop/game streaming. Targets webOS 5.x+. Built on `punktfunk-core` (pinned git dep).
 
 ## Commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.26.0#f80636f901820b42d9388ade6fbaf718ba948c7c"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.27.0#bde4276632c046e1ac2252cf9a094ca2d1809350"
 
 [[package]]
 name = "fiat-crypto"
@@ -1109,8 +1109,8 @@ dependencies = [
 
 [[package]]
 name = "punktfunk-core"
-version = "0.26.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.26.0#f80636f901820b42d9388ade6fbaf718ba948c7c"
+version = "0.27.0"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.27.0#bde4276632c046e1ac2252cf9a094ca2d1809350"
 dependencies = [
  "aes-gcm",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,9 @@ tracing-appender = "0.2"
 # `crossfade_drop`, and the redundant `0xD2` audio plane. At v0.24.0 `punktfunk_core::audio` is
 # 369 lines (layouts + `AudioGapTracker`); at v0.26.0 it is 2301. `connect`'s parameter list is
 # unchanged across the two, so this is a pin-only bump. See `docs/NOTES.md` § Audio.
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.26.0", features = ["quic"] }
+# v0.27.0 widens `RumbleCommand` to four motors — the handles plus the Xbox impulse triggers.
+# Additive (the handle pair is a literal prefix), so the bump is pin-only.
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.27.0", features = ["quic"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # mDNS LAN discovery; direct dep (not via pf-client-core — see session.rs docs).

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -139,7 +139,7 @@ MANIFEST (crate version — SPDX license — source)
   powerfmt 0.2.0 — MIT OR Apache-2.0 — https://github.com/jhpratt/powerfmt
   ppv-lite86 0.2.21 — MIT OR Apache-2.0 — https://github.com/cryptocorrosion/cryptocorrosion
   proc-macro2 1.0.107 — MIT OR Apache-2.0 — https://github.com/dtolnay/proc-macro2
-  punktfunk-core 0.26.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
+  punktfunk-core 0.27.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
   pxfm 0.1.30 — BSD-3-Clause OR Apache-2.0 — https://github.com/awxkee/pxfm
   quinn 0.11.11 — MIT OR Apache-2.0 — https://github.com/quinn-rs/quinn
   quinn-proto 0.11.16 — MIT OR Apache-2.0 — https://github.com/quinn-rs/quinn
@@ -238,7 +238,7 @@ MANIFEST (crate version — SPDX license — source)
 ----------------------------------------------------------------------------
 Crates whose package did not embed a license file (SPDX + source only)
 ----------------------------------------------------------------------------
-  punktfunk-core 0.26.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
+  punktfunk-core 0.27.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
   sdl2-sys 0.38.0 — MIT AND Zlib — https://github.com/rust-sdl2/rust-sdl2
   yasna 0.5.2 — MIT OR Apache-2.0 — https://github.com/qnighy/yasna.rs
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1066,8 +1066,9 @@ const FEEDBACK_DRAIN_BUDGET: usize = 32;
 ///
 /// The two planes go to different places, because each has one route that works for every
 /// controller rather than only one:
-///   * **rumble** → SDL's evdev force feedback (`GameController::set_rumble`), which works on
-///     any pad the TV has bound, `DualSense` included;
+///   * **rumble** → SDL's evdev force feedback (`GameController::set_rumble`, plus
+///     `set_rumble_triggers` for the impulse-trigger motors on pads that have them), which works
+///     on any pad the TV has bound, `DualSense` included;
 ///   * **`DualSense` HID feedback** (adaptive triggers, lightbar, player LEDs) → the Bluetooth
 ///     service, since SDL's own `DualSense` path needs a hidraw node the app's jail doesn't have
 ///     (see [`crate::platform::webos::dualsense`]).
@@ -1081,7 +1082,13 @@ pub fn pump_feedback_once(
     mut feedback: Option<&mut crate::platform::webos::dualsense::Feedback>,
 ) {
     // `next_rumble_command` is the policy-engine API: it already resolves lease expiry, stale
-    // legacy hosts and close-drain zeros, so commands apply verbatim — `(0, 0)` stops now.
+    // legacy hosts and close-drain zeros, so commands apply verbatim — all-zero stops now.
+    //
+    // Queried once per tick, not per command: SDL walks its joystick list for this, and a hotplug
+    // arrives as a new `GameController` rather than changing this answer mid-drain.
+    let has_triggers = controller
+        .as_deref()
+        .is_some_and(sdl2::controller::GameController::has_rumble_triggers);
     let mut budget = FEEDBACK_DRAIN_BUDGET;
     while budget > 0 {
         let Ok(cmd) = client.next_rumble_command(Duration::ZERO) else {
@@ -1098,6 +1105,16 @@ pub fn pump_feedback_once(
             // Errors here are the common "this pad has no rumble motors" case, not a fault:
             // logging per command would spam a tick loop, and there is no recovery to attempt.
             let _ = pad.set_rumble(cmd.low, cmd.high, cmd.backstop_ms);
+            // Dropping the trigger pair on a pad without those motors is the correct degrade;
+            // folding it into the handles would turn a racing title's continuous trigger stream
+            // into a handle motor droning flat-out for the whole race.
+            if has_triggers {
+                let _ = pad.set_rumble_triggers(
+                    cmd.left_trigger,
+                    cmd.right_trigger,
+                    cmd.backstop_ms,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Bumps `punktfunk-core` to v0.27.0 and renders the two motors the old pin had no way to reach.

`RumbleCommand` now carries four levels: the two handle motors plus the Xbox impulse-trigger pair. The handle pair is a literal prefix of the new struct, so the pin bump compiled untouched — it just silently dropped every trigger level on the floor.

- pin `punktfunk-core` v0.26.0 → v0.27.0
- `pump_feedback_once` calls `set_rumble_triggers` alongside `set_rumble`, same `backstop_ms`, same drain budget. One lease and one policy in core, so a stop silences all four motors on the same command.
- gated on `has_rumble_triggers()`, queried once per tick rather than per command — SDL walks its joystick list for that, and a hotplug arrives as a fresh `GameController` rather than changing the answer mid-drain.

Not folding the trigger levels into the handles is deliberate: a racing title streams the triggers continuously, and folding would leave a handle motor droning flat-out for the whole race.

Untested on device — the TV's DualSense reports no trigger motors, so this only shows up on an Xbox One or later pad.