### PR TITLE
Play modal open as the close animation in reverse, retime both

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -54,13 +54,11 @@ pub(crate) const CARD_POP: Duration = Duration::from_millis(300);
 pub(crate) const CARD_POP_SHRINK: f32 = 0.14;
 /// Modal open. Short: the card is the response to a keypress, and delay there reads as
 /// a slow TV, not as an animation.
-pub(crate) const MODAL_FADE: Duration = Duration::from_millis(50);
+pub(crate) const MODAL_FADE: Duration = Duration::from_millis(75);
 /// Modal close. Slower than the open — nothing is waiting on it, and outlasting the
 /// incoming card is what makes a modal-to-modal step read as one replacing the other.
-pub(crate) const MODAL_FADE_OUT: Duration = Duration::from_millis(100);
+pub(crate) const MODAL_FADE_OUT: Duration = Duration::from_millis(150);
 pub(crate) const DROPDOWN_FADE: Duration = MODAL_FADE;
-/// Scale during open — subtle, since fade dominates for full-screen modal.
-pub(crate) const MODAL_POP_SHRINK: f32 = 0.05;
 /// Transparent margin the modal tile leaves around the card so its drop shadow
 /// (`Painter::card_shadow`: blur `SHADOW_BLUR`=14, offset dy 5) fits inside the tile.
 /// The tile is sized to the card's bounding box plus this pad rather than the whole

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -69,18 +69,13 @@ impl App {
         if !matches!(screen, Screen::Home) {
             let dy = ((1.0 - m) * MODAL_RISE) as i32;
             // The tile now covers only the card region (see `prepare_modal`), so it
-            // composites there rather than full-screen. `pop_in_rect` scaling around this
-            // rect's center is the card's own center — the same visual pop as before.
+            // composites there rather than full-screen. Opening plays the same motion
+            // `compose_modal`'s closing snapshot uses below, in reverse — fade + rise, no
+            // scale.
             let modal_base = self.modal_tile_region.offset(0, dy);
-            let pop = ui::animation::pop_in_scale(m, MODAL_POP_SHRINK);
-            // Everything composited *onto* the card rides its pop, about the card's centre
-            // — otherwise the shell scales while its contents sit still. A modal whose rows
-            // live in the shell tile (the host menu) gets this free; scrollable ones don't.
-            let ride = |r: Rect| ui::animation::scale_about(r, modal_base, pop);
-            let modal_dst = ui::animation::pop_in_rect(modal_base, m, MODAL_POP_SHRINK);
             cmds.push(DrawCmd::Tex {
                 tile: tile::MODAL,
-                dst: modal_dst,
+                dst: modal_base,
                 alpha: (255.0 * m) as u8,
             });
             // Scrollable content geometry (Settings rows or About document), computed
@@ -95,7 +90,7 @@ impl App {
                     cmds.push(DrawCmd::TexCropped {
                         tile: tile::SCROLL_CONTENT,
                         src,
-                        dst: ride(dst.offset(0, dy)),
+                        dst: dst.offset(0, dy),
                         alpha: (255.0 * m) as u8,
                     });
                 }
@@ -113,19 +108,19 @@ impl App {
                 if scroll_px > 0 {
                     cmds.push(DrawCmd::Tex {
                         tile: tile::SCROLL_FADE_TOP,
-                        dst: ride(Rect::new(content.x(), content.y() + dy, content.width(), fade_h)),
+                        dst: Rect::new(content.x(), content.y() + dy, content.width(), fade_h),
                         alpha: (255.0 * m) as u8,
                     });
                 }
                 if scroll_px < Self::max_scroll_px(total, stride, content.height()) {
                     cmds.push(DrawCmd::Tex {
                         tile: tile::SCROLL_FADE,
-                        dst: ride(Rect::new(
+                        dst: Rect::new(
                             content.x(),
                             content.y() + dy + (content.height() - fade_h) as i32,
                             content.width(),
                             fade_h,
-                        )),
+                        ),
                         alpha: (255.0 * m) as u8,
                     });
                 }
@@ -137,12 +132,12 @@ impl App {
                     let options_len = self.dropdown_options_len(row);
                     cmds.push(DrawCmd::Tex {
                         tile: tile::DROPDOWN_OVERLAY,
-                        dst: ride(Rect::new(
+                        dst: Rect::new(
                             overlay_rect.x(),
                             overlay_rect.y() + dy,
                             overlay_rect.width(),
                             options_len as u32 * ui::widgets::DROPDOWN_OPTION_H,
-                        )),
+                        ),
                         alpha: (255.0 * m * dd_alpha) as u8,
                     });
                 }
@@ -197,7 +192,7 @@ impl App {
                 // this (except while `switch_anim` animates its content, see
                 // `prepare_tiles`).
                 let f = ui::animation::anim_frac(self.modal_focus_anim, ui::animation::FOCUS_POP);
-                let dst = ride(ui::animation::zoom_rect(base, f, 0.02));
+                let dst = ui::animation::zoom_rect(base, f, 0.02);
                 let alpha = (255.0 * m) as u8;
                 // In a scrolling modal the focused row can hang past the viewport's bottom
                 // edge mid-glide (the crop lags the row offset by up to one stride), so it is
@@ -206,7 +201,7 @@ impl App {
                 let tile_size = tiles.get(tile::MODAL_FOCUS).map(|p| (p.width(), p.height()));
                 match (scroll_geom, tile_size) {
                     (Some((_, _, _, content)), Some((tw, th))) => {
-                        let viewport = ride(content.inflate(pad).offset(0, dy));
+                        let viewport = content.inflate(pad).offset(0, dy);
                         if let Some((src, visible)) = Self::clip_tile(dst, viewport, tw, th) {
                             cmds.push(DrawCmd::TexCropped {
                                 tile: tile::MODAL_FOCUS,
@@ -233,12 +228,12 @@ impl App {
                     let option_rect = ui::widgets::dropdown_option_rect(overlay_rect, focused);
                     cmds.push(DrawCmd::Tex {
                         tile: tile::DROPDOWN_FOCUS,
-                        dst: ride(Rect::new(
+                        dst: Rect::new(
                             option_rect.x(),
                             option_rect.y() + dy,
                             option_rect.width(),
                             option_rect.height(),
-                        )),
+                        ),
                         alpha: (255.0 * m * dd_alpha) as u8,
                     });
                 }
@@ -264,12 +259,12 @@ impl App {
                         // overlap a Settings row's dropdown pill/slider/switch. The `26`
                         // offset isn't derived from either modal's own width fraction —
                         // re-check both if either changes.
-                        let dst = ride(Rect::new(
+                        let dst = Rect::new(
                             card.right() - 26,
                             content.y() + dy,
                             SCROLL_INDICATOR_TILE_W,
                             content.height(),
-                        ));
+                        );
                         cmds.push(DrawCmd::Tex {
                             tile: tile::SCROLL_INDICATOR,
                             dst,

--- a/src/runtime/input.rs
+++ b/src/runtime/input.rs
@@ -252,7 +252,7 @@ impl ConfirmDialog {
         h: u32,
         cmds: &mut Vec<DrawCmd>,
     ) -> Result<()> {
-        let Some((focus, m, closing)) = self.frame(MODAL_FADE) else {
+        let Some((focus, m, _closing)) = self.frame(MODAL_FADE) else {
             return Ok(());
         };
         let full = crate::ui::render::Rect::new(0, 0, w, h);
@@ -275,8 +275,8 @@ impl ConfirmDialog {
             )?;
             compositor.upload(texture_creator, tile::DISCONNECT_FOCUS_BUTTON, &tile, false)?;
         }
-        // Same open/close motion as the `App`'s `Screen` modals (see `draw_list`): slide
-        // in from ~26px below while fading, and the shell scales up on open.
+        // Same open/close motion as the `App`'s `Screen` modals (see `compose_modal`):
+        // slide in/out ~26px while fading, same curve in both directions, no scale.
         let dy = ((1.0 - m) * 26.0) as i32;
         let pad = crate::ui::tiles::ROW_TILE_PAD;
         let base = crate::ui::render::Rect::new(
@@ -286,12 +286,7 @@ impl ConfirmDialog {
             btn_rect.height() + 2 * pad as u32,
         );
         let f = crate::ui::animation::anim_frac(self.focus_anim, crate::ui::animation::FOCUS_POP);
-        let modal_base = crate::ui::render::Rect::new(0, dy, w, h);
-        let shell_dst = if closing {
-            modal_base
-        } else {
-            crate::ui::animation::pop_in_rect(modal_base, m, MODAL_POP_SHRINK)
-        };
+        let shell_dst = crate::ui::render::Rect::new(0, dy, w, h);
         cmds.push(DrawCmd::Fill {
             rect: full,
             color: crate::ui::render::Color::RGBA(0, 0, 0, (f32::from(crate::ui::style::theme().scrim.a) * m) as u8),

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -8,7 +8,7 @@ use sdl2::controller::GameController;
 
 use crate::app::hero::Connect;
 use crate::app::render::tile;
-use crate::app::{App, HomeFocus, Screen, MODAL_FADE, MODAL_POP_SHRINK};
+use crate::app::{App, HomeFocus, Screen, MODAL_FADE};
 use crate::core::event::MenuEvent;
 use crate::platform::webos::compositor::Compositor;
 use crate::platform::webos::cursor;


### PR DESCRIPTION
Opening popped in with its own scale-down zoom while closing only faded and rose — two different curves for what should read as one motion played backwards.

- Opening now uses the same fade + rise closing already used, with no scale, for both the `App::Screen` modal family (`compose_modal`) and the in-stream disconnect dialog.
- Dropped the now-dead `MODAL_POP_SHRINK` and the no-op `ride` scale-rider it drove.
- Retimed: open 50ms → 75ms, close 100ms → 150ms.

Not yet tried on the TV.