### PR TITLE
Play a button's press dip with its action, not before it

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -928,7 +928,7 @@ impl App {
             }
             animating = true;
         }
-        // Disarmed by `poll_press` (the render loop runs the deferred action), not here.
+        // Retired by `poll_press` once the dip has played out, not here.
         if self.press.armed() {
             animating = true;
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -422,14 +422,9 @@ pub struct App {
     /// modal (Settings row, Wake row, Pairing digit/button, `ForgetHost`
     /// button) since only one is ever open, and focused, at a time.
     pub(crate) modal_focus_anim: Option<Instant>,
-    /// The focused button's press dip, if one is in flight — the widget's action runs when
-    /// it lands (see `App::press`).
+    /// The pressed button's dip, if one is in flight — purely visual, and only for a
+    /// press that stayed on its screen (see `App::press`).
     pub(crate) press: ui::animation::Press,
-    /// Which screen's button armed `press`. The clock is App-wide but the button that owns
-    /// it isn't, and a modal's focus tile and the sidebar row behind the card both composite
-    /// the dip — without this, confirming a dialog pushes the sidebar row in with it.
-    /// Only meaningful while `press` is armed, so nothing has to clear it.
-    pub(crate) press_screen: Screen,
     /// In-flight `Toggle` row flip: `(when it started, the value it flipped
     /// from, the focused row it flipped)` — lets `modal_focus_tile`'s render
     /// slide the switch knob from its old state to its new one over
@@ -584,7 +579,6 @@ impl App {
             modal_fade: ui::fade::ModalFade::new(),
             modal_focus_anim: None,
             press: ui::animation::Press::default(),
-            press_screen: Screen::Home,
             switch_anim: None,
             last_screen: Screen::Home,
             pairing_rx: None,
@@ -928,7 +922,7 @@ impl App {
             }
             animating = true;
         }
-        // Retired by `poll_press` once the dip has played out, not here.
+        // Disarmed by `poll_press` (the render loop retires the dip), not here.
         if self.press.armed() {
             animating = true;
         }

--- a/src/app/press.rs
+++ b/src/app/press.rs
@@ -1,9 +1,9 @@
 //! Activating the focused widget: the press dip, and the one table that routes a
 //! `MenuEvent` to whichever screen is up.
 //!
-//! Every button presses the same way — its focus tile dips, the action runs when the dip
-//! lands — so nothing here asks which modal is open, only whether what is focused is a
-//! button (`pressable`).
+//! Every button presses the same way — its focus tile dips while its action runs — so
+//! nothing here asks which modal is open, only whether what is focused is a button
+//! (`pressable`).
 use crate::app::*;
 
 impl App {
@@ -17,8 +17,8 @@ impl App {
         screen_h: u32,
         fonts: &ui::text::Fonts,
     ) -> Option<ConnectTarget> {
-        // Anything but a confirm cancels an in-flight dip: it moves focus (or closes the
-        // screen), so landing the deferred action would confirm a widget nobody pressed.
+        // Anything but a confirm cancels an in-flight dip: focus (or the screen) has moved,
+        // so the tile it rides is no longer the pressed widget.
         if ev != MenuEvent::Confirm {
             self.press.take();
         }
@@ -43,27 +43,23 @@ impl App {
         None
     }
 
-    /// Confirms the focused widget, dipping it first if it is pressable.
+    /// Confirms the focused widget, dipping it if it is pressable.
     ///
-    /// The action waits for the dip to land (`poll_press`) because most of them close the
-    /// modal: acting now would swap the focus tile for the closing snapshot before a
-    /// single frame of the dip was drawn.
+    /// The action runs on the same frame the dip is armed, not after it: waiting put the
+    /// dip's whole 120ms in front of every screen transition. A closing modal's dip is then
+    /// never seen (its focus tile is already baked into the closing snapshot), which costs
+    /// nothing — there is nothing left on screen to push in.
     pub(crate) fn press(&mut self, screen_w: u32, screen_h: u32, fonts: &ui::text::Fonts) -> Option<ConnectTarget> {
-        // A press landing mid-dip runs that one now rather than dropping it.
-        if let Some(target) = self.run_press(screen_w, screen_h, fonts) {
-            return Some(target);
+        if self.pressable() {
+            self.press.arm();
+            self.press_screen = self.screen;
         }
-        if !self.pressable() {
-            return self.handle_menu_event(MenuEvent::Confirm, screen_w, screen_h, fonts);
-        }
-        self.press.arm();
-        self.press_screen = self.screen;
-        None
+        self.handle_menu_event(MenuEvent::Confirm, screen_w, screen_h, fonts)
     }
 
-    /// The dip, but only for the screen whose button armed it. Every focus tile on screen
-    /// composites through `App::press`, so an open modal's confirm would otherwise push the
-    /// sidebar row behind its card in alongside the button actually pressed.
+    /// The dip, but only for the screen whose button armed it. Every focus tile composites
+    /// through `App::press`, so a modal's confirm would otherwise dip the sidebar row behind
+    /// its card too.
     pub(crate) fn press_dip(&self, owner: Screen) -> ui::animation::Press {
         if self.press_screen == owner {
             self.press
@@ -102,21 +98,9 @@ impl App {
         }
     }
 
-    /// Runs a deferred press whose dip has landed; called every frame. The outer `Some`
-    /// means one fired (so the frame is dirty), the inner whatever its action produced.
-    pub(crate) fn poll_press(
-        &mut self,
-        screen_w: u32,
-        screen_h: u32,
-        fonts: &ui::text::Fonts,
-    ) -> Option<Option<ConnectTarget>> {
-        self.press.landed().then(|| self.run_press(screen_w, screen_h, fonts))
-    }
-
-    /// Runs the deferred press now, however far its dip has got.
-    fn run_press(&mut self, screen_w: u32, screen_h: u32, fonts: &ui::text::Fonts) -> Option<ConnectTarget> {
-        self.press
-            .take()
-            .then(|| self.handle_menu_event(MenuEvent::Confirm, screen_w, screen_h, fonts))?
+    /// Retires a dip that has played all the way out; called every frame. `true` on the
+    /// frame that must be redrawn without it.
+    pub(crate) fn poll_press(&mut self) -> bool {
+        self.press.landed() && self.press.take()
     }
 }

--- a/src/app/press.rs
+++ b/src/app/press.rs
@@ -1,9 +1,10 @@
 //! Activating the focused widget: the press dip, and the one table that routes a
 //! `MenuEvent` to whichever screen is up.
 //!
-//! Every button presses the same way — its focus tile dips while its action runs — so
-//! nothing here asks which modal is open, only whether what is focused is a button
-//! (`pressable`).
+//! The dip is kept only for a press that stays on its screen — "request access", the
+//! speed test's retry, picking a host. Anything that opens or closes a modal drops it:
+//! the modal fade (75ms, full-screen scrim) darkens the pressed row and replaces the
+//! tile that was dipping, so the 5px dip underneath is never seen. One motion per press.
 use crate::app::*;
 
 impl App {
@@ -17,8 +18,8 @@ impl App {
         screen_h: u32,
         fonts: &ui::text::Fonts,
     ) -> Option<ConnectTarget> {
-        // Anything but a confirm cancels an in-flight dip: focus (or the screen) has moved,
-        // so the tile it rides is no longer the pressed widget.
+        // Anything but a confirm moves focus or closes the screen, so a dip still running
+        // from an earlier press belongs to a widget that is no longer under the cursor.
         if ev != MenuEvent::Confirm {
             self.press.take();
         }
@@ -43,25 +44,29 @@ impl App {
         None
     }
 
-    /// Confirms the focused widget, dipping it if it is pressable.
+    /// Confirms the focused widget, dipping it if it is a button whose action stays put.
     ///
-    /// The action runs on the same frame the dip is armed, not after it: waiting put the
-    /// dip's whole 120ms in front of every screen transition. A closing modal's dip is then
-    /// never seen (its focus tile is already baked into the closing snapshot), which costs
-    /// nothing — there is nothing left on screen to push in.
+    /// The action runs immediately; the dip is retired afterwards rather than gated
+    /// beforehand, because whether a button opens anything is the screen handler's
+    /// business and a list of which ones do would be one more thing to keep in step.
     pub(crate) fn press(&mut self, screen_w: u32, screen_h: u32, fonts: &ui::text::Fonts) -> Option<ConnectTarget> {
+        let before = self.screen;
         if self.pressable() {
             self.press.arm();
-            self.press_screen = self.screen;
         }
-        self.handle_menu_event(MenuEvent::Confirm, screen_w, screen_h, fonts)
+        let launched = self.handle_menu_event(MenuEvent::Confirm, screen_w, screen_h, fonts);
+        if self.screen != before || launched.is_some() {
+            self.press.take();
+        }
+        launched
     }
 
-    /// The dip, but only for the screen whose button armed it. Every focus tile composites
-    /// through `App::press`, so a modal's confirm would otherwise dip the sidebar row behind
-    /// its card too.
+    /// The dip, but only for the screen that armed it — which, since a press leaving its
+    /// screen drops the dip, is simply the one that is up. Every focus tile on screen
+    /// composites through `App::press`, so without this an open modal's confirm would push
+    /// the sidebar row behind its card in alongside the button actually pressed.
     pub(crate) fn press_dip(&self, owner: Screen) -> ui::animation::Press {
-        if self.press_screen == owner {
+        if self.screen == owner {
             self.press
         } else {
             ui::animation::Press::default()
@@ -98,8 +103,8 @@ impl App {
         }
     }
 
-    /// Retires a dip that has played all the way out; called every frame. `true` on the
-    /// frame that must be redrawn without it.
+    /// Retires a dip that has played out; called every frame. `true` means the tile moved
+    /// back, so the frame is dirty.
     pub(crate) fn poll_press(&mut self) -> bool {
         self.press.landed() && self.press.take()
     }

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -329,13 +329,8 @@ pub(super) fn run_ui_flow(
         // Polled every tick like the streaming loop's toast, not gated behind
         // `content_dirty` — its own fade needs frames regardless of anything else.
         let notif_frame = notif.frame();
-        // The deferred half of a press (see `App::press`): the dip has played out, so the
-        // widget's action runs now.
-        if let Some(launched) = app.poll_press(display_mode.w as u32, display_mode.h as u32, fonts) {
+        if app.poll_press() {
             dirty = true;
-            if launched.is_some() {
-                break 'ui;
-            }
         }
         let animating = app.tick_animations()
             || app.tiles_pending

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -329,6 +329,7 @@ pub(super) fn run_ui_flow(
         // Polled every tick like the streaming loop's toast, not gated behind
         // `content_dirty` — its own fade needs frames regardless of anything else.
         let notif_frame = notif.frame();
+        // The dip has played out (see `App::press`) — the tile springs back.
         if app.poll_press() {
             dirty = true;
         }

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -25,7 +25,7 @@ pub const FOCUS_GROWTH: f32 = 0.02;
 pub struct Press(Option<Instant>);
 
 impl Press {
-    /// Starts the dip. The owner decides whether to wait for it before acting.
+    /// Starts the dip. Purely visual — the action runs the moment the press arrives.
     pub fn arm(&mut self) {
         self.0 = Some(Instant::now());
     }


### PR DESCRIPTION
Pressing a button used to defer its action until the 120ms dip had played out, so opening Settings or a host menu meant watching the dip, then the modal fade. Two animations end to end for one keypress, and it felt slow.

Now the action runs the moment the press arrives, and the dip is dropped if it would not have been visible anyway.

- The dip is purely visual: `App::press` arms it, runs the action in the same frame, and retires it if the action changed screens or launched a stream. A modal's fade drops a full-screen scrim over the pressed row within 75ms and replaces the tile that was dipping, so there was never anything to see there.
- Kept for buttons that stay put: in-stream confirmation dialogs, pairing's "request access", the speed test's retry, picking a host in the sidebar.
- `press_screen` is gone. The dip now only ever belongs to the screen that is up, since leaving a screen drops it.
- `poll_press` no longer runs deferred actions, it just retires the landed dip.