### PR TITLE
Dip only the button that was pressed

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -425,6 +425,11 @@ pub struct App {
     /// The focused button's press dip, if one is in flight — the widget's action runs when
     /// it lands (see `App::press`).
     pub(crate) press: ui::animation::Press,
+    /// Which screen's button armed `press`. The clock is App-wide but the button that owns
+    /// it isn't, and a modal's focus tile and the sidebar row behind the card both composite
+    /// the dip — without this, confirming a dialog pushes the sidebar row in with it.
+    /// Only meaningful while `press` is armed, so nothing has to clear it.
+    pub(crate) press_screen: Screen,
     /// In-flight `Toggle` row flip: `(when it started, the value it flipped
     /// from, the focused row it flipped)` — lets `modal_focus_tile`'s render
     /// slide the switch knob from its old state to its new one over
@@ -579,6 +584,7 @@ impl App {
             modal_fade: ui::fade::ModalFade::new(),
             modal_focus_anim: None,
             press: ui::animation::Press::default(),
+            press_screen: Screen::Home,
             switch_anim: None,
             last_screen: Screen::Home,
             pairing_rx: None,

--- a/src/app/press.rs
+++ b/src/app/press.rs
@@ -57,7 +57,19 @@ impl App {
             return self.handle_menu_event(MenuEvent::Confirm, screen_w, screen_h, fonts);
         }
         self.press.arm();
+        self.press_screen = self.screen;
         None
+    }
+
+    /// The dip, but only for the screen whose button armed it. Every focus tile on screen
+    /// composites through `App::press`, so an open modal's confirm would otherwise push the
+    /// sidebar row behind its card in alongside the button actually pressed.
+    pub(crate) fn press_dip(&self, owner: Screen) -> ui::animation::Press {
+        if self.press_screen == owner {
+            self.press
+        } else {
+            ui::animation::Press::default()
+        }
     }
 
     /// Whether the focused widget is a button — the only thing that dips. A row carries a

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -25,7 +25,7 @@ impl App {
             host_selected: self.selected_host.is_some(),
             has_status: self.home_status.is_some(),
             grid_reveal_ready: self.grid_reveal_ready,
-            press: self.press,
+            press: self.press_dip(Screen::Home),
         }
     }
 
@@ -155,7 +155,7 @@ impl App {
                 // rasterized once at its literal size, never re-rendered for
                 // this (except while `switch_anim` animates its content, see
                 // `prepare_tiles`).
-                let dst = ui::animation::focus_tile_rect(base, self.modal_focus_anim, self.press);
+                let dst = ui::animation::focus_tile_rect(base, self.modal_focus_anim, self.press_dip(screen));
                 let alpha = (255.0 * m) as u8;
                 // In a scrolling modal the focused row can hang past the viewport's bottom
                 // edge mid-glide (the crop lags the row offset by up to one stride), so it is


### PR DESCRIPTION
Confirming a dialog — Wake, Forget host, Send logs — also pushed the sidebar row in behind the modal card.

The press clock lives on `App` while the button owning it does not, and both the modal focus tile and the sidebar row composite through it. The arming screen is now recorded with the press, and each focus tile asks for the dip by owner, so only the pressed button gets it.

Not tested on the TV.