### PR TITLE
NDL Opus offload fixes, plus HID keyboard repeat

### DIFF
--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -127,26 +127,44 @@ The host stamps `pts_ns` on every audio datagram; this client decoded it and thr
 - ⚠ **Use `frame.pts_ns`, never the paced value.** Both are in scope at the submit site with near-identical names; the paced one has been mapped into NDL's *player* clock by `HostPtsAnchor`. Using it regulates against a fiction that still looks plausible.
 - The estimator's unit tests ship in-tree but **cannot run off-device**: `cargo test` links the whole binary and `-lNDL_directmedia` exists only in the cross sysroot.
 
-## Opus offload to NDL (ON, awaiting device re-test)
+## Opus offload to NDL (OPT-IN, working on CX)
 
 NDL is the sole video backend. Audio is either software Opus→SDL or, when NDL accepts an
-audio-enabled load, decoded by NDL itself — hardware decode is the default wherever it works.
+audio-enabled load, decoded by NDL itself. **Software Opus is the default**; the offload is
+opt-in per `Settings::ndl_audio_offload` while it is being proven on more models.
 
 **Software Opus is not a legacy path and must stay wired.** It is the correct outcome on five
 routes: NDL v1 (`NDL_DirectAudio*` has no Opus source type), SMP (loads `needAudio: false`),
 non-stereo layouts (NDL's Opus struct has no multistream mapping field), an audio-enabled load
-NDL rejects, and Experimental → "Software audio" (`Settings::force_software_audio`). The last
-exists because a TV can accept the offloaded load and then play nothing, which no runtime probe
-can detect. `Connected::audio_channels()` returns `None` only when offload actually took the
+NDL rejects, and the default state of Experimental → "Hardware audio decode"
+(`Settings::ndl_audio_offload`). The last exists because a TV can accept the offloaded load and
+then play nothing, which no runtime probe can detect. `Connected::audio_channels()` returns `None` only when offload actually took the
 stream, so every other route opens the SDL device and spawns `audio_feed_pump` as before. The
 session log names the route it took and why; the stats overlay leads its audio line with
 `Audio HW · NDL Opus` or `Audio SW · buf … · A/V …`.
 
 The load wiring is byte-exact with `mariotaku/ss4s` `ndl/webos5`: `NdlAudioConfig.sample_rate`
 in **kHz** (`48.0`, not `48000.0`), the stereo `opus_empty_frame_211 = {0xec,0xff,0xfe}` decoder
-prime fed once right after a successful audio-enabled `NDL_DirectMediaLoad`, and combined
-audio+video in one load. Struct layouts (`NDL_DIRECTMEDIA_AUDIO_OPUS_INFO_T`,
-`..._DATA_INFO_T`) match `webosbrew/webos-userland` field-for-field.
+prime, and combined audio+video in one load. Struct layouts
+(`NDL_DIRECTMEDIA_AUDIO_OPUS_INFO_T`, `..._DATA_INFO_T`) match `webosbrew/webos-userland`
+field-for-field, including the explicit trailing `_padding` — the whole struct is memcpy'd into a
+fixed-size union arm, so **any implicit padding in a `repr(C)` struct handed to NDL is
+uninitialized stack on the wire**.
+
+⚠ **The prime is what completes the load, and it was missing for months.** An audio-enabled load
+does not report `LOADCOMPLETED` until its audio plane has actually received a packet — but the
+pumps that would send one don't spawn until `session::connect` returns, which is after the load
+wait. The load waited on data the session refused to send until the load completed, and the
+result was a whole session of black picture with working sound, no error anywhere. So
+`NdlVideo::prime_audio` feeds bursts of empty frames (stamps from 0, 5 ms apart) through the
+load window itself. On a CX that turns "never" into `LOADCOMPLETED` in ~41 ms. The prime's
+highest stamp seeds `last_audio_pts_ms`, so the host's first real packets are floored rather
+than read as a rewind (see the LATCHED-offset warning below — a rewind mutes the session).
+Full history in `docs/HANDOVER-NDL-OPUS-OFFLOAD.md`.
+
+The corollary is that **`LOADCOMPLETED` is reliable** and can gate things. The earlier claim in
+these notes and in `ndl/v2.rs` that it "lands anywhere from 4s to never" was this bug, not the
+callback: a video-only load confirms in well under a second, every time, with nothing fed.
 
 **What was wrong, and what "full ss4s parity" hid.** The path held the first video frame forever
 on the tested G5 (webOS 10.3) despite that parity, because the parity was on the *load* and not on
@@ -167,8 +185,8 @@ This was the cause of "video fine, audio silent", and it took four device rounds
 every symptom pointed at timestamps. `NDL_DirectVideoFlushRenderBuffer` issued before
 `LOADCOMPLETED` takes the audio plane out permanently; video recovers and gives no sign. The sink
 used to reach it through its ordinary decode-error path, and frame 0 is refused
-(`NDL pipeline not loaded yet`) on any session where `LOADCOMPLETED` is late — routine on CX,
-where it lands ~3.3s after the first feed. `ensure_loaded` now returns a typed
+(`NDL pipeline not loaded yet`) on any session where `LOADCOMPLETED` is late — which, before the
+prime above, was every offloaded session on a CX. `ensure_loaded` now returns a typed
 `ndl::NotLoadedYet` and `sink::submit` holds + requests a keyframe **without** flushing. Nothing
 is queued in NDL at that point anyway, so the flush was never doing work.
 
@@ -194,7 +212,7 @@ one. Both guards are needed — the floor alone would leave audio stalled at a f
 ⚠ The audio-enabled load returns success even on a TV that then dies silently, so **no runtime
 probe can distinguish the two** — if a model regresses, the `NDL load state:`
 (`LOADCOMPLETED`/`PLAYING`) log is the signal for whether the present pipeline ever starts, and
-Experimental → "Software audio" is the way out.
+turning Experimental → "Hardware audio decode" back off is the way out.
 
 ## ABR startup probe: 2 Gbps, upstream-hardcoded
 

--- a/src/platform/webos/evdev.rs
+++ b/src/platform/webos/evdev.rs
@@ -106,6 +106,19 @@ const fn eviocgrab() -> libc::c_ulong {
     eioc(IOC_WRITE, 0x90, 4)
 }
 
+/// `EVIOCSREP` = `_IOW('E', 0x03, unsigned int[2])` — sets `[REP_DELAY, REP_PERIOD]` in ms,
+/// the parameters the kernel generates `value == 2` autorepeat from.
+const fn eviocsrep() -> libc::c_ulong {
+    const IOC_WRITE: u32 = 1;
+    eioc(IOC_WRITE, 0x03, 8)
+}
+
+/// Autorepeat delay/period pushed onto every keyboard node we own, in ms. The kernel's own
+/// defaults (250/33) are what a bare console uses; every desktop OS re-tunes them, and this
+/// client is the only thing between the node and the host, so it has to do it too.
+const REPEAT_DELAY_MS: u32 = 500;
+const REPEAT_PERIOD_MS: u32 = 33;
+
 /// How long after a keypress a HID keyboard still owns SDL's key events — bridges the gaps
 /// within a burst of typing, short enough that reaching for the remote still feels immediate.
 const IN_USE_WINDOW: Duration = Duration::from_millis(250);
@@ -364,6 +377,9 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
         // TV cursor is still the one you aim.
         return Probe::Skip;
     }
+    if dev.keyboard {
+        set_repeat(fd);
+    }
     tracing::info!(
         "HID {}: {} ({})",
         match (dev.mouse, dev.keyboard) {
@@ -375,6 +391,17 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
         path.display()
     );
     Probe::Hid(dev)
+}
+
+/// Retunes a keyboard node's autorepeat to desktop-like timing. Best-effort: a node that
+/// refuses (or generates no repeat at all) just keeps whatever the kernel set, which costs
+/// repeat timing, not input.
+fn set_repeat(fd: RawFd) {
+    let rep: [u32; 2] = [REPEAT_DELAY_MS, REPEAT_PERIOD_MS];
+    // SAFETY: `fd` is an open evdev node and the ioctl reads exactly the two u32s `rep` holds.
+    if unsafe { libc::ioctl(fd, eviocsrep(), rep.as_ptr()) } < 0 {
+        tracing::debug!("EVIOCSREP: {}", std::io::Error::last_os_error());
+    }
 }
 
 /// LG's virtual remotes advertise a full QWERTY keymap, so a "has `KEY_A`" filter would steal
