### PR TITLE
Fix RNG panic on webOS 4.x TVs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,7 +4,18 @@ linker = "scripts/cc-shim.sh"
 # Use softfp (real VFP/NEON instructions, not soft-float emulation) to avoid ~300ms/render tax.
 # Tune for cortex-a73 (LG CX's α9-gen3 SoC); binary still runs on cortex-a53.
 # See docs/NOTES.md for detailed rationale on both choices.
-rustflags = ["-C", "target-feature=+neon,+vfp3,-soft-float", "-C", "target-cpu=cortex-a73"]
+# getrandom's stock Linux backend resolves getrandom(2) through dlsym(RTLD_DEFAULT), which finds
+# nothing on webOS 4.x's old glibc, then falls back to /dev/urandom, which the app sandbox does not
+# expose — so every RNG user (rand, quinn) panicked with ENOENT before the first packet (issue #88).
+# `linux_raw` issues the syscall by inline asm instead: no libc symbol, no /dev.
+rustflags = [
+    "-C",
+    "target-feature=+neon,+vfp3,-soft-float",
+    "-C",
+    "target-cpu=cortex-a73",
+    "--cfg",
+    'getrandom_backend="linux_raw"',
+]
 
 [env]
 CC_armv7_unknown_linux_gnueabi = { value = "scripts/cc-shim.sh", relative = true }


### PR DESCRIPTION
Fixes #88.

On a C9 (webOS 4.5) the app dies before it can pair, with `could not initialize ThreadRng: No such file or directory` on both the pairing thread and an mDNS/QUIC thread. The host was found fine over mDNS — the panic just killed the request thread, so the UI reported "host didn't answer".

The cause is entropy, not networking. getrandom's stock Linux backend looks up `getrandom(2)` with `dlsym(RTLD_DEFAULT, "getrandom")`, which finds nothing on webOS 4.x's old glibc, and then falls back to opening `/dev/urandom`, which the app sandbox doesn't expose. Both doors shut, so every RNG user panics.

Switching that target to getrandom's `linux_raw` backend makes it issue `__NR_getrandom` (384) by inline asm instead — no libc symbol to resolve, no `/dev` to open.

- one line of build config, no new code and no new dependency
- no change on webOS 5+, which has always had the syscall; marginally faster startup (no dlsym + probe) and a slightly smaller binary since the `/dev/urandom` fallback drops out
- the fallback being given up was never reachable on the TV anyway — that's the bug

Not verified on hardware; needs someone with a webOS 4.x set to try a build. If that TV's kernel turns out to predate 3.17 the syscall won't exist either and we'd need a real fallback, but webOS 4.5 is kernel 4.9 so that's unlikely.

One thing this doesn't cover: aws-lc-rs seeds its own RNG in C and could hit the same missing `/dev/urandom`. Every panic in the report is `rand`/`quinn`, so it may well be fine, but if pairing then fails inside TLS instead, that's where to look next.