### PR TITLE
Grey out locked settings rows instead of hiding them

### DIFF
--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -112,7 +112,7 @@ pub const DIAGNOSTICS_ROW_COUNT: usize = 4;
 ///
 /// Consequence worth keeping: no user action changes this, so the display↔logical mapping is
 /// fixed for the run and no site has to re-anchor focus after a mutation.
-pub(crate) fn row_shown(row: usize, _settings: &Settings) -> bool {
+pub(crate) fn row_shown(row: usize) -> bool {
     match row {
         // Only a choice where NDL is the narrow v1 generation — everywhere else NDL v2 is
         // strictly better and the row would be a trap.
@@ -157,19 +157,20 @@ pub(crate) fn row_lock(row: usize, settings: &Settings, detected: Option<Gamepad
 }
 
 /// Logical `ROW_*` indices currently visible, in display order — the single source of truth
-/// every visibility-aware helper derives from.
-pub fn settings_visible_logical_rows(settings: &Settings) -> impl Iterator<Item = usize> + '_ {
-    (0..SETTINGS_ROW_COUNT).filter(|&row| row_shown(row, settings))
+/// every visibility-aware helper derives from. Settings-independent (see [`row_shown`]), so
+/// this mapping is fixed for the run.
+pub fn settings_visible_logical_rows() -> impl Iterator<Item = usize> {
+    (0..SETTINGS_ROW_COUNT).filter(|&row| row_shown(row))
 }
 
 /// Live row count (vs. `SETTINGS_ROW_COUNT`, the maximum).
-pub fn settings_row_count(settings: &Settings) -> usize {
-    settings_visible_logical_rows(settings).count()
+pub fn settings_row_count() -> usize {
+    settings_visible_logical_rows().count()
 }
 
 /// On-screen row position -> logical `ROW_*` index, skipping past any hidden rows.
-pub fn settings_logical_row(settings: &Settings, display: usize) -> usize {
-    settings_visible_logical_rows(settings).nth(display).unwrap_or(display)
+pub fn settings_logical_row(display: usize) -> usize {
+    settings_visible_logical_rows().nth(display).unwrap_or(display)
 }
 
 pub fn cycle_index(current: usize, len: usize, forward: bool) -> usize {

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -404,6 +404,10 @@ pub fn apply_dropdown_choice(
         ROW_CODEC => {
             if let Some(&pref) = video_caps().codec_prefs().get(choice_index) {
                 settings.codec = pref;
+                // H.264 never resolves HDR (see `RowLock::HdrNeedsHevc`).
+                if pref == CodecPref::H264 {
+                    settings.hdr_enabled = false;
+                }
             }
         }
         ROW_AUDIO => {

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -52,12 +52,12 @@ pub const ROW_BITRATE: usize = 2;
 /// choice (webOS 3.5-4.x, see `caps::smp_selectable`), and above Codec deliberately: the
 /// pick is what decides whether HEVC and HDR exist as options at all.
 pub const ROW_VIDEO_BACKEND: usize = 3;
-/// Hidden where the backend has no HEVC — there is only one decodable codec then (see `row_shown`).
+/// Locked where the backend has no HEVC — there is only one decodable codec then (see `row_lock`).
 pub const ROW_CODEC: usize = 4;
-/// Directly below Codec: HDR applies only to HEVC, so the row is hidden on an explicit
-/// H.264 pick (see `row_shown`) — adjacency keeps that dependency discoverable.
+/// Directly below Codec: HDR applies only to HEVC, so the row locks on an explicit
+/// H.264 pick (see `row_lock`) — adjacency keeps that dependency discoverable.
 pub const ROW_HDR: usize = 5;
-/// Hidden where the backend is capped at stereo — the only channel count then (see `row_shown`).
+/// Locked where the backend is capped at stereo — the only channel count then (see `row_lock`).
 pub const ROW_AUDIO: usize = 6;
 /// Which controller the host presents to the game — see `store::GamepadType`. Last of the
 /// real settings: it's the only input-side one, and picking `DualSense` is what turns on
@@ -102,25 +102,18 @@ pub const DIAG_ROW_SHOW_LOGS: usize = 2;
 pub const DIAG_ROW_SEND_LOGS: usize = 3;
 pub const DIAGNOSTICS_ROW_COUNT: usize = 4;
 
-/// Whether one focusable row is offered, given the settings and what this TV's video backend can
-/// do.
+/// Whether one focusable row is offered at all.
 ///
-/// **The sole visibility predicate — one arm per row, every condition for that row inside it.**
-/// Everything else (row list, count, display↔logical mapping, focus clamping) derives from
-/// [`settings_visible_logical_rows`]; a second opinion anywhere is a row you can focus but not see.
-pub(crate) fn row_shown(row: usize, settings: &Settings) -> bool {
-    let caps = video_caps();
+/// **The sole visibility predicate.** A row is hidden only when nothing the user can reach from
+/// inside the app could ever make it usable — the environment decides it (the OS release for the
+/// backend row, root for Experimental's Game mode). Everything a *setting* constrains stays on
+/// screen and greys out instead, so the dependency is visible rather than inferred from a
+/// vanishing row: see [`row_lock`].
+///
+/// Consequence worth keeping: no user action changes this, so the display↔logical mapping is
+/// fixed for the run and no site has to re-anchor focus after a mutation.
+pub(crate) fn row_shown(row: usize, _settings: &Settings) -> bool {
     match row {
-        // HDR only applies to HEVC: the host never resolves it for an explicit H.264 session, so
-        // the toggle would be a no-op (Automatic keeps the row — HEVC may still be resolved). A
-        // backend without HDR has nothing to toggle either way. Application is gated on the
-        // *negotiated* codec too — see `session::connect`.
-        ROW_HDR => settings.codec != CodecPref::H264 && caps.hdr,
-        // A dropdown with one entry is noise — without HEVC there is a single decodable codec
-        // (see `VideoCaps::codec_prefs`), so there is nothing to pick.
-        ROW_CODEC => caps.codec_prefs().len() > 1,
-        // Same rule: a backend capped at stereo leaves Stereo as the only entry.
-        ROW_AUDIO => audio_option_count() > 1,
         // Only a choice where NDL is the narrow v1 generation — everywhere else NDL v2 is
         // strictly better and the row would be a trap.
         ROW_VIDEO_BACKEND => crate::core::caps::smp_selectable(),
@@ -128,9 +121,43 @@ pub(crate) fn row_shown(row: usize, settings: &Settings) -> bool {
     }
 }
 
+/// Why a row is shown but not editable, or `None` while it is. Distinct from [`row_shown`]:
+/// a lock can lift without a restart (switching codec away from H.264, plugging in a pad),
+/// where an unshown row cannot become shown at all this run. The caption text is
+/// [`app::view::settings`]'s business (it needs the OS release to phrase it); this is the
+/// predicate both the renderer and the input path read, so a greyed row and a rejected
+/// keypress can't disagree.
+pub(crate) enum RowLock {
+    /// HDR under an explicit H.264 pick: the host never resolves HDR for such a session, so the
+    /// toggle would be a no-op. `Automatic` leaves it editable — HEVC may still be resolved.
+    /// Application is gated on the *negotiated* codec too, see `session::connect`.
+    HdrNeedsHevc,
+    /// The active backend has no HDR at all (NDL v1) — nothing to toggle either way.
+    NoHdr,
+    /// One decodable codec, so `codec_prefs` collapses to a single entry.
+    OneCodec,
+    /// The backend is capped at stereo, leaving one channel count.
+    StereoOnly,
+    /// Nothing is plugged into the TV, so there is no controller to describe to the host.
+    NoGamepad,
+}
+
+/// `detected` is the attached pad per `gamepad::detect_type` — `None` with nothing attached
+/// (or an unrecognized pad), which is what locks the Controller row.
+pub(crate) fn row_lock(row: usize, settings: &Settings, detected: Option<GamepadType>) -> Option<RowLock> {
+    let caps = video_caps();
+    match row {
+        ROW_HDR if !caps.hdr => Some(RowLock::NoHdr),
+        ROW_HDR if settings.codec == CodecPref::H264 => Some(RowLock::HdrNeedsHevc),
+        ROW_CODEC if caps.codec_prefs().len() < 2 => Some(RowLock::OneCodec),
+        ROW_AUDIO if audio_option_count() < 2 => Some(RowLock::StereoOnly),
+        ROW_GAMEPAD if detected.is_none() => Some(RowLock::NoGamepad),
+        _ => None,
+    }
+}
+
 /// Logical `ROW_*` indices currently visible, in display order — the single source of truth
-/// every visibility-aware helper derives from. Hidden rows are dropped rather than shown
-/// disabled, so the list renumbers itself and no caller carries a fixed index.
+/// every visibility-aware helper derives from.
 pub fn settings_visible_logical_rows(settings: &Settings) -> impl Iterator<Item = usize> + '_ {
     (0..SETTINGS_ROW_COUNT).filter(|&row| row_shown(row, settings))
 }
@@ -339,7 +366,18 @@ pub fn dropdown_current_index(settings: &Settings, row_index: usize) -> usize {
     }
 }
 
-pub fn apply_dropdown_choice(settings: &mut Settings, row_index: usize, choice_index: usize) {
+/// Applies a dropdown pick. Refuses on a locked row (see [`row_lock`]) rather than trusting
+/// every caller to have checked first — the same guard [`adjust_setting`] applies, so there is
+/// one place a locked row's value is actually protected, not one per call site.
+pub fn apply_dropdown_choice(
+    settings: &mut Settings,
+    row_index: usize,
+    choice_index: usize,
+    detected: Option<GamepadType>,
+) {
+    if row_lock(row_index, settings, detected).is_some() {
+        return;
+    }
     match row_index {
         ROW_RESOLUTION => {
             if let Some((w, h, _)) = RESOLUTIONS.get(choice_index) {
@@ -385,7 +423,13 @@ pub fn apply_dropdown_choice(settings: &mut Settings, row_index: usize, choice_i
 ///
 /// Every dropdown row shares one arm — the option list is the authority on how many entries
 /// there are (see [`dropdown_option_count`]), so a new dropdown row needs no code here.
-pub fn adjust_setting(settings: &mut Settings, row_index: usize, forward: bool) -> bool {
+///
+/// A locked row (see [`row_lock`]) refuses every adjustment: the same predicate that greys it
+/// is what rejects the keypress, so nothing can edit a value the UI shows as fixed.
+pub fn adjust_setting(settings: &mut Settings, row_index: usize, forward: bool, detected: Option<GamepadType>) -> bool {
+    if row_lock(row_index, settings, detected).is_some() {
+        return false;
+    }
     match row_index {
         ROW_BITRATE => {
             if settings.bitrate_kbps == BITRATE_AUTOMATIC {
@@ -413,7 +457,7 @@ pub fn adjust_setting(settings: &mut Settings, row_index: usize, forward: bool) 
                 return false;
             }
             let next = cycle_index(dropdown_current_index(settings, row), len, forward);
-            apply_dropdown_choice(settings, row, next);
+            apply_dropdown_choice(settings, row, next, detected);
             true
         }
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -616,9 +616,9 @@ impl App {
 
     /// Scrolls `settings_focused` into view.
     pub(crate) fn scroll_settings_into_view(&mut self, screen_h: u32) {
-        let visible = view::settings::visible_rows(&self.settings, screen_h);
+        let visible = view::settings::visible_rows(screen_h);
         self.scroll
-            .scroll_into_view(self.settings_focused, menu::settings_row_count(&self.settings), visible);
+            .scroll_into_view(self.settings_focused, menu::settings_row_count(), visible);
     }
 
     /// `(row, focused, alpha)` for the open dropdown or its close-fade; `None` if neither.

--- a/src/app/pointer.rs
+++ b/src/app/pointer.rs
@@ -216,9 +216,9 @@ impl App {
     ) -> Option<(Rect, i32)> {
         match screen {
             Screen::Settings => {
-                let (_, content) = view::settings::layout(&self.settings, screen_w, screen_h);
+                let (_, content) = view::settings::layout(screen_w, screen_h);
                 let stride = ui::widgets::focus_row_stride() as i32;
-                let total = menu::settings_row_count(&self.settings);
+                let total = menu::settings_row_count();
                 // Anchor to the animated offset so an open dropdown stays attached to
                 // its row while the list is still settling.
                 let px = self
@@ -236,12 +236,12 @@ impl App {
     /// `modal_scroll_px` the rows render with — a fixed-offset hit-test drifts a row
     /// off once the list has scrolled. `None` outside the viewport or in a row gap.
     pub(crate) fn settings_row_at(&self, x: i32, y: i32, screen_w: u32, screen_h: u32) -> Option<usize> {
-        let (_, content) = view::settings::layout(&self.settings, screen_w, screen_h);
+        let (_, content) = view::settings::layout(screen_w, screen_h);
         if !content.contains_point((x, y)) {
             return None;
         }
         let stride = ui::widgets::focus_row_stride() as i32;
-        let total = menu::settings_row_count(&self.settings);
+        let total = menu::settings_row_count();
         let scroll_px = self
             .modal_scroll_px
             .clamp(0, Self::max_scroll_px(total, stride, content.height()));

--- a/src/app/render/geometry.rs
+++ b/src/app/render/geometry.rs
@@ -40,9 +40,9 @@ impl App {
     ) -> Option<(usize, usize, Rect, Rect)> {
         match screen {
             Screen::Settings => {
-                let (card, content) = view::settings::layout(&self.settings, screen_w, screen_h);
-                let visible = view::settings::visible_rows(&self.settings, screen_h);
-                Some((menu::settings_row_count(&self.settings), visible, card, content))
+                let (card, content) = view::settings::layout(screen_w, screen_h);
+                let visible = view::settings::visible_rows(screen_h);
+                Some((menu::settings_row_count(), visible, card, content))
             }
             Screen::About => {
                 let card = view::about::card_rect(screen_w, screen_h);
@@ -258,7 +258,7 @@ impl App {
     pub(crate) fn dropdown_options_len(&self, screen: Screen, row: usize) -> usize {
         match screen {
             Screen::Diagnostics => menu::LOG_LEVEL_OPTIONS.len(),
-            _ => menu::dropdown_option_count(menu::settings_logical_row(&self.settings, row)),
+            _ => menu::dropdown_option_count(menu::settings_logical_row(row)),
         }
     }
 
@@ -272,9 +272,7 @@ impl App {
     pub(crate) fn with_modal_screen<R>(&self, f: impl FnOnce(&dyn ui::ModalScreen) -> R) -> Option<R> {
         Some(match self.screen {
             Screen::Home => return None,
-            Screen::Settings => f(&view::settings::Modal {
-                settings: &self.settings,
-            }),
+            Screen::Settings => f(&view::settings::Modal),
             Screen::Pairing => f(&view::pairing::Modal {
                 pin_digits: &self.pin_digits,
                 status: self.pairing_status.as_ref(),

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -529,7 +529,7 @@ impl App {
             if stale {
                 let tile = match self.screen {
                     Screen::Settings => {
-                        let (_, content) = view::settings::layout(&self.settings, screen_w, screen_h);
+                        let (_, content) = view::settings::layout(screen_w, screen_h);
                         let rows = self.settings_rows();
                         let dropdown_open = self.dropdown.as_ref().is_some_and(|dd| dd.row == self.settings_focused);
                         let target_on = rows.get(self.settings_focused).is_some_and(|r| r.value == "On");
@@ -662,8 +662,8 @@ impl App {
                     (menu::log_level_dropdown_options(), content.width())
                 }
                 _ => {
-                    let (_, content) = view::settings::layout(&self.settings, screen_w, screen_h);
-                    let logical = menu::settings_logical_row(&self.settings, dd.row);
+                    let (_, content) = view::settings::layout(screen_w, screen_h);
+                    let logical = menu::settings_logical_row(dd.row);
                     (
                         menu::dropdown_options(logical, self.detected_gamepad_type),
                         content.width(),
@@ -771,7 +771,7 @@ impl App {
                         // Settings' whole row list always fits one tile — no windowing.
                         self.content_window = ui::scroll::ContentWindow {
                             start: 0,
-                            len: menu::settings_row_count(&self.settings),
+                            len: menu::settings_row_count(),
                         };
                         updated.push(tile::SCROLL_CONTENT);
                     }
@@ -822,10 +822,9 @@ impl App {
         let mut scratch = Painter::new(screen_w, screen_h);
         view::settings::render(
             &mut ui::Canvas::new(&mut scratch, text_cache, fonts, screen_w, screen_h),
-            &self.settings,
             self.hover_close,
         )?;
-        let (_, content) = view::settings::layout(&self.settings, screen_w, screen_h);
+        let (_, content) = view::settings::layout(screen_w, screen_h);
         let rows = self.settings_rows();
         let _ = ui::widgets::render_focus_rows_tile(text_cache, fonts, &rows, content.width(), None)?;
         let _ = ui::widgets::render_focus_row_tile(text_cache, fonts, &rows, content.width(), 0, false, 0.0)?;

--- a/src/app/state/settings.rs
+++ b/src/app/state/settings.rs
@@ -27,12 +27,9 @@ impl App {
                     // Not persisted here — `MenuEvent::Back` below (leaving the
                     // whole Settings screen) saves once for every change made
                     // during this visit, not per-row.
-                    menu::apply_dropdown_choice(&mut self.settings, logical, choice);
+                    menu::apply_dropdown_choice(&mut self.settings, logical, choice, self.detected_gamepad_type);
                     self.dropdown_fade.close((row, dd.focused));
                     self.dropdown = None;
-                    // A codec change hides/shows the HDR row above; keep focus on the
-                    // row just edited rather than letting the shift slide it away.
-                    self.refocus_logical(logical);
                 }
                 MenuEvent::Back => {
                     self.dropdown_fade.close((row, dd.focused));
@@ -82,12 +79,16 @@ impl App {
                     self.persist();
                     self.open_diagnostics();
                 }
+                // A locked row (see `menu::row_lock`) never opens its dropdown — there is
+                // nothing to pick, which is exactly what the greyed row already says.
                 logical @ (menu::ROW_RESOLUTION
                 | menu::ROW_FRAMERATE
                 | menu::ROW_VIDEO_BACKEND
                 | menu::ROW_CODEC
                 | menu::ROW_AUDIO
-                | menu::ROW_GAMEPAD) => {
+                | menu::ROW_GAMEPAD)
+                    if menu::row_lock(logical, &self.settings, self.detected_gamepad_type).is_none() =>
+                {
                     let focused = menu::dropdown_current_index(&self.settings, logical);
                     // `row` is the display position (what the overlay is drawn against);
                     // the logical row is recovered on lookup via `settings_logical_row`.
@@ -115,30 +116,20 @@ impl App {
 
     /// Adjusts row in memory; persisted on `Back` (not per-keystroke). Starts `switch_anim` for toggle slides.
     /// `display_row` is the on-screen position; resolved to a logical `ROW_*` first.
+    ///
+    /// No focus re-anchoring afterwards: which rows are shown depends on the environment only
+    /// (see `menu::row_shown`), so no adjustment can renumber the list under the cursor.
     pub(crate) fn apply_setting_adjust(&mut self, display_row: usize, forward: bool) {
         let row = menu::settings_logical_row(&self.settings, display_row);
         let toggled_from = match row {
             menu::ROW_HDR => Some(self.settings.hdr_enabled),
             _ => None,
         };
-        if menu::adjust_setting(&mut self.settings, row, forward) {
+        if menu::adjust_setting(&mut self.settings, row, forward, self.detected_gamepad_type) {
             if let Some(from) = toggled_from {
                 // Scope the slide to the display row being rendered (see `toggle_frac`).
                 self.switch_anim = Some((Instant::now(), from, display_row));
             }
         }
-        // Cycling the codec can hide/show the HDR row above; keep focus on `row`.
-        self.refocus_logical(row);
-    }
-
-    /// After a mutation that may have shown or hidden rows (a codec change toggles the
-    /// HDR row's visibility), re-derive the display index of `logical` so focus stays on
-    /// the same setting instead of sliding to whatever now occupies its old slot.
-    fn refocus_logical(&mut self, logical: usize) {
-        let position = menu::settings_visible_logical_rows(&self.settings).position(|r| r == logical);
-        self.settings_focused = position.unwrap_or_else(|| {
-            let count = menu::settings_row_count(&self.settings);
-            self.settings_focused.min(count.saturating_sub(1))
-        });
     }
 }

--- a/src/app/state/settings.rs
+++ b/src/app/state/settings.rs
@@ -16,7 +16,7 @@ impl App {
         if let Some(dd) = self.dropdown.as_mut() {
             // `dd.row` is the display position; setting lookups need the logical row.
             let row = dd.row;
-            let logical = menu::settings_logical_row(&self.settings, row);
+            let logical = menu::settings_logical_row(row);
             let len = menu::dropdown_option_count(logical).max(1);
             match ev {
                 MenuEvent::Up | MenuEvent::Down => {
@@ -39,7 +39,7 @@ impl App {
             }
             return;
         }
-        let total = menu::settings_row_count(&self.settings);
+        let total = menu::settings_row_count();
         match ev {
             // No wraparound here (unlike most other row lists) — wrapping a scrolled
             // list would silently jump the scroll position across the whole card.
@@ -59,7 +59,7 @@ impl App {
             }
             MenuEvent::Left => self.apply_setting_adjust(self.settings_focused, false),
             MenuEvent::Right => self.apply_setting_adjust(self.settings_focused, true),
-            MenuEvent::Confirm => match menu::settings_logical_row(&self.settings, self.settings_focused) {
+            MenuEvent::Confirm => match menu::settings_logical_row(self.settings_focused) {
                 // Not a setting — a link out to the About screen (see `menu::ROW_ABOUT`).
                 // Settings are saved on the way out so the visit's changes aren't lost
                 // behind the navigation.
@@ -120,7 +120,7 @@ impl App {
     /// No focus re-anchoring afterwards: which rows are shown depends on the environment only
     /// (see `menu::row_shown`), so no adjustment can renumber the list under the cursor.
     pub(crate) fn apply_setting_adjust(&mut self, display_row: usize, forward: bool) {
-        let row = menu::settings_logical_row(&self.settings, display_row);
+        let row = menu::settings_logical_row(display_row);
         let toggled_from = match row {
             menu::ROW_HDR => Some(self.settings.hdr_enabled),
             _ => None,

--- a/src/app/view/diagnostics.rs
+++ b/src/app/view/diagnostics.rs
@@ -16,44 +16,31 @@ pub const SUBTITLE: &str = "Debug aids for on-device investigation.";
 /// Order must match `menu::DIAG_ROW_*`.
 pub fn rows(settings: &Settings) -> Vec<FocusRow> {
     vec![
-        FocusRow {
-            icon: crate::app::view::icons::ICON_BUG,
-            label: "Log level".into(),
-            value: menu::log_level_label(settings.log_level_override).into(),
-            kind: ui::widgets::RowKind::Dropdown,
-            fraction: 0.0,
-            danger: false,
-            menu: None,
-            subtext: None,
-        },
-        FocusRow {
-            icon: crate::app::view::icons::ICON_CHART,
-            label: "Stats overlay".into(),
-            value: if settings.stats_overlay {
-                "On".into()
-            } else {
-                "Off".into()
-            },
-            kind: ui::widgets::RowKind::Toggle,
-            fraction: 0.0,
-            danger: false,
-            menu: None,
-            subtext: settings
+        FocusRow::dropdown(
+            crate::app::view::icons::ICON_BUG,
+            "Log level",
+            menu::log_level_label(settings.log_level_override),
+        ),
+        FocusRow::toggle(
+            crate::app::view::icons::ICON_CHART,
+            "Stats overlay",
+            settings.stats_overlay,
+        )
+        .with_subtext_opt(
+            settings
                 .stats_overlay
                 .then(|| ui::widgets::RowSubtext::hint("Or use the Green button")),
-        },
-        FocusRow {
-            icon: crate::app::view::icons::ICON_VISIBILITY,
-            label: "Show logs".into(),
-            value: if settings.show_logs { "On".into() } else { "Off".into() },
-            kind: ui::widgets::RowKind::Toggle,
-            fraction: 0.0,
-            danger: false,
-            menu: None,
-            subtext: settings
+        ),
+        FocusRow::toggle(
+            crate::app::view::icons::ICON_VISIBILITY,
+            "Show logs",
+            settings.show_logs,
+        )
+        .with_subtext_opt(
+            settings
                 .show_logs
                 .then(|| ui::widgets::RowSubtext::hint("Or use the Yellow button")),
-        },
+        ),
         FocusRow::action(crate::app::view::icons::ICON_SEND, "Send logs to developer")
             .with_subtext(ui::widgets::RowSubtext::hint("If a developer asked you to")),
     ]

--- a/src/app/view/icons.rs
+++ b/src/app/view/icons.rs
@@ -48,6 +48,7 @@ pub fn install_style() {
             accent_bright: Color::RGB(0xa7, 0x9f, 0xf8),
             text: Color::RGB(0xf5, 0xf5, 0xf5),
             muted: Color::RGB(0x9b, 0x94, 0xb8),
+            disabled: Color::RGB(0x5c, 0x57, 0x72),
             warning: Color::RGB(0xff, 0xc1, 0x07),
             // A desaturated mint rather than a signal green — it sits next to brand purple
             // on every row, and a pure green fights it.

--- a/src/app/view/settings.rs
+++ b/src/app/view/settings.rs
@@ -172,7 +172,7 @@ pub(crate) fn rows(
     // locked there can never disagree here. Index == logical row, guaranteed by the assert above.
     rows.into_iter()
         .enumerate()
-        .filter(|(logical, _)| menu::row_shown(*logical, settings))
+        .filter(|(logical, _)| menu::row_shown(*logical))
         .map(
             |(logical, row)| match menu::row_lock(logical, settings, detected_gamepad_type) {
                 // The lock's caption replaces whatever contextual one the row carried: a row the
@@ -193,9 +193,9 @@ pub(crate) fn rows(
 /// the partially-visible sliver the bottom fade dissolves. Computed without the peek first,
 /// because a list that fits entirely has nothing below to peek at and should not give up
 /// the space.
-pub(crate) fn visible_rows(settings: &Settings, screen_h: u32) -> usize {
+pub(crate) fn visible_rows(screen_h: u32) -> usize {
     let stride = ui::widgets::focus_row_stride();
-    let total = menu::settings_row_count(settings);
+    let total = menu::settings_row_count();
     let budget = screen_h.saturating_sub(CHROME_TOP + CHROME_BOTTOM + EDGE_MARGIN);
     if (budget / stride) as usize >= total {
         return total.max(1);
@@ -207,9 +207,9 @@ pub(crate) fn visible_rows(settings: &Settings, screen_h: u32) -> usize {
 /// Height of the scrolling viewport: the fully-visible rows plus a peek strip past each
 /// edge while the list overflows. Deliberately *not* a whole multiple of the row stride
 /// when scrolling — see [`PEEK`].
-pub(crate) fn content_h(settings: &Settings, screen_h: u32) -> u32 {
-    let visible = visible_rows(settings, screen_h);
-    let peeks = if visible < menu::settings_row_count(settings) {
+pub(crate) fn content_h(screen_h: u32) -> u32 {
+    let visible = visible_rows(screen_h);
+    let peeks = if visible < menu::settings_row_count() {
         2 * PEEK
     } else {
         0
@@ -223,10 +223,10 @@ pub(crate) const SIDE_PAD: u32 = 40;
 
 /// Card and content rects, shared by render and hit-test. One split, read twice: the card's
 /// height is what its own stack adds up to, and the viewport is the middle slot of it.
-pub(crate) fn layout(settings: &Settings, screen_w: u32, screen_h: u32) -> (Rect, Rect) {
+pub(crate) fn layout(screen_w: u32, screen_h: u32) -> (Rect, Rect) {
     let stack = ui::layout::Layout::vertical([
         ui::layout::Constraint::Length(CHROME_TOP),
-        ui::layout::Constraint::Length(content_h(settings, screen_h)),
+        ui::layout::Constraint::Length(content_h(screen_h)),
         ui::layout::Constraint::Length(CHROME_BOTTOM),
     ]);
     // Widened from 0.56 to fit the scroll indicator on the right edge.
@@ -252,8 +252,8 @@ pub(crate) fn dropdown_overlay_rect_at_px(content: Rect, row: usize, scroll_px: 
 /// The shell only: card chrome, title and rule. The row list is its own scroll-content
 /// tile and the open dropdown its own overlay tile, so neither scrolling nor navigating
 /// options re-rasterizes this.
-pub(crate) fn render(c: &mut Canvas, settings: &Settings, hover_close: bool) -> Result<()> {
-    let (card, _content) = layout(settings, c.screen_w, c.screen_h);
+pub(crate) fn render(c: &mut Canvas, hover_close: bool) -> Result<()> {
+    let (card, _content) = layout(c.screen_w, c.screen_h);
     let column = content_column(card);
     c.modal_shell(card, hover_close)?;
     c.text(c.fonts.label, TITLE, column.x(), card.y() + 36, ui::style::theme().text)?;
@@ -262,16 +262,14 @@ pub(crate) fn render(c: &mut Canvas, settings: &Settings, hover_close: bool) -> 
 }
 
 /// The settings modal as a [`ModalScreen`].
-pub(crate) struct Modal<'a> {
-    pub settings: &'a Settings,
-}
+pub(crate) struct Modal;
 
-impl ModalScreen for Modal<'_> {
+impl ModalScreen for Modal {
     fn card_rect(&self, screen_w: u32, screen_h: u32, _fonts: &ui::text::Fonts) -> Rect {
-        layout(self.settings, screen_w, screen_h).0
+        layout(screen_w, screen_h).0
     }
 
     fn render(&self, c: &mut Canvas, hover_close: bool) -> Result<()> {
-        render(c, self.settings, hover_close)
+        render(c, hover_close)
     }
 }

--- a/src/app/view/settings.rs
+++ b/src/app/view/settings.rs
@@ -2,7 +2,7 @@
 //! Logic lives in `app::state::settings`.
 use crate::app::menu;
 use crate::core::VERSION;
-use crate::services::store::{CodecPref, GamepadType, Settings, VideoBackend};
+use crate::services::store::{GamepadType, Settings, VideoBackend};
 use crate::ui;
 use crate::ui::render::Rect;
 use crate::ui::widgets::FocusRow;
@@ -45,7 +45,37 @@ pub(crate) const EDGE_MARGIN: u32 = 120;
 /// shallower peek shows only the row's internal padding, i.e. nothing to dissolve.
 pub(crate) const PEEK: u32 = 44;
 
-/// One row per `menu::ROW_*`, in order, filtered by `menu::row_shown`.
+/// The caption a locked row carries: what fixed its value, and where to go to change it.
+///
+/// Lives on the row that is *immutable*, not on the one that caused it — the greyed control is
+/// what the user is looking at when they want the reason.
+///
+/// `webos_major` is the OS major (`None` where it couldn't be read); named only where the OS is
+/// the whole story, i.e. where there's no backend to switch to either.
+fn lock_caption(lock: menu::RowLock, webos_major: Option<u32>) -> String {
+    // Where the Video backend row exists, the limit is the *pick*, not the TV, and SMP lifts it —
+    // so the caption points at the fix instead of at a version number the user can't change.
+    let source = || {
+        if crate::core::caps::smp_selectable() {
+            "the NDL backend — try SMP".to_string()
+        } else {
+            match webos_major {
+                Some(major) => format!("webOS {major}"),
+                None => "this TV".to_string(),
+            }
+        }
+    };
+    match lock {
+        menu::RowLock::HdrNeedsHevc => "HDR is not supported by H.264".to_string(),
+        menu::RowLock::NoHdr => format!("HDR is not supported by {}", source()),
+        menu::RowLock::OneCodec => format!("H.264 is the only codec supported by {}", source()),
+        menu::RowLock::StereoOnly => format!("Stereo is the only audio supported by {}", source()),
+        menu::RowLock::NoGamepad => "Connect a controller to your TV".to_string(),
+    }
+}
+
+/// One row per `menu::ROW_*`, in order, filtered by `menu::row_shown` and greyed by
+/// `menu::row_lock` (whose reason becomes the row's caption, see [`lock_caption`]).
 ///
 /// `detected_gamepad_type` is the attached pad per `gamepad::detect_type`, `None` with nothing
 /// attached or an unrecognized pad — it only changes what "Automatic" reads as.
@@ -53,8 +83,7 @@ pub(crate) const PEEK: u32 = 44;
 /// `dualsense_limited`: the *effective* controller type (the explicit pick, or on `Auto`
 /// whatever's actually plugged in) is a `DualSense`/`Edge` and the TV's kernel isn't running
 /// `hid-playstation` — see `platform::webos::dualsense::hid_playstation_bound`. Computed by
-/// the caller, like `webos_major` (the OS major named in the Video backend row's caption,
-/// `None` where it couldn't be read), so this module stays platform-neutral.
+/// the caller, like `webos_major`, so this module stays platform-neutral.
 pub(crate) fn rows(
     settings: &Settings,
     detected_gamepad_type: Option<GamepadType>,
@@ -99,21 +128,11 @@ pub(crate) fn rows(
                 VideoBackend::Ndl => "NDL",
                 VideoBackend::Smp => "SMP",
             },
-        )
-        .with_subtext_opt((settings.video_backend == VideoBackend::Ndl).then(|| {
-            ui::widgets::RowSubtext::caution(match webos_major {
-                Some(major) => format!("Limitted HDR support on webOS {major}"),
-                None => String::new(),
-            })
-        })),
+        ),
         FocusRow::dropdown(
             crate::app::view::icons::ICON_MOVIE,
             "Codec",
             menu::codec_label(settings.codec),
-        )
-        .with_subtext_opt(
-            (settings.codec == CodecPref::H264)
-                .then(|| ui::widgets::RowSubtext::hint("HDR is not supported with this codec")),
         ),
         FocusRow::toggle(crate::app::view::icons::ICON_SUN, "HDR", settings.hdr_enabled),
         FocusRow::dropdown(
@@ -149,17 +168,26 @@ pub(crate) fn rows(
         menu::SETTINGS_ROW_COUNT,
         "one row per logical index, in order"
     );
-    // Driven by the one visibility predicate rather than repeating its conditions, so a row hidden
-    // there can never linger here. Index == logical row, guaranteed by the assert above.
+    // Driven by the two predicates rather than repeating their conditions, so a row hidden or
+    // locked there can never disagree here. Index == logical row, guaranteed by the assert above.
     rows.into_iter()
         .enumerate()
-        .filter(|(row, _)| menu::row_shown(*row, settings))
-        .map(|(_, row)| row)
+        .filter(|(logical, _)| menu::row_shown(*logical, settings))
+        .map(
+            |(logical, row)| match menu::row_lock(logical, settings, detected_gamepad_type) {
+                // The lock's caption replaces whatever contextual one the row carried: a row the
+                // user can't change has nothing more useful to say than why.
+                Some(lock) => row
+                    .locked(true)
+                    .with_subtext(ui::widgets::RowSubtext::hint(lock_caption(lock, webos_major))),
+                None => row,
+            },
+        )
         .collect()
 }
 
-/// How many rows are *fully* visible. Capped at the live row count so a hidden row (HDR on
-/// an explicit H.264 pick) leaves no empty slot.
+/// How many rows are *fully* visible. Capped at the live row count so a hidden row (the Video
+/// backend row off webOS 3.5-4.x) leaves no empty slot.
 ///
 /// When the list overflows, one row's worth of budget is spent on [`PEEK`] instead —
 /// the partially-visible sliver the bottom fade dissolves. Computed without the peek first,

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -35,6 +35,9 @@ pub struct Theme {
     pub text: Color,
     /// Secondary text, unfocused icons.
     pub muted: Color,
+    /// A control that exists but cannot be changed here — dimmer than [`Self::muted`], which
+    /// is merely "not focused". Reads as inert next to a focused row's white label.
+    pub disabled: Color,
     pub warning: Color,
     /// A muted caution caption — dimmer than [`Self::warning`], so it reads as a hint
     /// rather than an alert.
@@ -58,6 +61,7 @@ impl Theme {
         accent_bright: Color::RGB(0x9f, 0x9f, 0xf8),
         text: Color::RGB(0xf5, 0xf5, 0xf5),
         muted: Color::RGB(0x94, 0x94, 0x9b),
+        disabled: Color::RGB(0x5a, 0x5a, 0x60),
         warning: Color::RGB(0xff, 0xc1, 0x07),
         caution: Color::RGB(0xd1, 0x84, 0x4a),
         error: Color::RGB(0xff, 0x6b, 0x6b),

--- a/src/ui/widgets/rows.rs
+++ b/src/ui/widgets/rows.rs
@@ -32,6 +32,13 @@ pub struct FocusRow {
     /// Destructive action (Forget host) — drawn in `theme().error` rather than the
     /// normal muted/white pair, so it reads as dangerous before it's confirmed.
     pub danger: bool,
+    /// The row is shown but its value cannot be changed here — dictated by another setting or
+    /// by the hardware (e.g. HDR under an H.264 codec pick). Only the *control* greys out
+    /// (`theme().disabled`); icon and label keep their normal focus colors, so the row still
+    /// reads as a live list entry whose value happens to be fixed. Still focusable, so its
+    /// [`subtext`](Self::subtext) — where the reason belongs — can be read. Rejecting the
+    /// input is the caller's business, not this widget's.
+    pub locked: bool,
     /// `Some` gives this row its own ⋯ actions button, drawn and focused exactly like
     /// a sidebar host row's ([`Canvas::sidebar_menu_button`]) — the bool is whether the
     /// *button* has focus rather than the row body. A row with one has a second thing
@@ -72,6 +79,19 @@ impl RowSubtext {
     }
 }
 
+/// The one rule every row control's color follows: a locked row is `theme().disabled`
+/// regardless of `active` (focus, or an open dropdown) — locked overrides everything else,
+/// so every call site expresses that as data instead of repeating the same `if` three times.
+fn locked_fg(locked: bool, active: bool, active_color: Color, inactive_color: Color) -> Color {
+    if locked {
+        theme().disabled
+    } else if active {
+        active_color
+    } else {
+        inactive_color
+    }
+}
+
 impl FocusRow {
     /// A plain [`RowKind::Action`] row — the common case for list-modal screens.
     pub fn action(icon: &'static str, label: impl Into<String>) -> Self {
@@ -82,6 +102,7 @@ impl FocusRow {
             kind: RowKind::Action,
             fraction: 0.0,
             danger: false,
+            locked: false,
             menu: None,
             subtext: None,
         }
@@ -125,6 +146,12 @@ impl FocusRow {
     /// Marks this row destructive (see [`FocusRow::danger`]).
     pub fn danger(mut self) -> Self {
         self.danger = true;
+        self
+    }
+
+    /// Greys this row out and marks its value fixed (see [`FocusRow::locked`]).
+    pub fn locked(mut self, locked: bool) -> Self {
+        self.locked = locked;
         self
     }
 
@@ -281,8 +308,8 @@ pub fn render_focus_rows_tile(
 
 impl Canvas<'_, '_> {
     /// Draws one focus row (icon + label + control per `RowKind`) at normal size.
-    /// `dropdown_open` is independent of `focused` — pill brightens only when the
-    /// dropdown overlay itself is expanded, not on row focus alone.
+    /// `dropdown_open` is independent of `focused` — a dropdown row's pill brightens while
+    /// its overlay is expanded too, not only on row focus.
     pub fn focus_row(
         &mut self,
         row: &FocusRow,
@@ -332,7 +359,8 @@ impl Canvas<'_, '_> {
         match row.kind {
             RowKind::Dropdown => {
                 let right_edge = row_rect.right() - control_pad;
-                self.dropdown_value(row_rect, right_edge, &row.value, dropdown_open)?;
+                let value_fg = locked_fg(row.locked, focused || dropdown_open, theme().text, theme().muted);
+                self.dropdown_value(row_rect, right_edge, &row.value, value_fg)?;
             }
             RowKind::Slider => {
                 let value_w = self.fonts.raster.measure(value_font, &row.value).0;
@@ -342,7 +370,7 @@ impl Canvas<'_, '_> {
                     &row.value,
                     slot_right - value_w as i32,
                     value_y,
-                    if focused { theme().text } else { theme().muted },
+                    locked_fg(row.locked, focused, theme().text, theme().muted),
                 )?;
                 let track_w = 220u32.min(row_rect.width() / 3);
                 let track = Rect::new(
@@ -351,7 +379,8 @@ impl Canvas<'_, '_> {
                     track_w,
                     10,
                 );
-                self.painter.slider_with_thumb(track, row.fraction, focused);
+                self.painter
+                    .slider_with_thumb(track, row.fraction, focused, !row.locked);
             }
             RowKind::Toggle => {
                 let switch = Rect::new(
@@ -360,7 +389,7 @@ impl Canvas<'_, '_> {
                     64,
                     34,
                 );
-                self.painter.switch(switch, switch_frac);
+                self.painter.switch(switch, switch_frac, !row.locked);
             }
             // Action rows have no control; `value` is a muted hint only, never interactive.
             RowKind::Action => {
@@ -384,11 +413,10 @@ impl Canvas<'_, '_> {
     }
 
     /// The dropdown value + chevron, right-aligned to `right_edge` and vertically
-    /// centered on `row_rect` — no box, the row's own focus state already
-    /// provides one. Both tint toward accent when the dropdown overlay itself is
-    /// expanded.
-    pub fn dropdown_value(&mut self, row_rect: Rect, right_edge: i32, label: &str, open: bool) -> Result<()> {
-        let fg = if open { theme().accent_bright } else { theme().text };
+    /// centered on `row_rect` — no box, the row's own focus state already provides one.
+    /// Text and chevron share `fg`, so the caller decides what the pill's state means
+    /// (brighter while focused or the overlay is expanded, grey while the row is locked).
+    pub fn dropdown_value(&mut self, row_rect: Rect, right_edge: i32, label: &str, fg: Color) -> Result<()> {
         let chevron_size = 20u32;
         let chevron_rect = Rect::new(
             right_edge - chevron_size as i32,
@@ -412,20 +440,30 @@ impl Canvas<'_, '_> {
 }
 
 impl Painter {
-    /// Slider track with round-thumbed, shadowed knob.
-    pub fn slider_with_thumb(&mut self, rect: Rect, fraction: f32, focused: bool) {
+    /// Slider track with round-thumbed, shadowed knob. `enabled` false greys the fill and
+    /// knob — the value still reads, but not as something this screen will change.
+    pub fn slider_with_thumb(&mut self, rect: Rect, fraction: f32, focused: bool, enabled: bool) {
         let track_h = rect.height();
         self.fill_rounded_rect(rect, track_h as i32 / 2, Color::RGBA(0xff, 0xff, 0xff, 0x22));
         let filled_w = (rect.width() as f32 * fraction.clamp(0.0, 1.0)) as u32;
         if filled_w > 0 {
             let filled = Rect::new(rect.x(), rect.y(), filled_w.max(track_h), track_h);
-            self.fill_rounded_rect(filled, track_h as i32 / 2, theme().accent);
+            self.fill_rounded_rect(
+                filled,
+                track_h as i32 / 2,
+                if enabled { theme().accent } else { theme().disabled },
+            );
         }
         let thumb_r = 14.0;
         let cx = rect.x() as f32 + filled_w as f32;
         let cy = rect.y() as f32 + rect.height() as f32 / 2.0;
         self.fill_circle(cx + 2.0, cy + 3.0, thumb_r, Color::RGBA(0x00, 0x00, 0x00, 0x50));
-        self.fill_circle(cx, cy, thumb_r, if focused { theme().text } else { theme().muted });
+        self.fill_circle(
+            cx,
+            cy,
+            thumb_r,
+            locked_fg(!enabled, focused, theme().text, theme().muted),
+        );
     }
 }
 
@@ -445,18 +483,20 @@ pub const SWITCH_OFF_TRACK: Color = Color::RGBA(0xff, 0xff, 0xff, 0x22);
 
 impl Painter {
     /// Modern sliding pill switch. `frac` (0.0=off, 1.0=on) lerps position & color
-    /// for smooth animation; pass static 0.0/1.0 for immediate toggle.
-    pub fn switch(&mut self, rect: Rect, frac: f32) {
+    /// for smooth animation; pass static 0.0/1.0 for immediate toggle. `enabled` false
+    /// greys the "on" track, so a locked toggle still shows its state without inviting a press.
+    pub fn switch(&mut self, rect: Rect, frac: f32, enabled: bool) {
         let frac = frac.clamp(0.0, 1.0);
         let radius = rect.height() as i32 / 2;
-        self.fill_rounded_rect(rect, radius, lerp_color(SWITCH_OFF_TRACK, theme().accent, frac));
+        let on_track = if enabled { theme().accent } else { theme().disabled };
+        self.fill_rounded_rect(rect, radius, lerp_color(SWITCH_OFF_TRACK, on_track, frac));
         let knob_r = radius as f32 - 4.0;
         let cy = rect.y() as f32 + rect.height() as f32 / 2.0;
         let left = rect.x() as f32 + radius as f32;
         let right = rect.x() as f32 + rect.width() as f32 - radius as f32;
         let cx = left + (right - left) * frac;
         self.fill_circle(cx + 1.0, cy + 2.0, knob_r, Color::RGBA(0x00, 0x00, 0x00, 0x40));
-        self.fill_circle(cx, cy, knob_r, theme().text);
+        self.fill_circle(cx, cy, knob_r, if enabled { theme().text } else { theme().disabled });
     }
 }
 


### PR DESCRIPTION
## Summary
- HDR, Codec, Audio, and Controller rows now always show up in Settings, but grey out the control and reject input when the value is fixed by something else (HDR under an explicit H.264 pick, no HEVC/HDR/stereo-only backend, no gamepad plugged in). A caption on the greyed row explains why instead of the row just vanishing.
- Rows that genuinely can't be unlocked from inside the app (video backend choice off webOS 5+, Experimental's Game mode on non-rooted TVs) still stay hidden.
- Value text: dim when unfocused, brighter on focus, always grey when locked — consistent across dropdowns, sliders, and toggles.

## Test plan
- [ ] `task docker:check` / `task docker:lint` pass
- [ ] Manual check on device: HDR/Codec/Audio/Controller lock and show captions correctly under each condition