@@ -567,17 +594,20 @@ fn read_device(dev: &mut Device, sink: &impl Fn(&InputEvent), keys: &KeyActivity
                     }
                     _ => {}
                 },
-                // `value == 2` is autorepeat, keyboard-only; matching 0/1 explicitly to be safe.
-                EV_KEY if ev.value == 0 || ev.value == 1 => {
+                // 0 = release, 1 = press, 2 = autorepeat (keyboard-only).
+                EV_KEY if matches!(ev.value, 0..=2) => {
                     // Buttons and keys share `EV_KEY`, and a combo node reports both — the code
                     // ranges are what tells them apart, not the device.
-                    if let Some(button) = dev.mouse.then(|| button_code(ev.code)).flatten() {
+                    // Buttons take presses and releases only: a repeat would double-fire the click.
+                    if let Some(button) = (dev.mouse && ev.value != 2).then(|| button_code(ev.code)).flatten() {
                         // Motion first: the click must land where the pointer already is.
                         flush_motion(dev, sink);
                         sink(&mouse::raw_button_event(button, ev.value == 1));
                     } else if let Some(vk) = dev.keyboard.then(|| keyboard::vk_from_evdev(ev.code)).flatten() {
                         keys.touch();
-                        sink(&keyboard::raw_key_event(vk, ev.value == 1));
+                        // Autorepeat rides as a repeated KeyDown: the host has no repeat timer of
+                        // its own, so dropping these kills held-key repeat (Backspace, arrows).
+                        sink(&keyboard::raw_key_event(vk, ev.value != 0));
                     }
                 }
                 _ => {}

--- a/src/platform/webos/evdev.rs
+++ b/src/platform/webos/evdev.rs
@@ -106,16 +106,15 @@ const fn eviocgrab() -> libc::c_ulong {
     eioc(IOC_WRITE, 0x90, 4)
 }
 
-/// `EVIOCSREP` = `_IOW('E', 0x03, unsigned int[2])` — sets `[REP_DELAY, REP_PERIOD]` in ms,
-/// the parameters the kernel generates `value == 2` autorepeat from.
+/// `EVIOCSREP` = `_IOW('E', 0x03, unsigned int[2])` — `[REP_DELAY, REP_PERIOD]` in ms, what the
+/// kernel generates `value == 2` autorepeat from.
 const fn eviocsrep() -> libc::c_ulong {
     const IOC_WRITE: u32 = 1;
     eioc(IOC_WRITE, 0x03, 8)
 }
 
-/// Autorepeat delay/period pushed onto every keyboard node we own, in ms. The kernel's own
-/// defaults (250/33) are what a bare console uses; every desktop OS re-tunes them, and this
-/// client is the only thing between the node and the host, so it has to do it too.
+/// Autorepeat delay/period for every keyboard node we own, in ms. The kernel's 250/33 default is
+/// console timing; a desktop OS would re-tune it, and here nothing else will.
 const REPEAT_DELAY_MS: u32 = 500;
 const REPEAT_PERIOD_MS: u32 = 33;
 
@@ -393,9 +392,7 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
     Probe::Hid(dev)
 }
 
-/// Retunes a keyboard node's autorepeat to desktop-like timing. Best-effort: a node that
-/// refuses (or generates no repeat at all) just keeps whatever the kernel set, which costs
-/// repeat timing, not input.
+/// Best-effort: a node that refuses keeps the kernel's timing, which costs repeat feel, not input.
 fn set_repeat(fd: RawFd) {
     let rep: [u32; 2] = [REPEAT_DELAY_MS, REPEAT_PERIOD_MS];
     // SAFETY: `fd` is an open evdev node and the ioctl reads exactly the two u32s `rep` holds.
@@ -598,15 +595,15 @@ fn read_device(dev: &mut Device, sink: &impl Fn(&InputEvent), keys: &KeyActivity
                 EV_KEY if matches!(ev.value, 0..=2) => {
                     // Buttons and keys share `EV_KEY`, and a combo node reports both — the code
                     // ranges are what tells them apart, not the device.
-                    // Buttons take presses and releases only: a repeat would double-fire the click.
+                    // Buttons skip repeats: one would double-fire the click.
                     if let Some(button) = (dev.mouse && ev.value != 2).then(|| button_code(ev.code)).flatten() {
                         // Motion first: the click must land where the pointer already is.
                         flush_motion(dev, sink);
                         sink(&mouse::raw_button_event(button, ev.value == 1));
                     } else if let Some(vk) = dev.keyboard.then(|| keyboard::vk_from_evdev(ev.code)).flatten() {
                         keys.touch();
-                        // Autorepeat rides as a repeated KeyDown: the host has no repeat timer of
-                        // its own, so dropping these kills held-key repeat (Backspace, arrows).
+                        // Autorepeat rides as a repeated KeyDown — the host has no repeat timer of
+                        // its own, so dropping these kills held-key repeat.
                         sink(&keyboard::raw_key_event(vk, ev.value != 0));
                     }
                 }

--- a/src/platform/webos/ndl/ffi.rs
+++ b/src/platform/webos/ndl/ffi.rs
@@ -44,20 +44,38 @@ pub(super) struct AudioOpusInfo {
     pub(super) sample_rate: f64,
     /// Stream header (undocumented, passed null).
     pub(super) stream_header: *const c_char,
+    /// The struct's trailing padding, made explicit so it is *initialized*.
+    ///
+    /// `f64` is 8-aligned on this ABI, so the fields end at 28 and `size_of` rounds to 32 — and
+    /// [`Self::to_union`] copies all 32 bytes. Left implicit, those last four go to NDL as
+    /// whatever was on the stack: the load is then rejected asynchronously (returning 0, with no
+    /// `LOADCOMPLETED` ever) for some values and not others, which is why hardware Opus came up
+    /// black only some of the time.
+    pub(super) _padding: [u8; 4],
 }
+
+/// The union arm is 32 bytes (the header's own `char padding[32]`); the copy below assumes the
+/// struct fills it exactly, with no implicit padding left uninitialized.
+///
+/// Asserted only for the 32-bit-pointer ABI this ships on (armv7 webOS). A 64-bit `stream_header`
+/// makes the struct 40 bytes and `_padding` land in the wrong place — the layout would have to be
+/// re-derived for such a target, so the assert would be false there for a real reason rather than
+/// a portability nit; it is scoped instead of relaxed so a host `cargo check` still builds.
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(size_of::<AudioOpusInfo>() == 32);
 
 impl AudioOpusInfo {
     /// Pack into the union [`DataInfo`] takes.
     pub(super) fn to_union(self) -> AudioUnion {
         let mut bytes = [0u8; 32];
-        // SAFETY: `Self` is `repr(C)` and no larger than the union's 32-byte arm (the header's
-        // own `char padding[32]`), so this copy stays in bounds. Any trailing bytes remain
-        // zero, matching the C compiler's own padding.
+        // SAFETY: `Self` is `repr(C)` and exactly the union arm's 32 bytes on the shipping target
+        // (asserted above), so this copy stays in bounds and every byte of it is initialized. The
+        // clamp only matters on a host build, where the struct is wider and unusable anyway.
         unsafe {
             std::ptr::copy_nonoverlapping(
                 std::ptr::from_ref(&self).cast::<u8>(),
                 bytes.as_mut_ptr(),
-                size_of::<Self>().min(32),
+                size_of::<Self>().min(bytes.len()),
             );
         }
         AudioUnion { bytes }
@@ -81,7 +99,7 @@ pub(super) struct DataInfo {
 /// one, and which revision a given TV's `libndl-directmedia` was built against isn't knowable
 /// from here.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub(super) struct HdrInfo {
     pub(super) display_primaries_x0: c_uint,
     pub(super) display_primaries_y0: c_uint,

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -152,8 +152,7 @@ extern "C" fn on_load_state(state: c_int, num: c_longlong, detail: *const c_char
             PLAYING.bump();
             "PLAYING"
         }
-        // Never swallow one silently: an error state arriving here is the only signal a load
-        // rejected asynchronously, and NDL reports nothing else about it.
+        // Never swallowed: an error state here is the only signal a load rejected async.
         _ => {
             // SAFETY: NDL passes a NUL-terminated string or null, valid for this call only.
             let detail = if detail.is_null() {
@@ -221,8 +220,8 @@ fn lock_ffi() -> MutexGuard<'static, ()> {
     FFI_LOCK.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
-/// Sleeps in [`POLL`] steps until `done` or `limit` elapses; `true` if `done` won. Every wait in
-/// this module is a callback arriving on NDL's own thread with nothing to block on.
+/// Sleeps in [`POLL`] steps until `done` or `limit` elapses; `true` if `done` won. Polled, not
+/// blocked on: every wait here is for a callback on NDL's own thread.
 fn poll_until(limit: Duration, done: impl Fn() -> bool) -> bool {
     let start = Instant::now();
     while !done() {
@@ -241,8 +240,8 @@ fn unload_count() -> u64 {
 
 /// Lets the rejected audio-enabled load's callbacks land before the video-only retry is armed:
 /// waits for its `UNLOADCOMPLETED`, then a fixed settle for anything still in flight behind it.
-/// `unloads_before` is [`unload_count`] from before the rejected load was even attempted — the
-/// caller's own teardown may have unloaded already, and this must not wait out a spent callback.
+/// `unloads_before` is [`unload_count`] from before the rejected load was attempted: the caller's
+/// own teardown may have unloaded already, and a spent callback must not be waited out.
 fn settle_before_retry(unloads_before: u64) {
     poll_until(CALLBACK_SETTLE, || UNLOAD_COMPLETED.count() != unloads_before);
     std::thread::sleep(CALLBACK_SETTLE);

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -29,7 +29,7 @@ mod ffi;
 pub mod v1;
 mod v2;
 
-use std::ffi::{c_char, c_int, c_longlong, CString};
+use std::ffi::{c_char, c_int, c_longlong, CStr, CString};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Mutex, MutexGuard, PoisonError};
 use std::time::{Duration, Instant};
@@ -138,7 +138,7 @@ static PLAYING: EventSeq = EventSeq::new();
 static FRAME_FED: EventSeq = EventSeq::new();
 
 /// Records v2 load-state transitions so loads, feeds and the UI reveal can wait on them.
-extern "C" fn on_load_state(state: c_int, _num: c_longlong, _str: *const c_char) {
+extern "C" fn on_load_state(state: c_int, num: c_longlong, detail: *const c_char) {
     let name = match state {
         STATE_LOADCOMPLETED => {
             LOAD_COMPLETED.bump();
@@ -152,7 +152,18 @@ extern "C" fn on_load_state(state: c_int, _num: c_longlong, _str: *const c_char)
             PLAYING.bump();
             "PLAYING"
         }
-        _ => "other",
+        // Never swallow one silently: an error state arriving here is the only signal a load
+        // rejected asynchronously, and NDL reports nothing else about it.
+        _ => {
+            // SAFETY: NDL passes a NUL-terminated string or null, valid for this call only.
+            let detail = if detail.is_null() {
+                String::new()
+            } else {
+                unsafe { CStr::from_ptr(detail) }.to_string_lossy().into_owned()
+            };
+            tracing::warn!("NDL load state: unknown 0x{state:x} ({state}) num={num} {detail}");
+            return;
+        }
     };
     tracing::info!("NDL load state: {name} (0x{state:x})");
 }
@@ -191,11 +202,14 @@ pub fn mark_frame_fed() -> bool {
     FRAME_FED.bump_first()
 }
 
-/// [`mark_frame_fed`] plus the log line both generations emit; `since` is the handle's load instant.
-fn mark_frame_fed_logged(backend: &str, since: Instant) {
-    if mark_frame_fed() {
+/// [`mark_frame_fed`] plus the log line both generations emit; `since` is the handle's load
+/// instant. Returns whether this was the armed load's first frame.
+fn mark_frame_fed_logged(backend: &str, since: Instant) -> bool {
+    let first = mark_frame_fed();
+    if first {
         tracing::info!("{backend} first frame fed {:?} after load", since.elapsed());
     }
+    first
 }
 
 /// Every NDL entry point is a process singleton and none is documented as thread-safe, so one lock
@@ -207,28 +221,40 @@ fn lock_ffi() -> MutexGuard<'static, ()> {
     FFI_LOCK.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
-/// Lets the rejected audio-enabled load's callbacks land before the video-only retry is armed:
-/// waits for its `UNLOADCOMPLETED`, then a fixed settle for anything still in flight behind it.
-fn settle_before_retry() {
-    let unloads = UNLOAD_COMPLETED.count();
+/// Sleeps in [`POLL`] steps until `done` or `limit` elapses; `true` if `done` won. Every wait in
+/// this module is a callback arriving on NDL's own thread with nothing to block on.
+fn poll_until(limit: Duration, done: impl Fn() -> bool) -> bool {
     let start = Instant::now();
-    while UNLOAD_COMPLETED.count() == unloads && start.elapsed() < CALLBACK_SETTLE {
-        std::thread::sleep(POLL);
-    }
-    std::thread::sleep(CALLBACK_SETTLE);
-}
-
-/// Blocks until the armed load's `LOADCOMPLETED` lands. Returns `false` on timeout.
-fn wait_load_completed() -> bool {
-    let start = Instant::now();
-    while !LOAD_COMPLETED.fired() {
-        if start.elapsed() >= LOAD_COMPLETE_TIMEOUT {
-            tracing::warn!("NDL load: no LOADCOMPLETED within {LOAD_COMPLETE_TIMEOUT:?} — holding the first frames");
+    while !done() {
+        if start.elapsed() >= limit {
             return false;
         }
         std::thread::sleep(POLL);
     }
     true
+}
+
+/// `UNLOADCOMPLETED` count, for [`settle_before_retry`]'s baseline.
+fn unload_count() -> u64 {
+    UNLOAD_COMPLETED.count()
+}
+
+/// Lets the rejected audio-enabled load's callbacks land before the video-only retry is armed:
+/// waits for its `UNLOADCOMPLETED`, then a fixed settle for anything still in flight behind it.
+/// `unloads_before` is [`unload_count`] from before the rejected load was even attempted — the
+/// caller's own teardown may have unloaded already, and this must not wait out a spent callback.
+fn settle_before_retry(unloads_before: u64) {
+    poll_until(CALLBACK_SETTLE, || UNLOAD_COMPLETED.count() != unloads_before);
+    std::thread::sleep(CALLBACK_SETTLE);
+}
+
+/// Blocks until the armed load's `LOADCOMPLETED` lands. Returns `false` on timeout.
+fn wait_load_completed() -> bool {
+    let completed = poll_until(LOAD_COMPLETE_TIMEOUT, || LOAD_COMPLETED.fired());
+    if !completed {
+        tracing::warn!("NDL load: no LOADCOMPLETED within {LOAD_COMPLETE_TIMEOUT:?} — holding the first frames");
+    }
+    completed
 }
 
 /// Count of video/audio pump threads leaked past `SHUTDOWN_JOIN_TIMEOUT` (see

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -14,9 +14,36 @@ use anyhow::{bail, Result};
 use super::{arm_load, ensure_init, ensure_not_poisoned, ffi, settle_before_retry, wait_load_completed};
 use super::{lock_ffi, mark_frame_fed_logged, NdlCodec, LOAD_COMPLETED};
 
-/// How long past `load()` [`NdlVideo::ensure_loaded`] holds frames while `LOADCOMPLETED` is
-/// missing. Measured from the load, so it follows `LOAD_COMPLETE_TIMEOUT`.
+/// How long past the `NDL_DirectMediaLoad` CALL [`NdlVideo::ensure_loaded`] holds frames while
+/// `LOADCOMPLETED` is missing.
+///
+/// Measured from `load_requested`, not `load_instant`: the latter is stamped after
+/// `wait_load_completed`, so timing the grace from it stacks the two windows and a unit whose
+/// callback never comes eats `LOAD_COMPLETE_TIMEOUT` + this before the first frame — three seconds
+/// of black on a CX, for a callback that provably was not going to arrive. Overlapping them means
+/// the wait alone already spends the grace, so the first feed goes straight through.
 const FEED_ANYWAY_AFTER: Duration = Duration::from_millis(1_000);
+
+/// One empty Opus frame. `mariotaku/ss4s`'s `opus_empty_frame_211`, byte for byte: its TOC
+/// declares STEREO, which is what [`NdlAudioConfig`] loads with (stereo only, see there). The
+/// generic `0xF8 0xFF 0xFE` silence frame declares mono, and priming a stereo decoder with a mono
+/// TOC is the kind of mismatch the prime exists to get right — NDL accepted both on a CX, so the
+/// choice here is the known-good reference, not a measured difference.
+const OPUS_SILENCE: [u8; 3] = [0xec, 0xff, 0xfe];
+
+/// Packet duration of the prime's stamps (ms). punktfunk's audio plane is fixed at 48 kHz /
+/// 5 ms packets (`SAMPLE_RATE` in `platform::webos::audio`), and the prime must look like it.
+const PRIME_PACKET_MS: i64 = 5;
+
+/// How far ahead of wall-clock the prime's stamps are allowed to run, in packets — enough of a
+/// burst for a decoder to configure itself off, and the bound on how far the ceiling handed to
+/// `last_audio_pts_ms` can overshoot (see [`NdlVideo::prime_audio`]).
+const PRIME_LEAD: i64 = 8;
+
+/// Gap between prime bursts while waiting for `LOADCOMPLETED`. Polled through, not slept
+/// through: the callback landed mid-gap on both measured launches, and this sits in the launch
+/// path where every millisecond is black screen.
+const PRIME_RETRY: Duration = Duration::from_millis(20);
 
 /// [`NdlVideo::play`] refusing a frame because `LOADCOMPLETED` hasn't landed. A distinct type
 /// because the caller must NOT respond to it the way it responds to a decode error: the usual
@@ -54,6 +81,7 @@ impl NdlAudioConfig {
             unknown2: 0,
             sample_rate: self.sample_rate,
             stream_header: std::ptr::null(),
+            _padding: [0; 4],
         }
         .to_union()
     }
@@ -64,6 +92,10 @@ pub struct NdlVideo {
     fns: &'static ffi::V2,
     /// PTS in ms since load (NDL's local clock, not wall-clock or host capture clock).
     load_instant: Instant,
+    /// When `NDL_DirectMediaLoad` was issued — earlier than `load_instant` by however long
+    /// `wait_load_completed` blocked. Only [`FEED_ANYWAY_AFTER`] is measured from it; the PTS
+    /// domain stays on `load_instant`.
+    load_requested: Instant,
     audio_offloaded: bool,
     /// Host-PTS → NDL-player-clock offset in ns, republished by the video plane on every fed
     /// frame (`session::sink`) and read by [`Self::play_audio`] so both planes land in ONE
@@ -77,12 +109,29 @@ pub struct NdlVideo {
     /// refuses to feed until it lands or [`FEED_ANYWAY_AFTER`] passes. Latched once, so the
     /// steady-state feed path costs one relaxed load.
     load_confirmed: AtomicBool,
-    /// HDR mastering metadata that arrived while the pipeline was still loading.
-    /// `NDL_DirectVideoSetHDRInfo` returns success against an unloaded pipeline but does
-    /// nothing — the panel never enters HDR mode, and since the host only sends the packet
-    /// on change there is no second chance. Observed on a CX as an all-black launch that a
-    /// reconnect fixed. So the last value is kept here and replayed once the load confirms.
+    /// HDR mastering metadata that arrived before the video plane had taken a frame.
+    /// `NDL_DirectVideoSetHDRInfo` returns success against a pipeline that isn't ingesting yet
+    /// but does nothing — the panel never enters HDR mode, and since the host only sends the
+    /// packet on change there is no second chance. Observed on a CX as an all-black launch that
+    /// a reconnect fixed.
+    ///
+    /// The gate is the first ACCEPTED frame, not `LOADCOMPLETED`: the callback says the pipeline
+    /// loaded, not that it is ingesting, and a frame NDL took is the only evidence of the latter.
+    /// It matches what the working launches show — the metadata that stuck was always the one
+    /// applied after the first feed. (The sessions that appeared to run without any
+    /// `LOADCOMPLETED` at all were the unprimed audio-enabled loads of [`Self::prime_audio`],
+    /// not an unreliable callback.)
     pending_hdr: Mutex<Option<ffi::HdrInfo>>,
+    /// Last metadata actually handed to `NDL_DirectVideoSetHDRInfo`, so an unchanged one is never
+    /// re-applied.
+    ///
+    /// The host re-sends the mastering packet without waiting for it to change — three identical
+    /// ones inside 10 ms at session start — and `session::video_pump` treats every packet its
+    /// queue yields as fresh. Each call re-enters panel HDR mode, which on a CX drops 1440p120 out
+    /// of its high-rate mode and leaves the stream black. This was latent before the metadata was
+    /// deferred: the repeats used to land against a pipeline that wasn't ingesting yet and did
+    /// nothing, and deferring them bunched all of them onto the live plane at once.
+    applied_hdr: Mutex<Option<ffi::HdrInfo>>,
 }
 
 impl NdlVideo {
@@ -99,24 +148,37 @@ impl NdlVideo {
             unknown1: 0,
         };
         if let Some(audio) = audio {
+            // An audio-enabled load must PROVE itself with `LOADCOMPLETED`, where a video-only one
+            // is allowed to proceed unconfirmed (below). `NDL_DirectMediaLoad` returning 0 is only
+            // "request accepted": an Opus config the pipeline rejects fails asynchronously, so it
+            // returns 0, never reports `LOADCOMPLETED` or `PLAYING`, and then accepts every fed
+            // frame into a pipeline that is not running — an entire session of black picture with
+            // no error anywhere. Treating `ret != 0` as the only failure left this fallback
+            // unreachable for the exact case it exists to catch.
+            // Video-only fallback: audio offload is optimization, not critical. Unload first — a
+            // failed load may hold decoder resources (docs/NOTES.md). The unconfirmed handle has
+            // already dropped (and so unloaded) by here; the call below is what covers the `Err`
+            // arm, where there is no handle, and is harmless as a repeat.
+            // Snapshotted BEFORE the attempt, because the unconfirmed handle's own `Drop` unloads
+            // at the end of the match: a snapshot taken after it would miss that
+            // `UNLOADCOMPLETED` and wait out the settle for a callback already spent.
+            let unloads_before = super::unload_count();
             match Self::try_load(fns, video, audio.to_union(), true) {
-                Ok(loaded) => return Ok(loaded),
-                Err(e) => {
-                    // Video-only fallback: audio offload is optimization, not critical. Unload
-                    // first — a failed load may hold decoder resources (docs/NOTES.md).
-                    tracing::warn!("NDL audio-enabled load failed ({e:#}) — retrying video-only");
-                    // SAFETY: no arguments; best-effort cleanup of the rejected load.
-                    let _ = unsafe { (fns.unload)() };
-                    // The rejected load's callbacks are indistinguishable from the retry's, so let
-                    // them land BEFORE arming below rather than racing them.
-                    settle_before_retry();
-                }
+                Ok(loaded) if loaded.load_confirmed.load(Ordering::Relaxed) => return Ok(loaded),
+                Ok(_) => tracing::warn!("NDL audio-enabled load failed (no LOADCOMPLETED) — retrying video-only"),
+                Err(e) => tracing::warn!("NDL audio-enabled load failed ({e:#}) — retrying video-only"),
             }
+            // SAFETY: no arguments; best-effort cleanup of the rejected load.
+            let _ = unsafe { (fns.unload)() };
+            // The rejected load's callbacks are indistinguishable from the retry's, so let them
+            // land BEFORE arming below rather than racing them.
+            settle_before_retry(unloads_before);
         }
         Self::try_load(fns, video, ffi::AudioUnion::SILENT, false)
     }
 
-    /// One `NDL_DirectMediaLoad` attempt, waited out to `LOADCOMPLETED`.
+    /// One `NDL_DirectMediaLoad` attempt, waited out to `LOADCOMPLETED` — priming the audio plane
+    /// through the wait when the load asked for one (see [`Self::prime_audio`]).
     fn try_load(
         fns: &'static ffi::V2,
         video: ffi::VideoInfo,
@@ -125,23 +187,95 @@ impl NdlVideo {
     ) -> Result<Self> {
         let mut info = ffi::DataInfo { video, audio };
         arm_load();
+        let load_requested = Instant::now();
         // SAFETY: `info` is valid for the duration of this call.
         let ret = unsafe { (fns.load)(&mut info, Some(super::on_load_state)) };
         if ret != 0 {
             bail!("NDL_DirectMediaLoad failed: ret={ret} error={}", ffi::last_error());
         }
-        // `ret == 0` is "request accepted", not "pipeline ready" — the caller's first feed (and
-        // the Opus prime, when there is one) still needs LOADCOMPLETED.
-        let confirmed = wait_load_completed();
+        // `ret == 0` is "request accepted", not "pipeline ready" — the first feed still needs
+        // LOADCOMPLETED, and an audio-enabled load will not report it until its audio plane has
+        // seen a packet, which is what the prime supplies.
+        let (primed_pts_ms, confirmed) = if audio_offloaded {
+            Self::prime_audio(fns)
+        } else {
+            (0, wait_load_completed())
+        };
         Ok(Self {
             fns,
             load_instant: Instant::now(),
+            load_requested,
             audio_offloaded,
             pts_offset_ns: AtomicI64::new(NO_PTS_OFFSET),
-            last_audio_pts_ms: AtomicI64::new(0),
+            last_audio_pts_ms: AtomicI64::new(primed_pts_ms),
             load_confirmed: AtomicBool::new(confirmed),
             pending_hdr: Mutex::new(None),
+            applied_hdr: Mutex::new(None),
         })
+    }
+
+    /// Feed silent Opus packets until the audio-enabled load reports `LOADCOMPLETED`, bounded by
+    /// `LOAD_COMPLETE_TIMEOUT`. Returns the highest stamp fed and whether the load confirmed.
+    ///
+    /// An audio-enabled load does not complete on its own the way a video-only one does: it has a
+    /// decoder and a sink to configure and will not report until the audio plane has actually
+    /// received data. The pumps that would supply it don't spawn until `session::connect` returns,
+    /// i.e. until this wait is over — the load waits for data the session refuses to send until the
+    /// load completes, which is the whole of the black-picture-with-sound bug. So the load window
+    /// feeds itself.
+    ///
+    /// A burst at a time, because a packet fed before the plane exists may simply be dropped and
+    /// NDL reports success either way (`NDL_DirectAudioPlay` cannot distinguish them).
+    ///
+    /// Stamps run from 0 by [`PRIME_PACKET_MS`] and the ceiling is handed to `last_audio_pts_ms`:
+    /// the host's real packets arrive stamped in the video plane's domain, which also starts near
+    /// 0, so without the floor the first of them would look to NDL like a rewind — and a rewind
+    /// mutes the session permanently (see [`Self::play_audio`]). Flooring costs the first few
+    /// packets their exact stamp, which is inaudible; the alternative is no audio at all.
+    fn prime_audio(fns: &'static ffi::V2) -> (i64, bool) {
+        let start = Instant::now();
+        let mut pts_ms = 0;
+        while !LOAD_COMPLETED.fired() {
+            if start.elapsed() >= super::LOAD_COMPLETE_TIMEOUT {
+                tracing::warn!(
+                    "NDL load: no LOADCOMPLETED within {:?} of priming {pts_ms}ms of silence",
+                    super::LOAD_COMPLETE_TIMEOUT
+                );
+                return (pts_ms, false);
+            }
+            // Stamps track wall-clock, [`PRIME_LEAD`] packets ahead of it. A fixed count per gap
+            // advances them at ~2x real time instead, and the ceiling returned here is the floor
+            // real audio is pinned to — a 200ms load would hold the first 400ms of the session's
+            // audio at one stamp, ahead of a video plane starting from 0.
+            let target_ms = start.elapsed().as_millis() as i64 + PRIME_LEAD * PRIME_PACKET_MS;
+            {
+                let _ffi = lock_ffi();
+                while pts_ms < target_ms {
+                    // SAFETY: NDL reads `size` bytes synchronously and does not retain the pointer.
+                    let ret = unsafe {
+                        (fns.audio_play)(
+                            OPUS_SILENCE.as_ptr() as *mut c_void,
+                            OPUS_SILENCE.len() as c_uint,
+                            pts_ms as c_longlong,
+                        )
+                    };
+                    if ret != 0 {
+                        tracing::warn!(
+                            "NDL audio prime rejected at {pts_ms}ms: ret={ret} error={}",
+                            ffi::last_error()
+                        );
+                        return (pts_ms, LOAD_COMPLETED.fired());
+                    }
+                    pts_ms += PRIME_PACKET_MS;
+                }
+            }
+            super::poll_until(PRIME_RETRY, || LOAD_COMPLETED.fired());
+        }
+        tracing::info!(
+            "NDL audio prime: LOADCOMPLETED after {:?} ({pts_ms}ms of silence)",
+            start.elapsed()
+        );
+        (pts_ms, true)
     }
 
     /// Whether NDL accepted the Opus config and is decoding audio itself — if false the
@@ -224,7 +358,7 @@ impl NdlVideo {
         if self.load_confirmed.load(Ordering::Relaxed) {
             return Ok(());
         }
-        let elapsed = self.load_instant.elapsed();
+        let elapsed = self.load_requested.elapsed();
         if LOAD_COMPLETED.fired() {
             tracing::info!("NDL LOADCOMPLETED landed {elapsed:?} after load");
         } else if elapsed >= FEED_ANYWAY_AFTER {
@@ -232,24 +366,7 @@ impl NdlVideo {
         } else {
             return Err(NotLoadedYet.into());
         }
-        // Flag and slot move together under the one lock. `set_color_info` runs on a different
-        // thread (`session::connect` applies the host's colour info while the pump is starting),
-        // and reading the flag as unconfirmed, then storing into a slot this path has already
-        // drained, would strand that metadata in it for the rest of the session.
-        let held = {
-            let mut pending = self.pending_hdr();
-            self.load_confirmed.store(true, Ordering::Relaxed);
-            pending.take()
-        };
-        // The load just became real; anything held back for it applies now, before the first feed.
-        // A colour failure stays here: the caller reads an `Err` from this function as the feed
-        // being refused, and answers it with a flush and a keyframe request.
-        if let Some(info) = held {
-            tracing::info!("NDL: replaying HDR metadata held during load");
-            if let Err(e) = self.apply_hdr_info(info) {
-                tracing::warn!("NDL: replaying held HDR metadata failed: {e:#}");
-            }
-        }
+        self.load_confirmed.store(true, Ordering::Relaxed);
         Ok(())
     }
 
@@ -258,7 +375,37 @@ impl NdlVideo {
         self.pending_hdr.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
+    /// Apply metadata held back for the load, on the edge where the first frame was accepted.
+    /// A colour failure only logs: the caller reads an `Err` out of [`Self::play`] as a decode
+    /// error and answers it with a flush and a keyframe request.
+    fn replay_pending_hdr(&self) {
+        // Same lock the deferral decision is taken under, so a `set_color_info` racing this from
+        // the connect thread either lands before the drain or applies directly — never stores into
+        // a slot already drained, which would strand it there for the session. Held ACROSS the
+        // apply too: released at the drain, a racing newer value applies first and this stale one
+        // then overwrites it, and `applied_hdr` won't dedupe a value that genuinely differs.
+        let mut pending = self.pending_hdr();
+        if let Some(info) = pending.take() {
+            tracing::info!("NDL: applying HDR metadata held until the first accepted frame");
+            if let Err(e) = self.apply_hdr_info(info) {
+                tracing::warn!("NDL: applying held HDR metadata failed: {e:#}");
+            }
+        }
+    }
+
+    /// Apply metadata, unless it is what the panel is already on — see [`Self::applied_hdr`].
+    /// The slot is held across the FFI call so two threads can't both decide the value is new.
     fn apply_hdr_info(&self, info: ffi::HdrInfo) -> Result<()> {
+        let mut applied = self.applied_hdr.lock().unwrap_or_else(PoisonError::into_inner);
+        if *applied == Some(info) {
+            return Ok(());
+        }
+        self.set_hdr_info(info)?;
+        *applied = Some(info);
+        Ok(())
+    }
+
+    fn set_hdr_info(&self, info: ffi::HdrInfo) -> Result<()> {
         let _ffi = lock_ffi();
         // SAFETY: passed by value; no pointers or aliasing.
         let ret = unsafe { (self.fns.set_hdr_info)(info) };
@@ -276,14 +423,20 @@ impl NdlVideo {
     pub fn play(&self, au: &[u8], pts_ns: u64) -> Result<()> {
         self.ensure_loaded()?;
         let pts_ms = (pts_ns / 1_000_000) as c_longlong;
-        let _ffi = lock_ffi();
-        // SAFETY: NDL reads `size` bytes from `buffer` synchronously and does not
-        // retain the pointer.
-        let ret = unsafe { (self.fns.video_play)(au.as_ptr() as *mut c_void, au.len() as c_uint, pts_ms) };
-        if ret != 0 {
-            bail!("NDL_DirectVideoPlay failed: ret={ret} error={}", ffi::last_error());
+        let first_frame = {
+            let _ffi = lock_ffi();
+            // SAFETY: NDL reads `size` bytes from `buffer` synchronously and does not
+            // retain the pointer.
+            let ret = unsafe { (self.fns.video_play)(au.as_ptr() as *mut c_void, au.len() as c_uint, pts_ms) };
+            if ret != 0 {
+                bail!("NDL_DirectVideoPlay failed: ret={ret} error={}", ffi::last_error());
+            }
+            mark_frame_fed_logged("NDL", self.load_instant)
+        };
+        // Outside the FFI guard — `replay_pending_hdr` takes it again, and it isn't reentrant.
+        if first_frame {
+            self.replay_pending_hdr();
         }
-        mark_frame_fed_logged("NDL", self.load_instant);
         Ok(())
     }
 
@@ -299,7 +452,7 @@ impl NdlVideo {
     /// info — the earlier reason this was called unconditionally — but forcing the panel
     /// into HDR for SDR content is the worse outcome.)
     ///
-    /// Deferred until the load confirms — see [`Self::pending_hdr`].
+    /// Deferred until the plane has accepted a frame — see [`Self::pending_hdr`].
     pub fn set_color_info(
         &self,
         meta: Option<&punktfunk_core::quic::HdrMeta>,
@@ -328,9 +481,9 @@ impl NdlVideo {
             matrix_coeffs: c_uint::from(color.matrix),
             reserved: [0; 32],
         };
-        // Checked under the slot's lock, against the drain in `ensure_loaded`.
+        // Checked under the slot's lock, against the drain in `replay_pending_hdr`.
         let mut pending = self.pending_hdr();
-        if !self.load_confirmed.load(Ordering::Relaxed) {
+        if !super::presenting() {
             *pending = Some(info);
             return Ok(());
         }

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -474,7 +474,9 @@ impl NdlVideo {
             *pending = Some(info);
             return Ok(());
         }
-        drop(pending);
+        // Guard held across the apply, like `replay_pending_hdr`: released here, a racing replay
+        // could land its older value last, and `applied_hdr` won't dedupe differing values.
+        *pending = None;
         self.apply_hdr_info(info)
     }
 

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -22,27 +22,26 @@ use super::{lock_ffi, mark_frame_fed_logged, NdlCodec, LOAD_COMPLETED};
 /// callback never comes eats `LOAD_COMPLETE_TIMEOUT` + this before the first frame — three seconds
 /// of black on a CX, for a callback that provably was not going to arrive. Overlapping them means
 /// the wait alone already spends the grace, so the first feed goes straight through.
+///
+/// **A backstop, not a live path.** `load()` already waits `LOAD_COMPLETE_TIMEOUT` (longer than
+/// this), so the first `ensure_loaded` always feeds and [`NotLoadedYet`] is never constructed.
+/// Kept because it is what would make an early return from that wait safe.
 const FEED_ANYWAY_AFTER: Duration = Duration::from_millis(1_000);
 
-/// One empty Opus frame. `mariotaku/ss4s`'s `opus_empty_frame_211`, byte for byte: its TOC
-/// declares STEREO, which is what [`NdlAudioConfig`] loads with (stereo only, see there). The
-/// generic `0xF8 0xFF 0xFE` silence frame declares mono, and priming a stereo decoder with a mono
-/// TOC is the kind of mismatch the prime exists to get right — NDL accepted both on a CX, so the
-/// choice here is the known-good reference, not a measured difference.
+/// One empty Opus frame — `mariotaku/ss4s`'s `opus_empty_frame_211`. Its TOC declares STEREO,
+/// matching the load; the generic `0xF8 0xFF 0xFE` declares mono. (A CX took both.)
 const OPUS_SILENCE: [u8; 3] = [0xec, 0xff, 0xfe];
 
-/// Packet duration of the prime's stamps (ms). punktfunk's audio plane is fixed at 48 kHz /
-/// 5 ms packets (`SAMPLE_RATE` in `platform::webos::audio`), and the prime must look like it.
+/// Packet duration of the prime's stamps (ms), matching the real audio plane's 48 kHz / 5 ms
+/// (`SAMPLE_RATE` in `platform::webos::audio`).
 const PRIME_PACKET_MS: i64 = 5;
 
-/// How far ahead of wall-clock the prime's stamps are allowed to run, in packets — enough of a
-/// burst for a decoder to configure itself off, and the bound on how far the ceiling handed to
-/// `last_audio_pts_ms` can overshoot (see [`NdlVideo::prime_audio`]).
+/// How far ahead of wall-clock the prime's stamps may run, in packets — a burst big enough to
+/// configure a decoder, and the bound on how far its `last_audio_pts_ms` ceiling overshoots.
 const PRIME_LEAD: i64 = 8;
 
-/// Gap between prime bursts while waiting for `LOADCOMPLETED`. Polled through, not slept
-/// through: the callback landed mid-gap on both measured launches, and this sits in the launch
-/// path where every millisecond is black screen.
+/// Gap between prime bursts. Polled through, not slept through — the callback lands mid-gap,
+/// and this is launch-path time, i.e. black screen.
 const PRIME_RETRY: Duration = Duration::from_millis(20);
 
 /// [`NdlVideo::play`] refusing a frame because `LOADCOMPLETED` hasn't landed. A distinct type
@@ -105,9 +104,11 @@ pub struct NdlVideo {
     /// timestamp going backwards. Never reset — the ceiling has to survive a re-latch, which is
     /// exactly the case that would otherwise rewind it.
     last_audio_pts_ms: AtomicI64,
-    /// `false` while `LOADCOMPLETED` still hasn't been seen for this load — [`Self::play`]
-    /// refuses to feed until it lands or [`FEED_ANYWAY_AFTER`] passes. Latched once, so the
+    /// `false` while `LOADCOMPLETED` still hasn't been seen for this load. Latched once, so the
     /// steady-state feed path costs one relaxed load.
+    ///
+    /// It is also what [`Self::flush`] refuses on, which is the guard that matters most: flushing
+    /// a pipeline NDL has not finished loading kills the session's audio permanently.
     load_confirmed: AtomicBool,
     /// HDR mastering metadata that arrived before the video plane had taken a frame.
     /// `NDL_DirectVideoSetHDRInfo` returns success against a pipeline that isn't ingesting yet
@@ -115,22 +116,16 @@ pub struct NdlVideo {
     /// packet on change there is no second chance. Observed on a CX as an all-black launch that
     /// a reconnect fixed.
     ///
-    /// The gate is the first ACCEPTED frame, not `LOADCOMPLETED`: the callback says the pipeline
+    /// The gate is the first ACCEPTED frame, not `LOADCOMPLETED`: that callback says the pipeline
     /// loaded, not that it is ingesting, and a frame NDL took is the only evidence of the latter.
-    /// It matches what the working launches show — the metadata that stuck was always the one
-    /// applied after the first feed. (The sessions that appeared to run without any
-    /// `LOADCOMPLETED` at all were the unprimed audio-enabled loads of [`Self::prime_audio`],
-    /// not an unreliable callback.)
     pending_hdr: Mutex<Option<ffi::HdrInfo>>,
     /// Last metadata actually handed to `NDL_DirectVideoSetHDRInfo`, so an unchanged one is never
     /// re-applied.
     ///
-    /// The host re-sends the mastering packet without waiting for it to change — three identical
-    /// ones inside 10 ms at session start — and `session::video_pump` treats every packet its
-    /// queue yields as fresh. Each call re-enters panel HDR mode, which on a CX drops 1440p120 out
-    /// of its high-rate mode and leaves the stream black. This was latent before the metadata was
-    /// deferred: the repeats used to land against a pipeline that wasn't ingesting yet and did
-    /// nothing, and deferring them bunched all of them onto the live plane at once.
+    /// The host re-sends the mastering packet unchanged — three identical ones inside 10 ms at
+    /// session start — and every call re-enters panel HDR mode, which on a CX drops 1440p120 out of
+    /// its high-rate mode and leaves the stream black. (Latent until the metadata was deferred: the
+    /// repeats used to land on a pipeline that wasn't ingesting yet.)
     applied_hdr: Mutex<Option<ffi::HdrInfo>>,
 }
 
@@ -148,17 +143,13 @@ impl NdlVideo {
             unknown1: 0,
         };
         if let Some(audio) = audio {
-            // An audio-enabled load must PROVE itself with `LOADCOMPLETED`, where a video-only one
-            // is allowed to proceed unconfirmed (below). `NDL_DirectMediaLoad` returning 0 is only
-            // "request accepted": an Opus config the pipeline rejects fails asynchronously, so it
-            // returns 0, never reports `LOADCOMPLETED` or `PLAYING`, and then accepts every fed
-            // frame into a pipeline that is not running — an entire session of black picture with
-            // no error anywhere. Treating `ret != 0` as the only failure left this fallback
-            // unreachable for the exact case it exists to catch.
-            // Video-only fallback: audio offload is optimization, not critical. Unload first — a
-            // failed load may hold decoder resources (docs/NOTES.md). The unconfirmed handle has
-            // already dropped (and so unloaded) by here; the call below is what covers the `Err`
-            // arm, where there is no handle, and is harmless as a repeat.
+            // An audio-enabled load must PROVE itself with `LOADCOMPLETED`; a video-only one may
+            // proceed unconfirmed (below). `NDL_DirectMediaLoad` returning 0 is only "request
+            // accepted" — an Opus config the pipeline rejects fails asynchronously, then accepts
+            // every fed frame into a pipeline that is not running, which is a whole session of
+            // black picture with no error anywhere. Falling back needs an unload first (a failed
+            // load may hold decoder resources, docs/NOTES.md); it covers the `Err` arm, where no
+            // handle exists to unload on drop, and is harmless as a repeat.
             // Snapshotted BEFORE the attempt, because the unconfirmed handle's own `Drop` unloads
             // at the end of the match: a snapshot taken after it would miss that
             // `UNLOADCOMPLETED` and wait out the settle for a callback already spent.
@@ -217,21 +208,18 @@ impl NdlVideo {
     /// Feed silent Opus packets until the audio-enabled load reports `LOADCOMPLETED`, bounded by
     /// `LOAD_COMPLETE_TIMEOUT`. Returns the highest stamp fed and whether the load confirmed.
     ///
-    /// An audio-enabled load does not complete on its own the way a video-only one does: it has a
-    /// decoder and a sink to configure and will not report until the audio plane has actually
-    /// received data. The pumps that would supply it don't spawn until `session::connect` returns,
-    /// i.e. until this wait is over — the load waits for data the session refuses to send until the
-    /// load completes, which is the whole of the black-picture-with-sound bug. So the load window
+    /// An audio-enabled load will not report until its audio plane has received data, but the
+    /// pumps that would supply it don't spawn until `session::connect` returns — i.e. until this
+    /// wait is over. That deadlock is the whole black-picture-with-sound bug, so the load window
     /// feeds itself.
     ///
-    /// A burst at a time, because a packet fed before the plane exists may simply be dropped and
-    /// NDL reports success either way (`NDL_DirectAudioPlay` cannot distinguish them).
+    /// A burst at a time, because a packet fed before the plane exists may be dropped silently
+    /// (`NDL_DirectAudioPlay` reports success either way).
     ///
-    /// Stamps run from 0 by [`PRIME_PACKET_MS`] and the ceiling is handed to `last_audio_pts_ms`:
-    /// the host's real packets arrive stamped in the video plane's domain, which also starts near
-    /// 0, so without the floor the first of them would look to NDL like a rewind — and a rewind
-    /// mutes the session permanently (see [`Self::play_audio`]). Flooring costs the first few
-    /// packets their exact stamp, which is inaudible; the alternative is no audio at all.
+    /// The ceiling is handed to `last_audio_pts_ms`: real packets are stamped in the video plane's
+    /// domain, which also starts near 0, so without that floor the first would read as a rewind —
+    /// which mutes the session permanently (see [`Self::play_audio`]). Flooring costs a few early
+    /// packets their exact stamp; the alternative is no audio at all.
     fn prime_audio(fns: &'static ffi::V2) -> (i64, bool) {
         let start = Instant::now();
         let mut pts_ms = 0;
@@ -243,10 +231,8 @@ impl NdlVideo {
                 );
                 return (pts_ms, false);
             }
-            // Stamps track wall-clock, [`PRIME_LEAD`] packets ahead of it. A fixed count per gap
-            // advances them at ~2x real time instead, and the ceiling returned here is the floor
-            // real audio is pinned to — a 200ms load would hold the first 400ms of the session's
-            // audio at one stamp, ahead of a video plane starting from 0.
+            // Stamps track wall-clock, PRIME_LEAD packets ahead. A fixed count per gap advances
+            // them at ~2x real time, and this ceiling is the floor real audio is pinned to.
             let target_ms = start.elapsed().as_millis() as i64 + PRIME_LEAD * PRIME_PACKET_MS;
             {
                 let _ffi = lock_ffi();
@@ -362,7 +348,9 @@ impl NdlVideo {
         if LOAD_COMPLETED.fired() {
             tracing::info!("NDL LOADCOMPLETED landed {elapsed:?} after load");
         } else if elapsed >= FEED_ANYWAY_AFTER {
-            tracing::warn!("NDL: still no LOADCOMPLETED after {FEED_ANYWAY_AFTER:?} — feeding anyway");
+            // Real elapsed, not the constant — `load()` has already spent
+            // `LOAD_COMPLETE_TIMEOUT` by the time a frame gets here.
+            tracing::warn!("NDL: still no LOADCOMPLETED {elapsed:?} after the load — feeding anyway");
         } else {
             return Err(NotLoadedYet.into());
         }
@@ -379,9 +367,8 @@ impl NdlVideo {
     /// A colour failure only logs: the caller reads an `Err` out of [`Self::play`] as a decode
     /// error and answers it with a flush and a keyframe request.
     fn replay_pending_hdr(&self) {
-        // Same lock the deferral decision is taken under, so a `set_color_info` racing this from
-        // the connect thread either lands before the drain or applies directly — never stores into
-        // a slot already drained, which would strand it there for the session. Held ACROSS the
+        // Held across the apply: a `set_color_info` racing in from the connect thread must not
+        // store into a slot already drained (stranding it for the session) or overwrite this. Held ACROSS the
         // apply too: released at the drain, a racing newer value applies first and this stale one
         // then overwrites it, and `applied_hdr` won't dedupe a value that genuinely differs.
         let mut pending = self.pending_hdr();

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -950,9 +950,8 @@ fn video_pump(
                     tracing::info!("video: {frames_received} frames (idle)");
                 }
             }
-            // A teardown the user asked for reaches both pumps as `Closed`; only the audio one
-            // said so at INFO, so every clean disconnect left an ERROR as the last thing in the
-            // log — the one line triage looks for first.
+            // A teardown the user asked for reaches both pumps as `Closed`, so it is not an
+            // error in either — the audio pump already logged it at INFO.
             Err(punktfunk_core::PunktfunkError::Closed) => {
                 tracing::info!("video pump ending: session closed");
                 break;
@@ -964,10 +963,9 @@ fn video_pump(
         }
 
         if is_hdr {
-            // A non-blocking drain of freshly *received* packets — which is NOT the same as
-            // changed. The host re-sends unchanged mastering metadata (three identical packets
-            // inside 10 ms at session start, observed on a CX), so the on-change filtering has to
-            // happen against the last value actually applied; the player does it.
+            // Freshly *received* is not the same as changed: the host re-sends unchanged
+            // mastering metadata (three identical packets inside 10 ms on a CX), so the on-change
+            // filter has to run against the last value applied. The player does that.
             if let Ok(meta) = client.next_hdr_meta(Duration::ZERO) {
                 tracing::info!(
                     "HDR metadata received: primaries={:?} white={:?} max_dml={} min_dml={} max_cll={} max_fall={}",

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -950,6 +950,13 @@ fn video_pump(
                     tracing::info!("video: {frames_received} frames (idle)");
                 }
             }
+            // A teardown the user asked for reaches both pumps as `Closed`; only the audio one
+            // said so at INFO, so every clean disconnect left an ERROR as the last thing in the
+            // log — the one line triage looks for first.
+            Err(punktfunk_core::PunktfunkError::Closed) => {
+                tracing::info!("video pump ending: session closed");
+                break;
+            }
             Err(e) => {
                 tracing::error!("video pump: {e:#}");
                 break;
@@ -957,8 +964,10 @@ fn video_pump(
         }
 
         if is_hdr {
-            // `next_hdr_meta` is a queue drained non-blocking, so an Ok here is a
-            // freshly received / changed mastering-metadata packet, not a repeat.
+            // A non-blocking drain of freshly *received* packets — which is NOT the same as
+            // changed. The host re-sends unchanged mastering metadata (three identical packets
+            // inside 10 ms at session start, observed on a CX), so the on-change filtering has to
+            // happen against the last value actually applied; the player does it.
             if let Ok(meta) = client.next_hdr_meta(Duration::ZERO) {
                 tracing::info!(
                     "HDR metadata received: primaries={:?} white={:?} max_dml={} min_dml={} max_cll={} max_fall={}",

--- a/src/session/sink.rs
+++ b/src/session/sink.rs
@@ -545,22 +545,19 @@ impl NdlSink {
                 flags.index,
                 paced_ns as f64 / 1_000_000.0,
             );
-            // A frame refused because the pipeline hasn't finished loading is NOT a decode error,
-            // and gets neither of the two loss responses.
+            // A frame refused because the pipeline hasn't finished loading is NOT a decode
+            // error, and gets neither loss response.
             //
-            // No flush: `NDL_DirectVideoFlushRenderBuffer` against a not-yet-loaded pipeline
-            // silently kills the audio plane for the rest of the session (video recovers, audio
-            // never does — observed on CX). The frames are dropped on our side anyway, so there is
-            // nothing queued in NDL to discard.
+            // No flush: against a not-yet-loaded pipeline it silently kills the audio plane for
+            // the session (video recovers, audio never does — observed on CX), and nothing is
+            // queued in NDL to discard anyway.
             //
-            // No hold either: freeze-until-reanchor is a mid-stream recovery, and this fires at
-            // frame 0 where there is no last-good picture to freeze on — only the black
-            // punch-through plane. Worse, holding skips frames before [`Self::submit`] reaches
-            // `play`, which is the only caller of the pipeline's feed-anyway escape, so the hold
-            // outlives the condition that caused it: recovery then needs the host's reanchor or
-            // `HOLD_GIVE_UP`, both evaluated only when a frame arrives. A static desktop sends
-            // none, so the session sits black until the user generates motion. Asking for a
-            // keyframe and letting the next frame retry the feed is the whole correct response.
+            // No hold: freeze-until-reanchor is mid-stream recovery, and at frame 0 there is no
+            // last-good picture to freeze on. Worse, holding short-circuits `submit` before
+            // `play`, the only caller of the feed-anyway escape, so the hold outlives its own
+            // cause — release then needs the host's reanchor or `HOLD_GIVE_UP`, both evaluated
+            // only when a frame arrives, and a static desktop sends none. Request a keyframe and
+            // let the next frame retry.
             let not_loaded = e.downcast_ref::<NotLoadedYet>().is_some();
             if self.take_keyframe_slot() {
                 if !not_loaded {

--- a/src/session/sink.rs
+++ b/src/session/sink.rs
@@ -545,18 +545,28 @@ impl NdlSink {
                 flags.index,
                 paced_ns as f64 / 1_000_000.0,
             );
-            // A frame refused because the pipeline hasn't finished loading is NOT a decode
-            // error, and must not be answered with a flush: `NDL_DirectVideoFlushRenderBuffer`
-            // against a not-yet-loaded pipeline silently kills the audio plane for the rest of
-            // the session (video recovers, audio never does — observed on CX). Holding and asking
-            // for a keyframe is the whole of the correct response here; the frames are being
-            // dropped on our side, so there is nothing queued in NDL to discard anyway.
+            // A frame refused because the pipeline hasn't finished loading is NOT a decode error,
+            // and gets neither of the two loss responses.
+            //
+            // No flush: `NDL_DirectVideoFlushRenderBuffer` against a not-yet-loaded pipeline
+            // silently kills the audio plane for the rest of the session (video recovers, audio
+            // never does — observed on CX). The frames are dropped on our side anyway, so there is
+            // nothing queued in NDL to discard.
+            //
+            // No hold either: freeze-until-reanchor is a mid-stream recovery, and this fires at
+            // frame 0 where there is no last-good picture to freeze on — only the black
+            // punch-through plane. Worse, holding skips frames before [`Self::submit`] reaches
+            // `play`, which is the only caller of the pipeline's feed-anyway escape, so the hold
+            // outlives the condition that caused it: recovery then needs the host's reanchor or
+            // `HOLD_GIVE_UP`, both evaluated only when a frame arrives. A static desktop sends
+            // none, so the session sits black until the user generates motion. Asking for a
+            // keyframe and letting the next frame retry the feed is the whole correct response.
             let not_loaded = e.downcast_ref::<NotLoadedYet>().is_some();
             if self.take_keyframe_slot() {
                 if !not_loaded {
                     let _ = self.player.flush();
+                    self.begin_hold();
                 }
-                self.begin_hold();
                 need_keyframe = true;
             }
         }


### PR DESCRIPTION
Two unrelated-ish things that piled up on this branch.

**NDL Opus offload**
- Prime the audio plane so the offloaded load actually completes (flushing before LOADCOMPLETED was what made it silent).
- Keep the pending-HDR guard held across the apply. Released early, a first-frame replay from the pump thread could land its older metadata after a newer value, and `applied_hdr` can't dedupe values that genuinely differ.

**HID keyboard**
- Forward evdev autorepeat (`value == 2`) as a repeated KeyDown. It was being dropped, and the host has no repeat timer of its own, so held Backspace/arrows never repeated.
- Set the node's repeat timing with `EVIOCSREP` (500 ms delay, ~30/s). The kernel default of 250/33 is console timing and felt far too eager.

Repeat timing still wants a feel check on the TV.