### PR TITLE
Keep the d-pad alive when a host's library never loads

### DIFF
--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -443,7 +443,8 @@ impl App {
         // Dropping the loader stops its worker (its request channel closes), so a host
         // switch abandons in-flight fetches for the previous library.
         self.art_loader = None;
-        self.home_focus = HomeFocus::Grid(0);
+        // Focus stays on the sidebar until `drain_games` has cards to land on: `navigate`
+        // can't move off a key with no rect, so an empty grid would kill the d-pad.
         self.grid_focus_last = 0;
         self.sidebar_dirty = true;
         self.grid_dirty = true;
@@ -499,6 +500,12 @@ impl App {
                 ));
                 self.games = games;
                 self.games_loaded = true;
+                // Hand the grid the focus `select_host` held back — only if the user hasn't
+                // navigated off that row, so a late fetch can't yank them.
+                if matches!(self.home_focus, HomeFocus::Sidebar(i) if Some(i) == self.sidebar_index_of_selected_host())
+                {
+                    self.home_focus = HomeFocus::Grid(0);
+                }
                 if !self.home_status_sticky {
                     self.home_status = None;
                 }


### PR DESCRIPTION
Picking a host that turns out to be unreachable left the d-pad completely dead — the only way out was grabbing the Magic Remote pointer and hovering a sidebar row.

`select_host` moved focus to `HomeFocus::Grid(0)` immediately, but the library fetch is async, so the grid is empty until `drain_games` lands. `FocusMap::navigate` can't move off a key it holds no rect for, so every press was dropped. On a failed connect it never recovers; even on a good host the d-pad was dead for the whole loading window.

- `select_host` leaves focus on the sidebar row you just confirmed
- `drain_games` hands focus to the grid once there are actually cards, and only if you haven't navigated away meanwhile

Not tested on device yet.