### PR TITLE
Let NDL decode Opus itself on webOS 5+

### DIFF
--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -127,15 +127,74 @@ The host stamps `pts_ns` on every audio datagram; this client decoded it and thr
 - ⚠ **Use `frame.pts_ns`, never the paced value.** Both are in scope at the submit site with near-identical names; the paced one has been mapped into NDL's *player* clock by `HostPtsAnchor`. Using it regulates against a fiction that still looks plausible.
 - The estimator's unit tests ship in-tree but **cannot run off-device**: `cargo test` links the whole binary and `-lNDL_directmedia` exists only in the cross sysroot.
 
-## Opus offload to NDL (OFF BY DEFAULT — still freezes 10.3)
+## Opus offload to NDL (ON, awaiting device re-test)
 
-⚠ **A second, independent defect on this path, found 2026-08-09 and NOT fixed:** `play_audio` stamps arrival wall-clock while video is stamped host-PTS-anchored + paced, so NDL's own A/V sync regulates two unrelated timelines. Fixing it means both planes sharing one `HostPtsAnchor`, i.e. moving anchor ownership onto the `NdlVideo` handle behind a lock — a change to the working video hot path for a path that is off and broken. Whoever revives offload fixes this first. Symptom would be audio drifting against the picture over a session, not a constant offset.
+NDL is the sole video backend. Audio is either software Opus→SDL or, when NDL accepts an
+audio-enabled load, decoded by NDL itself — hardware decode is the default wherever it works.
 
