### PR TITLE
Cross-fade modals, drag the Bitrate slider, and other Settings polish

### DIFF
--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -20,11 +20,13 @@ pub fn nav_dir(ev: MenuEvent) -> Option<Dir> {
     }
 }
 
-/// User-requested presets: 1080p, 1440p, 4K.
-pub const RESOLUTIONS: [(u32, u32, &str); 3] = [
-    (1920, 1080, "1920 x 1080"),
-    (2560, 1440, "2560 x 1440"),
-    (3840, 2160, "3840 x 2160"),
+/// User-requested presets: 1080p, 1440p, 4K. `(width, height, row value, dropdown name)` —
+/// the row's collapsed value stays plain pixel dimensions, while the dropdown option gets
+/// the friendlier name alongside them (see `resolution_dropdown_label`).
+pub const RESOLUTIONS: [(u32, u32, &str, &str); 3] = [
+    (1920, 1080, "1920 x 1080", "FHD"),
+    (2560, 1440, "2560 x 1440", "QHD"),
+    (3840, 2160, "3840 x 2160", "4K"),
 ];
 
 /// Sent to host as exact wire refresh rate.
@@ -184,8 +186,15 @@ pub fn cycle_index(current: usize, len: usize, forward: bool) -> usize {
 pub fn resolution_label(width: u32, height: u32) -> String {
     RESOLUTIONS
         .iter()
-        .find(|(w, h, _)| *w == width && *h == height)
-        .map_or_else(|| format!("{width}x{height}"), |(_, _, s)| s.to_string())
+        .find(|(w, h, _, _)| *w == width && *h == height)
+        .map_or_else(|| format!("{width}x{height}"), |(_, _, s, _)| s.to_string())
+}
+
+/// Dropdown-only label — the row's own value stays the plain pixel dimensions
+/// ([`resolution_label`]); the option list gets the friendlier name plus the vertical count
+/// alongside them, e.g. "FHD - 1080p - 1920x1080".
+fn resolution_dropdown_label(width: u32, height: u32, name: &str) -> String {
+    format!("{name} - {height}p - {width}x{height}")
 }
 
 pub const LOG_LEVEL_OPTIONS: [LogLevelOverride; 4] = [
@@ -299,7 +308,10 @@ fn video_backend_label(backend: VideoBackend) -> &'static str {
 pub fn dropdown_options(row_index: usize, detected: Option<GamepadType>) -> Vec<String> {
     match row_index {
         ROW_VIDEO_BACKEND => VIDEO_BACKENDS.iter().map(|&b| video_backend_label(b).into()).collect(),
-        ROW_RESOLUTION => RESOLUTIONS.iter().map(|(w, h, _)| resolution_label(*w, *h)).collect(),
+        ROW_RESOLUTION => RESOLUTIONS
+            .iter()
+            .map(|(w, h, _, name)| resolution_dropdown_label(*w, *h, name))
+            .collect(),
         ROW_FRAMERATE => REFRESH_RATES.iter().map(|hz| format!("{hz} Hz")).collect(),
         ROW_CODEC => video_caps()
             .codec_prefs()
@@ -340,7 +352,7 @@ pub fn dropdown_current_index(settings: &Settings, row_index: usize) -> usize {
     match row_index {
         ROW_RESOLUTION => RESOLUTIONS
             .iter()
-            .position(|(w, h, _)| *w == settings.width && *h == settings.height)
+            .position(|(w, h, _, _)| *w == settings.width && *h == settings.height)
             .unwrap_or(0),
         ROW_FRAMERATE => REFRESH_RATES
             .iter()
@@ -381,7 +393,7 @@ pub fn apply_dropdown_choice(
     }
     match row_index {
         ROW_RESOLUTION => {
-            if let Some((w, h, _)) = RESOLUTIONS.get(choice_index) {
+            if let Some((w, h, _, _)) = RESOLUTIONS.get(choice_index) {
                 settings.width = *w;
                 settings.height = *h;
             }
@@ -466,4 +478,19 @@ pub fn adjust_setting(settings: &mut Settings, row_index: usize, forward: bool, 
             true
         }
     }
+}
+
+/// Sets the Bitrate row directly from a dragged/clicked `fraction` (0.0-1.0 along the
+/// track), snapped to [`BITRATE_STEP_KBPS`] — the mouse-drag counterpart of
+/// [`adjust_setting`]'s per-notch `Left`/`Right`. Below one step above the floor snaps to
+/// `Automatic`, mirroring the notch `adjust_setting` leaves for it at the low end.
+pub fn set_bitrate_fraction(settings: &mut Settings, fraction: f32) {
+    let span = BITRATE_MAX_KBPS - BITRATE_MIN_KBPS;
+    let raw = BITRATE_MIN_KBPS + (fraction.clamp(0.0, 1.0) * span as f32) as u32;
+    let stepped = ((raw + BITRATE_STEP_KBPS / 2) / BITRATE_STEP_KBPS) * BITRATE_STEP_KBPS;
+    settings.bitrate_kbps = if stepped <= BITRATE_MIN_KBPS {
+        BITRATE_AUTOMATIC
+    } else {
+        stepped.clamp(BITRATE_MIN_KBPS, BITRATE_MAX_KBPS)
+    };
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -22,6 +22,7 @@ use tiny_skia::Pixmap;
 use crate::app::hosts::HostEntry;
 use crate::app::render::key::ModalShellKey;
 use crate::app::render::tile;
+use crate::app::render::ModalSnapshot;
 use crate::app::state::addhost::AddHostState;
 use crate::core::event::MenuEvent;
 pub use crate::core::model::ConnectTarget;
@@ -51,7 +52,12 @@ pub(crate) const LAUNCH_GROWTH: f32 = 3.5;
 const PIN_BADGE_MARGIN: i32 = 10;
 pub(crate) const CARD_POP: Duration = Duration::from_millis(300);
 pub(crate) const CARD_POP_SHRINK: f32 = 0.14;
-pub(crate) const MODAL_FADE: Duration = Duration::from_millis(200);
+/// Modal open. Short: the card is the response to a keypress, and delay there reads as
+/// a slow TV, not as an animation.
+pub(crate) const MODAL_FADE: Duration = Duration::from_millis(50);
+/// Modal close. Slower than the open — nothing is waiting on it, and outlasting the
+/// incoming card is what makes a modal-to-modal step read as one replacing the other.
+pub(crate) const MODAL_FADE_OUT: Duration = Duration::from_millis(100);
 pub(crate) const DROPDOWN_FADE: Duration = MODAL_FADE;
 /// Scale during open — subtle, since fade dominates for full-screen modal.
 pub(crate) const MODAL_POP_SHRINK: f32 = 0.05;
@@ -372,10 +378,12 @@ pub struct App {
     pub(crate) modal_scroll_screen: Option<Screen>,
     /// Screen-space region the `tile::MODAL` painter currently covers (card bbox +
     /// [`MODAL_TILE_PAD`]) — set by `prepare_modal` when it (re)builds the tile, read by
-    /// `compose_modal` to place it. Held across frames so the close-fade, which renders
-    /// the still-uploaded tile after `self.screen` has moved to Home, still knows where
-    /// to draw it.
+    /// `compose_modal` to place it. Only the *live* modal's; a fading one carries its own
+    /// region in [`ModalSnapshot`].
     pub(crate) modal_tile_region: Rect,
+    /// The fading-out modal's pixels, taken the frame it was left. `None` when no close
+    /// fade is in flight.
+    pub(crate) modal_prev: Option<ModalSnapshot>,
     /// Whether the grid's initial build for the current library has finished — while
     /// `false`, the grid shows the loading spinner (`tile::spinner`) instead of
     /// popping cards in one by one. One-shot per library: only `prepare_tiles`'s
@@ -395,8 +403,8 @@ pub struct App {
     /// `ui::animation::FOCUS_POP` — set on every d-pad focus move).
     pub(crate) focus_anim: Option<Instant>,
     /// Open/close fade for whichever modal is up — see `ui::fade::ModalFade`'s docs. Payload
-    /// is the `Screen` that was open, so a close-fade can keep rendering it after
-    /// `self.screen` has already moved on.
+    /// is the `Screen` that was left — `snapshot_closing_modal` needs it to freeze that
+    /// screen's scroll crop after `self.screen` has moved on.
     pub(crate) modal_fade: ui::fade::ModalFade<Screen>,
     /// When the open modal's focused widget last moved (zooms it in over
     /// `ui::animation::FOCUS_POP`, same GPU-scale technique as `focus_anim` — see
@@ -546,6 +554,7 @@ impl App {
             modal_scroll_target_px: 0,
             modal_scroll_screen: None,
             modal_tile_region: Rect::new(0, 0, 1, 1),
+            modal_prev: None,
             grid_reveal_ready: true,
             spinner_frame: None,
             spinner_since: None,
@@ -945,7 +954,7 @@ impl App {
             }
             animating = true;
         }
-        if self.modal_fade.tick(MODAL_FADE) {
+        if self.modal_fade.tick_split(MODAL_FADE, MODAL_FADE_OUT) {
             animating = true;
         }
         if self.dropdown_fade.tick(DROPDOWN_FADE) {
@@ -1052,15 +1061,14 @@ impl App {
 
         // Every screen transition triggers close-fade for the left screen and
         // open-fade for the entered screen, centralized here rather than at each
-        // dispatch site. Close-fade only on returning to Home: a direct
-        // modal-to-modal jump (Settings <-> About) shares `modal_tile`, which
-        // `prepare_tiles` rebuilds for the entered screen — a close-fade
-        // there would replay a tile that already holds the new screen's content.
+        // dispatch site. Every modal exit fades, modal-to-modal included: the leaving
+        // card's pixels go to `tile::MODAL_PREV` (see `snapshot_closing_modal`), so the
+        // entering screen taking over `tile::MODAL` no longer forces the close to be a cut.
         let screen_changed = self.screen != self.last_screen;
         if screen_changed {
             let left = self.last_screen;
             self.last_screen = self.screen;
-            if !matches!(left, Screen::Home) && matches!(self.screen, Screen::Home) {
+            if !matches!(left, Screen::Home) {
                 self.modal_fade.close(left);
             }
             if !matches!(self.screen, Screen::Home) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -231,6 +231,12 @@ pub struct App {
     /// it's driving, but the Controller row's `DualSense` caption does (see `settings_rows`).
     pub(crate) detected_gamepad_type: Option<store::GamepadType>,
     pub settings_focused: usize,
+    /// Whether the mouse button is down on the Settings screen's slider row (Bitrate) with
+    /// the press having landed on the track itself — while `true`, `MouseMotion` drags the
+    /// thumb to the pointer's x instead of just moving hover focus. Cleared on
+    /// `MouseButtonUp`; never survives a screen change since the button can't be released
+    /// on another screen from webOS's own D-pad OK -> click translation.
+    pub(crate) slider_drag: bool,
     /// Scroll state for overflowing modal content.
     pub(crate) scroll: ui::scroll::ScrollWindow,
     /// Settings' scroll position, stashed while About borrows `scroll` for its
@@ -504,6 +510,7 @@ impl App {
             state_writer,
             detected_gamepad_type: None,
             settings_focused: 0,
+            slider_drag: false,
             scroll: ui::scroll::ScrollWindow::new(),
             settings_scroll: ui::scroll::ScrollWindow::new(),
             content_window: ui::scroll::ContentWindow::new(),

--- a/src/app/pointer.rs
+++ b/src/app/pointer.rs
@@ -31,6 +31,13 @@ impl App {
         screen_h: u32,
         fonts: &ui::text::Fonts,
     ) -> bool {
+        // A press already landed on the Bitrate track (see `handle_mouse_click`) — every
+        // motion until release drags the thumb, rather than re-hit-testing the row list
+        // under a pointer that may have wandered off it.
+        if self.slider_drag {
+            self.drag_bitrate_slider(x, screen_w, screen_h);
+            return true;
+        }
         let focus_changed = self.hover_focus_at(x, y, screen_w, screen_h, fonts);
         // Parity with the D-pad: a hover that moves modal focus replays the focus-pop zoom
         // (and shows the new row's caption). Home drives its own `focus_anim` instead, so
@@ -228,16 +235,54 @@ impl App {
     /// `modal_scroll_px` the rows render with — a fixed-offset hit-test drifts a row
     /// off once the list has scrolled. `None` outside the viewport or in a row gap.
     pub(crate) fn settings_row_at(&self, x: i32, y: i32, screen_w: u32, screen_h: u32) -> Option<usize> {
-        let (_, content) = view::settings::layout(screen_w, screen_h);
+        let (content, scroll_px) = self.settings_content_scroll(screen_w, screen_h);
         if !content.contains_point((x, y)) {
             return None;
         }
+        let total = menu::settings_row_count();
+        (0..total).find(|&r| ui::widgets::focus_row_rect_at_px(content, r, scroll_px).contains_point((x, y)))
+    }
+
+    /// Settings' content viewport and its current animated scroll offset — the shared
+    /// geometry `settings_row_at`'s hit test and `settings_row_rect`'s lookup both index
+    /// into, so a scrolled list can't put them at odds.
+    fn settings_content_scroll(&self, screen_w: u32, screen_h: u32) -> (Rect, i32) {
+        let (_, content) = view::settings::layout(screen_w, screen_h);
         let stride = ui::widgets::focus_row_stride() as i32;
         let total = menu::settings_row_count();
         let scroll_px = self
             .modal_scroll_px
             .clamp(0, Self::max_scroll_px(total, stride, content.height()));
-        (0..total).find(|&r| ui::widgets::focus_row_rect_at_px(content, r, scroll_px).contains_point((x, y)))
+        (content, scroll_px)
+    }
+
+    /// Display row `row`'s on-screen rect, same animated scroll offset `settings_row_at`
+    /// hit-tests against — the geometry the Bitrate drag anchors to.
+    fn settings_row_rect(&self, row: usize, screen_w: u32, screen_h: u32) -> Rect {
+        let (content, scroll_px) = self.settings_content_scroll(screen_w, screen_h);
+        ui::widgets::focus_row_rect_at_px(content, row, scroll_px)
+    }
+
+    /// The Bitrate row's rect and track — `settings_focused` is already that row (set by
+    /// whatever press started the drag), so this is the one geometry lookup both the arming
+    /// click and every later drag motion need.
+    fn bitrate_row_and_track(&self, screen_w: u32, screen_h: u32) -> (Rect, Rect) {
+        let row_rect = self.settings_row_rect(self.settings_focused, screen_w, screen_h);
+        (row_rect, ui::widgets::slider_track_rect(row_rect))
+    }
+
+    /// Sets the Bitrate row from the pointer's current x against its track — shared by the
+    /// initial press (which also has to decide whether the click landed on the track at
+    /// all) and every drag motion after it.
+    fn set_bitrate_from_x(&mut self, x: i32, track: Rect) {
+        let fraction = (x - track.x()) as f32 / track.width() as f32;
+        menu::set_bitrate_fraction(&mut self.settings, fraction);
+    }
+
+    /// Drags the Bitrate slider to `x`.
+    fn drag_bitrate_slider(&mut self, x: i32, screen_w: u32, screen_h: u32) {
+        let (_, track) = self.bitrate_row_and_track(screen_w, screen_h);
+        self.set_bitrate_from_x(x, track);
     }
 
     /// The dropdown option index under the pointer, if a dropdown is open and the
@@ -398,6 +443,23 @@ impl App {
                 // `?` bails if the click hit the gap between rows or outside the
                 // viewport — nothing to focus or confirm.
                 self.settings_focused = self.settings_row_at(x, y, screen_w, screen_h)?;
+                // A press on the Bitrate track sets the value under the cursor directly and
+                // arms the drag (see `handle_mouse_motion`) instead of nudging one notch the
+                // way `Confirm` below would — a slider is for landing on a value, not stepping
+                // to it one click at a time.
+                if menu::settings_logical_row(self.settings_focused) == menu::ROW_BITRATE
+                    && menu::row_lock(menu::ROW_BITRATE, &self.settings, self.detected_gamepad_type).is_none()
+                {
+                    let (row_rect, track) = self.bitrate_row_and_track(screen_w, screen_h);
+                    // Full row height, not just the thin track — vertical precision on a
+                    // slider isn't worth demanding of a Magic Remote pointer.
+                    let in_track = x >= track.x() && x < track.right() && y >= row_rect.y() && y < row_rect.bottom();
+                    if in_track {
+                        self.slider_drag = true;
+                        self.set_bitrate_from_x(x, track);
+                        return None;
+                    }
+                }
                 self.handle_settings_event(MenuEvent::Confirm, screen_h);
                 None
             }

--- a/src/app/pointer.rs
+++ b/src/app/pointer.rs
@@ -205,16 +205,8 @@ impl App {
     /// The `(content viewport, pixel scroll offset)` an open dropdown anchors its
     /// option overlay to, matching what `draw_list` renders so hit-testing lands
     /// exactly where options are drawn. `None` for a screen with no dropdown.
-    /// `screen` is a param (not `self.screen`) so `draw_list`'s close-fade can pass
-    /// the screen it captured at `back()` time.
-    pub(crate) fn dropdown_geom(
-        &self,
-        screen: Screen,
-        screen_w: u32,
-        screen_h: u32,
-        fonts: &ui::text::Fonts,
-    ) -> Option<(Rect, i32)> {
-        match screen {
+    pub(crate) fn dropdown_geom(&self, screen_w: u32, screen_h: u32, fonts: &ui::text::Fonts) -> Option<(Rect, i32)> {
+        match self.screen {
             Screen::Settings => {
                 let (_, content) = view::settings::layout(screen_w, screen_h);
                 let stride = ui::widgets::focus_row_stride() as i32;
@@ -261,9 +253,9 @@ impl App {
         fonts: &ui::text::Fonts,
     ) -> Option<usize> {
         let dd = self.dropdown.as_ref()?;
-        let (content, scroll_px) = self.dropdown_geom(self.screen, screen_w, screen_h, fonts)?;
+        let (content, scroll_px) = self.dropdown_geom(screen_w, screen_h, fonts)?;
         let overlay = view::settings::dropdown_overlay_rect_at_px(content, dd.row, scroll_px);
-        let options_len = self.dropdown_options_len(self.screen, dd.row);
+        let options_len = self.dropdown_options_len(dd.row);
         (0..options_len).find(|&i| ui::widgets::dropdown_option_rect(overlay, i).contains_point((x, y)))
     }
 

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -12,6 +12,9 @@ use crate::ui::render::{DrawCmd, Rect};
 // they read the same private tuning constants the rest of that module does.
 use crate::app::*;
 
+/// How far a modal card slides down as it fades out (and up as it fades in), in px.
+const MODAL_RISE: f32 = 26.0;
+
 impl App {
     /// Assembles the read-only view of state the render path consumes (see
     /// `render_input::RenderInput`). Grows as families migrate off direct `self` reads.
@@ -36,29 +39,45 @@ impl App {
         fonts: &ui::text::Fonts,
         cmds: &mut Vec<DrawCmd>,
     ) {
-        // While closing, `self.screen` has already moved on — render the fade's
-        // captured screen instead, so the still-uploaded tiles keep drawing for one
-        // more `MODAL_FADE` with alpha running in reverse (see `ui::fade::ModalFade`).
-        let closing_frame = self.modal_fade.closing_frame(MODAL_FADE);
-        let (screen, m) = match closing_frame {
-            Some((alpha, s)) => (s, alpha),
-            None => (self.screen, self.modal_fade.open_alpha(MODAL_FADE)),
+        // A left modal keeps drawing from its snapshot while its fade runs (see
+        // `snapshot_closing_modal`) — the entering one owns `tile::MODAL` from this frame.
+        // The two overlap, so leaving one modal for another cross-fades.
+        let closing = self
+            .modal_fade
+            .closing_frame(MODAL_FADE_OUT)
+            .and_then(|(alpha, _)| Some((alpha, self.modal_prev?)));
+        let screen = self.screen;
+        let m = if matches!(screen, Screen::Home) {
+            0.0
+        } else {
+            self.modal_fade.open_alpha(MODAL_FADE)
         };
-        if !matches!(screen, Screen::Home) {
+        // The backdrop belongs to "a modal is up", not to either card: re-fading it
+        // mid-step would brighten the whole screen and read as a blink. It only fades when
+        // the modal layer itself appears or disappears.
+        let scrim = if closing.is_some() && !matches!(screen, Screen::Home) {
+            1.0
+        } else {
+            m.max(closing.map_or(0.0, |(alpha, _)| alpha))
+        };
+        if scrim > 0.0 {
             cmds.push(DrawCmd::Fill {
                 rect: Rect::new(0, 0, screen_w, screen_h),
-                color: crate::ui::render::Color::RGBA(0, 0, 0, (f32::from(ui::style::theme().scrim.a) * m) as u8),
+                color: crate::ui::render::Color::RGBA(0, 0, 0, (f32::from(ui::style::theme().scrim.a) * scrim) as u8),
             });
-            let dy = ((1.0 - m) * 26.0) as i32;
+        }
+        if !matches!(screen, Screen::Home) {
+            let dy = ((1.0 - m) * MODAL_RISE) as i32;
             // The tile now covers only the card region (see `prepare_modal`), so it
             // composites there rather than full-screen. `pop_in_rect` scaling around this
             // rect's center is the card's own center — the same visual pop as before.
             let modal_base = self.modal_tile_region.offset(0, dy);
-            let modal_dst = if closing_frame.is_some() {
-                modal_base
-            } else {
-                ui::animation::pop_in_rect(modal_base, m, MODAL_POP_SHRINK)
-            };
+            let pop = ui::animation::pop_in_scale(m, MODAL_POP_SHRINK);
+            // Everything composited *onto* the card rides its pop, about the card's centre
+            // — otherwise the shell scales while its contents sit still. A modal whose rows
+            // live in the shell tile (the host menu) gets this free; scrollable ones don't.
+            let ride = |r: Rect| ui::animation::scale_about(r, modal_base, pop);
+            let modal_dst = ui::animation::pop_in_rect(modal_base, m, MODAL_POP_SHRINK);
             cmds.push(DrawCmd::Tex {
                 tile: tile::MODAL,
                 dst: modal_dst,
@@ -68,24 +87,18 @@ impl App {
             // once and reused. Scrolling crops the full baked tile, never re-rasterizes.
             let scroll_geom = self.scroll_geometry_for(screen, screen_w, screen_h, fonts);
             if let Some((total, _, _, content)) = scroll_geom {
-                // About uses a bounded window; for other screens, window_start is 0.
-                let window_start = match screen {
-                    Screen::About => self.content_window.start,
-                    _ => 0,
-                };
                 let stride = self.scroll_stride_for(screen, fonts);
-                // The animated offset (see `sync_modal_scroll`), in absolute content pixels,
-                // rebased onto whatever slice is currently baked into the tile.
                 let scroll_px = self
                     .modal_scroll_px
                     .clamp(0, Self::max_scroll_px(total, stride, content.height()));
-                let src_y = scroll_px - window_start as i32 * stride;
-                cmds.push(DrawCmd::TexCropped {
-                    tile: tile::SCROLL_CONTENT,
-                    src: Rect::new(0, src_y, content.width(), content.height()),
-                    dst: content.offset(0, dy),
-                    alpha: (255.0 * m) as u8,
-                });
+                if let Some((src, dst)) = self.scroll_src_rect(screen, screen_w, screen_h, fonts) {
+                    cmds.push(DrawCmd::TexCropped {
+                        tile: tile::SCROLL_CONTENT,
+                        src,
+                        dst: ride(dst.offset(0, dy)),
+                        alpha: (255.0 * m) as u8,
+                    });
+                }
                 // Bottom fade, only while rows remain below the viewport — it is the
                 // "there is more" signal, so it has to vanish exactly when scrolling has
                 // reached the end, or it reads as content that can never be got to.
@@ -100,90 +113,80 @@ impl App {
                 if scroll_px > 0 {
                     cmds.push(DrawCmd::Tex {
                         tile: tile::SCROLL_FADE_TOP,
-                        dst: Rect::new(content.x(), content.y() + dy, content.width(), fade_h),
+                        dst: ride(Rect::new(content.x(), content.y() + dy, content.width(), fade_h)),
                         alpha: (255.0 * m) as u8,
                     });
                 }
                 if scroll_px < Self::max_scroll_px(total, stride, content.height()) {
                     cmds.push(DrawCmd::Tex {
                         tile: tile::SCROLL_FADE,
-                        dst: Rect::new(
+                        dst: ride(Rect::new(
                             content.x(),
                             content.y() + dy + (content.height() - fade_h) as i32,
                             content.width(),
                             fade_h,
-                        ),
+                        )),
                         alpha: (255.0 * m) as u8,
                     });
                 }
             }
             // Dropdown overlay (Settings or Diagnostics).
             if let Some((row, _, dd_alpha)) = self.dropdown_draw_state() {
-                if let Some((content, scroll_px)) = self.dropdown_geom(screen, screen_w, screen_h, fonts) {
+                if let Some((content, scroll_px)) = self.dropdown_geom(screen_w, screen_h, fonts) {
                     let overlay_rect = view::settings::dropdown_overlay_rect_at_px(content, row, scroll_px);
-                    let options_len = self.dropdown_options_len(screen, row);
+                    let options_len = self.dropdown_options_len(row);
                     cmds.push(DrawCmd::Tex {
                         tile: tile::DROPDOWN_OVERLAY,
-                        dst: Rect::new(
+                        dst: ride(Rect::new(
                             overlay_rect.x(),
                             overlay_rect.y() + dy,
                             overlay_rect.width(),
                             options_len as u32 * ui::widgets::DROPDOWN_OPTION_H,
-                        ),
+                        )),
                         alpha: (255.0 * m * dd_alpha) as u8,
                     });
                 }
             }
             // Focused widget of the active modal (setting row, button, etc.);
             // composites on shell at its on-screen position (no re-rasterize on move).
-            //
-            // Skipped entirely once the modal is closing: the position is recomputed
-            // from live per-screen state, which Back may have already torn down (e.g.
-            // `host_menu_index` cleared, collapsing the host-menu card to the screen
-            // centre and floating the highlight there). The shell and scroll-content
-            // tiles still render the focused row through the fade, so dropping just the
-            // zoom-highlight overlay is invisible — and correct.
-            let focus_rect = if closing_frame.is_some() {
-                None
-            } else {
-                match screen {
-                    Screen::Settings => {
-                        let (total, _, _, content) = scroll_geom.expect("screen is Screen::Settings");
-                        // Positioned from the animated pixel offset, not the row index: the baked
-                        // list is cropped at that offset, and the focus tile *is* the focused row
-                        // re-rendered — so anchoring it to the quantized row would show that row's
-                        // content twice, in two places, for the length of every scroll.
-                        let stride = ui::widgets::focus_row_stride() as i32;
-                        let px = self
-                            .modal_scroll_px
-                            .clamp(0, Self::max_scroll_px(total, stride, content.height()));
-                        Some(ui::widgets::focus_row_rect_at_px(content, self.settings_focused, px))
-                    }
-                    // Every two-button confirm dialog: one subtitle drives the card, so one
-                    // button-row geometry serves all four.
-                    Screen::Wake | Screen::ForgetHost | Screen::SendLogs | Screen::SpeedTest => self
-                        .confirm_subtitle()
-                        .zip(self.confirm_focused())
-                        .map(|(subtitle, i)| Self::confirm_focus_button_rect(screen_w, screen_h, fonts, &subtitle, i)),
-                    Screen::Pairing => {
-                        let card = view::pairing::card_rect(screen_w, screen_h, fonts);
-                        Some(match self.pairing_focus {
-                            PairingFocus::Pin => {
-                                let digit_y = view::pairing::pin_row_y(card, fonts);
-                                view::pairing::digit_rect(card, digit_y, self.pin_digit_index)
-                            }
-                            PairingFocus::RequestAccess => view::pairing::request_button_rect(card, fonts),
-                        })
-                    }
-                    // Every plain list modal: one geometry, measured off the `ModalScreen`
-                    // the painter draws, indexed by that screen's own focus cursor.
-                    Screen::HostMenu
-                    | Screen::WakeSettings
-                    | Screen::Diagnostics
-                    | Screen::Experimental
-                    | Screen::CursorSettings => self.list_modal_focus_rect(screen_w, screen_h, fonts),
-                    Screen::Home | Screen::AddHost | Screen::EditHost | Screen::About | Screen::PinLimit => None,
+            // The entering screen's only — the snapshot has its own focused row baked in.
+            let focus_rect = match screen {
+                Screen::Settings => {
+                    let (total, _, _, content) = scroll_geom.expect("screen is Screen::Settings");
+                    // Positioned from the animated pixel offset, not the row index: the baked
+                    // list is cropped at that offset, and the focus tile *is* the focused row
+                    // re-rendered — so anchoring it to the quantized row would show that row's
+                    // content twice, in two places, for the length of every scroll.
+                    let stride = ui::widgets::focus_row_stride() as i32;
+                    let px = self
+                        .modal_scroll_px
+                        .clamp(0, Self::max_scroll_px(total, stride, content.height()));
+                    Some(ui::widgets::focus_row_rect_at_px(content, self.settings_focused, px))
                 }
+                // Every two-button confirm dialog: one subtitle drives the card, so one
+                // button-row geometry serves all four.
+                Screen::Wake | Screen::ForgetHost | Screen::SendLogs | Screen::SpeedTest => self
+                    .confirm_subtitle()
+                    .zip(self.confirm_focused())
+                    .map(|(subtitle, i)| Self::confirm_focus_button_rect(screen_w, screen_h, fonts, &subtitle, i)),
+                Screen::Pairing => {
+                    let card = view::pairing::card_rect(screen_w, screen_h, fonts);
+                    Some(match self.pairing_focus {
+                        PairingFocus::Pin => {
+                            let digit_y = view::pairing::pin_row_y(card, fonts);
+                            view::pairing::digit_rect(card, digit_y, self.pin_digit_index)
+                        }
+                        PairingFocus::RequestAccess => view::pairing::request_button_rect(card, fonts),
+                    })
+                }
+                // Every plain list modal: one geometry, measured off the `ModalScreen`
+                // the painter draws, indexed by that screen's own focus cursor.
+                Screen::HostMenu
+                | Screen::WakeSettings
+                | Screen::Diagnostics
+                | Screen::Experimental
+                | Screen::CursorSettings => self.list_modal_focus_rect(screen_w, screen_h, fonts),
+                Screen::Home | Screen::AddHost | Screen::EditHost | Screen::About | Screen::PinLimit => None,
             };
             if let Some(rect) = focus_rect {
                 let pad = ui::tiles::ROW_TILE_PAD;
@@ -194,7 +197,7 @@ impl App {
                 // this (except while `switch_anim` animates its content, see
                 // `prepare_tiles`).
                 let f = ui::animation::anim_frac(self.modal_focus_anim, ui::animation::FOCUS_POP);
-                let dst = ui::animation::zoom_rect(base, f, 0.02);
+                let dst = ride(ui::animation::zoom_rect(base, f, 0.02));
                 let alpha = (255.0 * m) as u8;
                 // In a scrolling modal the focused row can hang past the viewport's bottom
                 // edge mid-glide (the crop lags the row offset by up to one stride), so it is
@@ -203,7 +206,7 @@ impl App {
                 let tile_size = tiles.get(tile::MODAL_FOCUS).map(|p| (p.width(), p.height()));
                 match (scroll_geom, tile_size) {
                     (Some((_, _, _, content)), Some((tw, th))) => {
-                        let viewport = content.inflate(pad).offset(0, dy);
+                        let viewport = ride(content.inflate(pad).offset(0, dy));
                         if let Some((src, visible)) = Self::clip_tile(dst, viewport, tw, th) {
                             cmds.push(DrawCmd::TexCropped {
                                 tile: tile::MODAL_FOCUS,
@@ -225,17 +228,17 @@ impl App {
             // position, so navigating dropdown options needs no modal
             // re-rasterize either. `Settings` or `Diagnostics`.
             if let Some((row, focused, dd_alpha)) = self.dropdown_draw_state() {
-                if let Some((content, scroll_px)) = self.dropdown_geom(screen, screen_w, screen_h, fonts) {
+                if let Some((content, scroll_px)) = self.dropdown_geom(screen_w, screen_h, fonts) {
                     let overlay_rect = view::settings::dropdown_overlay_rect_at_px(content, row, scroll_px);
                     let option_rect = ui::widgets::dropdown_option_rect(overlay_rect, focused);
                     cmds.push(DrawCmd::Tex {
                         tile: tile::DROPDOWN_FOCUS,
-                        dst: Rect::new(
+                        dst: ride(Rect::new(
                             option_rect.x(),
                             option_rect.y() + dy,
                             option_rect.width(),
                             option_rect.height(),
-                        ),
+                        )),
                         alpha: (255.0 * m * dd_alpha) as u8,
                     });
                 }
@@ -261,12 +264,12 @@ impl App {
                         // overlap a Settings row's dropdown pill/slider/switch. The `26`
                         // offset isn't derived from either modal's own width fraction —
                         // re-check both if either changes.
-                        let dst = Rect::new(
+                        let dst = ride(Rect::new(
                             card.right() - 26,
                             content.y() + dy,
                             SCROLL_INDICATOR_TILE_W,
                             content.height(),
-                        );
+                        ));
                         cmds.push(DrawCmd::Tex {
                             tile: tile::SCROLL_INDICATOR,
                             dst,
@@ -274,6 +277,25 @@ impl App {
                         });
                     }
                 }
+            }
+        }
+        // Last, so it fades away *over* what it uncovers: the entering card is often the
+        // larger (a submenu returning to Settings) and would otherwise hide it entirely.
+        if let Some((alpha, prev)) = closing {
+            let dy = ((1.0 - alpha) * MODAL_RISE) as i32;
+            let a = (255.0 * alpha) as u8;
+            cmds.push(DrawCmd::Tex {
+                tile: tile::MODAL_PREV,
+                dst: prev.region.offset(0, dy),
+                alpha: a,
+            });
+            if let Some((src, dst)) = prev.content {
+                cmds.push(DrawCmd::TexCropped {
+                    tile: tile::MODAL_PREV_CONTENT,
+                    src,
+                    dst: dst.offset(0, dy),
+                    alpha: a,
+                });
             }
         }
     }

--- a/src/app/render/geometry.rs
+++ b/src/app/render/geometry.rs
@@ -28,9 +28,8 @@ impl App {
         self.scroll_geometry_for(self.screen, screen_w, screen_h, fonts)
     }
 
-    /// Same as `scroll_geometry`, but for an explicit screen rather than
-    /// `self.screen` — `draw_list`'s closing-fade needs the screen it captured at
-    /// `back()` time, not whatever `self.screen` (already `Home`) says now.
+    /// Same as `scroll_geometry`, but for an explicit screen — `snapshot_closing_modal`
+    /// needs the screen being *left*, which `self.screen` has already moved off.
     pub(crate) fn scroll_geometry_for(
         &self,
         screen: Screen,
@@ -87,6 +86,39 @@ impl App {
     /// the final row (and is what the row-quantized version did).
     pub(crate) fn max_scroll_px(total: usize, stride: i32, viewport_h: u32) -> i32 {
         (total as i32 * stride - viewport_h as i32).max(0)
+    }
+
+    /// Which slice of `screen`'s baked `tile::SCROLL_CONTENT` is showing, as `(src crop,
+    /// dst rect)` — `None` for a screen whose body lives in its shell tile.
+    ///
+    /// The one place the window rebase lives: `compose_modal` draws the live modal with it,
+    /// `snapshot_closing_modal` freezes the same crop for the fading one.
+    pub(crate) fn scroll_src_rect(
+        &self,
+        screen: Screen,
+        screen_w: u32,
+        screen_h: u32,
+        fonts: &ui::text::Fonts,
+    ) -> Option<(Rect, Rect)> {
+        let (total, _, _, content) = self.scroll_geometry_for(screen, screen_w, screen_h, fonts)?;
+        // About uses a bounded window; for other screens, window_start is 0.
+        let window_start = match screen {
+            Screen::About => self.content_window.start,
+            _ => 0,
+        };
+        let stride = self.scroll_stride_for(screen, fonts);
+        // The animated offset (see `sync_modal_scroll`), in absolute content pixels,
+        // rebased onto whatever slice is currently baked into the tile.
+        let scroll_px = self
+            .modal_scroll_px
+            .clamp(0, Self::max_scroll_px(total, stride, content.height()));
+        let src = Rect::new(
+            0,
+            scroll_px - window_start as i32 * stride,
+            content.width(),
+            content.height(),
+        );
+        Some((src, content))
     }
 
     /// Re-derives `modal_scroll_target_px` from the integral offset, snapping rather than
@@ -255,8 +287,8 @@ impl App {
 
     /// How many options the open dropdown lists. Read by both the overlay's drawn height
     /// and its hit test, so the two can't disagree about where the last option ends.
-    pub(crate) fn dropdown_options_len(&self, screen: Screen, row: usize) -> usize {
-        match screen {
+    pub(crate) fn dropdown_options_len(&self, row: usize) -> usize {
+        match self.screen {
             Screen::Diagnostics => menu::LOG_LEVEL_OPTIONS.len(),
             _ => menu::dropdown_option_count(menu::settings_logical_row(row)),
         }

--- a/src/app/render/key.rs
+++ b/src/app/render/key.rs
@@ -49,11 +49,10 @@ pub enum ScrollContentKey {
 pub enum ModalShellKey {
     // Only what `render_settings` reads — the whole `Settings` struct (or the
     // dropdown row) would invalidate this key, forcing a full-screen re-raster,
-    // on every keystroke or dropdown open/close.
-    Settings {
-        show_bitrate_warning: bool,
-        hover_close: bool,
-    },
+    // on every keystroke or dropdown open/close. The shell draws chrome only (no
+    // row content, not even the Bitrate caution — that's the focus tile's job),
+    // so the only thing that can actually change it is the close-button hover.
+    Settings { hover_close: bool },
     Wake {
         name: String,
         mac_empty: bool,

--- a/src/app/render/mod.rs
+++ b/src/app/render/mod.rs
@@ -6,6 +6,18 @@
 //! [`TileId`](crate::ui::render::TileId) and an opaque `u64` version, and everything that
 //! gives those meaning lives here.
 
+use crate::ui::render::Rect;
+
+/// Where a left modal's card was, and which slice of its scrolled body was showing. The
+/// pixels are cloned into [`tile::MODAL_PREV`]/[`tile::MODAL_PREV_CONTENT`], leaving the
+/// entering modal free to rebuild [`tile::MODAL`] in the same frame — hence the cross-fade.
+#[derive(Clone, Copy)]
+pub(crate) struct ModalSnapshot {
+    pub region: Rect,
+    /// `(src crop, dst rect)` of the scrolled content, for Settings/About.
+    pub content: Option<(Rect, Rect)>,
+}
+
 pub(crate) mod compose;
 pub(crate) mod geometry;
 pub(crate) mod key;

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -354,6 +354,54 @@ impl App {
         updated.push(tile::HERO);
     }
 
+    /// Copies the leaving modal's pixels aside so it can fade out while the entering one
+    /// rebuilds `tile::MODAL` — on the frame `advance_frame` started a close fade, only.
+    /// Cloned rather than re-rendered: the left screen's state may already be torn down
+    /// (a cleared `host_menu_index`), and these pixels are what was on screen last frame.
+    fn snapshot_closing_modal(
+        &mut self,
+        tiles: &mut TileStore,
+        fonts: &ui::text::Fonts,
+        screen_w: u32,
+        screen_h: u32,
+        screen_changed: bool,
+        updated: &mut Vec<TileId>,
+    ) {
+        let closing = self.modal_fade.closing_frame(MODAL_FADE_OUT);
+        if closing.is_none() {
+            // Fade over (or cancelled by reopening the same screen) — drop the copies
+            // rather than keep two card-sized textures alive for nothing.
+            if self.modal_prev.take().is_some() {
+                tiles.remove(tile::MODAL_PREV);
+                tiles.remove(tile::MODAL_PREV_CONTENT);
+                self.evicted_tiles.push(tile::MODAL_PREV);
+                self.evicted_tiles.push(tile::MODAL_PREV_CONTENT);
+            }
+            return;
+        }
+        let Some((_, left)) = closing.filter(|_| screen_changed) else {
+            return;
+        };
+        let Some(shell) = tiles.get(tile::MODAL).cloned() else {
+            return;
+        };
+        // Still the left card's — `modal_painter` moves it on later in this same call.
+        let region = self.modal_tile_region;
+        // The crop `compose_modal` was drawing for this screen last frame, frozen.
+        let content = self
+            .scroll_src_rect(left, screen_w, screen_h, fonts)
+            .zip(tiles.get(tile::SCROLL_CONTENT).cloned())
+            .map(|((src, dst), body)| (body, src, dst));
+        tiles.put(tile::MODAL_PREV, cache::STATIC, shell);
+        updated.push(tile::MODAL_PREV);
+        let content = content.map(|(body, src, dst)| {
+            tiles.put(tile::MODAL_PREV_CONTENT, cache::STATIC, body);
+            updated.push(tile::MODAL_PREV_CONTENT);
+            (src, dst)
+        });
+        self.modal_prev = Some(crate::app::render::ModalSnapshot { region, content });
+    }
+
     /// Modal family: the open modal's full-screen shell tile (rebuilt only on content
     /// change, keyed by `ModalShellKey`) and its single focused-widget tile (keyed by
     /// `ModalFocusKey`). Extracted from `prepare_tiles` (A2 staging).
@@ -369,6 +417,7 @@ impl App {
         screen_changed: bool,
         updated: &mut Vec<TileId>,
     ) -> Result<()> {
+        self.snapshot_closing_modal(tiles, fonts, screen_w, screen_h, screen_changed, updated);
         let modal_open = !matches!(self.screen, Screen::Home);
         // Every modal's shell only reacts to *content* changes — not to
         // `content_dirty`, which is also `true` on plain focus movement (see
@@ -849,6 +898,8 @@ impl App {
         screen_changed: bool,
     ) -> Result<Vec<TileId>> {
         let mut updated = Vec::new();
+        // The transition frame's cost is what decides whether the open fade is visible.
+        let started = screen_changed.then(Instant::now);
         let available_w = screen_w.saturating_sub(ui::widgets::SIDEBAR_W);
         let columns = view::home::grid_columns(available_w);
         // `self.card_size` is set by `advance_frame` (same formula) before this runs; the
@@ -909,6 +960,20 @@ impl App {
         self.prepare_dropdown(tiles, text_cache, fonts, screen_w, screen_h, &mut updated)?;
 
         self.prepare_scroll(tiles, text_cache, fonts, screen_w, screen_h, &mut updated)?;
+
+        // Entering a modal rasterizes it — shell, rows, and (Settings/About) the full
+        // content strip: tens of ms on this SoC, more than the fade itself. `advance_frame`
+        // started the clocks before all that, so re-stamp them here and the fade is
+        // measured from the first frame that can show it.
+        if let Some(started) = started {
+            tracing::debug!(
+                "entered {:?}: {} tiles rasterized in {:?}",
+                self.screen,
+                updated.len(),
+                started.elapsed()
+            );
+            self.modal_fade.restart();
+        }
         Ok(updated)
     }
 }

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -426,7 +426,6 @@ impl App {
         // `content_dirty` tick, same as every modal did before this split.
         let modal_shell_key = match self.screen {
             Screen::Settings => Some(ModalShellKey::Settings {
-                show_bitrate_warning: self.settings.bitrate_kbps > menu::BITRATE_WARN_KBPS,
                 hover_close: self.hover_close,
             }),
             Screen::Wake => self.wake.as_ref().map(|w| ModalShellKey::Wake {

--- a/src/app/render/tile.rs
+++ b/src/app/render/tile.rs
@@ -57,6 +57,12 @@ pub const CARD_TITLE: TileId = TileId(21);
 /// The card drop shadow, drawn behind every card — identical on all of them, so it is one
 /// shared tile rather than a margin baked into each.
 pub const CARD_SHADOW: TileId = TileId(22);
+/// The modal fading *out* — a snapshot of [`MODAL`] taken the frame it was left, so the
+/// entering modal can own [`MODAL`] while this one finishes (see `App::modal_prev`).
+pub const MODAL_PREV: TileId = TileId(23);
+/// That snapshot's scrolled content, for a leaving modal whose body lives in
+/// [`SCROLL_CONTENT`] rather than in its shell (Settings, About).
+pub const MODAL_PREV_CONTENT: TileId = TileId(24);
 
 /// First id of the spinner band. One per decoded GIF frame, so the compositor keeps every
 /// frame's texture and the animation is a swap rather than an upload.

--- a/src/app/state/cursorsettings.rs
+++ b/src/app/state/cursorsettings.rs
@@ -11,8 +11,6 @@ impl App {
     /// toggles: capture mode and the OK-button gestures.
     pub(crate) fn open_cursor_settings(&mut self) {
         self.cursor_settings_focused = 0;
-        // Stash scroll so Back can restore it; this screen doesn't use it.
-        self.settings_scroll = self.scroll;
         self.screen = Screen::CursorSettings;
     }
 
@@ -40,7 +38,6 @@ impl App {
             (_, MenuEvent::Back) => {
                 self.persist();
                 self.screen = Screen::Settings;
-                self.scroll = self.settings_scroll;
             }
             _ => {}
         }

--- a/src/app/state/diagnostics.rs
+++ b/src/app/state/diagnostics.rs
@@ -13,8 +13,6 @@ impl App {
     /// bottom of Settings (`menu::ROW_DIAGNOSTICS`), not a hidden/remote-button menu.
     pub(crate) fn open_diagnostics(&mut self) {
         self.diagnostics_focused = 0;
-        // Stash scroll so Back can restore it; Diagnostics doesn't use it.
-        self.settings_scroll = self.scroll;
         self.screen = Screen::Diagnostics;
     }
 
@@ -77,7 +75,6 @@ impl App {
             (_, MenuEvent::Back) => {
                 self.persist();
                 self.screen = Screen::Settings;
-                self.scroll = self.settings_scroll;
             }
             _ => {}
         }

--- a/src/app/state/experimental.rs
+++ b/src/app/state/experimental.rs
@@ -11,8 +11,6 @@ impl App {
     /// off-by-default toggles (the frame pacer).
     pub(crate) fn open_experimental(&mut self) {
         self.experimental_focused = 0;
-        // Stash scroll so Back can restore it; Experimental doesn't use it.
-        self.settings_scroll = self.scroll;
         self.screen = Screen::Experimental;
     }
 
@@ -37,7 +35,6 @@ impl App {
             (_, MenuEvent::Back) => {
                 self.persist();
                 self.screen = Screen::Settings;
-                self.scroll = self.settings_scroll;
             }
             _ => {}
         }

--- a/src/runtime/input.rs
+++ b/src/runtime/input.rs
@@ -635,6 +635,14 @@ pub(super) fn handle_ui_event(
                 EventAction::Next
             };
         }
+        // Ends a Bitrate drag armed in `handle_mouse_click` — without this the slider
+        // would keep tracking the pointer (or a stale last position) past the release.
+        Event::MouseButtonUp {
+            mouse_btn: sdl2::mouse::MouseButton::Left,
+            ..
+        } => {
+            app.slider_drag = false;
+        }
         // Direct digit entry via the remote's number buttons — PIN entry on the
         // pairing screen, IP entry on the add/edit-host screens.
         Event::KeyDown { keycode: Some(k), .. }

--- a/src/ui/fade.rs
+++ b/src/ui/fade.rs
@@ -50,6 +50,20 @@ impl<T: Copy + PartialEq> ModalFade<T> {
         self.closing = Some((Instant::now(), payload));
     }
 
+    /// Re-stamps whichever fades are in flight to now — for a caller that does expensive
+    /// work between starting a fade and the first frame that can show it (rasterizing a
+    /// modal outlasts `MODAL_FADE`, so the clock is spent before there are pixels and the
+    /// card snaps in opaque). Both clocks move together, keeping a cross-fade in step.
+    pub fn restart(&mut self) {
+        let now = Instant::now();
+        if self.open_since.is_some() {
+            self.open_since = Some(now);
+        }
+        if let Some((t, _)) = self.closing.as_mut() {
+            *t = now;
+        }
+    }
+
     /// Cancels an in-flight close only if it's fading out `payload`.
     pub fn cancel_closing(&mut self, payload: T) {
         if self.closing.is_some_and(|(_, p)| p == payload) {
@@ -88,15 +102,21 @@ impl<T: Copy + PartialEq> ModalFade<T> {
 
     /// Advances the clock; returns whether either fade is still in flight.
     pub fn tick(&mut self, dur: Duration) -> bool {
+        self.tick_split(dur, dur)
+    }
+
+    /// [`tick`](Self::tick) for a caller whose two directions run at different speeds —
+    /// each clock clears on its own duration, or the shorter keeps asking for dead redraws.
+    pub fn tick_split(&mut self, open_dur: Duration, close_dur: Duration) -> bool {
         let mut animating = false;
         if let Some(t) = self.open_since {
-            if t.elapsed() >= dur {
+            if t.elapsed() >= open_dur {
                 self.open_since = None;
             }
             animating = true;
         }
         if let Some((t, _)) = self.closing {
-            if t.elapsed() >= dur {
+            if t.elapsed() >= close_dur {
                 self.closing = None;
             }
             animating = true;

--- a/src/ui/painter.rs
+++ b/src/ui/painter.rs
@@ -59,6 +59,7 @@ pub fn rounded_rect_path(x: f32, y: f32, w: f32, h: f32, radius: f32) -> Option<
 /// single `Painter`; `main.rs` uploads the result to one SDL2 texture and presents
 /// it, rather than issuing a texture copy per widget as the old canvas-based
 /// version did.
+#[derive(Clone)]
 pub struct Painter {
     pixmap: Pixmap,
     /// Drawing offset: every coordinate a caller passes is shifted by `-origin`

--- a/src/ui/widgets/rows.rs
+++ b/src/ui/widgets/rows.rs
@@ -200,6 +200,21 @@ pub const SLIDER_VALUE_SLOT_W: i32 = 150;
 /// Extra gap between the track's right edge and the value slot.
 const SLIDER_TRACK_GAP: i32 = 16;
 
+/// A slider row's track rect within `row_rect` — shared by [`Canvas::focus_row`]'s draw and
+/// the pointer path's click/drag hit-testing, so a dragged thumb always lands under the
+/// cursor exactly where the track was drawn.
+pub fn slider_track_rect(row_rect: Rect) -> Rect {
+    let control_pad = 28;
+    let slot_right = row_rect.right() - control_pad;
+    let track_w = 220u32.min(row_rect.width() / 3);
+    Rect::new(
+        slot_right - SLIDER_VALUE_SLOT_W - SLIDER_TRACK_GAP - track_w as i32,
+        row_rect.y() + (row_rect.height() as i32 - 10) / 2,
+        track_w,
+        10,
+    )
+}
+
 /// A modal's focus-row list: icon + label left, control right, one row per
 /// [`FocusRow`] stacked at [`focus_row_stride`]. Only the focused row gets a background
 /// card; others draw bare. Rows render at normal size — the focused row's zoom is a GPU
@@ -372,13 +387,7 @@ impl Canvas<'_, '_> {
                     value_y,
                     locked_fg(row.locked, focused, theme().text, theme().muted),
                 )?;
-                let track_w = 220u32.min(row_rect.width() / 3);
-                let track = Rect::new(
-                    slot_right - SLIDER_VALUE_SLOT_W - SLIDER_TRACK_GAP - track_w as i32,
-                    row_rect.y() + (row_rect.height() as i32 - 10) / 2,
-                    track_w,
-                    10,
-                );
+                let track = slider_track_rect(row_rect);
                 self.painter
                     .slider_with_thumb(track, row.fraction, focused, !row.locked);
             }


### PR DESCRIPTION
Stepping from one modal to another had no closing animation — Settings → Diagnostics, host menu → Wake settings, and back. The fade only ever ran when a modal closed to Home, because every modal shares `tile::MODAL` and the entering screen rebuilds it in the same frame, so there was nothing left to fade out.

The leaving card's pixels are now copied into `tile::MODAL_PREV` on the transition frame, which lets both cards be on screen at once. It draws last, over what it uncovers — underneath the (usually larger) entering card it was simply hidden, which is what made the close read as a cut.

While in there:

- Settings never animated on open either. The fade clock started before the frame that rasterizes the modal — shell, rows, and the full-height content strip, tens of ms on this SoC — so it was already spent by the time there were pixels. It's re-stamped after rasterizing now, and there's a debug line reporting what that frame actually cost.
- Only `tile::MODAL` was popping; the scrolled body, edge fades, dropdown and focus highlight sat still while the shell scaled. They all ride the card's pop now. The host menu never showed this because its rows live inside the shell tile.
- The backdrop no longer re-fades when one modal replaces another — it was dipping mid-step and reading as a blink.
- Open is 50ms, close 100ms.
- Dropped the scroll stash/restore in the Settings submenus. Those screens never touch `scroll`; it was copy-paste from About, which does.
- `dropdown_geom`/`dropdown_options_len` took an explicit screen only so the old close-fade could pass the one captured at `back()` time. Nothing does that any more.

## Bitrate slider drag + Settings cleanup

- Mouse press/drag on the Bitrate track now sets the value directly under the pointer instead of stepping one notch per click; release ends the drag. Clicking elsewhere on the row still steps one notch, unchanged.
- `ModalShellKey::Settings` no longer carries `show_bitrate_warning` — the shell only draws chrome (border/title/rule), never the caution subtext, so that field was forcing a full-screen modal re-raster every time bitrate crossed the 150 Mbps warning line for no visible reason. That was the stutter felt while dragging past that point.
- Resolution dropdown options now read `FHD - 1080p - 1920x1080`, `QHD - 1440p - 2560x1440`, `4K - 2160p - 3840x2160`; the collapsed row value is unchanged (still plain pixel dimensions).

Not yet tried on the TV.