### PR TITLE
Fix the DualSense touchpad, and forward its contacts and motion to the host

### DIFF
--- a/src/platform/webos/evdev.rs
+++ b/src/platform/webos/evdev.rs
@@ -59,6 +59,13 @@ const BTN_RIGHT: u16 = 0x111;
 const BTN_MIDDLE: u16 = 0x112;
 const BTN_SIDE: u16 = 0x113;
 const BTN_EXTRA: u16 = 0x114;
+/// Finger-on-surface, which only touch-class nodes carry — the pad's own node reports
+/// `BTN_SOUTH`/`BTN_EAST` and never this. See [`is_pad_touchpad`].
+const BTN_TOUCH: u16 = 0x14a;
+
+/// Sony's USB/BT vendor id. `hid-playstation` binds only Sony pads, and it's the split-node
+/// layout that creates the touchpad node this identifies.
+const VENDOR_SONY: u16 = 0x054c;
 
 const KEY_LEFTCTRL: u16 = 29;
 const KEY_A: u16 = 30;
@@ -270,6 +277,9 @@ struct Device {
     mouse: bool,
     /// Alphanumeric/modifier keys. Magic Remote nodes are excluded by [`open_hid`].
     keyboard: bool,
+    /// Claimed purely to keep it away from the compositor — nothing is forwarded (neither
+    /// `mouse` nor `keyboard`, so [`read_device`] drains and drops it). See [`is_pad_touchpad`].
+    silent: bool,
 }
 
 impl Drop for Device {
@@ -353,6 +363,7 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
         grab_warned_for: None,
         mouse: false,
         keyboard: false,
+        silent: false,
     };
     let rel = event_bits(fd, EV_REL);
     let abs = event_bits(fd, EV_ABS);
@@ -371,7 +382,10 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
     // where a separate mouse node keeps aiming absolutely. Better than the alternatives: not
     // grabbing means the modifier bug this exists to fix comes back on exactly that hardware.
     dev.mouse = pointer && (grab_mouse || dev.keyboard);