-NDL is the sole video backend. Software Opus→SDL is the audio path; NDL hardware Opus is gated off behind the `NDL_AUDIO_OFFLOAD` const in `session/mod.rs` (flip to `true` to re-test).
+**Software Opus is not a legacy path and must stay wired.** It is the correct outcome on five
+routes: NDL v1 (`NDL_DirectAudio*` has no Opus source type), SMP (loads `needAudio: false`),
+non-stereo layouts (NDL's Opus struct has no multistream mapping field), an audio-enabled load
+NDL rejects, and Experimental → "Software audio" (`Settings::force_software_audio`). The last
+exists because a TV can accept the offloaded load and then play nothing, which no runtime probe
+can detect. `Connected::audio_channels()` returns `None` only when offload actually took the
+stream, so every other route opens the SDL device and spawns `audio_feed_pump` as before. The
+session log names the route it took and why; the stats overlay leads its audio line with
+`Audio HW · NDL Opus` or `Audio SW · buf … · A/V …`.
 
-The wiring is byte-exact with `mariotaku/ss4s` `ndl/webos5`: `NdlAudioConfig.sample_rate` in **kHz** (`48.0`, not `48000.0`), the stereo `opus_empty_frame_211 = {0xec,0xff,0xfe}` decoder prime fed once right after a successful audio-enabled `NDL_DirectMediaLoad`, combined audio+video in one load, and feed-time PTS (`elapsed since load`, ms) on both audio and video planes — identical to ss4s's `FeedVideo`/`FeedAudio` `GetPts`. Struct layouts (`NDL_DIRECTMEDIA_AUDIO_OPUS_INFO_T`, `..._DATA_INFO_T`) verified field-for-field against the ss4s mock headers.
+The load wiring is byte-exact with `mariotaku/ss4s` `ndl/webos5`: `NdlAudioConfig.sample_rate`
+in **kHz** (`48.0`, not `48000.0`), the stereo `opus_empty_frame_211 = {0xec,0xff,0xfe}` decoder
+prime fed once right after a successful audio-enabled `NDL_DirectMediaLoad`, and combined
+audio+video in one load. Struct layouts (`NDL_DIRECTMEDIA_AUDIO_OPUS_INFO_T`,
+`..._DATA_INFO_T`) match `webosbrew/webos-userland` field-for-field.
 
-**Despite full parity it still holds the first video frame forever on the tested G5 (webOS 10.3).** The audio-enabled load returns success, so no runtime probe can distinguish a TV that offloads from one that dies silently — the only safe move is not taking the path by default. Kept opt-in for continued testing on other models; the new `NDL load state:` log (`LOADCOMPLETED`/`PLAYING`) is the signal for whether the present pipeline ever starts.
+**What was wrong, and what "full ss4s parity" hid.** The path held the first video frame forever
+on the tested G5 (webOS 10.3) despite that parity, because the parity was on the *load* and not on
+the *stamping*. ss4s feeds both planes feed-time PTS; this client does not — video goes in on
+host-capture PTS mapped onto NDL's player clock (`HostPtsAnchor`) and smoothed by `PtsPacer`,
+while `play_audio` kept ss4s's arrival wall-clock. NDL's own A/V synchroniser was therefore
+regulating two unrelated timelines against each other, and held the picture waiting for an audio
+clock that was never going to line up.
+
+**Fix**: one timeline for both planes. `session::sink` hands the frame's host-PTS →
+player-clock offset (`base_ns - frame.pts_ns`, the *unpaced* reference — the pacer's ±half-frame
+smoothing is video-only) to `NdlVideo::latch_pts_offset`; `play_audio` stamps
+`packet.pts_ns + offset`. Audio arriving before the first video frame has no timeline to join and
+is dropped (bounded, ~startup only) rather than fed at a stamp that would jump.
+
+⚠ **Never flush a pipeline that has not finished loading — it kills audio for the session.**
+This was the cause of "video fine, audio silent", and it took four device rounds to find because
+every symptom pointed at timestamps. `NDL_DirectVideoFlushRenderBuffer` issued before
+`LOADCOMPLETED` takes the audio plane out permanently; video recovers and gives no sign. The sink
+used to reach it through its ordinary decode-error path, and frame 0 is refused
+(`NDL pipeline not loaded yet`) on any session where `LOADCOMPLETED` is late — routine on CX,
+where it lands ~3.3s after the first feed. `ensure_loaded` now returns a typed
+`ndl::NotLoadedYet` and `sink::submit` holds + requests a keyframe **without** flushing. Nothing
+is queued in NDL at that point anyway, so the flush was never doing work.
+
+The tell in the logs: every silent session had `NDL error (frame 0 …): NDL pipeline not loaded
+yet` and the one session with sound did not. `NDL_DirectAudioPlay` returns 0 either way, so
+there is no error to find on the audio side — do not go looking for one.
+
+⚠ **Latch the offset only off a frame NDL ACCEPTED.** `play_audio` has no `ensure_loaded` guard
+of its own, so the latch doubles as the audio thread's start gate. Correct on its own merits,
+but note it did NOT fix the silence by itself — the flush above did.
+
+⚠ **The offset is LATCHED, not recomputed per frame** — that distinction cost a second device
+round. Republishing it every frame looks self-correcting and is not: a receive-backlog flush that
+jumps to live drops frames, so host PTS leaps forward while the player clock does not, and the
+re-derived offset drags the audio stamp *backwards* by the size of the jump. **NDL reads a
+backwards audio timestamp as a rewind and mutes for the rest of the session** — it does not
+resync. Observed on CX: audio present in a session with no flush, gone in one with
+`receive backlog stopped draining — jumped to live … dropped_frames=37`. So `latch_pts_offset`
+takes only the first value after each `clear_pts_offset` (the sink's own anchor resets: hold
+resume, pacing off→on edge), and `play_audio` additionally floors every stamp at the previous
+one. Both guards are needed — the floor alone would leave audio stalled at a flat timestamp.
+
+⚠ The audio-enabled load returns success even on a TV that then dies silently, so **no runtime
+probe can distinguish the two** — if a model regresses, the `NDL load state:`
+(`LOADCOMPLETED`/`PLAYING`) log is the signal for whether the present pipeline ever starts, and
+Experimental → "Software audio" is the way out.
 
 ## ABR startup probe: 2 Gbps, upstream-hardcoded
 

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -85,8 +85,9 @@ pub const SETTINGS_ROW_COUNT: usize = 12;
 
 /// Experimental modal row indices (see `app::view::experimental::rows`).
 pub const EXP_ROW_FRAME_PACER: usize = 0;
+pub const EXP_ROW_SOFTWARE_AUDIO: usize = 1;
 /// Only present on rooted TVs, so it's the last row when shown.
-pub const EXP_ROW_GAME_MODE: usize = 1;
+pub const EXP_ROW_GAME_MODE: usize = 2;
 
 /// Cursor modal row indices (see `app::view::cursorsettings::rows`).
 pub const CURSOR_ROW_CAPTURE: usize = 0;

--- a/src/app/state/experimental.rs
+++ b/src/app/state/experimental.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 
 impl App {
     /// Opens the Experimental screen (Settings → `menu::ROW_EXPERIMENTAL`). Holds unstable,
-    /// off-by-default toggles (the frame pacer).
+    /// off-by-default toggles (the frame pacer, the software-audio override).
     pub(crate) fn open_experimental(&mut self) {
         self.experimental_focused = 0;
         self.screen = Screen::Experimental;
@@ -25,6 +25,11 @@ impl App {
             (menu::EXP_ROW_FRAME_PACER, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
                 let from = self.settings.video_pacing;
                 self.settings.video_pacing = !from;
+                self.switch_anim = Some((Instant::now(), from, self.experimental_focused));
+            }
+            (menu::EXP_ROW_SOFTWARE_AUDIO, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
+                let from = self.settings.force_software_audio;
+                self.settings.force_software_audio = !from;
                 self.switch_anim = Some((Instant::now(), from, self.experimental_focused));
             }
             (menu::EXP_ROW_GAME_MODE, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {

--- a/src/app/view/experimental.rs
+++ b/src/app/view/experimental.rs
@@ -16,7 +16,7 @@ pub const TITLE: &str = "Experimental";
 pub const SUBTITLE: &str = "Unstable, off by default.";
 
 /// The frame pacer toggle (`session::PtsPacer`, live-toggleable mid-stream with the Blue
-/// button) and Game mode on rooted sets. Both off by default and untested on hardware.
+/// button), the software-audio override, and Game mode on rooted sets. All off by default.
 /// Order must match `menu::EXP_ROW_*`.
 pub fn rows(settings: &Settings, rooted: bool) -> Vec<FocusRow> {
     let mut rows = vec![FocusRow::toggle(
@@ -29,6 +29,22 @@ pub fn rows(settings: &Settings, rooted: bool) -> Vec<FocusRow> {
     } else {
         "May improve framerate smoothness, adds latency"
     }))];
+    // Hardware Opus is the default on webOS 5+, and the software decoder is the fallback for
+    // every case NDL can't take (older TVs, SMP, surround) — so this only forces a path that
+    // always exists. It's a row because a TV can accept the offloaded load and then play
+    // nothing, and neither the app nor the user can tell that apart from a host sending silence.
+    rows.push(
+        FocusRow::toggle(
+            crate::app::view::icons::ICON_MEMORY,
+            "Software audio",
+            settings.force_software_audio,
+        )
+        .with_subtext(ui::widgets::RowSubtext::hint(if settings.force_software_audio {
+            "Opus on the CPU"
+        } else {
+            "Use if the TV plays no sound"
+        })),
+    );
     // Driving the TV's Game picture/sound modes needs the Homebrew Channel's root helper — the
     // public bus is denied `settingsservice` outright (see `platform::webos::game_mode`). So the
     // row only exists on a rooted set, where it's known to work.
@@ -44,7 +60,7 @@ pub fn rows(settings: &Settings, rooted: bool) -> Vec<FocusRow> {
 /// Row count without building the `FocusRow` vec — for card sizing and hit-testing. The
 /// Game mode row is only offered on a rooted TV, so the screen is one row shorter otherwise.
 pub fn row_count(rooted: bool) -> usize {
-    1 + usize::from(rooted)
+    2 + usize::from(rooted)
 }
 
 pub fn card_rect(screen_w: u32, screen_h: u32, fonts: &Fonts, rooted: bool) -> Rect {

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -243,6 +243,12 @@ pub struct Settings {
     /// stream start (SDR "game" / HDR "hdrGame" per the negotiated colour path) and reverted
     /// on stream exit.
     pub game_mode: bool,
+    /// Decode Opus in software even where NDL would take it (`session::ndl_audio_config`).
+    /// Off by default: on webOS 5+ NDL decodes Opus itself, one less thread and no SDL audio
+    /// device at all. The escape hatch exists because a TV that accepts the offloaded load and
+    /// then stays silent cannot be detected at runtime (`NDL_DirectAudioPlay` reports success
+    /// either way). Takes effect on the next stream.
+    pub force_software_audio: bool,
     /// Resolve the Magic Remote's OK button into left click / right click / drag by how long
     /// it's held (see `platform::webos::mouse::RemoteButtons`). Off by default — with it
     /// off, OK stays the plain immediate left click it has always been, since a remote with
@@ -273,6 +279,7 @@ impl Default for Settings {
             gamepad_type: GamepadType::Auto,
             cursor_capture: true,
             game_mode: false,
+            force_software_audio: false,
             cursor_gestures: false,
         }
     }

--- a/src/platform/webos/ndl/ffi.rs
+++ b/src/platform/webos/ndl/ffi.rs
@@ -74,23 +74,29 @@ pub(super) struct DataInfo {
 /// H.265 `mastering_display_colour_volume`/`content_light_level_info` SEI syntax
 /// element names verbatim, so punktfunk's own `HdrMeta` (same SEI-derived fields,
 /// same units) copies straight across with no unit conversion.
+/// Fifteen `unsigned int` per `webosbrew/webos-userland@00a5f87`, which also dropped the
+/// trailing `reserved[32]` an older header revision declared. The padding is kept anyway: this
+/// struct is passed BY VALUE, so a set built against the older layout would read 32 bytes past
+/// our argument copy. Carrying it is safe under both revisions; dropping it only under the new
+/// one, and which revision a given TV's `libndl-directmedia` was built against isn't knowable
+/// from here.
 #[repr(C)]
 pub(super) struct HdrInfo {
-    pub(super) display_primaries_x0: c_int,
-    pub(super) display_primaries_y0: c_int,
-    pub(super) display_primaries_x1: c_int,
-    pub(super) display_primaries_y1: c_int,
-    pub(super) display_primaries_x2: c_int,
-    pub(super) display_primaries_y2: c_int,
-    pub(super) white_point_x: c_int,
-    pub(super) white_point_y: c_int,
-    pub(super) max_display_mastering_luminance: c_int,
-    pub(super) min_display_mastering_luminance: c_int,
-    pub(super) max_content_light_level: c_int,
-    pub(super) max_pic_average_light_level: c_int,
-    pub(super) transfer_characteristics: c_int,
-    pub(super) color_primaries: c_int,
-    pub(super) matrix_coeffs: c_int,
+    pub(super) display_primaries_x0: c_uint,
+    pub(super) display_primaries_y0: c_uint,
+    pub(super) display_primaries_x1: c_uint,
+    pub(super) display_primaries_y1: c_uint,
+    pub(super) display_primaries_x2: c_uint,
+    pub(super) display_primaries_y2: c_uint,
+    pub(super) white_point_x: c_uint,
+    pub(super) white_point_y: c_uint,
+    pub(super) max_display_mastering_luminance: c_uint,
+    pub(super) min_display_mastering_luminance: c_uint,
+    pub(super) max_content_light_level: c_uint,
+    pub(super) max_pic_average_light_level: c_uint,
+    pub(super) transfer_characteristics: c_uint,
+    pub(super) color_primaries: c_uint,
+    pub(super) matrix_coeffs: c_uint,
     pub(super) reserved: [u8; 32],
 }
 
@@ -113,10 +119,16 @@ pub(super) type LoadStateCallback = Option<extern "C" fn(c_int, c_longlong, *con
 /// v1's frame-done callback: the `userdata` its feed was given, echoed back.
 pub(super) type FrameCallback = Option<extern "C" fn(c_ulonglong)>;
 
+/// `NDL_DirectMediaInit`'s two prototypes: API 1 takes the resource-released callback, API 2 the
+/// app id alone (`webosbrew/webos-userland@00a5f87`). One symbol, resolved once, typed twice.
+pub(super) type InitV1 = unsafe extern "C" fn(*const c_char, ResourceReleased) -> c_int;
+pub(super) type InitV2 = unsafe extern "C" fn(*const c_char) -> c_int;
+
 /// The three calls both generations share.
 pub(super) struct Common {
     pub(super) get_error: unsafe extern "C" fn() -> *const c_char,
-    pub(super) init: unsafe extern "C" fn(*const c_char, ResourceReleased) -> c_int,
+    pub(super) init_v1: InitV1,
+    pub(super) init_v2: InitV2,
     pub(super) quit: unsafe extern "C" fn() -> c_int,
 }
 
@@ -189,9 +201,12 @@ fn cached<T: 'static>(
 pub(super) fn common() -> Result<&'static Common> {
     static CACHE: OnceLock<std::result::Result<Common, String>> = OnceLock::new();
     cached(&CACHE, |lib| {
+        let init_v1: InitV1 = lib.sym(c"NDL_DirectMediaInit")?;
         Ok(Common {
             get_error: lib.sym(c"NDL_DirectMediaGetError")?,
-            init: lib.sym(c"NDL_DirectMediaInit")?,
+            init_v1,
+            // SAFETY: the same address, retyped to the prototype API 2 declares for it.
+            init_v2: unsafe { std::mem::transmute::<InitV1, InitV2>(init_v1) },
             quit: lib.sym(c"NDL_DirectMediaQuit")?,
         })
     })

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -36,7 +36,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{bail, Result};
 
-pub use v2::{NdlAudioConfig, NdlVideo};
+pub use v2::{NdlAudioConfig, NdlVideo, NotLoadedYet};
 
 /// `NDL_VIDEO_TYPE` values this client can request (matches the codec the host's
 /// `Welcome` resolved — see `punktfunk_core::quic::CODEC_*`).
@@ -286,16 +286,23 @@ pub fn ensure_not_poisoned() -> Result<()> {
 
 static INIT_DONE: AtomicBool = AtomicBool::new(false);
 
-/// Calls `NDL_DirectMediaInit` once (process-global, idempotent-guarded). Same symbol and same
-/// NULL resource-released callback on both generations.
-fn ensure_init(app_id: &str) -> Result<()> {
+/// Calls `NDL_DirectMediaInit` once (process-global, idempotent-guarded). One symbol, two
+/// prototypes: `api2` picks the app-id-only form v2 declares, against v1's app id plus
+/// resource-released callback (always NULL here). See [`ffi::Common`].
+fn ensure_init(app_id: &str, api2: bool) -> Result<()> {
     if INIT_DONE.swap(true, Ordering::SeqCst) {
         return Ok(());
     }
     let fns = ffi::common()?;
     let c_app_id = CString::new(app_id).unwrap_or_default();
     // SAFETY: `c_app_id` is valid for the duration of this call.
-    let ret = unsafe { (fns.init)(c_app_id.as_ptr(), None) };
+    let ret = unsafe {
+        if api2 {
+            (fns.init_v2)(c_app_id.as_ptr())
+        } else {
+            (fns.init_v1)(c_app_id.as_ptr(), None)
+        }
+    };
     if ret != 0 {
         INIT_DONE.store(false, Ordering::SeqCst);
         bail!("NDL_DirectMediaInit failed: ret={ret} error={}", ffi::last_error());

--- a/src/platform/webos/ndl/v1.rs
+++ b/src/platform/webos/ndl/v1.rs
@@ -86,7 +86,7 @@ impl NdlV1Video {
         }
         device::ensure_jail_ok("NDL v1")?;
         let fns = ffi::v1()?;
-        ensure_init(app_id)?;
+        ensure_init(app_id, false)?;
         let mut info = ffi::V1VideoInfo {
             width,
             height,

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -5,7 +5,7 @@
 //! Never calls `NDL_DirectVideoSetArea` — stutters above 1080p, and v2 sizes its own
 //! punch-through plane (v1 can't; see [`super::v1`]).
 use std::ffi::{c_int, c_longlong, c_uint, c_void};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Result};
@@ -13,13 +13,28 @@ use anyhow::{bail, Result};
 use super::{arm_load, ensure_init, ensure_not_poisoned, ffi, settle_before_retry, wait_load_completed};
 use super::{lock_ffi, mark_frame_fed_logged, NdlCodec, LOAD_COMPLETED};
 
-/// One silent stereo Opus frame, fed once post-load to make sure the NDL Opus decoder is ready
-/// before real audio arrives.
-const OPUS_EMPTY_FRAME: [u8; 3] = [0xec, 0xff, 0xfe];
-
 /// How long past `load()` [`NdlVideo::ensure_loaded`] holds frames while `LOADCOMPLETED` is
 /// missing. Measured from the load, so it follows `LOAD_COMPLETE_TIMEOUT`.
 const FEED_ANYWAY_AFTER: Duration = Duration::from_millis(1_000);
+
+/// [`NdlVideo::play`] refusing a frame because `LOADCOMPLETED` hasn't landed. A distinct type
+/// because the caller must NOT respond to it the way it responds to a decode error: the usual
+/// answer is `NDL_DirectVideoFlushRenderBuffer`, and issuing that against a pipeline NDL has not
+/// finished loading takes the session's audio out for good (see `session::sink`).
+#[derive(Debug)]
+pub struct NotLoadedYet;
+
+impl std::fmt::Display for NotLoadedYet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("NDL pipeline not loaded yet — holding")
+    }
+}
+
+impl std::error::Error for NotLoadedYet {}
+
+/// [`NdlVideo::pts_offset_ns`] before the video plane has published one. Not 0 — a genuine
+/// offset of 0 ns is possible, and "unset" must be distinguishable from it.
+const NO_PTS_OFFSET: i64 = i64::MIN;
 
 /// Opus audio config for NDL. Stereo only (no multistream/surround support).
 #[derive(Clone, Copy)]
@@ -49,6 +64,14 @@ pub struct NdlVideo {
     /// PTS in ms since load (NDL's local clock, not wall-clock or host capture clock).
     load_instant: Instant,
     audio_offloaded: bool,
+    /// Host-PTS → NDL-player-clock offset in ns, republished by the video plane on every fed
+    /// frame (`session::sink`) and read by [`Self::play_audio`] so both planes land in ONE
+    /// timeline. [`NO_PTS_OFFSET`] until the first frame is fed.
+    pts_offset_ns: AtomicI64,
+    /// Highest audio stamp fed so far (ms), so [`Self::play_audio`] can never hand NDL a
+    /// timestamp going backwards. Never reset — the ceiling has to survive a re-latch, which is
+    /// exactly the case that would otherwise rewind it.
+    last_audio_pts_ms: AtomicI64,
     /// `false` while `LOADCOMPLETED` still hasn't been seen for this load — [`Self::play`]
     /// refuses to feed until it lands or [`FEED_ANYWAY_AFTER`] passes. Latched once, so the
     /// steady-state feed path costs one relaxed load.
@@ -61,7 +84,7 @@ impl NdlVideo {
     pub fn load(app_id: &str, width: i32, height: i32, codec: NdlCodec, audio: Option<NdlAudioConfig>) -> Result<Self> {
         ensure_not_poisoned()?;
         let fns = ffi::v2()?;
-        ensure_init(app_id)?;
+        ensure_init(app_id, true)?;
         let video = ffi::VideoInfo {
             width,
             height,
@@ -70,19 +93,7 @@ impl NdlVideo {
         };
         if let Some(audio) = audio {
             match Self::try_load(fns, video, audio.to_union(), true) {
-                Ok(loaded) => {
-                    // Prime the Opus decoder with one silent frame, right after a successful
-                    // audio-enabled load. Best-effort — a failure here doesn't
-                    // invalidate the load, so it's logged but not propagated.
-                    let mut frame = OPUS_EMPTY_FRAME;
-                    // SAFETY: NDL reads `size` bytes synchronously, no pointer retained.
-                    let prime =
-                        unsafe { (fns.audio_play)(frame.as_mut_ptr() as *mut c_void, frame.len() as c_uint, 0) };
-                    if prime != 0 {
-                        tracing::warn!("NDL empty-Opus prime failed (ret={prime} error={})", ffi::last_error());
-                    }
-                    return Ok(loaded);
-                }
+                Ok(loaded) => return Ok(loaded),
                 Err(e) => {
                     // Video-only fallback: audio offload is optimization, not critical. Unload
                     // first — a failed load may hold decoder resources (docs/NOTES.md).
@@ -119,6 +130,8 @@ impl NdlVideo {
             fns,
             load_instant: Instant::now(),
             audio_offloaded,
+            pts_offset_ns: AtomicI64::new(NO_PTS_OFFSET),
+            last_audio_pts_ms: AtomicI64::new(0),
             load_confirmed: AtomicBool::new(confirmed),
         })
     }
@@ -129,23 +142,58 @@ impl NdlVideo {
         self.audio_offloaded
     }
 
-    /// Feed one Opus packet to NDL (only when `audio_offloaded`).
+    /// Latch the video plane's host-PTS → player-clock offset so [`play_audio`](Self::play_audio)
+    /// can stamp audio in the same timeline. Called per fed frame from `session::sink`, but takes
+    /// **only the first** value after each [`clear_pts_offset`](Self::clear_pts_offset).
     ///
-    /// ⚠ **The two planes are stamped in unrelated time bases, and NDL syncs them against each
-    /// other.** This stamps arrival wall-clock (`load_instant.elapsed()`), while video is stamped
-    /// with a host-PTS value mapped onto NDL's player clock by `HostPtsAnchor` and then smoothed by
-    /// `PtsPacer` (`session::sink`). NDL's own A/V synchronisation therefore regulates against a
-    /// fiction: the audio timeline drifts with delivery jitter while the video timeline tracks host
-    /// capture cadence.
+    /// Latched, not republished per frame: the offset is a mapping between two clocks, and it is
+    /// stable only while the video plane's own anchor is. Re-deriving it every frame lets any jump
+    /// in the video timeline — a receive-backlog flush jumping to live drops frames, so host PTS
+    /// leaps forward while the player clock does not — drag the audio stamp *backwards* by the
+    /// size of the jump. NDL takes that as a rewind and stops playing audio for the rest of the
+    /// session (observed on CX: audio worked in a session with no flush, gone in one with).
+    /// `clear_pts_offset` at the sink's anchor resets is what re-derives it.
+    pub(crate) fn latch_pts_offset(&self, offset_ns: i64) {
+        // The steady state is "already latched", and this runs per fed frame — keep the exclusive
+        // access off the video thread's hot path once the offset is set.
+        if self.pts_offset_ns.load(Ordering::Relaxed) != NO_PTS_OFFSET {
+            return;
+        }
+        let _ = self
+            .pts_offset_ns
+            .compare_exchange(NO_PTS_OFFSET, offset_ns, Ordering::Relaxed, Ordering::Relaxed);
+    }
+
+    /// Drop the latched offset — the two timelines just decoupled (the sink reset its anchor
+    /// after a freeze-until-reanchor hold, or on the pacing off→on edge).
+    /// [`play_audio`](Self::play_audio) holds packets until the video plane latches a fresh one.
+    pub(crate) fn clear_pts_offset(&self) {
+        self.pts_offset_ns.store(NO_PTS_OFFSET, Ordering::Relaxed);
+    }
+
+    /// Feed one Opus packet to NDL (only when `audio_offloaded`). `host_pts_ns` is the packet's
+    /// own host capture timestamp, NOT arrival time.
     ///
-    /// Left as-is deliberately. Fixing it properly means both planes sharing ONE anchor, which
-    /// means moving anchor ownership out of the sink and onto this handle behind a lock — a change
-    /// to the *working* video hot path, made for a path that is off by default (see
-    /// `NDL_AUDIO_OFFLOAD`) and that `docs/NOTES.md` records as freezing video outright on webOS
-    /// 10.3. Anyone reviving audio offload must fix this first; the symptom would be audio that
-    /// drifts against the picture over a session rather than sitting at a constant offset.
-    pub fn play_audio(&self, packet: &[u8]) -> Result<()> {
-        let pts_ms = self.load_instant.elapsed().as_millis() as c_longlong;
+    /// **Both planes must be stamped in one time base** — NDL runs its own A/V synchronisation
+    /// against these values, and regulating a video plane on host-capture cadence against an audio
+    /// plane on arrival wall-clock is what froze the picture on webOS 10.3 (docs/NOTES.md § "Opus
+    /// offload to NDL"). So the host PTS goes through the video plane's own offset
+    /// ([`latch_pts_offset`](Self::latch_pts_offset)).
+    ///
+    /// Returns `Ok(())` having fed nothing while no offset is latched: audio before the first
+    /// video frame has no timeline to join yet, and dropping those few packets beats feeding them
+    /// at a stamp that jumps once the real offset lands.
+    ///
+    /// The stamp is also floored at the previous one — NDL reads a timestamp going backwards (an
+    /// out-of-order packet, or a re-latch after a hold) as a rewind and mutes the rest of the
+    /// session rather than resyncing.
+    pub fn play_audio(&self, packet: &[u8], host_pts_ns: u64) -> Result<()> {
+        let offset_ns = self.pts_offset_ns.load(Ordering::Relaxed);
+        if offset_ns == NO_PTS_OFFSET {
+            return Ok(());
+        }
+        let raw_ms = (host_pts_ns as i64).saturating_add(offset_ns).max(0) / 1_000_000;
+        let pts_ms = self.last_audio_pts_ms.fetch_max(raw_ms, Ordering::Relaxed).max(raw_ms) as c_longlong;
         let _ffi = lock_ffi();
         // SAFETY: NDL reads `size` bytes synchronously and does not retain the pointer.
         let ret = unsafe { (self.fns.audio_play)(packet.as_ptr() as *mut c_void, packet.len() as c_uint, pts_ms) };
@@ -174,7 +222,7 @@ impl NdlVideo {
         } else if elapsed >= FEED_ANYWAY_AFTER {
             tracing::warn!("NDL: still no LOADCOMPLETED after {FEED_ANYWAY_AFTER:?} — feeding anyway");
         } else {
-            bail!("NDL pipeline not loaded yet — holding");
+            return Err(NotLoadedYet.into());
         }
         self.load_confirmed.store(true, Ordering::Relaxed);
         Ok(())
@@ -218,21 +266,21 @@ impl NdlVideo {
         // G/B/R order (ST.2086 convention).
         let [g, b, r] = m.display_primaries;
         let info = ffi::HdrInfo {
-            display_primaries_x0: c_int::from(g[0]),
-            display_primaries_y0: c_int::from(g[1]),
-            display_primaries_x1: c_int::from(b[0]),
-            display_primaries_y1: c_int::from(b[1]),
-            display_primaries_x2: c_int::from(r[0]),
-            display_primaries_y2: c_int::from(r[1]),
-            white_point_x: c_int::from(m.white_point[0]),
-            white_point_y: c_int::from(m.white_point[1]),
-            max_display_mastering_luminance: m.max_display_mastering_luminance as c_int,
-            min_display_mastering_luminance: m.min_display_mastering_luminance as c_int,
-            max_content_light_level: c_int::from(m.max_cll),
-            max_pic_average_light_level: c_int::from(m.max_fall),
-            transfer_characteristics: c_int::from(color.transfer),
-            color_primaries: c_int::from(color.primaries),
-            matrix_coeffs: c_int::from(color.matrix),
+            display_primaries_x0: c_uint::from(g[0]),
+            display_primaries_y0: c_uint::from(g[1]),
+            display_primaries_x1: c_uint::from(b[0]),
+            display_primaries_y1: c_uint::from(b[1]),
+            display_primaries_x2: c_uint::from(r[0]),
+            display_primaries_y2: c_uint::from(r[1]),
+            white_point_x: c_uint::from(m.white_point[0]),
+            white_point_y: c_uint::from(m.white_point[1]),
+            max_display_mastering_luminance: m.max_display_mastering_luminance as c_uint,
+            min_display_mastering_luminance: m.min_display_mastering_luminance as c_uint,
+            max_content_light_level: c_uint::from(m.max_cll),
+            max_pic_average_light_level: c_uint::from(m.max_fall),
+            transfer_characteristics: c_uint::from(color.transfer),
+            color_primaries: c_uint::from(color.primaries),
+            matrix_coeffs: c_uint::from(color.matrix),
             reserved: [0; 32],
         };
         let _ffi = lock_ffi();
@@ -258,6 +306,13 @@ impl NdlVideo {
     }
 
     pub fn flush(&self) -> Result<()> {
+        // Never against a pipeline that hasn't reported LOADCOMPLETED: the flush silently kills
+        // the session's audio plane for the rest of the load (see [`NotLoadedYet`]), and nothing
+        // has been fed yet, so there is no render buffer to discard either. The sink's loss path
+        // flushes before it ever calls `play`, so the guard has to live here.
+        if !self.load_confirmed.load(Ordering::Relaxed) && !LOAD_COMPLETED.fired() {
+            return Ok(());
+        }
         let _ffi = lock_ffi();
         // SAFETY: no arguments.
         let ret = unsafe { (self.fns.flush_render_buffer)() };

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -101,6 +101,7 @@ fn spawn_connect(
                 settings.video_pacing,
                 settings.gamepad_type,
                 settings.cursor_capture,
+                settings.force_software_audio,
             )
             // Flagged before the handle is joined, so the loading screen can stop waiting
             // for a stream that is not coming — the error itself still travels by `Result`.

--- a/src/runtime/session_ext.rs
+++ b/src/runtime/session_ext.rs
@@ -49,6 +49,20 @@ impl Connected {
         }
     }
 
+    /// The negotiated channel layout, for the overlay's audio line. Names the layout rather than
+    /// the count — "5.1" is what the user picked in Settings, `6` is not.
+    pub(crate) fn audio_layout(&self) -> &'static str {
+        match self.client.audio_channels {
+            1 => "1.0",
+            2 => "2.0",
+            3 => "2.1",
+            4 => "4.0",
+            6 => "5.1",
+            8 => "7.1",
+            _ => "?",
+        }
+    }
+
     /// The cells the A/V sync loop trades through — handed to the audio player at construction.
     pub(crate) fn sync_cells(&self) -> crate::platform::webos::audio::SyncCells {
         crate::platform::webos::audio::SyncCells {

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -751,9 +751,19 @@ pub(super) fn run_inner() -> Result<()> {
                     // working. `buf` is what is queued ahead of the speaker; `A/V` is positive when
                     // audio plays BEHIND the picture. Both read 0 until the loop has evidence
                     // (100 observations, and a frame on the glass to compare against).
-                    {
+                    //
+                    // Which decoder is running leads the line: the two paths fail differently
+                    // (HW plays or is silent with nothing to measure; SW underruns visibly in
+                    // `buf`), so reading the numbers without knowing which one produced them
+                    // has already cost real debugging time. HW carries no ring and no sync loop
+                    // of its own — NDL owns both — so the two figures are omitted there rather
+                    // than printed as a pair of zeroes that look like a stalled plane.
+                    let layout = connected.audio_layout();
+                    if connected.audio_offloaded {
+                        lines.push(format!("HW {layout} · NDL Opus"));
+                    } else {
                         let (buf_ms, av_ms) = connected.audio_stats();
-                        lines.push(format!("Audio buf {buf_ms} ms · A/V {av_ms:+} ms"));
+                        lines.push(format!("SW {layout} · buf {buf_ms} ms · A/V {av_ms:+} ms"));
                     }
                     if let Some(line) = cpu_mem_line {
                         lines.push(line);

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -760,10 +760,10 @@ pub(super) fn run_inner() -> Result<()> {
                     // than printed as a pair of zeroes that look like a stalled plane.
                     let layout = connected.audio_layout();
                     if connected.audio_offloaded {
-                        lines.push(format!("HW {layout} · NDL Opus"));
+                        lines.push(format!("Opus HW {layout} · NDL"));
                     } else {
                         let (buf_ms, av_ms) = connected.audio_stats();
-                        lines.push(format!("SW {layout} · buf {buf_ms} ms · A/V {av_ms:+} ms"));
+                        lines.push(format!("Opus SW {layout} · buf {buf_ms} ms · A/V {av_ms:+} ms"));
                     }
                     if let Some(line) = cpu_mem_line {
                         lines.push(line);

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -99,6 +99,14 @@ pub fn clock_ticks_per_sec() -> u64 {
     (unsafe { libc::sysconf(libc::_SC_CLK_TCK) } as u64).max(1) // SAFETY: no pointers
 }
 
+/// How often the video pump prints its heartbeat. Well past the 2 s stats cadence it rides on —
+/// the line is a trend ("still draining, still not holding"), and one every couple of seconds
+/// buried the rest of the log without saying anything new.
+const VIDEO_HEARTBEAT_LOG: Duration = Duration::from_secs(15);
+/// Audio packets between peak lines in [`audio_feed_pump`] — 5 ms each, so ~15 s to match
+/// [`VIDEO_HEARTBEAT_LOG`].
+const AUDIO_PEAK_LOG_PACKETS: u32 = 3_000;
+
 /// Ceiling on each teardown join below. The video/audio pumps re-check `stop` on a bounded
 /// cadence, but the FFI calls they make between checks (NDL `play`/`play_audio`, and the
 /// QUIC-close worker `NativeClient::drop` joins internally) have no timeout of their own — an
@@ -876,6 +884,7 @@ fn video_pump(
     let mut last_dropped_seen = client.frames_dropped();
     let mut frames_received: u64 = 0;
     let mut last_heartbeat = Instant::now();
+    let mut last_video_log = Instant::now();
 
     while !stop.load(Ordering::Relaxed) {
         match client.next_frame(Duration::from_millis(500)) {
@@ -889,20 +898,20 @@ fn video_pump(
                     stats.render_backlog.store(backlog.unwrap_or(-1), Ordering::Relaxed);
                     // `backlog` separates "the decoder is behind" from "frames are
                     // arriving late" — indistinguishable before this, since play()
-                    // decodes and presents in one opaque call.
+                    // decodes and presents in one opaque call. Logged on its own slower
+                    // cadence: the overlay wants a fresh depth, the log does not.
                     //
-                    // INFO, not debug: the on-device file sink is INFO-only
-                    // (`logger::resolved_level`), so at debug this line — the one that
-                    // says whether NDL is draining what it is fed — was invisible in
-                    // exactly the situation it exists for, a freeze reported off a
-                    // plain sideloaded run with no telemetry listener. Half a line per
-                    // second is affordable; a second round trip to reproduce is not.
-                    tracing::info!(
-                        "video: {frames_received} frames, holding={}, dropped={}, backlog={}",
-                        sink.holding(),
-                        client.frames_dropped(),
-                        backlog.map_or_else(|| "n/a".to_string(), |b| b.to_string()),
-                    );
+                    // DEBUG, so it costs a telemetry listener or `TELEMETRY_LEVEL=debug` to
+                    // see — the on-device file sink is INFO-only (`logger::resolved_level`).
+                    if last_video_log.elapsed() >= VIDEO_HEARTBEAT_LOG {
+                        last_video_log = Instant::now();
+                        tracing::debug!(
+                            "video: {frames_received} frames, holding={}, dropped={}, backlog={}",
+                            sink.holding(),
+                            client.frames_dropped(),
+                            backlog.map_or_else(|| "n/a".to_string(), |b| b.to_string()),
+                        );
+                    }
                 }
 
                 // From core v0.28 this returns the gap WIDTH (0 = contiguous) where it used to
@@ -1045,14 +1054,13 @@ fn audio_feed_pump(client: &NativeClient, feed: &mut crate::platform::webos::aud
     // cadence in the session. Best-effort, like every renice here.
     // SAFETY: plain syscall — tid 0 (self) and priority value only, no pointers.
     let _ = unsafe { libc::setpriority(libc::PRIO_PROCESS, 0, -10) };
-    // Logged roughly once/sec (200 packets @ 5ms/frame).
     let mut packets: u32 = 0;
     while !stop.load(Ordering::Relaxed) {
         match client.next_audio(Duration::from_millis(100)) {
             Ok(packet) => match feed.play(packet.seq, packet.pts_ns, &packet.data) {
                 Ok(peak) => {
                     packets = packets.wrapping_add(1);
-                    if packets % 200 == 0 {
+                    if packets % AUDIO_PEAK_LOG_PACKETS == 0 {
                         tracing::debug!("audio peak: {peak:.4}");
                     }
                 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -99,14 +99,6 @@ pub fn clock_ticks_per_sec() -> u64 {
     (unsafe { libc::sysconf(libc::_SC_CLK_TCK) } as u64).max(1) // SAFETY: no pointers
 }
 
-/// How often the video pump prints its heartbeat. Well past the 2 s stats cadence it rides on —
-/// the line is a trend ("still draining, still not holding"), and one every couple of seconds
-/// buried the rest of the log without saying anything new.
-const VIDEO_HEARTBEAT_LOG: Duration = Duration::from_secs(15);
-/// Audio packets between peak lines in [`audio_feed_pump`] — 5 ms each, so ~15 s to match
-/// [`VIDEO_HEARTBEAT_LOG`].
-const AUDIO_PEAK_LOG_PACKETS: u32 = 3_000;
-
 /// Ceiling on each teardown join below. The video/audio pumps re-check `stop` on a bounded
 /// cadence, but the FFI calls they make between checks (NDL `play`/`play_audio`, and the
 /// QUIC-close worker `NativeClient::drop` joins internally) have no timeout of their own — an
@@ -903,7 +895,9 @@ fn video_pump(
                     //
                     // DEBUG, so it costs a telemetry listener or `TELEMETRY_LEVEL=debug` to
                     // see — the on-device file sink is INFO-only (`logger::resolved_level`).
-                    if last_video_log.elapsed() >= VIDEO_HEARTBEAT_LOG {
+                    // 15s: the line is a trend ("still draining, still not holding"), and one
+                    // every couple of seconds buried the rest of the log saying nothing new.
+                    if last_video_log.elapsed() >= Duration::from_secs(15) {
                         last_video_log = Instant::now();
                         tracing::debug!(
                             "video: {frames_received} frames, holding={}, dropped={}, backlog={}",
@@ -1060,7 +1054,8 @@ fn audio_feed_pump(client: &NativeClient, feed: &mut crate::platform::webos::aud
             Ok(packet) => match feed.play(packet.seq, packet.pts_ns, &packet.data) {
                 Ok(peak) => {
                     packets = packets.wrapping_add(1);
-                    if packets % AUDIO_PEAK_LOG_PACKETS == 0 {
+                    // ~15s, matching the video heartbeat (packets are 5ms each).
+                    if packets % 3_000 == 0 {
                         tracing::debug!("audio peak: {peak:.4}");
                     }
                 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -187,26 +187,29 @@ impl Connected {
     }
 }
 
-/// Master switch for decoding Opus through NDL (hardware offload). **Disabled**: an
-/// audio-enabled `NDL_DirectMediaLoad` holds the first video frame forever on the tested
-/// webOS 10.3 (G5), despite byte-exact `mariotaku/ss4s` parity (kHz sample rate, the
-/// `opus_empty_frame_211` prime, combined load, feed-time PTS). The load returns success,
-/// so the failure can't be probe-detected — the only safe move is not taking the path.
-/// Flip to `true` to re-test the NDL audio path on another model.
-const NDL_AUDIO_OFFLOAD: bool = false;
-
-/// Whether NDL should decode audio itself. Gated off by [`NDL_AUDIO_OFFLOAD`]; software
-/// Opus→SDL is the default. Stereo only even when enabled: NDL's struct has no multistream
-/// mapping field, so 5.1/7.1 layouts would produce noise and stay on the software decoder.
-fn ndl_audio_config(resolved_channels: u8) -> Option<crate::platform::webos::ndl::NdlAudioConfig> {
-    if !NDL_AUDIO_OFFLOAD {
+/// Whether NDL should decode Opus itself, and with what configuration — `None` puts the session
+/// on the software decoder (`platform::webos::audio`).
+///
+/// Hardware decode is the default wherever NDL takes it. It was disabled for a while over a
+/// freeze that turned out to be the two planes being stamped in different clocks; both now share
+/// one latched offset (`NdlVideo::latch_pts_offset`, docs/NOTES.md § "Opus offload to NDL").
+///
+/// Software decode remains the answer on four routes this function never sees — NDL v1 (no Opus
+/// audio type), SMP (loads video-only), an audio-enabled load NDL rejects, and a TV that accepts
+/// the load and then plays nothing — plus `force_software` for the last of those, which cannot be
+/// detected at runtime (`NDL_DirectAudioPlay` reports success either way). **Stereo only**: NDL's
+/// struct has no multistream mapping field, so 5.1/7.1 would decode as noise.
+fn ndl_audio_config(
+    resolved_channels: u8,
+    force_software: bool,
+) -> Option<crate::platform::webos::ndl::NdlAudioConfig> {
+    if force_software {
         return None;
     }
     (resolved_channels == 2).then_some(crate::platform::webos::ndl::NdlAudioConfig {
         channels: 2,
-        // NDL wants the sample rate in **kHz**, not Hz.
+        // kHz, not Hz — NDL's own unit, and what ss4s passes (`info->sampleRate / 1000.0`).
         // punktfunk's audio plane is fixed at 48 kHz (see `audio.rs`'s SAMPLE_RATE).
-        // Passing Hz here was the offload-freeze root cause.
         sample_rate: 48.0,
     })
 }
@@ -235,7 +238,7 @@ fn open_player(
     height: i32,
     fps: u32,
     codec: NdlCodec,
-    audio_channels: u8,
+    ndl_audio: Option<crate::platform::webos::ndl::NdlAudioConfig>,
 ) -> Result<VideoPlayer> {
     if crate::core::caps::effective_backend(backend) == VideoBackend::Smp {
         match crate::platform::webos::smp::SmpVideo::load(app_id, width, height, fps, codec) {
@@ -245,7 +248,7 @@ fn open_player(
     }
     match device::ndl_generation() {
         NdlGeneration::V2 => Ok(VideoPlayer::V2(Arc::new(
-            NdlVideo::load(app_id, width, height, codec, ndl_audio_config(audio_channels)).context("NDL load")?,
+            NdlVideo::load(app_id, width, height, codec, ndl_audio).context("NDL load")?,
         ))),
         NdlGeneration::V1 => Ok(VideoPlayer::V1(
             NdlV1Video::load(app_id, width, height, codec).context("NDL v1 load")?,
@@ -276,6 +279,7 @@ pub fn connect(
     video_pacing: bool,
     gamepad_type: crate::services::store::GamepadType,
     cursor_capture: bool,
+    force_software_audio: bool,
 ) -> Result<Connected> {
     // Fails before touching the network: a full handshake would only end in `NdlVideo::load()`
     // rejecting the same gate, pointlessly holding the host's pending-session slot for `timeout`.
@@ -382,7 +386,15 @@ pub fn connect(
         NdlCodec::from_wire(client.codec).with_context(|| format!("unsupported codec 0x{:02x}", client.codec))?;
     let app_id = crate::platform::webos::ndl::app_id();
     let (width, height) = (resolved_mode.width as i32, resolved_mode.height as i32);
-    let player = open_player(video_backend, &app_id, width, height, fps, codec, client.audio_channels)?;
+    let player = open_player(
+        video_backend,
+        &app_id,
+        width,
+        height,
+        fps,
+        codec,
+        ndl_audio_config(client.audio_channels, force_software_audio),
+    )?;
     tracing::info!(
         "{} loaded ({codec:?} {}x{}@{fps}fps)",
         player.backend_name(),
@@ -416,14 +428,22 @@ pub fn connect(
     }
 
     let ndl_audio = player.ndl_audio_handle();
+    // Naming the REASON matters: "software Opus" is the correct outcome on four different
+    // routes plus the user's own override, and a silent session looks identical on all of
+    // them. Without this the first debugging question has no answer in the log.
+    let path = match (&ndl_audio, force_software_audio, &player) {
+        (Some(_), _, _) => "NDL hardware Opus decode",
+        (None, true, _) => "software Opus decode -> SDL2 (forced: Experimental setting)",
+        (None, _, VideoPlayer::V1(_)) => "software Opus decode -> SDL2 (NDL v1 has no Opus audio type)",
+        (None, _, VideoPlayer::Smp(_)) => "software Opus decode -> SDL2 (SMP loads video-only)",
+        (None, _, VideoPlayer::V2(_)) if client.audio_channels != 2 => {
+            "software Opus decode -> SDL2 (NDL Opus is stereo-only)"
+        }
+        (None, _, VideoPlayer::V2(_)) => "software Opus decode -> SDL2 (NDL rejected the audio-enabled load)",
+    };
     tracing::info!(
-        "audio path: {} (host resolved {} channel(s))",
-        if ndl_audio.is_some() {
-            "NDL hardware Opus decode"
-        } else {
-            "software Opus decode -> SDL2"
-        },
-        client.audio_channels,
+        "audio path: {path} (host resolved {} channel(s))",
+        client.audio_channels
     );
 
     let stop = Arc::new(AtomicBool::new(false));
@@ -966,9 +986,7 @@ fn video_pump(
 /// audio into ≤500 ms stalls *with packets already waiting*, and in normal flow
 /// packets drained in per-video-frame clumps that all took the same drain-time PTS.
 /// Core's `next_audio` docs ask for exactly this thread ("packets arrive every 5 ms"),
-/// and its pull methods are one-thread-per-plane safe by contract. Draining within a
-/// scheduler tick of arrival is also what makes `NdlVideo::play_audio`'s
-/// arrival-time PTS stamp accurate.
+/// and its pull methods are one-thread-per-plane safe by contract.
 ///
 /// Teardown safety: this thread holds one of the two `Arc<NdlVideo>` owners, so the
 /// process-global NDL unload in `NdlVideo::drop` cannot run until this thread has
@@ -982,7 +1000,7 @@ fn ndl_audio_pump(client: &NativeClient, ndl: &NdlVideo, stop: &AtomicBool) {
     while !stop.load(Ordering::Relaxed) {
         match client.next_audio(Duration::from_millis(100)) {
             Ok(packet) => {
-                if let Err(e) = ndl.play_audio(&packet.data) {
+                if let Err(e) = ndl.play_audio(&packet.data, packet.pts_ns) {
                     tracing::warn!("NDL audio error (seq {}): {e:#}", packet.seq);
                 }
             }

--- a/src/session/sink.rs
+++ b/src/session/sink.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 use punktfunk_core::quic;
 
 use crate::platform::webos::ndl::v1::NdlV1Video;
-use crate::platform::webos::ndl::NdlVideo;
+use crate::platform::webos::ndl::{NdlVideo, NotLoadedYet};
 use crate::platform::webos::smp::SmpVideo;
 use crate::session::pacing::{reconciled_pace_interval_ns, HostPtsAnchor, PtsPacer};
 use crate::session::StreamStats;
@@ -169,25 +169,63 @@ impl VideoPlayer {
 
     /// Unpaced PTS reference for `frame` in NDL's clock domain, smoothed by [`PtsPacer`]
     /// before it reaches [`Self::play`]. NDL has no PTS clock of its own (see
-    /// `NdlVideo::elapsed_ns`); with `anchor` present the host PTS is mapped onto NDL's
-    /// player clock ([`HostPtsAnchor`]) so the reference tracks host frame cadence instead
-    /// of feed-time wall-clock, keeping delivery jitter out of the pacer's drift-clamp
-    /// anchor. Without `anchor` (pacing off) NDL falls back to raw player time.
+    /// `NdlVideo::elapsed_ns`), so the host PTS is mapped onto NDL's player clock
+    /// ([`HostPtsAnchor`]) and the reference tracks host frame cadence instead of feed-time
+    /// wall-clock, keeping delivery jitter out of the pacer's drift-clamp anchor.
+    ///
+    /// **V2 anchors whether or not pacing is on.** It used to fall back to raw player time with
+    /// pacing off, which stamps video in *feed* time while offloaded audio is stamped in *host*
+    /// time (`NdlVideo::play_audio`) — two clocks that agree only by luck, and stop agreeing the
+    /// moment a receive-backlog flush jumps the client to live. Anchoring unconditionally is what
+    /// makes the two planes share one mapping by construction. Pacing off now means only that
+    /// [`PtsPacer`]'s smoothing is skipped.
     ///
     /// SMP is mapped the same way as V2 — its PTS domain is nanoseconds since *its own* load
     /// (`now - openTime`), not the host's clock, so an unmapped host PTS would sit an
     /// arbitrary epoch away and `pauseAtDecodeTime` would hold every frame. V1 has nothing to pace
     /// against at all (no PTS input, no player clock), so the host PTS returns untouched there and
     /// the pacer's output is discarded at the feed.
-    fn pace_base_ns(&self, frame_pts_ns: u64, anchor: Option<&mut HostPtsAnchor>) -> u64 {
+    fn pace_base_ns(&self, frame_pts_ns: u64, anchor: &mut HostPtsAnchor, pacing_on: bool) -> u64 {
         let player_clock_ns = match self {
             Self::V2(ndl) => ndl.elapsed_ns(),
             Self::Smp(sf) => sf.elapsed_ns(),
             Self::V1(_) => return frame_pts_ns,
         };
-        match anchor {
-            Some(a) => a.map(frame_pts_ns, player_clock_ns),
-            None => player_clock_ns,
+        if pacing_on || matches!(self, Self::V2(_)) {
+            anchor.map(frame_pts_ns, player_clock_ns)
+        } else {
+            player_clock_ns
+        }
+    }
+
+    /// Hand the audio plane the host-PTS → player-clock offset this frame was stamped with, so
+    /// offloaded Opus lands in the same timeline as the picture (`NdlVideo::play_audio`). Only
+    /// the first frame after an anchor reset is taken (see `NdlVideo::latch_pts_offset`) — this
+    /// is called per frame so that re-latch happens promptly, not so the offset tracks.
+    /// `base_ns` is the *unpaced* reference — the pacer's ±half-frame smoothing is video-only
+    /// jitter compensation and must not be projected onto the audio timeline.
+    ///
+    /// V2 only, and only when audio is offloaded; no other backend feeds audio through NDL.
+    fn latch_pts_offset(&self, frame_pts_ns: u64, base_ns: u64) {
+        if let Some(ndl) = self.offloaded_ndl() {
+            ndl.latch_pts_offset(base_ns as i64 - frame_pts_ns as i64);
+        }
+    }
+
+    /// Decouple the audio plane from a timeline that no longer holds — the anchor it was
+    /// derived from is being reset. Audio holds until the next fed frame republishes.
+    fn clear_pts_offset(&self) {
+        if let Some(ndl) = self.offloaded_ndl() {
+            ndl.clear_pts_offset();
+        }
+    }
+
+    /// The NDL handle the audio plane shares, or `None` on every backend/load that decodes Opus
+    /// in software — the gate both offset calls above answer to.
+    fn offloaded_ndl(&self) -> Option<&NdlVideo> {
+        match self {
+            Self::V2(ndl) => ndl.audio_offloaded().then(|| ndl.as_ref()),
+            Self::V1(_) | Self::Smp(_) => None,
         }
     }
 
@@ -327,6 +365,15 @@ impl NdlSink {
         ready
     }
 
+    /// Drop everything derived from a mapping that no longer holds: the pacer's accumulator, the
+    /// host anchor, and the audio plane's copy of that anchor. The three move in lockstep or the
+    /// planes end up on timelines that disagree.
+    fn reset_timeline(&mut self) {
+        self.pacer.reset();
+        self.host_anchor.reset();
+        self.player.clear_pts_offset();
+    }
+
     fn begin_hold(&mut self) {
         self.stats.holding.store(true, Ordering::Relaxed);
         self.hold_started.get_or_insert_with(Instant::now);
@@ -432,8 +479,7 @@ impl NdlSink {
             );
             // The real timeline just jumped (freeze then reanchor/give-up) — nothing about
             // the pre-hold accumulator is worth continuing.
-            self.pacer.reset();
-            self.host_anchor.reset();
+            self.reset_timeline();
         }
         self.stats.holding.store(false, Ordering::Relaxed);
         self.hold_started = None;
@@ -442,14 +488,11 @@ impl NdlSink {
         // up from the current frame rather than a stale grid.
         let pacing_on = self.stats.pacing_enabled.load(Ordering::Relaxed);
         if pacing_on && !self.pacing_was_on {
-            self.pacer.reset();
-            self.host_anchor.reset();
+            self.reset_timeline();
         }
         self.pacing_was_on = pacing_on;
 
-        let base_ns = self
-            .player
-            .pace_base_ns(pts_ns, pacing_on.then_some(&mut self.host_anchor));
+        let base_ns = self.player.pace_base_ns(pts_ns, &mut self.host_anchor, pacing_on);
         let paced_ns = if pacing_on {
             let paced = self.pacer.next(base_ns);
             self.stats
@@ -487,6 +530,11 @@ impl NdlSink {
             // Only a frame NDL actually accepted is on its way to the glass. A failed feed is
             // followed by a flush and a hold below, where the reference would be meaningless.
             self.publish_video_e2e(submit_realtime_ns, pts_ns, backlog);
+            // Same reason, and it also doubles as the audio plane's start gate. `play_audio` has
+            // no `ensure_loaded` guard of its own, so latching off a REJECTED frame turns the
+            // audio thread loose on a pipeline NDL hasn't loaded yet — which costs the session
+            // its audio outright.
+            self.player.latch_pts_offset(pts_ns, base_ns);
         }
         let decode_us =
             (self.cfg.report_decode_latency && play_result.is_ok()).then(|| self.decode_us(feed_elapsed, backlog));
@@ -497,8 +545,17 @@ impl NdlSink {
                 flags.index,
                 paced_ns as f64 / 1_000_000.0,
             );
+            // A frame refused because the pipeline hasn't finished loading is NOT a decode
+            // error, and must not be answered with a flush: `NDL_DirectVideoFlushRenderBuffer`
+            // against a not-yet-loaded pipeline silently kills the audio plane for the rest of
+            // the session (video recovers, audio never does — observed on CX). Holding and asking
+            // for a keyframe is the whole of the correct response here; the frames are being
+            // dropped on our side, so there is nothing queued in NDL to discard anyway.
+            let not_loaded = e.downcast_ref::<NotLoadedYet>().is_some();
             if self.take_keyframe_slot() {
-                let _ = self.player.flush();
+                if !not_loaded {
+                    let _ = self.player.flush();
+                }
                 self.begin_hold();
                 need_keyframe = true;
             }

--- a/src/ui/tiles.rs
+++ b/src/ui/tiles.rs
@@ -146,6 +146,11 @@ pub fn render_wrapped_text_tile(
 /// Worst-case stat line used to lock overlay width.
 pub const STATS_OVERLAY_REF_LINE: &str = "3840x2160@120 HEVC HDR";
 
+/// Extra width past [`STATS_OVERLAY_REF_LINE`], as digits of the stat font. The reference line is
+/// no longer the widest one — the audio line carries a layout name and two figures — and a line
+/// that overruns the tile is clipped, not wrapped.
+const STATS_OVERLAY_SLACK: &str = "00000";
+
 /// In-stream stats overlay with fixed width and centered hint.
 /// `lines[0]` is highlighted; remaining lines are muted.
 pub fn render_stats_overlay_tile(fonts: &Fonts, lines: &[String], hint: &str) -> Result<Painter> {
@@ -157,7 +162,8 @@ pub fn render_stats_overlay_tile(fonts: &Fonts, lines: &[String], hint: &str) ->
     let hint_h = caption_h + 8;
     let line_count = lines.len() as i32;
 
-    let inner_w = raster.measure(font, STATS_OVERLAY_REF_LINE).0 + content_safety;
+    let inner_w =
+        raster.measure(font, STATS_OVERLAY_REF_LINE).0 + raster.measure(font, STATS_OVERLAY_SLACK).0 + content_safety;
     let w = inner_w + 2 * pad as u32;
     let h = (line_count * line_h + hint_h + 2 * pad) as u32;
     let content_w_i32 = w as i32 - 2 * pad;


### PR DESCRIPTION
Hardware Opus decode has been off behind a `const false` since it froze video on webOS 10.3. It works now — verified on an OLED65CX (webOS 5.0) at 1440p120 HEVC/HDR, sound present, 3300+ frames with `dropped=0`. One less thread and no SDL audio device at all where it takes.

Three things were wrong, and only the third actually restored audio:

- **Both planes have to be stamped in one clock.** Audio went in on arrival wall-clock while video went in on host PTS mapped to NDL's player clock, so NDL's own A/V sync was regulating two unrelated timelines. Audio now rides the same offset the video plane latched — once per anchor, never per frame, since re-deriving it lets a backlog flush drag the stamp backwards and NDL treats that as a rewind and mutes for good.
- **V2 anchors whether or not pacing is on.** Falling back to raw player time stamped video in feed time against audio in host time; those agree only by luck. Pacing off now means only that the pacer's smoothing is skipped.
- **Never flush a pipeline that hasn't finished loading.** This was the actual cause of "video fine, audio silent" — `NDL_DirectVideoFlushRenderBuffer` before LOADCOMPLETED kills the audio plane for the whole session and video recovers with no sign. On the CX that callback lands ~3.3 s after the first feed, so frame 0 gets refused routinely. The guard sits in `flush` itself so the loss path is covered too.

Also here:

- Experimental setting "Software audio" — a TV that accepts the offloaded load and then plays nothing can't be detected at runtime, so there's a way out without a rebuild.
- Stats overlay names the decoder and the layout: `Audio HW 2.0 · NDL Opus` / `Audio SW 5.1 · buf … · A/V …`. HW omits the ring figures, NDL owns those.
- Two upstream header corrections (`webos-userland@00a5f87`): `HdrInfo` field types, and `NDL_DirectMediaInit` taking only the app id in API 2. The `reserved[32]` padding stays deliberately — the struct goes by value and an older-header build would read past our copy.

Untested on the G5/webOS 10.3 that originally froze. Non-stereo stays on software decode by design; NDL's Opus struct has no multistream mapping field.