### PR TITLE
Press animation, settings hover fix, anti-aliased curves

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -399,6 +399,11 @@ pub struct App {
     pub(crate) spinner_frame: Option<usize>,
     /// When the grid last became not-ready — feeds the spinner's rotation phase.
     pub(crate) spinner_since: Option<Instant>,
+    /// The clock [`SPINNER_MAX_WAIT`] is measured against, armed on the first frame the grid
+    /// has a library to build from. Stays `None` for the fetch before that, which is why it
+    /// can't be `spinner_since`: that one starts at the fetch and must run continuously, or
+    /// the spinner's rotation jumps when the games land.
+    pub(crate) grid_build_since: Option<Instant>,
     // ------------------------------------------------------------ animations --
     /// Grid scroll offset actually rendered this frame (px; 0 = row 0 at
     /// `GRID_TOP_Y`) — eases toward `grid_scroll_target` each tick.
@@ -567,6 +572,7 @@ impl App {
             grid_reveal_ready: true,
             spinner_frame: None,
             spinner_since: None,
+            grid_build_since: None,
             grid_scroll: 0,
             grid_scroll_target: 0,
             focus_anim: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod hero;
 pub(crate) mod hosts;
 pub(crate) mod menu;
 pub(crate) mod pointer;
+pub(crate) mod press;
 pub(crate) mod render;
 pub(crate) mod render_input;
 pub(crate) mod state;
@@ -416,6 +417,9 @@ pub struct App {
     /// modal (Settings row, Wake row, Pairing digit/button, `ForgetHost`
     /// button) since only one is ever open, and focused, at a time.
     pub(crate) modal_focus_anim: Option<Instant>,
+    /// The focused button's press dip, if one is in flight — the widget's action runs when
+    /// it lands (see `App::press`).
+    pub(crate) press: ui::animation::Press,
     /// In-flight `Toggle` row flip: `(when it started, the value it flipped
     /// from, the focused row it flipped)` — lets `modal_focus_tile`'s render
     /// slide the switch knob from its old state to its new one over
@@ -568,6 +572,7 @@ impl App {
             focus_anim: None,
             modal_fade: ui::fade::ModalFade::new(),
             modal_focus_anim: None,
+            press: ui::animation::Press::default(),
             switch_anim: None,
             last_screen: Screen::Home,
             pairing_rx: None,
@@ -826,87 +831,24 @@ impl App {
     /// dispatch: `main.rs`'s Back handling on Home (a no-op there, but routed
     /// through here so the policy lives in one place) and a modal's close (X)
     /// button click (`handle_mouse_click`'s `hover_close` branch below).
-    pub fn back(&mut self) -> Option<ConnectTarget> {
-        match self.screen {
-            // Back steps focus out of the game grid (and the ⋯ column) back onto the
-            // host sidebar first. Only a Back from the sidebar itself is a no-op here
-            // — the menu loop turns that into the quit dialog.
-            Screen::Home => {
-                match self.home_focus {
-                    HomeFocus::Grid(_) => {
-                        self.home_focus = HomeFocus::Sidebar(self.sidebar_index_for_selected());
-                    }
-                    HomeFocus::SidebarMenu(i) => self.home_focus = HomeFocus::Sidebar(i),
-                    HomeFocus::Sidebar(_) => {}
+    pub fn back(&mut self, screen_w: u32, screen_h: u32, fonts: &ui::text::Fonts) -> Option<ConnectTarget> {
+        // Back steps focus out of the game grid (and the ⋯ column) back onto the
+        // host sidebar first. Only a Back from the sidebar itself is a no-op here
+        // — the menu loop turns that into the quit dialog.
+        if matches!(self.screen, Screen::Home) {
+            match self.home_focus {
+                HomeFocus::Grid(_) => {
+                    self.home_focus = HomeFocus::Sidebar(self.sidebar_index_for_selected());
                 }
-                None
+                HomeFocus::SidebarMenu(i) => self.home_focus = HomeFocus::Sidebar(i),
+                HomeFocus::Sidebar(_) => {}
             }
-            Screen::Pairing => {
-                self.handle_pairing_event(MenuEvent::Back);
-                None
-            }
-            Screen::Settings => {
-                // `Back` never consults `screen_h` (only `Up`/`Down` scroll) — 0 is fine.
-                self.handle_settings_event(MenuEvent::Back, 0);
-                None
-            }
-            Screen::AddHost => {
-                self.handle_add_host_event(MenuEvent::Back);
-                None
-            }
-            Screen::Wake => {
-                self.handle_wake_event(MenuEvent::Back);
-                None
-            }
-            Screen::ForgetHost => {
-                self.handle_forget_host_event(MenuEvent::Back);
-                None
-            }
-            Screen::HostMenu => {
-                self.handle_host_menu_event(MenuEvent::Back);
-                None
-            }
-            Screen::WakeSettings => {
-                self.handle_wake_settings_event(MenuEvent::Back);
-                None
-            }
-            Screen::SpeedTest => {
-                self.handle_speed_test_event(MenuEvent::Back);
-                None
-            }
-            Screen::EditHost => {
-                self.handle_edit_host_event(MenuEvent::Back);
-                None
-            }
-            // About's Back returns to Settings, not Home — see `handle_about_event`.
-            // The screen size/fonts are irrelevant for a Back, so a zero probe is fine.
-            Screen::About => {
-                self.screen = Screen::Settings;
-                self.scroll = self.settings_scroll;
-                None
-            }
-            Screen::PinLimit => {
-                self.handle_pin_limit_event(MenuEvent::Back);
-                None
-            }
-            Screen::Diagnostics => {
-                self.handle_diagnostics_event(MenuEvent::Back);
-                None
-            }
-            Screen::Experimental => {
-                self.handle_experimental_event(MenuEvent::Back);
-                None
-            }
-            Screen::CursorSettings => {
-                self.handle_cursor_settings_event(MenuEvent::Back);
-                None
-            }
-            Screen::SendLogs => {
-                self.handle_send_logs_event(MenuEvent::Back);
-                None
-            }
+            return None;
         }
+        // Every modal decides for itself where Back goes.
+        self.handle_menu_event(MenuEvent::Back, screen_w, screen_h, fonts)
     }
+
     /// Advances every live animation one tick — the eased scroll, the focus pop,
     /// the modal fade — and reports whether anything is still moving (the main
     /// loop keeps rendering while true). Expired animations report one final
@@ -972,6 +914,10 @@ impl App {
             if t.elapsed() >= ui::animation::FOCUS_POP {
                 self.modal_focus_anim = None;
             }
+            animating = true;
+        }
+        // Disarmed by `poll_press` (the render loop runs the deferred action), not here.
+        if self.press.armed() {
             animating = true;
         }
         if let Some((t, _, _)) = self.switch_anim {

--- a/src/app/pointer.rs
+++ b/src/app/pointer.rs
@@ -240,7 +240,12 @@ impl App {
             return None;
         }
         let total = menu::settings_row_count();
-        (0..total).find(|&r| ui::widgets::focus_row_rect_at_px(content, r, scroll_px).contains_point((x, y)))
+        (0..total).find(|&r| {
+            let rect = ui::widgets::focus_row_rect_at_px(content, r, scroll_px);
+            // Clipped edge rows aren't hoverable: a focused row composites on its own
+            // unclipped tile, so hovering one would pop it outside the card.
+            rect.y() >= content.y() && rect.bottom() <= content.bottom() && rect.contains_point((x, y))
+        })
     }
 
     /// Settings' content viewport and its current animated scroll offset — the shared
@@ -395,11 +400,20 @@ impl App {
         self.handle_mouse_motion(x, y, screen_w, screen_h, fonts);
         if self.hover_close {
             // Same "what Back means here" as everywhere else — see `back`'s docs.
-            return self.back();
+            return self.back(screen_w, screen_h, fonts);
+        }
+        // An open dropdown owns the click wherever it landed: an option, or outside it,
+        // which closes it. Same as hover.
+        if self.dropdown.is_some() {
+            let ev = self.dropdown_click_event(x, y, screen_w, screen_h, fonts);
+            self.handle_menu_event(ev, screen_w, screen_h, fonts);
+            return None;
         }
         // Unlike hover, a click DOES move `home_focus`/`settings_focused` — fresh at
         // the click's own position, so it confirms what was actually clicked rather
-        // than whatever the keyboard/remote last focused elsewhere.
+        // than whatever the keyboard/remote last focused elsewhere. Each arm only
+        // *places* focus (or bails on a click that landed on nothing); the shared
+        // `press` below is what confirms it, so a click and an OK press act alike.
         match self.screen {
             Screen::Home => {
                 // The ⋯ button sits inside its row, so it has to be tested first or the
@@ -432,14 +446,8 @@ impl App {
                     }
                     self.home_focus = HomeFocus::Grid(idx);
                 }
-                self.handle_home_event(MenuEvent::Confirm, screen_w, screen_h)
             }
             Screen::Settings => {
-                if self.dropdown.is_some() {
-                    let ev = self.dropdown_click_event(x, y, screen_w, screen_h, fonts);
-                    self.handle_settings_event(ev, screen_h);
-                    return None;
-                }
                 // `?` bails if the click hit the gap between rows or outside the
                 // viewport — nothing to focus or confirm.
                 self.settings_focused = self.settings_row_at(x, y, screen_w, screen_h)?;
@@ -460,87 +468,39 @@ impl App {
                         return None;
                     }
                 }
-                self.handle_settings_event(MenuEvent::Confirm, screen_h);
-                None
             }
             Screen::Pairing => {
                 // The Magic Remote pointer is the most reliable input on this TV, so the
                 // "Request access" button is clickable directly: focus it and confirm.
                 let card = view::pairing::card_rect(screen_w, screen_h, fonts);
-                if view::pairing::request_button_rect(card, fonts).contains_point((x, y)) {
-                    self.pairing_focus = PairingFocus::RequestAccess;
-                    self.handle_pairing_event(MenuEvent::Confirm);
+                if !view::pairing::request_button_rect(card, fonts).contains_point((x, y)) {
+                    return None;
                 }
-                None
+                self.pairing_focus = PairingFocus::RequestAccess;
             }
-            Screen::Wake => {
-                self.handle_wake_event(MenuEvent::Confirm);
-                None
-            }
-            Screen::ForgetHost => {
-                self.handle_forget_host_event(MenuEvent::Confirm);
-                None
-            }
-            // A click focuses the row it landed on first, then confirms it — same
-            // click-moves-focus rule as Home/Settings above.
             Screen::HostMenu => {
                 let (i, dots) = self.host_menu_row_at(x, y, screen_w, screen_h, fonts)?;
                 self.menu_focused = i;
                 self.host_menu_dots = dots;
-                self.handle_host_menu_event(MenuEvent::Confirm);
-                None
             }
+            // One row, already focused — the click only has to have landed on it.
             Screen::WakeSettings => {
                 let (_, content) = self.modal_list_geometry(screen_w, screen_h, fonts)?;
-                if ui::widgets::focus_row_rect(content, 0).contains_point((x, y)) {
-                    self.handle_wake_settings_event(MenuEvent::Confirm);
-                }
-                None
-            }
-            Screen::SpeedTest => {
-                self.handle_speed_test_event(MenuEvent::Confirm);
-                None
-            }
-            // A click anywhere but the close button (handled above) dismisses it,
-            // same as the one OK button would — there's nothing else on this card.
-            Screen::PinLimit => {
-                self.handle_pin_limit_event(MenuEvent::Confirm);
-                None
-            }
-            Screen::Diagnostics => {
-                if self.dropdown.is_some() {
-                    let ev = self.dropdown_click_event(x, y, screen_w, screen_h, fonts);
-                    self.handle_diagnostics_event(ev);
+                if !ui::widgets::focus_row_rect(content, 0).contains_point((x, y)) {
                     return None;
                 }
-                if let Some(row) = self.modal_list_row_at(x, y, screen_w, screen_h, fonts) {
-                    self.diagnostics_focused = row;
-                    self.handle_diagnostics_event(MenuEvent::Confirm);
-                }
-                None
             }
-            Screen::Experimental => {
-                if let Some(row) = self.modal_list_row_at(x, y, screen_w, screen_h, fonts) {
-                    self.experimental_focused = row;
-                    self.handle_experimental_event(MenuEvent::Confirm);
-                }
-                None
+            // Identical row-list geometry; only which focus field they carry differs.
+            Screen::Diagnostics | Screen::Experimental | Screen::CursorSettings => {
+                let row = self.modal_list_row_at(x, y, screen_w, screen_h, fonts)?;
+                *self.list_modal_focused_mut()? = row;
             }
-            Screen::CursorSettings => {
-                if let Some(row) = self.modal_list_row_at(x, y, screen_w, screen_h, fonts) {
-                    self.cursor_settings_focused = row;
-                    self.handle_cursor_settings_event(MenuEvent::Confirm);
-                }
-                None
-            }
-            // A click confirms whichever of Cancel/Send currently has focus —
-            // same click-confirms-the-focused-button shape as ForgetHost.
-            Screen::SendLogs => {
-                self.handle_send_logs_event(MenuEvent::Confirm);
-                None
-            }
+            // Nothing positional to hit: the confirm dialogs confirm whichever button
+            // already has focus, and PinLimit has a single OK.
+            Screen::Wake | Screen::ForgetHost | Screen::SpeedTest | Screen::SendLogs | Screen::PinLimit => {}
             // Nothing clickable but the close button (handled above).
-            Screen::AddHost | Screen::EditHost | Screen::About => None,
+            Screen::AddHost | Screen::EditHost | Screen::About => return None,
         }
+        self.press(screen_w, screen_h, fonts)
     }
 }

--- a/src/app/press.rs
+++ b/src/app/press.rs
@@ -1,0 +1,110 @@
+//! Activating the focused widget: the press dip, and the one table that routes a
+//! `MenuEvent` to whichever screen is up.
+//!
+//! Every button presses the same way — its focus tile dips, the action runs when the dip
+//! lands — so nothing here asks which modal is open, only whether what is focused is a
+//! button (`pressable`).
+use crate::app::*;
+
+impl App {
+    /// Routes one `MenuEvent` to the open screen — the single dispatch table, which
+    /// `press`, `back` and the runtime's event pump all come through. `Some` only when
+    /// the event launched a stream.
+    pub(crate) fn handle_menu_event(
+        &mut self,
+        ev: MenuEvent,
+        screen_w: u32,
+        screen_h: u32,
+        fonts: &ui::text::Fonts,
+    ) -> Option<ConnectTarget> {
+        // Anything but a confirm cancels an in-flight dip: it moves focus (or closes the
+        // screen), so landing the deferred action would confirm a widget nobody pressed.
+        if ev != MenuEvent::Confirm {
+            self.press.take();
+        }
+        match self.screen {
+            Screen::Home => return self.handle_home_event(ev, screen_w, screen_h),
+            Screen::Pairing => self.handle_pairing_event(ev),
+            Screen::Settings => self.handle_settings_event(ev, screen_h),
+            Screen::AddHost => self.handle_add_host_event(ev),
+            Screen::Wake => self.handle_wake_event(ev),
+            Screen::ForgetHost => self.handle_forget_host_event(ev),
+            Screen::HostMenu => self.handle_host_menu_event(ev),
+            Screen::WakeSettings => self.handle_wake_settings_event(ev),
+            Screen::SpeedTest => self.handle_speed_test_event(ev),
+            Screen::EditHost => self.handle_edit_host_event(ev),
+            Screen::About => self.handle_about_event(ev, screen_w, screen_h, fonts),
+            Screen::PinLimit => self.handle_pin_limit_event(ev),
+            Screen::Diagnostics => self.handle_diagnostics_event(ev),
+            Screen::Experimental => self.handle_experimental_event(ev),
+            Screen::CursorSettings => self.handle_cursor_settings_event(ev),
+            Screen::SendLogs => self.handle_send_logs_event(ev),
+        }
+        None
+    }
+
+    /// Confirms the focused widget, dipping it first if it is pressable.
+    ///
+    /// The action waits for the dip to land (`poll_press`) because most of them close the
+    /// modal: acting now would swap the focus tile for the closing snapshot before a
+    /// single frame of the dip was drawn.
+    pub(crate) fn press(&mut self, screen_w: u32, screen_h: u32, fonts: &ui::text::Fonts) -> Option<ConnectTarget> {
+        // A press landing mid-dip runs that one now rather than dropping it.
+        if let Some(target) = self.run_press(screen_w, screen_h, fonts) {
+            return Some(target);
+        }
+        if !self.pressable() {
+            return self.handle_menu_event(MenuEvent::Confirm, screen_w, screen_h, fonts);
+        }
+        self.press.arm();
+        None
+    }
+
+    /// Whether the focused widget is a button — the only thing that dips. A row carries a
+    /// value the press changes in place, and pushing a full-width row in for that reads as
+    /// the list lurching; a button *is* its action.
+    fn pressable(&self) -> bool {
+        // Focus is on a dropdown option, which has its own tile — the row behind the
+        // overlay is not what was pressed.
+        if self.dropdown.is_some() {
+            return false;
+        }
+        match self.screen {
+            // Sidebar rows are buttons: pick a host, add one, open Settings. A grid card
+            // isn't — launching one is already an animation of its own.
+            Screen::Home => matches!(self.home_focus, HomeFocus::Sidebar(_) | HomeFocus::SidebarMenu(_)),
+            // The button only; the PIN digits above it are a field.
+            Screen::Pairing => matches!(self.pairing_focus, PairingFocus::RequestAccess),
+            Screen::Wake | Screen::ForgetHost | Screen::SpeedTest | Screen::SendLogs => true,
+            // Rows, not buttons.
+            Screen::Settings
+            | Screen::AddHost
+            | Screen::EditHost
+            | Screen::About
+            | Screen::HostMenu
+            | Screen::WakeSettings
+            | Screen::PinLimit
+            | Screen::Diagnostics
+            | Screen::Experimental
+            | Screen::CursorSettings => false,
+        }
+    }
+
+    /// Runs a deferred press whose dip has landed; called every frame. The outer `Some`
+    /// means one fired (so the frame is dirty), the inner whatever its action produced.
+    pub(crate) fn poll_press(
+        &mut self,
+        screen_w: u32,
+        screen_h: u32,
+        fonts: &ui::text::Fonts,
+    ) -> Option<Option<ConnectTarget>> {
+        self.press.landed().then(|| self.run_press(screen_w, screen_h, fonts))
+    }
+
+    /// Runs the deferred press now, however far its dip has got.
+    fn run_press(&mut self, screen_w: u32, screen_h: u32, fonts: &ui::text::Fonts) -> Option<ConnectTarget> {
+        self.press
+            .take()
+            .then(|| self.handle_menu_event(MenuEvent::Confirm, screen_w, screen_h, fonts))?
+    }
+}

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -25,6 +25,7 @@ impl App {
             host_selected: self.selected_host.is_some(),
             has_status: self.home_status.is_some(),
             grid_reveal_ready: self.grid_reveal_ready,
+            press: self.press,
         }
     }
 
@@ -145,44 +146,7 @@ impl App {
             // Focused widget of the active modal (setting row, button, etc.);
             // composites on shell at its on-screen position (no re-rasterize on move).
             // The entering screen's only — the snapshot has its own focused row baked in.
-            let focus_rect = match screen {
-                Screen::Settings => {
-                    let (total, _, _, content) = scroll_geom.expect("screen is Screen::Settings");
-                    // Positioned from the animated pixel offset, not the row index: the baked
-                    // list is cropped at that offset, and the focus tile *is* the focused row
-                    // re-rendered — so anchoring it to the quantized row would show that row's
-                    // content twice, in two places, for the length of every scroll.
-                    let stride = ui::widgets::focus_row_stride() as i32;
-                    let px = self
-                        .modal_scroll_px
-                        .clamp(0, Self::max_scroll_px(total, stride, content.height()));
-                    Some(ui::widgets::focus_row_rect_at_px(content, self.settings_focused, px))
-                }
-                // Every two-button confirm dialog: one subtitle drives the card, so one
-                // button-row geometry serves all four.
-                Screen::Wake | Screen::ForgetHost | Screen::SendLogs | Screen::SpeedTest => self
-                    .confirm_subtitle()
-                    .zip(self.confirm_focused())
-                    .map(|(subtitle, i)| Self::confirm_focus_button_rect(screen_w, screen_h, fonts, &subtitle, i)),
-                Screen::Pairing => {
-                    let card = view::pairing::card_rect(screen_w, screen_h, fonts);
-                    Some(match self.pairing_focus {
-                        PairingFocus::Pin => {
-                            let digit_y = view::pairing::pin_row_y(card, fonts);
-                            view::pairing::digit_rect(card, digit_y, self.pin_digit_index)
-                        }
-                        PairingFocus::RequestAccess => view::pairing::request_button_rect(card, fonts),
-                    })
-                }
-                // Every plain list modal: one geometry, measured off the `ModalScreen`
-                // the painter draws, indexed by that screen's own focus cursor.
-                Screen::HostMenu
-                | Screen::WakeSettings
-                | Screen::Diagnostics
-                | Screen::Experimental
-                | Screen::CursorSettings => self.list_modal_focus_rect(screen_w, screen_h, fonts),
-                Screen::Home | Screen::AddHost | Screen::EditHost | Screen::About | Screen::PinLimit => None,
-            };
+            let focus_rect = self.modal_focus_rect(screen, screen_w, screen_h, fonts);
             if let Some(rect) = focus_rect {
                 let pad = ui::tiles::ROW_TILE_PAD;
                 let base = rect.inflate(pad).offset(0, dy);
@@ -191,8 +155,7 @@ impl App {
                 // rasterized once at its literal size, never re-rendered for
                 // this (except while `switch_anim` animates its content, see
                 // `prepare_tiles`).
-                let f = ui::animation::anim_frac(self.modal_focus_anim, ui::animation::FOCUS_POP);
-                let dst = ui::animation::zoom_rect(base, f, 0.02);
+                let dst = ui::animation::focus_tile_rect(base, self.modal_focus_anim, self.press);
                 let alpha = (255.0 * m) as u8;
                 // In a scrolling modal the focused row can hang past the viewport's bottom
                 // edge mid-glide (the crop lags the row offset by up to one stride), so it is
@@ -308,7 +271,7 @@ impl App {
             let pad = ui::tiles::ROW_TILE_PAD;
             cmds.push(DrawCmd::Tex {
                 tile: tile::FOCUS_ROW,
-                dst: rect.inflate(pad),
+                dst: input.press.rect(rect.inflate(pad)),
                 alpha: 0xff,
             });
         }

--- a/src/app/render/geometry.rs
+++ b/src/app/render/geometry.rs
@@ -264,6 +264,57 @@ impl App {
         changed
     }
 
+    /// Rect of the focused widget of whichever modal `screen` is — the setting row, the
+    /// confirm button, the pairing digit, the list row. This is what `tile::MODAL_FOCUS`
+    /// composites at, and what the press dip scales; `None` for the screens whose focus
+    /// is baked into their shell (Home's grid has its own pop).
+    pub(crate) fn modal_focus_rect(
+        &self,
+        screen: Screen,
+        screen_w: u32,
+        screen_h: u32,
+        fonts: &ui::text::Fonts,
+    ) -> Option<Rect> {
+        match screen {
+            Screen::Settings => {
+                let (total, _, _, content) = self.scroll_geometry_for(screen, screen_w, screen_h, fonts)?;
+                // Positioned from the animated pixel offset, not the row index: the baked
+                // list is cropped at that offset, and the focus tile *is* the focused row
+                // re-rendered — so anchoring it to the quantized row would show that row's
+                // content twice, in two places, for the length of every scroll.
+                let stride = ui::widgets::focus_row_stride() as i32;
+                let px = self
+                    .modal_scroll_px
+                    .clamp(0, Self::max_scroll_px(total, stride, content.height()));
+                Some(ui::widgets::focus_row_rect_at_px(content, self.settings_focused, px))
+            }
+            // Every two-button confirm dialog: one subtitle drives the card, so one
+            // button-row geometry serves all four.
+            Screen::Wake | Screen::ForgetHost | Screen::SendLogs | Screen::SpeedTest => self
+                .confirm_subtitle()
+                .zip(self.confirm_focused())
+                .map(|(subtitle, i)| Self::confirm_focus_button_rect(screen_w, screen_h, fonts, &subtitle, i)),
+            Screen::Pairing => {
+                let card = view::pairing::card_rect(screen_w, screen_h, fonts);
+                Some(match self.pairing_focus {
+                    PairingFocus::Pin => {
+                        let digit_y = view::pairing::pin_row_y(card, fonts);
+                        view::pairing::digit_rect(card, digit_y, self.pin_digit_index)
+                    }
+                    PairingFocus::RequestAccess => view::pairing::request_button_rect(card, fonts),
+                })
+            }
+            // Every plain list modal: one geometry, measured off the `ModalScreen`
+            // the painter draws, indexed by that screen's own focus cursor.
+            Screen::HostMenu
+            | Screen::WakeSettings
+            | Screen::Diagnostics
+            | Screen::Experimental
+            | Screen::CursorSettings => self.list_modal_focus_rect(screen_w, screen_h, fonts),
+            Screen::Home | Screen::AddHost | Screen::EditHost | Screen::About | Screen::PinLimit => None,
+        }
+    }
+
     /// The open list modal's focused row index — the cursor `focus_row_rect` indexes with.
     /// One field per screen so a nested menu keeps its place on the way back; `None` on a
     /// screen that has no plain row list (Settings scrolls, and owns its own geometry).
@@ -274,6 +325,19 @@ impl App {
             Screen::Diagnostics => self.diagnostics_focused,
             Screen::Experimental => self.experimental_focused,
             Screen::CursorSettings => self.cursor_settings_focused,
+            _ => return None,
+        })
+    }
+
+    /// [`list_modal_focused`](Self::list_modal_focused)'s field itself, for the pointer's
+    /// click-moves-focus rule — same table, so the two can't name different fields.
+    pub(crate) fn list_modal_focused_mut(&mut self) -> Option<&mut usize> {
+        Some(match self.screen {
+            Screen::HostMenu => &mut self.menu_focused,
+            Screen::WakeSettings => &mut self.wake_settings_focused,
+            Screen::Diagnostics => &mut self.diagnostics_focused,
+            Screen::Experimental => &mut self.experimental_focused,
+            Screen::CursorSettings => &mut self.cursor_settings_focused,
             _ => return None,
         })
     }

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -19,6 +19,14 @@ use crate::ui::render::{Rect, TileId};
 use crate::ui::Painter;
 
 impl App {
+    /// Stands the loading spinner down: both its clocks and the frame it last showed. Called
+    /// wherever the grid stops waiting — whether it revealed, was invalidated, or lost its host.
+    fn clear_spinner(&mut self) {
+        self.spinner_since = None;
+        self.spinner_frame = None;
+        self.grid_build_since = None;
+    }
+
     /// Sidebar family: the focus-free strip (rebuilt on content change) plus the
     /// single focused-row overlay tile. Pushes any rebuilt tiles onto `updated`.
     /// Extracted from `prepare_tiles` as a self-contained family (A2 staging).
@@ -122,9 +130,17 @@ impl App {
                 self.grid_cards_dirty.clear();
                 // Scrolling or re-pinning a card must not hide the already-visible
                 // grid behind the spinner again.
+                let was_spinning = !self.grid_reveal_ready;
                 self.grid_reveal_ready = false;
-                self.spinner_since = None;
-                self.spinner_frame = None;
+                // This rebuild *is* the build the deadline times, so its clock always restarts.
+                self.grid_build_since = None;
+                // The rotation doesn't. A landing fetch sets `grid_dirty`, so this reset fires
+                // mid-spin on the handover from waiting to building, and starting the phase over
+                // there reads as the spinner visibly jumping.
+                if !was_spinning {
+                    self.spinner_since = None;
+                    self.spinner_frame = None;
+                }
             } else {
                 for id in std::mem::take(&mut self.grid_cards_dirty) {
                     if let Some(t) = self.card_ids.release(&id) {
@@ -271,21 +287,28 @@ impl App {
             // built earlier can still be waiting behind a re-dirtied sibling; requires
             // `art_ready` too so a placeholder built this tick can't count as revealed.
             if !self.grid_reveal_ready {
-                let window_ready = (0..count)
-                    .filter(|&idx| {
-                        let row = row_of(idx);
-                        row >= build_lo && row <= build_hi
-                    })
-                    .all(|idx| {
-                        layout
-                            .pin_id_at(&self.games, idx)
-                            .is_none_or(|id| self.card_ids.get(id).is_some_and(|t| tiles.contains(t)) && art_ready(idx))
-                    });
                 let since = *self.spinner_since.get_or_insert_with(Instant::now);
-                self.grid_reveal_ready = window_ready || since.elapsed() >= SPINNER_MAX_WAIT;
+                // The spinner covers the fetch too, not just the card build: while the request
+                // is in flight `count` is 0, so the window check below would find nothing
+                // outstanding and reveal an empty grid for a whole network round-trip. The
+                // build's deadline stays unarmed for the same reason — it must not expire on
+                // time the build never got.
+                if !self.library_fetch_in_flight() {
+                    let build_since = *self.grid_build_since.get_or_insert_with(Instant::now);
+                    let window_ready = (0..count)
+                        .filter(|&idx| {
+                            let row = row_of(idx);
+                            row >= build_lo && row <= build_hi
+                        })
+                        .all(|idx| {
+                            layout.pin_id_at(&self.games, idx).is_none_or(|id| {
+                                self.card_ids.get(id).is_some_and(|t| tiles.contains(t)) && art_ready(idx)
+                            })
+                        });
+                    self.grid_reveal_ready = window_ready || build_since.elapsed() >= SPINNER_MAX_WAIT;
+                }
                 if self.grid_reveal_ready {
-                    self.spinner_since = None;
-                    self.spinner_frame = None;
+                    self.clear_spinner();
                     // Everything built behind the spinner becomes visible in this
                     // one frame, so it all zooms in off a single clock.
                     let now = Instant::now();
@@ -321,7 +344,7 @@ impl App {
             }
         } else {
             self.grid_reveal_ready = true;
-            self.spinner_since = None;
+            self.clear_spinner();
             if tiles.ensure_static(tile::NO_HOST, || {
                 ui::tiles::render_text_tile(
                     text_cache,

--- a/src/app/render_input.rs
+++ b/src/app/render_input.rs
@@ -19,4 +19,6 @@ pub struct RenderInput<'a> {
     pub has_status: bool,
     /// The grid's cards are built and revealed (past the load spinner).
     pub grid_reveal_ready: bool,
+    /// The focused row's press dip (see `App::press`) — the sidebar's rows are buttons.
+    pub press: crate::ui::animation::Press,
 }

--- a/src/app/state/about.rs
+++ b/src/app/state/about.rs
@@ -20,21 +20,19 @@ impl App {
 
     /// Navigate: Up/Down scroll by line, Left/Right by page.
     pub(crate) fn handle_about_event(&mut self, ev: MenuEvent, screen_w: u32, screen_h: u32, fonts: &ui::text::Fonts) {
-        let (total, visible) = self.about_scroll_geometry(screen_w, screen_h, fonts);
-        // Page step with anchor: show last few lines of previous page
-        let page_step = visible.saturating_sub(2).max(1);
+        // Only the scrolling events need the document measured (wrapping it is the
+        // expensive part), so leaving is not made to pay for it.
         match ev {
-            MenuEvent::Up => {
-                self.scroll.scroll_by(-1, total, visible);
-            }
-            MenuEvent::Down => {
-                self.scroll.scroll_by(1, total, visible);
-            }
-            MenuEvent::Left => {
-                self.scroll.page(page_step, false, total, visible);
-            }
-            MenuEvent::Right => {
-                self.scroll.page(page_step, true, total, visible);
+            MenuEvent::Up | MenuEvent::Down | MenuEvent::Left | MenuEvent::Right => {
+                let (total, visible) = self.about_scroll_geometry(screen_w, screen_h, fonts);
+                // Page step with anchor: show last few lines of previous page
+                let page_step = visible.saturating_sub(2).max(1);
+                match ev {
+                    MenuEvent::Up => self.scroll.scroll_by(-1, total, visible),
+                    MenuEvent::Down => self.scroll.scroll_by(1, total, visible),
+                    MenuEvent::Left => self.scroll.page(page_step, false, total, visible),
+                    _ => self.scroll.page(page_step, true, total, visible),
+                };
             }
             // Return to Settings (not Home) to preserve settings context
             MenuEvent::Back | MenuEvent::Confirm => {

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -465,6 +465,13 @@ impl App {
         ));
     }
 
+    /// Whether `select_host`'s library fetch is still out. Deliberately not `!games_loaded`:
+    /// that stays `false` down the `Unreachable` path too, which would leave the grid's
+    /// loading spinner running forever behind the Wake dialog.
+    pub(crate) fn library_fetch_in_flight(&self) -> bool {
+        self.games_rx.is_some()
+    }
+
     /// Drains `select_host`'s library fetch; switching hosts aborts old fetches safely.
     pub fn drain_games(&mut self) -> bool {
         let Some(rx) = &self.games_rx else { return false };

--- a/src/app/view/pairing.rs
+++ b/src/app/view/pairing.rs
@@ -134,10 +134,7 @@ pub fn render_digit_tile(text_cache: &mut ui::text::TextCache, fonts: &Fonts, di
 /// like the shell's copy (see `ui::Canvas::primary_button`), not the surface-card treatment
 /// the digit tiles use, so the primary action keeps its emphasis while focused.
 pub fn render_button_tile(text_cache: &mut ui::text::TextCache, fonts: &Fonts, w: u32, h: u32) -> Result<ui::Painter> {
-    let pad = ui::tiles::ROW_TILE_PAD;
-    let mut p = ui::Painter::new(w + 2 * pad as u32, h + 2 * pad as u32);
-    ui::Canvas::tile(&mut p, text_cache, fonts).primary_button(Rect::new(pad, pad, w, h), REQUEST_LABEL)?;
-    Ok(p)
+    ui::tiles::padded_widget_tile(text_cache, fonts, w, h, |c, rect| c.primary_button(rect, REQUEST_LABEL))
 }
 
 /// The pairing modal as a [`ModalScreen`].

--- a/src/app/view/sidebar.rs
+++ b/src/app/view/sidebar.rs
@@ -199,31 +199,28 @@ pub fn render_focused_row_tile(
     menu_focused: bool,
     online: Option<bool>,
 ) -> Result<ui::Painter> {
-    let pad = ui::tiles::ROW_TILE_PAD;
     let (w, h) = (
         ui::widgets::SIDEBAR_W - 2 * ui::widgets::SIDEBAR_PAD as u32,
         ui::widgets::SIDEBAR_ROW_H,
     );
-    let rect = Rect::new(pad, pad, w, h);
-    let mut p = ui::Painter::new(w + 2 * pad as u32, h + 2 * pad as u32);
-    let c = &mut Canvas::tile(&mut p, text_cache, fonts);
-    if let Some(entry) = entries.get(index) {
-        draw_host_row(
-            c,
-            rect,
-            entry.name(),
-            &HostRowState {
-                paired: entry.is_paired(),
-                focused: true,
-                selected: false,
-                menu_focused,
-                online,
-            },
-        )?;
-    } else if index == entries.len() {
-        draw_utility_row(c, rect, "+ Add host", true)?;
-    } else {
-        draw_utility_row(c, rect, "Settings", true)?;
-    }
-    Ok(p)
+    ui::tiles::padded_widget_tile(text_cache, fonts, w, h, |c, rect| {
+        if let Some(entry) = entries.get(index) {
+            draw_host_row(
+                c,
+                rect,
+                entry.name(),
+                &HostRowState {
+                    paired: entry.is_paired(),
+                    focused: true,
+                    selected: false,
+                    menu_focused,
+                    online,
+                },
+            )
+        } else if index == entries.len() {
+            draw_utility_row(c, rect, "+ Add host", true)
+        } else {
+            draw_utility_row(c, rect, "Settings", true)
+        }
+    })
 }

--- a/src/runtime/input.rs
+++ b/src/runtime/input.rs
@@ -114,6 +114,8 @@ pub(super) struct ConfirmDialog {
     shell_dirty: bool,
     focus_dirty: bool,
     focus_anim: Option<Instant>,
+    /// The focused button's press dip, playing out over the close fade it starts.
+    press: crate::ui::animation::Press,
     tc: crate::ui::text::TextCache,
 }
 
@@ -132,6 +134,7 @@ impl ConfirmDialog {
             shell_dirty: false,
             focus_dirty: false,
             focus_anim: None,
+            press: crate::ui::animation::Press::default(),
             tc: crate::ui::text::TextCache::new(),
         }
     }
@@ -143,6 +146,7 @@ impl ConfirmDialog {
     /// Opens (or reopens) with `focus` focused.
     pub(super) fn open(&mut self, focus: usize) {
         self.focus = Some(focus);
+        self.press = crate::ui::animation::Press::default();
         self.fade.reopen();
         self.shell_dirty = true;
         self.focus_dirty = true;
@@ -154,6 +158,11 @@ impl ConfirmDialog {
         self.focus = Some(focus);
         self.focus_dirty = true;
         self.focus_anim = Some(Instant::now());
+    }
+
+    /// Dips the focused button, over whatever the press starts (close fade, teardown).
+    fn press(&mut self) {
+        self.press.arm();
     }
 
     /// Starts close-fade with the focused button.
@@ -207,14 +216,14 @@ impl ConfirmDialog {
                 y,
                 ..
             } => {
-                return match button_at(x, y) {
-                    Some(0) => Some(ConfirmAction::Confirmed),
-                    Some(_) => {
-                        self.dismiss();
-                        Some(ConfirmAction::Dismissed)
-                    }
-                    None => None,
-                };
+                let i = button_at(x, y)?;
+                self.press();
+                return Some(if i == 0 {
+                    ConfirmAction::Confirmed
+                } else {
+                    self.dismiss();
+                    ConfirmAction::Dismissed
+                });
             }
             _ => {}
         }
@@ -232,8 +241,15 @@ impl ConfirmDialog {
                 self.set_focus(1 - focus);
                 Some(ConfirmAction::Navigated)
             }
-            Some(MenuEvent::Confirm) if focus == 0 => Some(ConfirmAction::Confirmed),
-            Some(MenuEvent::Confirm | MenuEvent::Back) => {
+            Some(MenuEvent::Confirm) if focus == 0 => {
+                self.press();
+                Some(ConfirmAction::Confirmed)
+            }
+            Some(ev @ (MenuEvent::Confirm | MenuEvent::Back)) => {
+                // Back is a dismissal, not a press — only the pressed button dips.
+                if ev == MenuEvent::Confirm {
+                    self.press();
+                }
                 self.dismiss();
                 Some(ConfirmAction::Dismissed)
             }
@@ -285,7 +301,6 @@ impl ConfirmDialog {
             btn_rect.width() + 2 * pad as u32,
             btn_rect.height() + 2 * pad as u32,
         );
-        let f = crate::ui::animation::anim_frac(self.focus_anim, crate::ui::animation::FOCUS_POP);
         let shell_dst = crate::ui::render::Rect::new(0, dy, w, h);
         cmds.push(DrawCmd::Fill {
             rect: full,
@@ -298,7 +313,7 @@ impl ConfirmDialog {
         });
         cmds.push(DrawCmd::Tex {
             tile: tile::DISCONNECT_FOCUS_BUTTON,
-            dst: crate::ui::animation::zoom_rect(base, f, 0.02),
+            dst: crate::ui::animation::focus_tile_rect(base, self.focus_anim, self.press),
             alpha: (255.0 * m) as u8,
         });
         Ok(())
@@ -496,10 +511,7 @@ fn pin_hold_gate(
     // toggled, or one whose screen/focus moved out from under it, resolves to
     // nothing.
     let tapped = !hold.fired && matches!(app.screen, Screen::Home) && hold.focus == app.home_focus;
-    let launched = tapped
-        && app
-            .handle_home_event(MenuEvent::Confirm, display_mode.w as u32, display_mode.h as u32)
-            .is_some();
+    let launched = tapped && app.press(display_mode.w as u32, display_mode.h as u32, fonts).is_some();
     Some(if launched {
         EventAction::Launch
     } else {
@@ -507,8 +519,8 @@ fn pin_hold_gate(
     })
 }
 
-/// Routes a resolved `MenuEvent` to whichever screen is up — one of the
-/// dispatch sites a new screen has to be added to.
+/// Feeds a resolved `MenuEvent` to the app, translating what it returns into this
+/// loop's terms. The per-screen routing is `App::handle_menu_event`.
 fn dispatch_menu_event(
     app: &mut App,
     menu_ev: MenuEvent,
@@ -517,33 +529,20 @@ fn dispatch_menu_event(
 ) -> EventAction {
     let (w, h) = (display_mode.w as u32, display_mode.h as u32);
     if menu_ev == MenuEvent::Back {
-        return if app.back().is_some() {
+        return if app.back(w, h, fonts).is_some() {
             EventAction::Launch
         } else {
             EventAction::Next
         };
     }
-    match app.screen {
-        Screen::Home => {
-            if app.handle_home_event(menu_ev, w, h).is_some() {
-                return EventAction::Launch;
-            }
-        }
-        Screen::Pairing => app.handle_pairing_event(menu_ev),
-        Screen::Settings => app.handle_settings_event(menu_ev, h),
-        Screen::AddHost => app.handle_add_host_event(menu_ev),
-        Screen::Wake => app.handle_wake_event(menu_ev),
-        Screen::ForgetHost => app.handle_forget_host_event(menu_ev),
-        Screen::HostMenu => app.handle_host_menu_event(menu_ev),
-        Screen::WakeSettings => app.handle_wake_settings_event(menu_ev),
-        Screen::SpeedTest => app.handle_speed_test_event(menu_ev),
-        Screen::EditHost => app.handle_edit_host_event(menu_ev),
-        Screen::About => app.handle_about_event(menu_ev, w, h, fonts),
-        Screen::PinLimit => app.handle_pin_limit_event(menu_ev),
-        Screen::Diagnostics => app.handle_diagnostics_event(menu_ev),
-        Screen::Experimental => app.handle_experimental_event(menu_ev),
-        Screen::CursorSettings => app.handle_cursor_settings_event(menu_ev),
-        Screen::SendLogs => app.handle_send_logs_event(menu_ev),
+    // Confirm goes through the press animation; everything else dispatches straight.
+    let launched = if menu_ev == MenuEvent::Confirm {
+        app.press(w, h, fonts)
+    } else {
+        app.handle_menu_event(menu_ev, w, h, fonts)
+    };
+    if launched.is_some() {
+        return EventAction::Launch;
     }
     EventAction::Next
 }

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -329,6 +329,14 @@ pub(super) fn run_ui_flow(
         // Polled every tick like the streaming loop's toast, not gated behind
         // `content_dirty` — its own fade needs frames regardless of anything else.
         let notif_frame = notif.frame();
+        // The deferred half of a press (see `App::press`): the dip has played out, so the
+        // widget's action runs now.
+        if let Some(launched) = app.poll_press(display_mode.w as u32, display_mode.h as u32, fonts) {
+            dirty = true;
+            if launched.is_some() {
+                break 'ui;
+            }
+        }
         let animating = app.tick_animations()
             || app.tiles_pending
             || !app.grid_reveal_ready

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -9,6 +9,57 @@ pub const FOCUS_POP: Duration = Duration::from_millis(140);
 /// driving them (`App::focus_anim`) is cleared on it, so nothing may outlast it.
 pub const CARD_FOCUS_POP: Duration = Duration::from_millis(160);
 
+/// How long a pressed button takes to spring back out of its dip.
+pub const PRESS_POP: Duration = Duration::from_millis(120);
+
+/// How far a pressed widget sinks, in px.
+const PRESS_DROP: f32 = 5.0;
+
+/// How far a focused widget's tile grows while focused — the pop every composited focus
+/// tile rides (see [`focus_tile_rect`]).
+pub const FOCUS_GROWTH: f32 = 0.02;
+
+/// A button being pushed in. Same animation wherever a button lives, so only the clock
+/// belongs to its owner (`App`'s focused widget, the in-stream `ConfirmDialog`).
+#[derive(Default, Clone, Copy)]
+pub struct Press(Option<Instant>);
+
+impl Press {
+    /// Starts the dip. The owner decides whether to wait for it before acting.
+    pub fn arm(&mut self) {
+        self.0 = Some(Instant::now());
+    }
+
+    /// Whether a dip is in flight — frames are owed while it is.
+    pub fn armed(self) -> bool {
+        self.0.is_some()
+    }
+
+    /// Whether an armed dip has played all the way out.
+    pub fn landed(self) -> bool {
+        self.0.is_some_and(|t| t.elapsed() >= PRESS_POP)
+    }
+
+    /// Disarms, reporting whether anything was armed.
+    pub fn take(&mut self) -> bool {
+        self.0.take().is_some()
+    }
+
+    /// `base` pushed down by however far this press has got.
+    ///
+    /// A translation, not a scale: the tile blits 1:1, so its label and icon never
+    /// resample, and it reads the same on a narrow button as on a full-width row.
+    pub fn rect(self, base: Rect) -> Rect {
+        base.offset(0, (PRESS_DROP * (1.0 - anim_frac(self.0, PRESS_POP))) as i32)
+    }
+}
+
+/// Where a composited focus tile is drawn: the focus pop's zoom with any press dip on
+/// top. Every focus tile goes through this, so the two motions always compose alike.
+pub fn focus_tile_rect(base: Rect, focus_anim: Option<Instant>, press: Press) -> Rect {
+    press.rect(zoom_rect(base, anim_frac(focus_anim, FOCUS_POP), FOCUS_GROWTH))
+}
+
 /// Cubic ease-out function.
 pub fn ease(f: f32) -> f32 {
     1.0 - (1.0 - f).powi(3)

--- a/src/ui/painter.rs
+++ b/src/ui/painter.rs
@@ -19,6 +19,15 @@ pub fn solid_paint(color: Color) -> Paint<'static> {
     paint
 }
 
+/// [`solid_paint`] with anti-aliasing on, for curved or diagonal edges. Affordable where
+/// `solid_paint` isn't because AA costs per edge-pixel, not per covered pixel: a corner arc
+/// pays for a handful, a full-screen fill for all of them.
+fn aa_paint(color: Color) -> Paint<'static> {
+    let mut paint = solid_paint(color);
+    paint.anti_alias = true;
+    paint
+}
+
 /// [`rounded_rect_path`] over a `Rect` — `None` for an empty one, so callers need no
 /// size guard of their own. The rect must already be painter-local (see `Painter::off`).
 fn rect_path(rect: Rect, radius: i32) -> Option<tiny_skia::Path> {
@@ -31,13 +40,25 @@ fn rect_path(rect: Rect, radius: i32) -> Option<tiny_skia::Path> {
     )
 }
 
+/// The radius [`rounded_rect_path`] will actually draw with: a caller's request clamped to
+/// what the box can hold. Below half a pixel it draws a plain rect instead, so this doubles
+/// as the test for whether a shape has corner arcs worth anti-aliasing.
+fn effective_radius(w: f32, h: f32, radius: f32) -> f32 {
+    let r = radius.max(0.0).min(w / 2.0).min(h / 2.0);
+    if r < 0.5 {
+        0.0
+    } else {
+        r
+    }
+}
+
 /// Rounded-rect as Bezier path (`tiny_skia` has no built-in); falls back to plain rect if radius ~0.
 pub fn rounded_rect_path(x: f32, y: f32, w: f32, h: f32, radius: f32) -> Option<tiny_skia::Path> {
     const K: f32 = 0.552_284_7;
 
-    let r = radius.max(0.0).min(w / 2.0).min(h / 2.0);
+    let r = effective_radius(w, h, radius);
     let mut pb = PathBuilder::new();
-    if r < 0.5 {
+    if r == 0.0 {
         pb.push_rect(tiny_skia::Rect::from_xywh(x, y, w, h)?);
         return pb.finish();
     }
@@ -197,14 +218,17 @@ impl Painter {
         let Some(path) = rect_path(self.off(rect), radius) else {
             return;
         };
-        self.fill(&path, color);
+        let curved = effective_radius(rect.width() as f32, rect.height() as f32, radius as f32) > 0.0;
+        self.fill_with(&path, if curved { aa_paint(color) } else { solid_paint(color) });
     }
 
+    /// Always anti-aliased, even for a square rect: a fractional-width stroke straddles the
+    /// pixel grid on every edge, so hard scan-conversion renders it at uneven widths.
     pub fn stroke_rounded_rect(&mut self, rect: Rect, radius: i32, color: Color, width: f32) {
         let Some(path) = rect_path(self.off(rect), radius) else {
             return;
         };
-        let paint = solid_paint(color);
+        let paint = aa_paint(color);
         let stroke = Stroke {
             width,
             ..Stroke::default()
@@ -221,7 +245,7 @@ impl Painter {
         let Some(path) = PathBuilder::from_circle(cx, cy, r) else {
             return;
         };
-        self.fill(&path, color);
+        self.fill_with(&path, aa_paint(color));
     }
 
     /// [`fill_circle`](Self::fill_circle) with `Screen` blend (overlapping circles lighten).
@@ -235,15 +259,12 @@ impl Painter {
         };
         let paint = Paint {
             blend_mode: tiny_skia::BlendMode::Screen,
-            anti_alias: true,
-            ..solid_paint(color)
+            ..aa_paint(color)
         };
-        self.pixmap
-            .fill_path(&path, &paint, FillRule::Winding, Transform::identity(), None);
+        self.fill_with(&path, paint);
     }
 
-    fn fill(&mut self, path: &tiny_skia::Path, color: Color) {
-        let paint = solid_paint(color);
+    fn fill_with(&mut self, path: &tiny_skia::Path, paint: Paint<'_>) {
         self.pixmap
             .fill_path(path, &paint, FillRule::Winding, Transform::identity(), None);
     }

--- a/src/ui/tiles.rs
+++ b/src/ui/tiles.rs
@@ -25,6 +25,23 @@ fn padded_card_tile(w: u32, h: u32, pad: i32, draw: impl FnOnce(&mut Painter, Re
     p
 }
 
+/// A widget rasterized with [`ROW_TILE_PAD`] of transparent margin all round, handed its
+/// own rect within it — the shape every composited focus tile shares. The margin is what
+/// lets the compositor pop and dip the tile without clipping its shadow.
+pub fn padded_widget_tile(
+    text_cache: &mut TextCache,
+    fonts: &Fonts,
+    w: u32,
+    h: u32,
+    draw: impl FnOnce(&mut Canvas, Rect) -> Result<()>,
+) -> Result<Painter> {
+    let pad = ROW_TILE_PAD;
+    let mut p = Painter::new(w + 2 * pad as u32, h + 2 * pad as u32);
+    let mut c = Canvas::tile(&mut p, text_cache, fonts);
+    draw(&mut c, Rect::new(pad, pad, w, h))?;
+    Ok(p)
+}
+
 /// The card drop shadow as a shared tile (all cards are one size), composited *behind*
 /// each card rather than baked into it. Every card's shadow is identical, so baking it in
 /// bought nothing and cost every card tile a 20px margin a side — ~35% more pixels

--- a/src/ui/widgets/rows.rs
+++ b/src/ui/widgets/rows.rs
@@ -294,14 +294,12 @@ pub fn render_focus_row_tile(
     dropdown_open: bool,
     switch_frac: f32,
 ) -> Result<Painter> {
-    let pad = ROW_TILE_PAD;
-    let rect = Rect::new(pad, pad, content_width, FOCUS_ROW_H);
-    let mut p = Painter::new(content_width + 2 * pad as u32, FOCUS_ROW_H + 2 * pad as u32);
-    if let Some(row) = rows.get(index) {
-        let mut c = Canvas::tile(&mut p, text_cache, fonts);
-        c.focus_row(row, true, dropdown_open, switch_frac, rect)?;
-    }
-    Ok(p)
+    crate::ui::tiles::padded_widget_tile(text_cache, fonts, content_width, FOCUS_ROW_H, |c, rect| {
+        match rows.get(index) {
+            Some(row) => c.focus_row(row, true, dropdown_open, switch_frac, rect),
+            None => Ok(()),
+        }
+    })
 }
 
 /// All rows unfocused as one tile. GPU-side `DrawCmd::TexCropped` handles
@@ -746,11 +744,7 @@ pub fn render_confirm_button_tile(
     w: u32,
     h: u32,
 ) -> Result<Painter> {
-    let pad = ROW_TILE_PAD;
-    let mut p = Painter::new(w + 2 * pad as u32, h + 2 * pad as u32);
-    let mut c = Canvas::tile(&mut p, text_cache, fonts);
-    c.confirm_button(button, true, Rect::new(pad, pad, w, h))?;
-    Ok(p)
+    crate::ui::tiles::padded_widget_tile(text_cache, fonts, w, h, |c, rect| c.confirm_button(button, true, rect))
 }
 
 impl Canvas<'_, '_> {


### PR DESCRIPTION
Two fixes and a polish pass.

**Hover fix.** In Settings, the partially-visible rows at a scroll edge were hoverable with the Magic Remote, and the focused row composites from its own unclipped tile, so hovering one popped it outside the card. Hover and click now only land on rows wholly inside the viewport. The d-pad never hit this, since it scrolls a row into view before focusing it.

**Press animation.** A pressed button pushes in 5px and springs back over 120ms, then the action runs. It translates rather than scales, so the tile blits 1:1 and the label does not resample. Buttons dip (confirm dialogs, pairing, sidebar rows); rows do not, because shoving a full-width row down reads as the list lurching. Lives in `ui::animation::Press`.

**Anti-aliasing.** Modal and card outlines, the toggle knob, the slider thumb and the rounded corners had hard stair-stepped edges. AA is off globally because it costs too much on the big axis-aligned fills, but the cost is per edge-pixel, so curves are cheap. Square fills keep the fast path.

Cleanup that fell out: one per-screen dispatch table instead of two, a single shared `press` so a click and an OK press take the same path (-40 lines), the dropdown-click case written once instead of twice, shared `ui::tiles::padded_widget_tile`, and About no longer re-wraps its document on every Back.

Not tested on the TV yet — the 120ms defer is the part worth feeling on device.

**Loading spinner.** Picking a host showed an empty grid for the length of the library fetch, then a spinner once cards started building — the reveal check asks whether every card in the window is built, and with the request in flight there are no cards. The spinner now covers the whole wait, fetch included.

**Press-dip scoping.** Confirming a dialog (Wake, Forget host, Send logs) also pushed the sidebar row in behind the modal card — the press clock lives on `App` while the button owning it does not, and both focus tiles composite through it. The arming screen is now recorded with the press, so only the pressed button dips.