### PR TITLE
Default to software Opus, make NDL hardware decode opt-in

### DIFF
--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -85,7 +85,7 @@ pub const SETTINGS_ROW_COUNT: usize = 12;
 
 /// Experimental modal row indices (see `app::view::experimental::rows`).
 pub const EXP_ROW_FRAME_PACER: usize = 0;
-pub const EXP_ROW_SOFTWARE_AUDIO: usize = 1;
+pub const EXP_ROW_HW_AUDIO: usize = 1;
 /// Only present on rooted TVs, so it's the last row when shown.
 pub const EXP_ROW_GAME_MODE: usize = 2;
 

--- a/src/app/render/key.rs
+++ b/src/app/render/key.rs
@@ -51,7 +51,9 @@ pub enum ModalShellKey {
     // on every keystroke or dropdown open/close. The shell draws chrome only (no
     // row content, not even the Bitrate caution — that's the focus tile's job),
     // so the only thing that can actually change it is the close-button hover.
-    Settings { hover_close: bool },
+    Settings {
+        hover_close: bool,
+    },
     Wake {
         name: String,
         mac_empty: bool,
@@ -94,7 +96,7 @@ pub enum ModalShellKey {
     },
     Experimental {
         video_pacing: bool,
-        force_software_audio: bool,
+        ndl_audio_offload: bool,
         game_mode: bool,
         hover_close: bool,
     },

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -475,7 +475,7 @@ impl App {
             }),
             Screen::Experimental => Some(ModalShellKey::Experimental {
                 video_pacing: self.settings.video_pacing,
-                force_software_audio: self.settings.force_software_audio,
+                ndl_audio_offload: self.settings.ndl_audio_offload,
                 game_mode: self.settings.game_mode,
                 hover_close: self.hover_close,
             }),
@@ -557,7 +557,7 @@ impl App {
             Screen::Experimental => Some(ModalFocusKey::ExperimentalRow(
                 self.experimental_focused,
                 self.settings.video_pacing,
-                self.settings.force_software_audio,
+                self.settings.ndl_audio_offload,
                 self.settings.game_mode,
             )),
             Screen::CursorSettings => Some(ModalFocusKey::CursorSettingsRow(

--- a/src/app/state/experimental.rs
+++ b/src/app/state/experimental.rs
@@ -27,9 +27,9 @@ impl App {
                 self.settings.video_pacing = !from;
                 self.switch_anim = Some((Instant::now(), from, self.experimental_focused));
             }
-            (menu::EXP_ROW_SOFTWARE_AUDIO, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
-                let from = self.settings.force_software_audio;
-                self.settings.force_software_audio = !from;
+            (menu::EXP_ROW_HW_AUDIO, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
+                let from = self.settings.ndl_audio_offload;
+                self.settings.ndl_audio_offload = !from;
                 self.switch_anim = Some((Instant::now(), from, self.experimental_focused));
             }
             (menu::EXP_ROW_GAME_MODE, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {

--- a/src/app/view/experimental.rs
+++ b/src/app/view/experimental.rs
@@ -29,20 +29,20 @@ pub fn rows(settings: &Settings, rooted: bool) -> Vec<FocusRow> {
     } else {
         "May improve framerate smoothness, adds latency"
     }))];
-    // Hardware Opus is the default on webOS 5+, and the software decoder is the fallback for
-    // every case NDL can't take (older TVs, SMP, surround) — so this only forces a path that
-    // always exists. It's a row because a TV can accept the offloaded load and then play
-    // nothing, and neither the app nor the user can tell that apart from a host sending silence.
+    // Opt-in, not the default: the audio-enabled load is rejected on at least some webOS 5+ sets
+    // and takes the video plane down with it (black picture, sound fine — see
+    // `Settings::ndl_audio_offload`). Software Opus is the path that always exists, so it stays
+    // the default and this offers the offload to anyone whose TV can take it.
     rows.push(
         FocusRow::toggle(
             crate::app::view::icons::ICON_MEMORY,
-            "Software audio",
-            settings.force_software_audio,
+            "Hardware audio decode",
+            settings.ndl_audio_offload,
         )
-        .with_subtext(ui::widgets::RowSubtext::hint(if settings.force_software_audio {
-            "Opus on the CPU"
+        .with_subtext(ui::widgets::RowSubtext::hint(if settings.ndl_audio_offload {
+            "Opus decoded by NDL"
         } else {
-            "Use if the TV plays no sound"
+            "Opus on the CPU — turn on to let NDL decode it"
         })),
     );
     // Driving the TV's Game picture/sound modes needs the Homebrew Channel's root helper — the

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -243,12 +243,16 @@ pub struct Settings {
     /// stream start (SDR "game" / HDR "hdrGame" per the negotiated colour path) and reverted
     /// on stream exit.
     pub game_mode: bool,
-    /// Decode Opus in software even where NDL would take it (`session::ndl_audio_config`).
-    /// Off by default: on webOS 5+ NDL decodes Opus itself, one less thread and no SDL audio
-    /// device at all. The escape hatch exists because a TV that accepts the offloaded load and
-    /// then stays silent cannot be detected at runtime (`NDL_DirectAudioPlay` reports success
-    /// either way). Takes effect on the next stream.
-    pub force_software_audio: bool,
+    /// Ask NDL to decode Opus itself instead of running the software decoder
+    /// (`session::ndl_audio_config`). Takes effect on the next stream.
+    ///
+    /// **Off by default, and opt-in for now.** The audio-enabled load is rejected on at least
+    /// some webOS 5+ sets (an OLED65CX): `NDL_DirectMediaLoad` returns 0 but the pipeline never
+    /// reports `LOADCOMPLETED`, and while the audio plane does play, the video plane never
+    /// starts — an entire session of black picture with sound. Until that is understood, the
+    /// software path is the one that always works, so it is the default and this row is the
+    /// escape hatch rather than the other way round.
+    pub ndl_audio_offload: bool,
     /// Resolve the Magic Remote's OK button into left click / right click / drag by how long
     /// it's held (see `platform::webos::mouse::RemoteButtons`). Off by default — with it
     /// off, OK stays the plain immediate left click it has always been, since a remote with
@@ -279,7 +283,7 @@ impl Default for Settings {
             gamepad_type: GamepadType::Auto,
             cursor_capture: true,
             game_mode: false,
-            force_software_audio: false,
+            ndl_audio_offload: false,
             cursor_gestures: false,
         }
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -101,7 +101,7 @@ fn spawn_connect(
                 settings.video_pacing,
                 settings.gamepad_type,
                 settings.cursor_capture,
-                settings.force_software_audio,
+                settings.ndl_audio_offload,
             )
             // Flagged before the handle is joined, so the loading screen can stop waiting
             // for a stream that is not coming — the error itself still travels by `Result`.

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -190,20 +190,18 @@ impl Connected {
 /// Whether NDL should decode Opus itself, and with what configuration — `None` puts the session
 /// on the software decoder (`platform::webos::audio`).
 ///
-/// Hardware decode is the default wherever NDL takes it. It was disabled for a while over a
-/// freeze that turned out to be the two planes being stamped in different clocks; both now share
-/// one latched offset (`NdlVideo::latch_pts_offset`, docs/NOTES.md § "Opus offload to NDL").
+/// Software decode is the default, and hardware offload is **opt-in** (`offload`, the
+/// Experimental screen's "Hardware audio decode"). The audio-enabled load is rejected on at least
+/// some webOS 5+ sets — `NDL_DirectMediaLoad` returns 0, `LOADCOMPLETED` never arrives, the audio
+/// plane plays and the video plane never starts, so the session is black with sound. Until that is
+/// understood the offload cannot be the default, whatever it saves.
 ///
-/// Software decode remains the answer on four routes this function never sees — NDL v1 (no Opus
-/// audio type), SMP (loads video-only), an audio-enabled load NDL rejects, and a TV that accepts
-/// the load and then plays nothing — plus `force_software` for the last of those, which cannot be
-/// detected at runtime (`NDL_DirectAudioPlay` reports success either way). **Stereo only**: NDL's
-/// struct has no multistream mapping field, so 5.1/7.1 would decode as noise.
-fn ndl_audio_config(
-    resolved_channels: u8,
-    force_software: bool,
-) -> Option<crate::platform::webos::ndl::NdlAudioConfig> {
-    if force_software {
+/// Software decode is also the only answer on three routes this function never sees — NDL v1 (no
+/// Opus audio type), SMP (loads video-only), and an audio-enabled load NDL refuses outright.
+/// **Stereo only**: NDL's struct has no multistream mapping field, so 5.1/7.1 would decode as
+/// noise.
+fn ndl_audio_config(resolved_channels: u8, offload: bool) -> Option<crate::platform::webos::ndl::NdlAudioConfig> {
+    if !offload {
         return None;
     }
     (resolved_channels == 2).then_some(crate::platform::webos::ndl::NdlAudioConfig {
@@ -279,7 +277,7 @@ pub fn connect(
     video_pacing: bool,
     gamepad_type: crate::services::store::GamepadType,
     cursor_capture: bool,
-    force_software_audio: bool,
+    ndl_audio_offload: bool,
 ) -> Result<Connected> {
     // Fails before touching the network: a full handshake would only end in `NdlVideo::load()`
     // rejecting the same gate, pointlessly holding the host's pending-session slot for `timeout`.
@@ -393,7 +391,7 @@ pub fn connect(
         height,
         fps,
         codec,
-        ndl_audio_config(client.audio_channels, force_software_audio),
+        ndl_audio_config(client.audio_channels, ndl_audio_offload),
     )?;
     tracing::info!(
         "{} loaded ({codec:?} {}x{}@{fps}fps)",
@@ -431,9 +429,9 @@ pub fn connect(
     // Naming the REASON matters: "software Opus" is the correct outcome on four different
     // routes plus the user's own override, and a silent session looks identical on all of
     // them. Without this the first debugging question has no answer in the log.
-    let path = match (&ndl_audio, force_software_audio, &player) {
+    let path = match (&ndl_audio, ndl_audio_offload, &player) {
         (Some(_), _, _) => "NDL hardware Opus decode",
-        (None, true, _) => "software Opus decode -> SDL2 (forced: Experimental setting)",
+        (None, false, _) => "software Opus decode -> SDL2 (default; Experimental setting opts in)",
         (None, _, VideoPlayer::V1(_)) => "software Opus decode -> SDL2 (NDL v1 has no Opus audio type)",
         (None, _, VideoPlayer::Smp(_)) => "software Opus decode -> SDL2 (SMP loads video-only)",
         (None, _, VideoPlayer::V2(_)) if client.audio_channels != 2 => {


### PR DESCRIPTION
Streams were coming up black — most often on the desktop card, sometimes games too. Turned out the Opus offload is the cause: the audio-enabled NDL load never completes on the CX, and it takes the video plane down with it.

`NDL_DirectMediaLoad` returns 0 (which only means "request accepted"), `LOADCOMPLETED` never arrives, and the pipeline ends up half-alive — the audio plane decodes and plays fine, the video plane never starts. Confirmed by turning the old software-audio override on: sound and picture both fine. A video-only load reports `LOADCOMPLETED` and `PLAYING` within a second, every time.

So until that's understood, software Opus goes back to being the default.

- rename `force_software_audio` to `ndl_audio_offload` and flip the polarity — the field now says what it does, and old saved settings can't carry the wrong meaning across (`#[serde(default)]` on the container handles the key change)
- Experimental row is now "Hardware audio decode", off by default
- `ndl_audio_config` returns `None` unless the offload is explicitly asked for
- audio-path log line names the new default

Note this also drops the ~3s every launch was spending on a load probe that always failed on this TV.

Still open, not in this PR: why the audio-enabled load is rejected. `unknown1`/`unknown2` in `AudioOpusInfo` are guesses and `stream_header` is passed null, which is the next thing to check. Also worth revisiting the "CX delivers LOADCOMPLETED 4s to never" assumption baked into `ndl/mod.rs` — it looks like it was always this bug, so `LOAD_COMPLETE_TIMEOUT` can probably be tightened.