### PR TITLE
Ignore a stale SMP backend pick on NDL v2 TVs

### DIFF
--- a/src/core/caps.rs
+++ b/src/core/caps.rs
@@ -76,7 +76,7 @@ pub fn install(ndl_caps: VideoCaps) {
 /// which does have HEVC and HDR on the releases NDL v1 does not — so the pick widens what this
 /// client advertises, and the row/wire clamps follow from here.
 pub fn set_backend(backend: VideoBackend) {
-    let smp = backend == VideoBackend::Smp;
+    let smp = effective_backend(backend) == VideoBackend::Smp;
     if SMP_ACTIVE.swap(smp, Ordering::Relaxed) != smp {
         tracing::info!("video caps now {:?} ({backend:?})", video_caps());
     }
@@ -98,4 +98,12 @@ pub fn video_caps() -> VideoCaps {
 /// (`session::open_player`) rather than costing the user the choice.
 pub fn smp_selectable() -> bool {
     NDL_BASELINE.get() == Some(&VideoCaps::H264_SDR)
+}
+
+pub fn effective_backend(pick: VideoBackend) -> VideoBackend {
+    if pick == VideoBackend::Smp && !smp_selectable() {
+        VideoBackend::Ndl
+    } else {
+        pick
+    }
 }

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -282,6 +282,11 @@ impl Settings {
     /// whenever the backend row changes, so the document never holds a *set* value whose row
     /// the UI has just hidden. `session::connect` clamps the wire regardless.
     pub fn clamp_to_caps(&mut self) {
+        let backend = crate::core::caps::effective_backend(self.video_backend);
+        if backend != self.video_backend {
+            tracing::info!("settings: SMP isn't offerable on this TV — using NDL");
+            self.video_backend = backend;
+        }
         let caps = crate::core::caps::video_caps();
         let codecs = caps.codec_prefs();
         if !codecs.contains(&self.codec) {

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -50,8 +50,14 @@ pub(super) fn run_inner() -> Result<()> {
         display_mode.refresh_rate
     );
 
+    // The stream clears to alpha 0 for NDL's punch-through plane, and the GLES2 renderer's EGL
+    // config carries no alpha channel by default — without this every transparent clear composites
+    // as opaque black. `.opengl()` below is what makes the attribute apply.
+    video.gl_attr().set_alpha_size(8);
+
     let window = video
         .window("punktfunk", display_mode.w as u32, display_mode.h as u32)
+        .opengl()
         .fullscreen()
         .build()
         .map_err(|e| anyhow::anyhow!("create window: {e}"))?;

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -237,7 +237,7 @@ fn open_player(
     codec: NdlCodec,
     audio_channels: u8,
 ) -> Result<VideoPlayer> {
-    if matches!(backend, VideoBackend::Smp) {
+    if crate::core::caps::effective_backend(backend) == VideoBackend::Smp {
         match crate::platform::webos::smp::SmpVideo::load(app_id, width, height, fps, codec) {
             Ok(sf) => return Ok(VideoPlayer::Smp(sf)),
             Err(e) => tracing::warn!("SMP load failed ({e:#}) — falling back to NDL"),


### PR DESCRIPTION
Black screen on stream start, no reaction to Back, and core logging `receive backlog stopped draining ... dropped_frames=90` every couple of seconds.

Cause: my `settings.json` still had `video_backend: Smp` from a run under a webOS 4 override. Nothing clamped it once the override was gone, so a webOS 5 TV kept opening every session with `StarfishMediaAPIs_load` — which on that generation just doesn't return. `open_player` never got to spawn the video pump, so nobody drained the receive queue and the main thread sat in `connect_thread.join()`.

SMP is only ever offerable where NDL is the narrow v1 generation, so the pick is now ignored rather than honoured anywhere else.

- new `caps::effective_backend(pick)` — the one place that rule is spelled
- `set_backend` and `Settings::clamp_to_caps` go through it, so the caps view and the stored document agree (and the document gets corrected on load instead of re-clamped every boot)
- `session::open_player` checks it too — that's the call that actually hangs, and it already derived the NDL generation from the platform, so it may as well ask whether SMP is real on that generation in the same three lines

Also in here: the stream window now asks for an 8-bit alpha EGL config. Since #109 made the canvas `.accelerated()`, the GLES2 config carries no alpha by default, which would make NDL's punch-through clears composite as opaque black. Unrelated to the hang, but wrong either way.