-    if !dev.mouse && !dev.keyboard {
+    // Claimed in both cursor modes, unlike a mouse node: leaving it to the compositor is what
+    // produces the stuck left button, which desktop mode wants gone just as much.
+    dev.silent = is_pad_touchpad(absolute_pointer, bit(&key, BTN_TOUCH), || device_vendor(fd));
+    if !dev.mouse && !dev.keyboard && !dev.silent {
         // Not ours, or a pointer-only node in desktop mode — left with the compositor so the
         // TV cursor is still the one you aim.
         return Probe::Skip;
@@ -381,9 +395,10 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
     }
     tracing::info!(
         "HID {}: {} ({})",
-        match (dev.mouse, dev.keyboard) {
-            (true, true) => "mouse+keyboard",
-            (true, false) => "mouse",
+        match (dev.mouse, dev.keyboard, dev.silent) {
+            (_, _, true) => "pad touchpad (claimed, dropped)",
+            (true, true, _) => "mouse+keyboard",
+            (true, false, _) => "mouse",
             _ => "keyboard",
         },
         name,
@@ -404,6 +419,32 @@ fn set_repeat(fd: RawFd) {
 /// LG's virtual remotes advertise a full QWERTY keymap, so a "has `KEY_A`" filter would steal
 /// the Magic Remote / RCU from the compositor and leave the TV unnavigable. Names as they read
 /// in `/proc/bus/input/devices` on-device.
+/// A `PlayStation` pad's touchpad, which the kernel publishes as its own absolute/multitouch node
+/// alongside the pad itself — the source of the stuck left button [`mouse::is_touch_emulated`]
+/// describes, since the compositor drives the TV cursor from it. Claiming it takes it away from
+/// the compositor entirely; the events go nowhere, as the wire has no controller-touch kind to
+/// forward them on. The pad's own *click* is unaffected — that arrives on the pad node as
+/// `BTN_TOUCHPAD` through SDL's controller layer, not here.
+///
+/// Matched on ids and capability bits, not the device name, which varies by driver and firmware:
+/// `BTN_TOUCH` on an absolute pointer (the pad's own node reports face buttons instead), from a
+/// Sony vendor id. `vendor` is lazy because it costs an ioctl the bit tests don't.
+fn is_pad_touchpad(absolute_pointer: bool, has_btn_touch: bool, vendor: impl FnOnce() -> u16) -> bool {
+    absolute_pointer && has_btn_touch && vendor() == VENDOR_SONY
+}
+
+/// The vendor id out of `EVIOCGID`'s `struct input_id` (`bustype, vendor, product, version`) —
+/// the only field anything here needs. `0` when the ioctl fails, which matches no vendor.
+fn device_vendor(fd: RawFd) -> u16 {
+    let mut id = [0u16; 4];
+    // SAFETY: as `event_bits` — length-encoding request, buffer of exactly that length.
+    let rc = unsafe { libc::ioctl(fd, eviocg(0x02, std::mem::size_of_val(&id) as u32), id.as_mut_ptr()) };
+    if rc < 0 {
+        return 0;
+    }
+    id[1]
+}
+
 fn is_tv_builtin(name: &str) -> bool {
     name.starts_with("LGE") || name.starts_with("Bluetooth-audio") || matches!(name, "CHECK INPUT" | "IoT keypad")
 }
@@ -567,6 +608,15 @@ fn read_device(dev: &mut Device, sink: &impl Fn(&InputEvent), keys: &KeyActivity
             return; // EAGAIN on an empty non-blocking node, or the node went away
         }
         let n = n as usize;
+        // A claimed touchpad reports multitouch continuously for as long as a thumb rests on it,
+        // and every one of those events decodes to nothing — drain it without looking. Draining
+        // is still required: an unread node keeps polling ready and spins this thread.
+        if dev.silent {
+            if n < buf.len() {
+                return;
+            }
+            continue;
+        }
         for chunk in buf[..n].chunks_exact(size) {
             // SAFETY: `InputEventRaw` is plain `repr(C)` integers with no padding
             // invariants, and the chunk is exactly its size; read unaligned because the
@@ -643,7 +693,7 @@ fn button_code(code: u16) -> Option<u32> {
 
 #[cfg(test)]
 mod tests {
-    use super::is_tv_builtin;
+    use super::{is_pad_touchpad, is_tv_builtin};
 
     #[test]
     fn tv_builtins_are_skipped_by_name() {
@@ -652,5 +702,20 @@ mod tests {
         assert!(is_tv_builtin("CHECK INPUT"));
         assert!(!is_tv_builtin("M720 Triathlon Mouse"));
         assert!(!is_tv_builtin("MX MCHNCL M Keyboard"));
+    }
+
+    /// Sony's other nodes must not match: claiming the pad node would take the gamepad away from
+    /// SDL, and the motion-sensor node reports absolutely without ever being touched.
+    #[test]
+    fn pad_touchpad_matches_only_the_touch_node() {
+        let sony = || 0x054c;
+        // Touchpad: BTN_TOUCH on an absolute pointer.
+        assert!(is_pad_touchpad(true, true, sony));
+        // Pad node — absolute (sticks), face buttons instead of BTN_TOUCH.
+        assert!(!is_pad_touchpad(true, false, sony));
+        // Motion sensors — no touch, no pointer axes.
+        assert!(!is_pad_touchpad(false, false, sony));
+        // A touchscreen from anyone else stays the compositor's.
+        assert!(!is_pad_touchpad(true, true, || 0x046d));
     }
 }

--- a/src/platform/webos/evdev.rs
+++ b/src/platform/webos/evdev.rs
@@ -1,5 +1,9 @@
 //! Raw HID mouse **and keyboard** input straight from `/dev/input/event*`, bypassing SDL.
 //!
+//! **Also a pad's touchpad.** A `DualSense`'s touchpad is a third evdev node the compositor would
+//! otherwise turn into a cursor (see [`is_pad_touchpad`]); it's claimed here and decoded into
+//! rich-input contacts for the host's virtual pad, the only route a game's touchpad swipes have.
+//!
 //! **Why.** SDL mouse events on webOS come from the compositor's pointer, smoothed/resampled
 //! for a wrist-waved remote rather than a 125–1000 Hz mouse — jittery deltas no matter what the
 //! client does with them. evdev is the same bypass aurora-tv ships as "Use Hardware Mouse".
@@ -39,16 +43,28 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use punktfunk_core::input::InputEvent;
+use punktfunk_core::quic::RichInput;
 
 use super::keyboard;
 use super::mouse;
 
+const EV_SYN: u16 = 0x00;
 const EV_KEY: u16 = 0x01;
 const EV_REL: u16 = 0x02;
 const EV_ABS: u16 = 0x03;
 
+/// End of one report — every `EV_ABS` since the last one describes the same instant, so touch
+/// contacts are only sent here (see [`read_touch`]).
+const SYN_REPORT: u16 = 0x00;
+
 const ABS_X: u16 = 0x00;
 const ABS_Y: u16 = 0x01;
+/// Multitouch protocol B: which contact the following `ABS_MT_*` values belong to.
+const ABS_MT_SLOT: u16 = 0x2f;
+const ABS_MT_POSITION_X: u16 = 0x35;
+const ABS_MT_POSITION_Y: u16 = 0x36;
+/// `-1` lifts the slot's contact; anything else is a new or continuing one.
+const ABS_MT_TRACKING_ID: u16 = 0x39;
 const REL_X: u16 = 0x00;
 const REL_Y: u16 = 0x01;
 const REL_HWHEEL: u16 = 0x06;
@@ -129,6 +145,14 @@ const REPEAT_PERIOD_MS: u32 = 33;
 /// within a burst of typing, short enough that reaching for the remote still feels immediate.
 const IN_USE_WINDOW: Duration = Duration::from_millis(250);
 
+/// One report off a claimed node. Two variants because the two go to different wire planes: a
+/// mouse/keyboard event is an `InputEvent` datagram, a pad touchpad contact is a rich-input one
+/// applied to the host's virtual `DualSense`.
+pub enum HidReport<'a> {
+    Input(&'a InputEvent),
+    Touch(RichInput),
+}
+
 /// A HID reader: one thread polling every mouse- or keyboard-shaped evdev node, handing each
 /// wire event straight to `sink`. Dropping it stops and joins the thread.
 pub struct HidInput {
@@ -188,13 +212,14 @@ impl HidInput {
     ///
     /// `sink` runs **on the reader thread**, once per input frame, only while active (see the
     /// module docs), and must not block: queueing for the main loop would re-quantize motion to
-    /// tick rate, the resampling this escapes.
+    /// tick rate, the resampling this escapes. It takes a [`HidReport`] because a claimed pad
+    /// touchpad reports contacts, not `InputEvent`s.
     ///
     /// `active` is the initial [`set_active`](Self::set_active) state — passed here instead of
     /// left to a follow-up call so a caller that always wants "started active" can't forget it.
     /// `grab_mouse` is cursor capture: false leaves pointer-only nodes with the compositor
     /// (desktop/absolute), keyboards are taken either way.
-    pub fn start(active: bool, grab_mouse: bool, sink: impl Fn(&InputEvent) + Send + 'static) -> Option<Self> {
+    pub fn start(active: bool, grab_mouse: bool, sink: impl Fn(HidReport) + Send + 'static) -> Option<Self> {
         let shared = Arc::new(Shared {
             stop: AtomicBool::new(false),
             has_mouse: AtomicBool::new(false),
@@ -207,9 +232,9 @@ impl HidInput {
             .name("pf-evdev".into())
             .spawn(move || {
                 let gate = Arc::clone(&thread_shared);
-                let gated_sink = move |ev: &InputEvent| {
+                let gated_sink = move |report: HidReport| {
                     if gate.grab.load(Ordering::Relaxed) {
-                        sink(ev);
+                        sink(report);
                     }
                 };
                 reader_loop(&gated_sink, &thread_shared)
@@ -277,9 +302,34 @@ struct Device {
     mouse: bool,
     /// Alphanumeric/modifier keys. Magic Remote nodes are excluded by [`open_hid`].
     keyboard: bool,
-    /// Claimed purely to keep it away from the compositor — nothing is forwarded (neither
-    /// `mouse` nor `keyboard`, so [`read_device`] drains and drops it). See [`is_pad_touchpad`].
-    silent: bool,
+    /// A pad's touchpad ([`is_pad_touchpad`]), claimed so the compositor can't make a cursor of
+    /// it and decoded into [`RichInput::Touchpad`] contacts instead. `None` on every other node.
+    touchpad: Option<Touchpad>,
+}
+
+/// Multitouch decode state for a claimed pad touchpad, plus the axis ranges its coordinates are
+/// normalized against.
+///
+/// Protocol B (`ABS_MT_SLOT` + `ABS_MT_TRACKING_ID`), which is what `hid-playstation` reports and
+/// all the wire has room for: two contacts, matching the `finger` field's `0`/`1`.
+struct Touchpad {
+    /// The slot `ABS_MT_*` values currently apply to. Out-of-range slots are parked on the last
+    /// finger rather than dropped, so a driver reporting more contacts than the wire carries
+    /// can't silently write past the array.
+    slot: usize,
+    fingers: [Finger; 2],
+    /// `(min, max)` of `ABS_MT_POSITION_X` / `_Y`, for the 0..=65535 normalization.
+    x_range: (i32, i32),
+    y_range: (i32, i32),
+}
+
+#[derive(Clone, Copy, Default)]
+struct Finger {
+    active: bool,
+    x: i32,
+    y: i32,
+    /// Something in this report changed the contact — sent at the next `SYN_REPORT` and cleared.
+    dirty: bool,
 }
 
 impl Drop for Device {
@@ -363,7 +413,7 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
         grab_warned_for: None,
         mouse: false,
         keyboard: false,
-        silent: false,
+        touchpad: None,
     };
     let rel = event_bits(fd, EV_REL);
     let abs = event_bits(fd, EV_ABS);
@@ -384,8 +434,10 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
     dev.mouse = pointer && (grab_mouse || dev.keyboard);
     // Claimed in both cursor modes, unlike a mouse node: leaving it to the compositor is what
     // produces the stuck left button, which desktop mode wants gone just as much.
-    dev.silent = is_pad_touchpad(absolute_pointer, bit(&key, BTN_TOUCH), || device_vendor(fd));
-    if !dev.mouse && !dev.keyboard && !dev.silent {
+    if is_pad_touchpad(absolute_pointer, bit(&key, BTN_TOUCH), || device_vendor(fd)) {
+        dev.touchpad = Some(Touchpad::new(fd));
+    }
+    if !dev.mouse && !dev.keyboard && dev.touchpad.is_none() {
         // Not ours, or a pointer-only node in desktop mode — left with the compositor so the
         // TV cursor is still the one you aim.
         return Probe::Skip;
@@ -395,8 +447,8 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
     }
     tracing::info!(
         "HID {}: {} ({})",
-        match (dev.mouse, dev.keyboard, dev.silent) {
-            (_, _, true) => "pad touchpad (claimed, dropped)",
+        match (dev.mouse, dev.keyboard, dev.touchpad.is_some()) {
+            (_, _, true) => "pad touchpad",
             (true, true, _) => "mouse+keyboard",
             (true, false, _) => "mouse",
             _ => "keyboard",
@@ -422,15 +474,60 @@ fn set_repeat(fd: RawFd) {
 /// A `PlayStation` pad's touchpad, which the kernel publishes as its own absolute/multitouch node
 /// alongside the pad itself — the source of the stuck left button [`mouse::is_touch_emulated`]
 /// describes, since the compositor drives the TV cursor from it. Claiming it takes it away from
-/// the compositor entirely; the events go nowhere, as the wire has no controller-touch kind to
-/// forward them on. The pad's own *click* is unaffected — that arrives on the pad node as
-/// `BTN_TOUCHPAD` through SDL's controller layer, not here.
+/// the compositor entirely and gives [`read_touch`] the contacts to forward as
+/// [`RichInput::Touchpad`], which is what makes a game's touchpad swipes work. The pad's own
+/// *click* doesn't come through here at all — that arrives on the pad node as `BTN_TOUCHPAD`
+/// through SDL's controller layer.
 ///
 /// Matched on ids and capability bits, not the device name, which varies by driver and firmware:
 /// `BTN_TOUCH` on an absolute pointer (the pad's own node reports face buttons instead), from a
 /// Sony vendor id. `vendor` is lazy because it costs an ioctl the bit tests don't.
 fn is_pad_touchpad(absolute_pointer: bool, has_btn_touch: bool, vendor: impl FnOnce() -> u16) -> bool {
     absolute_pointer && has_btn_touch && vendor() == VENDOR_SONY
+}
+
+impl Touchpad {
+    /// Reads the node's axis ranges once, at open. A node whose `ABS_MT_POSITION_*` ranges are
+    /// unusable is still worth claiming (the compositor must not have it) — it just reports no
+    /// contacts, which [`Self::normalize`] enforces.
+    fn new(fd: RawFd) -> Self {
+        Self {
+            slot: 0,
+            fingers: [Finger::default(); 2],
+            x_range: abs_range(fd, ABS_MT_POSITION_X),
+            y_range: abs_range(fd, ABS_MT_POSITION_Y),
+        }
+    }
+
+    /// Device units → the wire's `0..=65535` across the pad. `None` when the driver gave no
+    /// range to scale against, since a bogus coordinate is worse than no contact at all.
+    fn normalize(&self, x: i32, y: i32) -> Option<(u16, u16)> {
+        let scale = |v: i32, (min, max): (i32, i32)| {
+            let span = i64::from(max) - i64::from(min);
+            (span > 0).then(|| ((i64::from(v.clamp(min, max)) - i64::from(min)) * 65535 / span) as u16)
+        };
+        // evdev's +y is already down, the direction the wire and the host's virtual pad expect.
+        Some((scale(x, self.x_range)?, scale(y, self.y_range)?))
+    }
+}
+
+/// `EVIOCGABS(code)`'s `(minimum, maximum)` out of `struct input_absinfo`
+/// (`value, minimum, maximum, fuzz, flat, resolution`). Falls back to `(0, 0)` when the ioctl
+/// fails, which [`Touchpad::normalize`] reads as "no usable range".
+fn abs_range(fd: RawFd, code: u16) -> (i32, i32) {
+    let mut info = [0i32; 6];
+    // SAFETY: as `event_bits` — length-encoding request, buffer of exactly that length.
+    let rc = unsafe {
+        libc::ioctl(
+            fd,
+            eviocg(0x40 + u32::from(code), std::mem::size_of_val(&info) as u32),
+            info.as_mut_ptr(),
+        )
+    };
+    if rc < 0 {
+        return (0, 0);
+    }
+    (info[1], info[2])
 }
 
 /// The vendor id out of `EVIOCGID`'s `struct input_id` (`bustype, vendor, product, version`) —
@@ -503,7 +600,7 @@ fn device_name(fd: RawFd) -> Option<String> {
     Some(String::from_utf8_lossy(&buf[..len]).into_owned())
 }
 
-fn reader_loop(sink: &impl Fn(&InputEvent), shared: &Shared) {
+fn reader_loop(sink: &impl Fn(HidReport), shared: &Shared) {
     // Scan at the default niceness: `open`/`ioctl` cost here is the driver's, not scheduling
     // delay, so boosting priority wouldn't speed it up — it would just pull CPU from the video
     // pump during exactly the busiest window (stream connect) for no benefit.
@@ -598,7 +695,7 @@ fn pollfds(devices: &[Device]) -> Vec<libc::pollfd> {
 /// Drains one device's pending events, emitting the summed motion once at the end — a burst is
 /// reports the kernel already queued, so summing costs no latency and beats a datagram per event
 /// at 1kHz (the host's own injector coalesces the same way).
-fn read_device(dev: &mut Device, sink: &impl Fn(&InputEvent), keys: &KeyActivity) {
+fn read_device(dev: &mut Device, sink: &impl Fn(HidReport), keys: &KeyActivity) {
     let size = std::mem::size_of::<InputEventRaw>();
     let mut buf = [0u8; 1024];
     loop {
@@ -608,10 +705,10 @@ fn read_device(dev: &mut Device, sink: &impl Fn(&InputEvent), keys: &KeyActivity
             return; // EAGAIN on an empty non-blocking node, or the node went away
         }
         let n = n as usize;
-        // A claimed touchpad reports multitouch continuously for as long as a thumb rests on it,
-        // and every one of those events decodes to nothing — drain it without looking. Draining
-        // is still required: an unread node keeps polling ready and spins this thread.
-        if dev.silent {
+        // A claimed touchpad shares none of the mouse/keyboard decode below — different axes,
+        // different wire plane — so it takes the whole burst on its own path.
+        if let Some(pad) = dev.touchpad.as_mut() {
+            read_touch(pad, &buf[..n], size, sink);
             if n < buf.len() {
                 return;
             }
@@ -636,7 +733,7 @@ fn read_device(dev: &mut Device, sink: &impl Fn(&InputEvent), keys: &KeyActivity
                     REL_WHEEL | REL_HWHEEL => {
                         flush_motion(dev, sink);
                         if let Some(e) = dev.scroll.scroll_event(ev.value, ev.code == REL_HWHEEL) {
-                            sink(&e);
+                            sink(HidReport::Input(&e));
                         }
                     }
                     _ => {}
@@ -649,12 +746,12 @@ fn read_device(dev: &mut Device, sink: &impl Fn(&InputEvent), keys: &KeyActivity
                     if let Some(button) = (dev.mouse && ev.value != 2).then(|| button_code(ev.code)).flatten() {
                         // Motion first: the click must land where the pointer already is.
                         flush_motion(dev, sink);
-                        sink(&mouse::raw_button_event(button, ev.value == 1));
+                        sink(HidReport::Input(&mouse::raw_button_event(button, ev.value == 1)));
                     } else if let Some(vk) = dev.keyboard.then(|| keyboard::vk_from_evdev(ev.code)).flatten() {
                         keys.touch();
                         // Autorepeat rides as a repeated KeyDown — the host has no repeat timer of
                         // its own, so dropping these kills held-key repeat.
-                        sink(&keyboard::raw_key_event(vk, ev.value != 0));
+                        sink(HidReport::Input(&keyboard::raw_key_event(vk, ev.value != 0)));
                     }
                 }
                 _ => {}
@@ -667,13 +764,67 @@ fn read_device(dev: &mut Device, sink: &impl Fn(&InputEvent), keys: &KeyActivity
     flush_motion(dev, sink);
 }
 
+/// Decodes one read burst off a claimed pad touchpad into [`RichInput::Touchpad`] contacts.
+///
+/// Contacts are sent at `SYN_REPORT`, not per axis event: a moving finger reports x and y as two
+/// events, and sending between them would put half the samples on a stale axis. Only contacts a
+/// report actually touched are sent, so a resting finger costs one burst of decode and no
+/// datagrams at all.
+fn read_touch(pad: &mut Touchpad, buf: &[u8], size: usize, sink: &impl Fn(HidReport)) {
+    for chunk in buf.chunks_exact(size) {
+        // SAFETY: as `read_device` — exact-size chunk of plain `repr(C)` integers, read unaligned.
+        let ev = unsafe { chunk.as_ptr().cast::<InputEventRaw>().read_unaligned() };
+        match (ev.kind, ev.code) {
+            // A slot the wire can't carry is parked on the last finger, where its coordinates are
+            // simply overwritten by a contact that does fit — the pad only ever reports two.
+            (EV_ABS, ABS_MT_SLOT) => pad.slot = (ev.value.max(0) as usize).min(pad.fingers.len() - 1),
+            (EV_ABS, ABS_MT_TRACKING_ID) => {
+                let finger = &mut pad.fingers[pad.slot];
+                finger.active = ev.value >= 0;
+                finger.dirty = true;
+            }
+            (EV_ABS, ABS_MT_POSITION_X | ABS_MT_POSITION_Y) => {
+                let finger = &mut pad.fingers[pad.slot];
+                if ev.code == ABS_MT_POSITION_X {
+                    finger.x = ev.value;
+                } else {
+                    finger.y = ev.value;
+                }
+                finger.dirty = true;
+            }
+            (EV_SYN, SYN_REPORT) => {
+                for i in 0..pad.fingers.len() {
+                    let finger = pad.fingers[i];
+                    if !finger.dirty {
+                        continue;
+                    }
+                    pad.fingers[i].dirty = false;
+                    // A lift's coordinates are whatever the contact last had, which is what the
+                    // host wants — the release still has to land where the finger was.
+                    let Some((x, y)) = pad.normalize(finger.x, finger.y) else {
+                        continue;
+                    };
+                    sink(HidReport::Touch(RichInput::Touchpad {
+                        pad: 0,
+                        finger: i as u8,
+                        active: finger.active,
+                        x,
+                        y,
+                    }));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Sends the accumulated deltas as one `MouseMove`, undamped — damping is for the remote's
 /// coarse deltas and would make a real mouse sluggish.
-fn flush_motion(dev: &mut Device, sink: &impl Fn(&InputEvent)) {
+fn flush_motion(dev: &mut Device, sink: &impl Fn(HidReport)) {
     if dev.dx == 0 && dev.dy == 0 {
         return;
     }
-    sink(&mouse::move_relative_event(dev.dx, dev.dy));
+    sink(HidReport::Input(&mouse::move_relative_event(dev.dx, dev.dy)));
     dev.dx = 0;
     dev.dy = 0;
 }

--- a/src/platform/webos/evdev.rs
+++ b/src/platform/webos/evdev.rs
@@ -61,6 +61,11 @@ const SYN_REPORT: u16 = 0x00;
 
 const ABS_X: u16 = 0x00;
 const ABS_Y: u16 = 0x01;
+/// The motion node's six axes, contiguous and in the `DualSense` report's own order: `ABS_X`..`_Z`
+/// accelerometer, `ABS_RX`..`_RZ` gyro (pitch/yaw/roll).
+const ABS_Z: u16 = 0x02;
+const ABS_RX: u16 = 0x03;
+const ABS_RZ: u16 = 0x05;
 /// Multitouch protocol B: which contact the following `ABS_MT_*` values belong to.
 const ABS_MT_SLOT: u16 = 0x2f;
 const ABS_MT_POSITION_X: u16 = 0x35;
@@ -80,6 +85,10 @@ const BTN_EXTRA: u16 = 0x114;
 /// Finger-on-surface, which only touch-class nodes carry — the pad's own node reports
 /// `BTN_SOUTH`/`BTN_EAST` and never this. See [`is_pad_touchpad`].
 const BTN_TOUCH: u16 = 0x14a;
+
+/// The pad's own south face button — what parts the gamepad node from the motion node, which
+/// advertises the same six absolute axes but no buttons at all. See [`is_pad_motion`].
+const BTN_SOUTH: u16 = 0x130;
 
 /// Sony's USB/BT vendor id. `hid-playstation` binds only Sony pads, and it's the split-node
 /// layout that creates the touchpad node this identifies.
@@ -148,11 +157,11 @@ const REPEAT_PERIOD_MS: u32 = 33;
 const IN_USE_WINDOW: Duration = Duration::from_millis(250);
 
 /// One report off a claimed node. Two variants because the two go to different wire planes: a
-/// mouse/keyboard event is an `InputEvent` datagram, a pad touchpad contact is a rich-input one
-/// applied to the host's virtual `DualSense`.
+/// mouse/keyboard event is an `InputEvent` datagram, a pad's touch contacts and motion samples
+/// are rich-input ones applied to the host's virtual `DualSense`.
 pub enum HidReport<'a> {
     Input(&'a InputEvent),
-    Touch(RichInput),
+    Rich(RichInput),
 }
 
 /// A HID reader: one thread polling every mouse- or keyboard-shaped evdev node, handing each
@@ -235,10 +244,11 @@ impl HidInput {
             .spawn(move || {
                 let gate = Arc::clone(&thread_shared);
                 let gated_sink = move |report: HidReport| {
-                    // Touch is exempt from the gate: a contact is a level, not an edge, so a
-                    // dropped lift is a finger the host holds down forever (see
-                    // `release_touches`). Keys and clicks self-clear on the next report.
-                    if gate.grab.load(Ordering::Relaxed) || matches!(report, HidReport::Touch(_)) {
+                    // Rich reports are exempt from the gate: both are levels, not edges, so a
+                    // dropped contact is a finger the host holds down forever (see
+                    // `release_touches`) and a dropped motion sample is an attitude it keeps.
+                    // Keys and clicks self-clear on the next report.
+                    if gate.grab.load(Ordering::Relaxed) || matches!(report, HidReport::Rich(_)) {
                         sink(report);
                     }
                 };
@@ -310,6 +320,23 @@ struct Device {
     /// A pad's touchpad ([`is_pad_touchpad`]), claimed so the compositor can't make a cursor of
     /// it and decoded into [`RichInput::Touchpad`] contacts instead. `None` on every other node.
     touchpad: Option<Touchpad>,
+    /// A pad's motion sensors ([`is_pad_motion`]), on their own node — never set together with
+    /// [`Self::touchpad`]. `None` on every other node.
+    sensors: Option<Sensors>,
+}
+
+/// Motion decode state. Sensor readings are levels, not deltas, so a read burst collapses to its
+/// newest sample and an unchanged sample is worth no datagram at all — a resting pad reports at
+/// its full rate forever.
+#[derive(Default)]
+struct Sensors {
+    /// Pitch/yaw/roll then accelerometer, in the pad's own units (`hid-playstation` keeps the
+    /// report's scale), as the wire orders them.
+    axes: [i32; 6],
+    /// A `SYN_REPORT` completed a sample since the last send.
+    dirty: bool,
+    /// Last sample actually sent, for the unchanged-sample skip.
+    sent: Option<[i16; 6]>,
 }
 
 /// Multitouch decode state for a claimed pad touchpad, plus the axis ranges its coordinates are
@@ -423,6 +450,7 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
         mouse: false,
         keyboard: false,
         touchpad: None,
+        sensors: None,
     };
     let rel = event_bits(fd, EV_REL);
     let abs = event_bits(fd, EV_ABS);
@@ -445,8 +473,10 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
     // produces the stuck left button, which desktop mode wants gone just as much.
     if is_pad_touchpad(absolute_pointer, bit(&key, BTN_TOUCH), || device_vendor(fd)) {
         dev.touchpad = Some(Touchpad::new(fd));
+    } else if is_pad_motion(&abs, bit(&key, BTN_TOUCH) || bit(&key, BTN_SOUTH), || device_vendor(fd)) {
+        dev.sensors = Some(Sensors::default());
     }
-    if !dev.mouse && !dev.keyboard && dev.touchpad.is_none() {
+    if !dev.mouse && !dev.keyboard && dev.touchpad.is_none() && dev.sensors.is_none() {
         // Not ours, or a pointer-only node in desktop mode — left with the compositor so the
         // TV cursor is still the one you aim.
         return Probe::Skip;
@@ -454,17 +484,18 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
     if dev.keyboard {
         set_repeat(fd);
     }
-    tracing::info!(
-        "HID {}: {} ({})",
-        match (dev.mouse, dev.keyboard, dev.touchpad.is_some()) {
-            (_, _, true) => "pad touchpad",
-            (true, true, _) => "mouse+keyboard",
-            (true, false, _) => "mouse",
-            _ => "keyboard",
-        },
-        name,
-        path.display()
-    );
+    let kind = if dev.touchpad.is_some() {
+        "pad touchpad"
+    } else if dev.sensors.is_some() {
+        "pad motion"
+    } else if dev.mouse && dev.keyboard {
+        "mouse+keyboard"
+    } else if dev.mouse {
+        "mouse"
+    } else {
+        "keyboard"
+    };
+    tracing::info!("HID {kind}: {} ({})", name, path.display());
     Probe::Hid(dev)
 }
 
@@ -493,6 +524,18 @@ fn set_repeat(fd: RawFd) {
 /// Sony vendor id. `vendor` is lazy because it costs an ioctl the bit tests don't.
 fn is_pad_touchpad(absolute_pointer: bool, has_btn_touch: bool, vendor: impl FnOnce() -> u16) -> bool {
     absolute_pointer && has_btn_touch && vendor() == VENDOR_SONY
+}
+
+/// A `PlayStation` pad's motion sensors, published as a third node beside the pad and its
+/// touchpad. SDL2 never reads it, so gyro aiming reaches the host only if this reader forwards it
+/// as [`RichInput::Motion`].
+///
+/// Matched on capability bits and vendor, like [`is_pad_touchpad`]: all six sensor axes and no
+/// buttons. Both other nodes carry those same axes — the pad node's are its sticks and triggers,
+/// the touchpad's are the contact — so the buttons (`BTN_SOUTH`, `BTN_TOUCH`) are what part them.
+/// Matching the pad node here would grab the gamepad away from SDL entirely.
+fn is_pad_motion(abs: &[u8; 128], has_buttons: bool, vendor: impl FnOnce() -> u16) -> bool {
+    (ABS_X..=ABS_RZ).all(|c| bit(abs, c)) && !has_buttons && vendor() == VENDOR_SONY
 }
 
 impl Touchpad {
@@ -579,7 +622,9 @@ fn apply_grab(devices: &mut [Device], want: bool) {
         // A pad touchpad is claimed whether the reader is active or not: ungrabbing it hands the
         // compositor back a node it turns into a cursor with a stuck left button, which is the
         // whole reason it's claimed (see `is_pad_touchpad`).
-        let want = want || dev.touchpad.is_some();
+        // Same for the motion node: it too advertises absolute axes the compositor would
+        // otherwise turn into a cursor, and its samples are only useful forwarded.
+        let want = want || dev.touchpad.is_some() || dev.sensors.is_some();
         if dev.grabbed == want {
             continue;
         }
@@ -727,6 +772,8 @@ fn read_device(dev: &mut Device, sink: &impl Fn(HidReport), keys: &KeyActivity) 
         // different wire plane — so it takes the whole burst on its own path.
         if let Some(pad) = dev.touchpad.as_mut() {
             read_touch(pad, &buf[..n], size, sink);
+        } else if let Some(sensors) = dev.sensors.as_mut() {
+            read_sensors(sensors, &buf[..n], size);
         } else {
             decode_hid(dev, &buf[..n], size, sink, keys);
         }
@@ -735,6 +782,9 @@ fn read_device(dev: &mut Device, sink: &impl Fn(HidReport), keys: &KeyActivity) 
         }
     }
     flush_motion(dev, sink);
+    if let Some(sensors) = dev.sensors.as_mut() {
+        flush_sensors(sensors, sink);
+    }
 }
 
 /// Decodes one read burst off a mouse/keyboard node — see [`read_device`] for the drain.
@@ -826,7 +876,7 @@ fn read_touch(pad: &mut Touchpad, buf: &[u8], size: usize, sink: &impl Fn(HidRep
                         continue;
                     };
                     finger.sent = finger.active;
-                    sink(HidReport::Touch(contact));
+                    sink(HidReport::Rich(contact));
                 }
             }
             _ => {}
@@ -849,7 +899,7 @@ fn release_touches(dev: &mut Device, sink: &impl Fn(HidReport)) {
         finger.active = false;
         finger.dirty = false;
         if let Some(contact) = contact(i, finger, x_range, y_range) {
-            sink(HidReport::Touch(contact));
+            sink(HidReport::Rich(contact));
         }
     }
 }
@@ -868,6 +918,47 @@ fn contact(finger_idx: usize, finger: &Finger, x_range: (i32, i32), y_range: (i3
         x,
         y,
     })
+}
+
+/// Decodes one read burst off a claimed motion node into the newest complete sample.
+fn read_sensors(sensors: &mut Sensors, buf: &[u8], size: usize) {
+    for chunk in buf.chunks_exact(size) {
+        // SAFETY: as `read_device` — exact-size chunk of plain `repr(C)` integers, read unaligned.
+        let ev = unsafe { chunk.as_ptr().cast::<InputEventRaw>().read_unaligned() };
+        match (ev.kind, ev.code) {
+            // Gyro first, then accelerometer: the wire's order, so no shuffling at send.
+            (EV_ABS, ABS_RX..=ABS_RZ) => sensors.axes[(ev.code - ABS_RX) as usize] = ev.value,
+            (EV_ABS, ABS_X..=ABS_Z) => sensors.axes[(ev.code - ABS_X) as usize + 3] = ev.value,
+            // Only a completed report is a sample: sending mid-report would mix axes from two.
+            (EV_SYN, SYN_REPORT) => sensors.dirty = true,
+            _ => {}
+        }
+    }
+}
+
+/// Sends the newest sample once per read burst, and only when it moved — a pad lying still
+/// reports forever, and re-sending its resting attitude at 500 Hz would cost a datagram per
+/// sample to tell the host nothing.
+///
+/// Clamped to `i16`: the wire carries the `DualSense` report's own signed-16 units, and
+/// `hid-playstation`'s calibration can push a sample a little past that at the extremes.
+fn flush_sensors(sensors: &mut Sensors, sink: &impl Fn(HidReport)) {
+    if !std::mem::take(&mut sensors.dirty) {
+        return;
+    }
+    let axes = sensors
+        .axes
+        .map(|v| v.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16);
+    if sensors.sent == Some(axes) {
+        return;
+    }
+    sensors.sent = Some(axes);
+    let [gx, gy, gz, ax, ay, az] = axes;
+    sink(HidReport::Rich(RichInput::Motion {
+        pad: 0,
+        gyro: [gx, gy, gz],
+        accel: [ax, ay, az],
+    }));
 }
 
 /// Sends the accumulated deltas as one `MouseMove`, undamped — damping is for the remote's
@@ -896,7 +987,7 @@ fn button_code(code: u16) -> Option<u32> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_pad_touchpad, is_tv_builtin};
+    use super::{is_pad_motion, is_pad_touchpad, is_tv_builtin, ABS_RZ, ABS_X};
 
     #[test]
     fn tv_builtins_are_skipped_by_name() {
@@ -920,5 +1011,19 @@ mod tests {
         assert!(!is_pad_touchpad(false, false, sony));
         // A touchscreen from anyone else stays the compositor's.
         assert!(!is_pad_touchpad(true, true, || 0x046d));
+    }
+
+    #[test]
+    fn pad_motion_matches_only_the_sensor_node() {
+        let sony = || 0x054c;
+        let mut sensors = [0u8; 128];
+        for c in ABS_X..=ABS_RZ {
+            sensors[(c / 8) as usize] |= 1 << (c % 8);
+        }
+        assert!(is_pad_motion(&sensors, false, sony));
+        // The touchpad node (BTN_TOUCH) and the pad node (BTN_SOUTH, sticks and triggers) cover
+        // the same six axes — the buttons are the only thing that parts them from the sensors.
+        assert!(!is_pad_motion(&sensors, true, sony));
+        assert!(!is_pad_motion(&sensors, false, || 0x046d));
     }
 }

--- a/src/platform/webos/evdev.rs
+++ b/src/platform/webos/evdev.rs
@@ -34,7 +34,9 @@
 //! construction, not two atomics a caller has to keep in sync: [`HidInput::set_active`]`(false)`
 //! both releases the node and stops calling `sink`, in one store — needed for the disconnect
 //! dialog, which hands the pointer back to the Magic Remote and needs a HID mouse to go quiet for
-//! the same window.
+//! the same window. A claimed pad touchpad is the one exception on both counts: it stays grabbed
+//! (handing it back is what re-creates the cursor it exists to suppress) and its contacts still
+//! reach the sink, since a dropped lift is a finger the host holds down forever.
 
 use std::os::unix::io::RawFd;
 use std::path::{Path, PathBuf};
@@ -233,7 +235,10 @@ impl HidInput {
             .spawn(move || {
                 let gate = Arc::clone(&thread_shared);
                 let gated_sink = move |report: HidReport| {
-                    if gate.grab.load(Ordering::Relaxed) {
+                    // Touch is exempt from the gate: a contact is a level, not an edge, so a
+                    // dropped lift is a finger the host holds down forever (see
+                    // `release_touches`). Keys and clicks self-clear on the next report.
+                    if gate.grab.load(Ordering::Relaxed) || matches!(report, HidReport::Touch(_)) {
                         sink(report);
                     }
                 };
@@ -326,6 +331,10 @@ struct Touchpad {
 #[derive(Clone, Copy, Default)]
 struct Finger {
     active: bool,
+    /// The host currently believes this contact is down. Gates the lift: a node claimed with a
+    /// finger already on it reports coordinates without a `ABS_MT_TRACKING_ID`, which would
+    /// otherwise send a lift for a contact the host never saw start.
+    sent: bool,
     x: i32,
     y: i32,
     /// Something in this report changed the contact — sent at the next `SYN_REPORT` and cleared.
@@ -489,7 +498,7 @@ fn is_pad_touchpad(absolute_pointer: bool, has_btn_touch: bool, vendor: impl FnO
 impl Touchpad {
     /// Reads the node's axis ranges once, at open. A node whose `ABS_MT_POSITION_*` ranges are
     /// unusable is still worth claiming (the compositor must not have it) — it just reports no
-    /// contacts, which [`Self::normalize`] enforces.
+    /// contacts, which [`normalize`] enforces.
     fn new(fd: RawFd) -> Self {
         Self {
             slot: 0,
@@ -498,22 +507,22 @@ impl Touchpad {
             y_range: abs_range(fd, ABS_MT_POSITION_Y),
         }
     }
+}
 
-    /// Device units → the wire's `0..=65535` across the pad. `None` when the driver gave no
-    /// range to scale against, since a bogus coordinate is worse than no contact at all.
-    fn normalize(&self, x: i32, y: i32) -> Option<(u16, u16)> {
-        let scale = |v: i32, (min, max): (i32, i32)| {
-            let span = i64::from(max) - i64::from(min);
-            (span > 0).then(|| ((i64::from(v.clamp(min, max)) - i64::from(min)) * 65535 / span) as u16)
-        };
-        // evdev's +y is already down, the direction the wire and the host's virtual pad expect.
-        Some((scale(x, self.x_range)?, scale(y, self.y_range)?))
-    }
+/// Device units → the wire's `0..=65535` across the pad. `None` when the driver gave no range to
+/// scale against, since a bogus coordinate is worse than no contact at all.
+fn normalize(x: i32, y: i32, x_range: (i32, i32), y_range: (i32, i32)) -> Option<(u16, u16)> {
+    let scale = |v: i32, (min, max): (i32, i32)| {
+        let span = i64::from(max) - i64::from(min);
+        (span > 0).then(|| ((i64::from(v.clamp(min, max)) - i64::from(min)) * 65535 / span) as u16)
+    };
+    // evdev's +y is already down, the direction the wire and the host's virtual pad expect.
+    Some((scale(x, x_range)?, scale(y, y_range)?))
 }
 
 /// `EVIOCGABS(code)`'s `(minimum, maximum)` out of `struct input_absinfo`
 /// (`value, minimum, maximum, fuzz, flat, resolution`). Falls back to `(0, 0)` when the ioctl
-/// fails, which [`Touchpad::normalize`] reads as "no usable range".
+/// fails, which [`normalize`] reads as "no usable range".
 fn abs_range(fd: RawFd, code: u16) -> (i32, i32) {
     let mut info = [0i32; 6];
     // SAFETY: as `event_bits` — length-encoding request, buffer of exactly that length.
@@ -567,6 +576,10 @@ fn bit(bits: &[u8; 128], code: u16) -> bool {
 /// `commons-evmouse`'s `evmouse_set_grab`, so a steady state costs no ioctls at all.
 fn apply_grab(devices: &mut [Device], want: bool) {
     for dev in devices {
+        // A pad touchpad is claimed whether the reader is active or not: ungrabbing it hands the
+        // compositor back a node it turns into a cursor with a stuck left button, which is the
+        // whole reason it's claimed (see `is_pad_touchpad`).
+        let want = want || dev.touchpad.is_some();
         if dev.grabbed == want {
             continue;
         }
@@ -640,6 +653,7 @@ fn reader_loop(sink: &impl Fn(HidReport), shared: &Shared) {
                     if fds[i].revents & DEAD == 0 {
                         continue;
                     }
+                    release_touches(&mut devices[i], sink);
                     let gone = devices.remove(i);
                     tracing::info!("HID device gone: {}", gone.path.display());
                     seen.retain(|p| *p != gone.path);
@@ -670,6 +684,10 @@ fn reader_loop(sink: &impl Fn(HidReport), shared: &Shared) {
                 }
             }
         }
+    }
+    // Stopping with a finger on the pad must not leave the host holding it.
+    for dev in &mut devices {
+        release_touches(dev, sink);
     }
 }
 
@@ -709,59 +727,61 @@ fn read_device(dev: &mut Device, sink: &impl Fn(HidReport), keys: &KeyActivity) 
         // different wire plane — so it takes the whole burst on its own path.
         if let Some(pad) = dev.touchpad.as_mut() {
             read_touch(pad, &buf[..n], size, sink);
-            if n < buf.len() {
-                return;
-            }
-            continue;
-        }
-        for chunk in buf[..n].chunks_exact(size) {
-            // SAFETY: `InputEventRaw` is plain `repr(C)` integers with no padding
-            // invariants, and the chunk is exactly its size; read unaligned because the
-            // buffer offset carries no alignment guarantee.
-            let ev = unsafe { chunk.as_ptr().cast::<InputEventRaw>().read_unaligned() };
-            match ev.kind {
-                EV_REL if dev.mouse => match ev.code {
-                    REL_X | REL_Y => {
-                        if ev.code == REL_X {
-                            dev.dx += ev.value;
-                        } else {
-                            dev.dy += ev.value;
-                        }
-                    }
-                    // evdev's wheel is one unit per notch, same as SDL's, so the ×120 wire
-                    // scaling accumulator applies unchanged.
-                    REL_WHEEL | REL_HWHEEL => {
-                        flush_motion(dev, sink);
-                        if let Some(e) = dev.scroll.scroll_event(ev.value, ev.code == REL_HWHEEL) {
-                            sink(HidReport::Input(&e));
-                        }
-                    }
-                    _ => {}
-                },
-                // 0 = release, 1 = press, 2 = autorepeat (keyboard-only).
-                EV_KEY if matches!(ev.value, 0..=2) => {
-                    // Buttons and keys share `EV_KEY`, and a combo node reports both — the code
-                    // ranges are what tells them apart, not the device.
-                    // Buttons skip repeats: one would double-fire the click.
-                    if let Some(button) = (dev.mouse && ev.value != 2).then(|| button_code(ev.code)).flatten() {
-                        // Motion first: the click must land where the pointer already is.
-                        flush_motion(dev, sink);
-                        sink(HidReport::Input(&mouse::raw_button_event(button, ev.value == 1)));
-                    } else if let Some(vk) = dev.keyboard.then(|| keyboard::vk_from_evdev(ev.code)).flatten() {
-                        keys.touch();
-                        // Autorepeat rides as a repeated KeyDown — the host has no repeat timer of
-                        // its own, so dropping these kills held-key repeat.
-                        sink(HidReport::Input(&keyboard::raw_key_event(vk, ev.value != 0)));
-                    }
-                }
-                _ => {}
-            }
+        } else {
+            decode_hid(dev, &buf[..n], size, sink, keys);
         }
         if n < buf.len() {
             break;
         }
     }
     flush_motion(dev, sink);
+}
+
+/// Decodes one read burst off a mouse/keyboard node — see [`read_device`] for the drain.
+fn decode_hid(dev: &mut Device, buf: &[u8], size: usize, sink: &impl Fn(HidReport), keys: &KeyActivity) {
+    for chunk in buf.chunks_exact(size) {
+        // SAFETY: `InputEventRaw` is plain `repr(C)` integers with no padding
+        // invariants, and the chunk is exactly its size; read unaligned because the
+        // buffer offset carries no alignment guarantee.
+        let ev = unsafe { chunk.as_ptr().cast::<InputEventRaw>().read_unaligned() };
+        match ev.kind {
+            EV_REL if dev.mouse => match ev.code {
+                REL_X | REL_Y => {
+                    if ev.code == REL_X {
+                        dev.dx += ev.value;
+                    } else {
+                        dev.dy += ev.value;
+                    }
+                }
+                // evdev's wheel is one unit per notch, same as SDL's, so the ×120 wire
+                // scaling accumulator applies unchanged.
+                REL_WHEEL | REL_HWHEEL => {
+                    flush_motion(dev, sink);
+                    if let Some(e) = dev.scroll.scroll_event(ev.value, ev.code == REL_HWHEEL) {
+                        sink(HidReport::Input(&e));
+                    }
+                }
+                _ => {}
+            },
+            // 0 = release, 1 = press, 2 = autorepeat (keyboard-only).
+            EV_KEY if matches!(ev.value, 0..=2) => {
+                // Buttons and keys share `EV_KEY`, and a combo node reports both — the code
+                // ranges are what tells them apart, not the device.
+                // Buttons skip repeats: one would double-fire the click.
+                if let Some(button) = (dev.mouse && ev.value != 2).then(|| button_code(ev.code)).flatten() {
+                    // Motion first: the click must land where the pointer already is.
+                    flush_motion(dev, sink);
+                    sink(HidReport::Input(&mouse::raw_button_event(button, ev.value == 1)));
+                } else if let Some(vk) = dev.keyboard.then(|| keyboard::vk_from_evdev(ev.code)).flatten() {
+                    keys.touch();
+                    // Autorepeat rides as a repeated KeyDown — the host has no repeat timer of
+                    // its own, so dropping these kills held-key repeat.
+                    sink(HidReport::Input(&keyboard::raw_key_event(vk, ev.value != 0)));
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Decodes one read burst off a claimed pad touchpad into [`RichInput::Touchpad`] contacts.
@@ -793,29 +813,61 @@ fn read_touch(pad: &mut Touchpad, buf: &[u8], size: usize, sink: &impl Fn(HidRep
                 finger.dirty = true;
             }
             (EV_SYN, SYN_REPORT) => {
-                for i in 0..pad.fingers.len() {
-                    let finger = pad.fingers[i];
+                let (x_range, y_range) = (pad.x_range, pad.y_range);
+                for (i, finger) in pad.fingers.iter_mut().enumerate() {
                     if !finger.dirty {
                         continue;
                     }
-                    pad.fingers[i].dirty = false;
-                    // A lift's coordinates are whatever the contact last had, which is what the
-                    // host wants — the release still has to land where the finger was.
-                    let Some((x, y)) = pad.normalize(finger.x, finger.y) else {
+                    finger.dirty = false;
+                    if !finger.active && !finger.sent {
+                        continue; // never announced — nothing to lift
+                    }
+                    let Some(contact) = contact(i, finger, x_range, y_range) else {
                         continue;
                     };
-                    sink(HidReport::Touch(RichInput::Touchpad {
-                        pad: 0,
-                        finger: i as u8,
-                        active: finger.active,
-                        x,
-                        y,
-                    }));
+                    finger.sent = finger.active;
+                    sink(HidReport::Touch(contact));
                 }
             }
             _ => {}
         }
     }
+}
+
+/// Lifts every contact the host still believes is down on this node. A touch is a level, not an
+/// edge: a pad unplugged (or a reader stopped) mid-gesture would otherwise leave the finger down
+/// on the host's virtual pad with nothing left to release it.
+fn release_touches(dev: &mut Device, sink: &impl Fn(HidReport)) {
+    let Some(pad) = dev.touchpad.as_mut() else {
+        return;
+    };
+    let (x_range, y_range) = (pad.x_range, pad.y_range);
+    for (i, finger) in pad.fingers.iter_mut().enumerate() {
+        if !std::mem::take(&mut finger.sent) {
+            continue;
+        }
+        finger.active = false;
+        finger.dirty = false;
+        if let Some(contact) = contact(i, finger, x_range, y_range) {
+            sink(HidReport::Touch(contact));
+        }
+    }
+}
+
+/// One contact for the wire, or `None` when the node gave no usable axis range ([`normalize`]).
+///
+/// A lift's coordinates are whatever the contact last had, which is what the host wants — the
+/// release still has to land where the finger was. `pad` is 0 throughout: this client drives a
+/// single pad.
+fn contact(finger_idx: usize, finger: &Finger, x_range: (i32, i32), y_range: (i32, i32)) -> Option<RichInput> {
+    let (x, y) = normalize(finger.x, finger.y, x_range, y_range)?;
+    Some(RichInput::Touchpad {
+        pad: 0,
+        finger: finger_idx as u8,
+        active: finger.active,
+        x,
+        y,
+    })
 }
 
 /// Sends the accumulated deltas as one `MouseMove`, undamped — damping is for the remote's

--- a/src/platform/webos/mouse.rs
+++ b/src/platform/webos/mouse.rs
@@ -21,6 +21,30 @@ fn button_code(button: MouseButton) -> Option<u32> {
     }
 }
 
+/// Whether this is a mouse event synthesized from a touch device (`which` is
+/// `SDL_TOUCH_MOUSEID`) rather than one a real pointer reported. Dropped at the head of both of
+/// `runtime`'s event loops, so nothing downstream has to know the difference.
+///
+/// A `DualSense` publishes its touchpad as its own absolute/multitouch evdev node, which the
+/// compositor picks up as a touch device; the emulation then holds the left button down for as
+/// long as a finger is on the pad, so a thumb resting there drags whatever the host cursor is
+/// over. `SDL_TOUCH_MOUSE_EVENTS=0` (set in `runtime::stream`) turns SDL's own half off, and
+/// [`super::evdev`] claims the node so the compositor can't drive the TV cursor from it either;
+/// this is the last of the three, covering anything synthesized before SDL sees it.
+///
+/// `SDL_TOUCH_MOUSEID` is `(Uint32)-1`; rust-sdl2 doesn't re-export it.
+pub fn is_touch_emulated(event: &sdl2::event::Event) -> bool {
+    use sdl2::event::Event;
+    let (Event::MouseMotion { which, .. }
+    | Event::MouseButtonDown { which, .. }
+    | Event::MouseButtonUp { which, .. }
+    | Event::MouseWheel { which, .. }) = *event
+    else {
+        return false;
+    };
+    which == u32::MAX
+}
+
 /// `None` for a button id the host has no mapping for (`MouseButton::Unknown`) —
 /// the caller just drops the event.
 pub fn button_event(button: MouseButton, pressed: bool) -> Option<InputEvent> {

--- a/src/runtime/session_ext.rs
+++ b/src/runtime/session_ext.rs
@@ -19,6 +19,14 @@ impl InputSender {
     pub(crate) fn send(&self, ev: &InputEvent) {
         let _ = session::send_input(&self.0, ev);
     }
+
+    /// One pad touchpad contact, on the rich-input plane the host applies to its virtual
+    /// `DualSense` — the only route a swipe has, since a touch surface has no `InputEvent`
+    /// shape. Best-effort like every datagram, and a no-op toward a host running a different
+    /// gamepad backend.
+    pub(crate) fn send_touch(&self, touch: punktfunk_core::quic::RichInput) {
+        let _ = self.0.send_rich_input(touch);
+    }
 }
 
 impl Connected {

--- a/src/runtime/session_ext.rs
+++ b/src/runtime/session_ext.rs
@@ -20,12 +20,12 @@ impl InputSender {
         let _ = session::send_input(&self.0, ev);
     }
 
-    /// One pad touchpad contact, on the rich-input plane the host applies to its virtual
-    /// `DualSense` — the only route a swipe has, since a touch surface has no `InputEvent`
-    /// shape. Best-effort like every datagram, and a no-op toward a host running a different
-    /// gamepad backend.
-    pub(crate) fn send_touch(&self, touch: punktfunk_core::quic::RichInput) {
-        let _ = session::send_rich_input(&self.0, touch);
+    /// One pad touchpad contact or motion sample, on the rich-input plane the host applies to
+    /// its virtual `DualSense` — the only route a swipe or gyro aim has, since neither has an
+    /// `InputEvent` shape. Best-effort like every datagram, and a no-op toward a host running a
+    /// different gamepad backend.
+    pub(crate) fn send_rich(&self, rich: punktfunk_core::quic::RichInput) {
+        let _ = session::send_rich_input(&self.0, rich);
     }
 }
 

--- a/src/runtime/session_ext.rs
+++ b/src/runtime/session_ext.rs
@@ -25,7 +25,7 @@ impl InputSender {
     /// shape. Best-effort like every datagram, and a no-op toward a host running a different
     /// gamepad backend.
     pub(crate) fn send_touch(&self, touch: punktfunk_core::quic::RichInput) {
-        let _ = self.0.send_rich_input(touch);
+        let _ = session::send_rich_input(&self.0, touch);
     }
 }
 

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -245,7 +245,7 @@ pub(super) fn run_inner() -> Result<()> {
             use crate::platform::webos::evdev::HidReport;
             match report {
                 HidReport::Input(ev) => input.send(ev),
-                HidReport::Touch(touch) => input.send_touch(touch),
+                HidReport::Rich(rich) => input.send_rich(rich),
             }
         });
         // Flips once a HID mouse is found — `HidInput::start` no longer scans before returning

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -29,6 +29,9 @@ pub(super) fn run_inner() -> Result<()> {
     sdl2::hint::set("SDL_WEBOS_ACCESS_POLICY_RIBBON", "false");
     // Linear texture filtering — the focus-pop scale shimmers on SDL's default nearest.
     sdl2::hint::set("SDL_RENDER_SCALE_QUALITY", "1");
+    // Nothing here wants a mouse synthesized from touch — the Magic Remote is a real pointer,
+    // and a pad's touchpad must not be one at all (`mouse::is_touch_emulated`).
+    sdl2::hint::set("SDL_TOUCH_MOUSE_EVENTS", "0");
     let sdl = sdl2::init().map_err(|e| anyhow::anyhow!("SDL_Init: {e}"))?;
     let ttf = sdl2::ttf::init().map_err(|e| anyhow::anyhow!("SDL_ttf init: {e}"))?;
     let video = sdl.video().map_err(|e| anyhow::anyhow!("SDL video subsystem: {e}"))?;
@@ -323,6 +326,10 @@ pub(super) fn run_inner() -> Result<()> {
             }
             for event in events.poll_iter() {
                 use sdl2::event::Event;
+                // Never real pointer input, so never the host's — see `mouse::is_touch_emulated`.
+                if mouse::is_touch_emulated(&event) {
+                    continue;
+                }
                 // Which SDL events are the compositor's echo of input this app already read off
                 // evdev. Owning the pointer node is the whole answer for buttons — it's decided
                 // in `evdev` (Capture, and whether the keyboard shares the node), so it isn't

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -241,8 +241,13 @@ pub(super) fn run_inner() -> Result<()> {
         // the compositor sees Ctrl/Alt/Shift and warps its pointer mid-click; mouse nodes follow
         // Capture: on = exclusive relative grab, off = compositor keeps the pointer to aim with.
         let input = connected.input();
-        let hid =
-            crate::platform::webos::evdev::HidInput::start(true, settings.cursor_capture, move |ev| input.send(ev));
+        let hid = crate::platform::webos::evdev::HidInput::start(true, settings.cursor_capture, move |report| {
+            use crate::platform::webos::evdev::HidReport;
+            match report {
+                HidReport::Input(ev) => input.send(ev),
+                HidReport::Touch(touch) => input.send_touch(touch),
+            }
+        });
         // Flips once a HID mouse is found — `HidInput::start` no longer scans before returning
         // (that blocked every stream connect on the node-open cost), so presence is only known
         // once the reader thread's own scan catches up; checked each tick below.

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -217,6 +217,11 @@ pub(super) fn run_ui_flow(
         }
         for event in events.poll_iter() {
             use sdl2::event::Event;
+            // Dropped in the menu too, or a thumb resting on a pad's touchpad hovers rows and
+            // clicks them — see `mouse::is_touch_emulated`.
+            if mouse::is_touch_emulated(&event) {
+                continue;
+            }
             // Launch committed: the menu is behind the loading screen and its input would
             // move a grid the user can no longer see. Only shutdown still counts.
             if app.launch_anim.is_some() {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1078,7 +1078,7 @@ pub fn send_input(client: &NativeClient, ev: &InputEvent) -> Result<()> {
     client.send_input(ev).context("send_input")
 }
 
-/// Sends one rich-input report (pad touchpad contacts) to the host.
+/// Sends one rich-input report (pad touchpad contacts, motion samples) to the host.
 pub fn send_rich_input(client: &NativeClient, input: quic::RichInput) -> Result<()> {
     client.send_rich_input(input).context("send_rich_input")
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1078,6 +1078,11 @@ pub fn send_input(client: &NativeClient, ev: &InputEvent) -> Result<()> {
     client.send_input(ev).context("send_input")
 }
 
+/// Sends one rich-input report (pad touchpad contacts) to the host.
+pub fn send_rich_input(client: &NativeClient, input: quic::RichInput) -> Result<()> {
+    client.send_rich_input(input).context("send_rich_input")
+}
+
 /// Ceiling on feedback events handled per tick.
 ///
 /// Both planes are human-paced (a rumble change, a weapon swap), so this is never reached in


### PR DESCRIPTION
Reported by a user with a DualSense on a webOS TV: the pad's touchpad drives the host cursor, and it behaves as if the left button is permanently held, so anything under the pointer gets dragged around. Fixing that turned into claiming the pad's auxiliary evdev nodes properly, so this now also forwards touchpad contacts and gyro/accelerometer to the host.

## Stop the touchpad acting as a mouse

Nothing here was translating the touchpad to a mouse. The pad publishes its touchpad as a separate absolute/multitouch evdev node; the compositor picks that up as a touch device, and touch-to-mouse emulation holds the left button down for as long as a finger is on the pad. Every SDL mouse event then gets forwarded to the host regardless of where it came from. A thumb resting on the pad is a held left button for the whole session.

- Set `SDL_TOUCH_MOUSE_EVENTS=0` so SDL stops synthesizing mouse from touch.
- Drop mouse events whose `which` is `SDL_TOUCH_MOUSEID` at the head of both event loops, in case the compositor synthesizes them before SDL sees them.
- Claim (`EVIOCGRAB`) the touchpad node in `evdev.rs` so the compositor can't drive the TV cursor from it either.

The pad's touchpad *click* is unaffected — that arrives on the pad node as `BTN_TOUCHPAD` through SDL's controller layer.

## Forward touchpad contacts

The node we now grab is decoded instead of dropped: multitouch protocol B slots become `RichInput::Touchpad` contacts on the rich-input plane, which the host applies to its virtual DualSense. That's what makes a game's touchpad swipes (Detroit, Ghost of Tsushima) work.

A contact is a level, not an edge, so anything that silently drops one leaves the host holding a finger down with nothing to release it. Touch bypasses the active gate, a claimed node stays grabbed while inactive, and unplug/reader-exit lift whatever is still down. A contact is also not sent until it has been announced, so a node claimed mid-touch can't lift a finger the host never saw.

## Forward gyro and accelerometer

`hid-playstation` publishes the pad's motion sensors as a third node beside the pad and its touchpad. SDL2 never reads it, so nothing sent the samples and the host saw no motion at all — gyro aiming was simply absent.

That node is now claimed and decoded as `RichInput::Motion`. The wire has carried it since punktfunk-core v0.28.0 and it needs no capability negotiation, so nothing on the host side had to change. A sample is a level, not a delta, so a read burst collapses to its newest one and an unchanged sample sends nothing — a pad lying still reports at its full rate forever, and re-sending its resting attitude at 500 Hz would tell the host nothing.

## Node matching

All three nodes are matched on capability bits and vendor id rather than device name, which varies by driver and firmware:

- touchpad — `BTN_TOUCH` on an absolute pointer, Sony vendor;
- motion — all six contiguous sensor axes, no buttons, Sony vendor.

The buttons test is load-bearing: the gamepad node reports exactly the same six axes (sticks and triggers), so without it the reader would grab the pad node and take the controller away from SDL entirely. The vendor ioctl only runs for a node whose capability bits already match.

## Not verified on hardware

I don't have a `hid-playstation` TV. The `HID pad touchpad: …` and `HID pad motion: …` log lines confirm which nodes were claimed; worth checking that the controller itself still works (i.e. no `HID pad motion` line naming the gamepad node) alongside swipes and gyro aim.
