### PR TITLE
Give NDL an audio plane on every load so it paces the picture

### DIFF
--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -127,92 +127,71 @@ The host stamps `pts_ns` on every audio datagram; this client decoded it and thr
 - ⚠ **Use `frame.pts_ns`, never the paced value.** Both are in scope at the submit site with near-identical names; the paced one has been mapped into NDL's *player* clock by `HostPtsAnchor`. Using it regulates against a fiction that still looks plausible.
 - The estimator's unit tests ship in-tree but **cannot run off-device**: `cargo test` links the whole binary and `-lNDL_directmedia` exists only in the cross sysroot.
 
-## Opus offload to NDL (OPT-IN, working on CX)
+## NDL's audio plane: why every load has one
 
-NDL is the sole video backend. Audio is either software Opus→SDL or, when NDL accepts an
-audio-enabled load, decoded by NDL itself. **Software Opus is the default**; the offload is
-opt-in per `Settings::ndl_audio_offload` while it is being proven on more models.
+⚠ **NDL only paces the picture when its audio plane is fed.** On a video-only load it ignores
+`pauseAtDecodeTime` entirely and presents at feed cadence, which beats against a 120 Hz panel —
+the long-standing "smooth at 1080p, randomly smooth above it" stutter. Measured on a CX: frames
+stamped ~60 ms ahead of the player clock still left `render_buffer_length` at 0-1 and still
+stuttered, and the same session with the audio plane fed was smooth.
 
-**Software Opus is not a legacy path and must stay wired.** It is the correct outcome on five
-routes: NDL v1 (`NDL_DirectAudio*` has no Opus source type), SMP (loads `needAudio: false`),
-non-stereo layouts (NDL's Opus struct has no multistream mapping field), an audio-enabled load
-NDL rejects, and the default state of Experimental → "Hardware audio decode"
-(`Settings::ndl_audio_offload`). The last exists because a TV can accept the offloaded load and
-then play nothing, which no runtime probe can detect. `Connected::audio_channels()` returns `None` only when offload actually took the
-stream, so every other route opens the SDL device and spawns `audio_feed_pump` as before. The
-session log names the route it took and why; the stats overlay leads its audio line with
-`Audio HW · NDL Opus` or `Audio SW · buf … · A/V …`.
+So **every accepted V2 load asks for a stereo audio plane**, and what rides it is a separate
+question:
 
-The load wiring is byte-exact with `mariotaku/ss4s` `ndl/webos5`: `NdlAudioConfig.sample_rate`
-in **kHz** (`48.0`, not `48000.0`), the stereo `opus_empty_frame_211 = {0xec,0xff,0xfe}` decoder
-prime, and combined audio+video in one load. Struct layouts
-(`NDL_DIRECTMEDIA_AUDIO_OPUS_INFO_T`, `..._DATA_INFO_T`) match `webosbrew/webos-userland`
-field-for-field, including the explicit trailing `_padding` — the whole struct is memcpy'd into a
-fixed-size union arm, so **any implicit padding in a `repr(C)` struct handed to NDL is
-uninitialized stack on the wire**.
+- **Hardware Opus decode** (Experimental → "Audio offload", opt-in) — `session::ndl_audio_pump`
+  feeds the real stream, stamped on the video timeline; no SDL device is opened.
+- **The clock plane** (default, and the only option for 5.1/7.1) — `NdlVideo::run_clock_plane`
+  feeds a silent Opus metronome stamped in NDL's own player-clock domain, while
+  `platform::webos::audio` decodes the real audio to SDL as before. Confirmed at 4K120 5.1.
 
-⚠ **The prime is what completes the load, and it was missing for months.** An audio-enabled load
-does not report `LOADCOMPLETED` until its audio plane has actually received a packet — but the
-pumps that would send one don't spawn until `session::connect` returns, which is after the load
-wait. The load waited on data the session refused to send until the load completed, and the
-result was a whole session of black picture with working sound, no error anywhere. So
-`NdlVideo::prime_audio` feeds bursts of empty frames (stamps from 0, 5 ms apart) through the
-load window itself. On a CX that turns "never" into `LOADCOMPLETED` in ~41 ms. The prime's
-highest stamp seeds `last_audio_pts_ms`, so the host's first real packets are floored rather
-than read as a rewind (see the LATCHED-offset warning below — a rewind mutes the session).
-Full history in `docs/HANDOVER-NDL-OPUS-OFFLOAD.md`.
+A set that refuses the audio-enabled load falls back to video-only inside `NdlVideo::load` and
+gives up pacing with it; the session log names which of the routes it took. **NDL v1 and SMP have
+no Opus audio type at all**, so webOS 4 has no pacing reference — the lever there would be gating
+frame release at feed time, which is not built.
 
-The corollary is that **`LOADCOMPLETED` is reliable** and can gate things. The earlier claim in
-these notes and in `ndl/v2.rs` that it "lands anywhere from 4s to never" was this bug, not the
-callback: a video-only load confirms in well under a second, every time, with nothing fed.
+Blind alleys, measured and ruled out, so they are not re-tried: NDL's standing cushion depth
+(`render_buffer_length` is 0-1 in smooth AND stuttery sessions), feed lateness (45-60 ms of slack
+either way), software Opus decode cost (5% of a core, `dropped=0`), and HDR mode re-entry (which
+is a real bug, fixed below, but not this one).
 
-**What was wrong, and what "full ss4s parity" hid.** The path held the first video frame forever
-on the tested G5 (webOS 10.3) despite that parity, because the parity was on the *load* and not on
-the *stamping*. ss4s feeds both planes feed-time PTS; this client does not — video goes in on
-host-capture PTS mapped onto NDL's player clock (`HostPtsAnchor`) and smoothed by `PtsPacer`,
-while `play_audio` kept ss4s's arrival wall-clock. NDL's own A/V synchroniser was therefore
-regulating two unrelated timelines against each other, and held the picture waiting for an audio
-clock that was never going to line up.
+### Wiring the plane
 
-**Fix**: one timeline for both planes. `session::sink` hands the frame's host-PTS →
-player-clock offset (`base_ns - frame.pts_ns`, the *unpaced* reference — the pacer's ±half-frame
-smoothing is video-only) to `NdlVideo::latch_pts_offset`; `play_audio` stamps
-`packet.pts_ns + offset`. Audio arriving before the first video frame has no timeline to join and
-is dropped (bounded, ~startup only) rather than fed at a stamp that would jump.
+Byte-exact with `mariotaku/ss4s` `ndl/webos5`: `NdlAudioConfig.sample_rate` in **kHz** (`48.0`,
+not `48000.0`), the stereo `opus_empty_frame_211 = {0xec,0xff,0xfe}` decoder prime, and combined
+audio+video in one load. Struct layouts (`NDL_DIRECTMEDIA_AUDIO_OPUS_INFO_T`, `..._DATA_INFO_T`)
+match `webosbrew/webos-userland` field-for-field, including the explicit trailing `_padding` — the
+whole struct is memcpy'd into a fixed-size union arm, so **any implicit padding in a `repr(C)`
+struct handed to NDL is uninitialized stack on the wire**.
+
+⚠ **The prime is what completes the load.** An audio-enabled load does not report `LOADCOMPLETED`
+until its audio plane has received a packet — but the pumps that would send one don't spawn until
+`session::connect` returns, which is after the load wait. That deadlock read as a whole session of
+black picture with working sound, no error anywhere. `NdlVideo::prime_audio` feeds bursts of empty
+frames through the load window itself; on a CX that turns "never" into `LOADCOMPLETED` in ~40 ms.
+The prime's highest stamp seeds `last_audio_pts_ms`, so the first real packets are floored rather
+than read as a rewind. The corollary: **`LOADCOMPLETED` is reliable** and can gate things — the
+earlier claim that it "lands anywhere from 4s to never" was this bug.
 
 ⚠ **Never flush a pipeline that has not finished loading — it kills audio for the session.**
-This was the cause of "video fine, audio silent", and it took four device rounds to find because
-every symptom pointed at timestamps. `NDL_DirectVideoFlushRenderBuffer` issued before
-`LOADCOMPLETED` takes the audio plane out permanently; video recovers and gives no sign. The sink
-used to reach it through its ordinary decode-error path, and frame 0 is refused
-(`NDL pipeline not loaded yet`) on any session where `LOADCOMPLETED` is late — which, before the
-prime above, was every offloaded session on a CX. `ensure_loaded` now returns a typed
-`ndl::NotLoadedYet` and `sink::submit` holds + requests a keyframe **without** flushing. Nothing
-is queued in NDL at that point anyway, so the flush was never doing work.
+`NDL_DirectVideoFlushRenderBuffer` before `LOADCOMPLETED` takes the audio plane out permanently;
+video recovers and gives no sign. `ensure_loaded` returns a typed `ndl::NotLoadedYet` and
+`sink::submit` holds + requests a keyframe **without** flushing. Nothing is queued at that point
+anyway, so the flush was never doing work. `NDL_DirectAudioPlay` returns 0 either way — there is
+no error to find on the audio side, so do not go looking for one.
 
-The tell in the logs: every silent session had `NDL error (frame 0 …): NDL pipeline not loaded
-yet` and the one session with sound did not. `NDL_DirectAudioPlay` returns 0 either way, so
-there is no error to find on the audio side — do not go looking for one.
+⚠ **Audio stamps must never go backwards — NDL reads a rewind as a mute for the rest of the
+session**, and does not resync. `NdlVideo::feed_audio` is the single feed point for both riders
+and floors every stamp at the previous one. For hardware decode the offset is additionally
+**latched, not recomputed per frame**: a receive-backlog flush jumps host PTS forward while the
+player clock does not, and a re-derived offset would drag the audio stamp backwards by the size of
+the jump. `latch_pts_offset` takes only the first value after each `clear_pts_offset` (hold
+resume, pacing off→on edge), and only off a frame NDL **accepted** — `play_audio` has no
+`ensure_loaded` guard of its own, so the latch doubles as the audio thread's start gate.
 
-⚠ **Latch the offset only off a frame NDL ACCEPTED.** `play_audio` has no `ensure_loaded` guard
-of its own, so the latch doubles as the audio thread's start gate. Correct on its own merits,
-but note it did NOT fix the silence by itself — the flush above did.
-
-⚠ **The offset is LATCHED, not recomputed per frame** — that distinction cost a second device
-round. Republishing it every frame looks self-correcting and is not: a receive-backlog flush that
-jumps to live drops frames, so host PTS leaps forward while the player clock does not, and the
-re-derived offset drags the audio stamp *backwards* by the size of the jump. **NDL reads a
-backwards audio timestamp as a rewind and mutes for the rest of the session** — it does not
-resync. Observed on CX: audio present in a session with no flush, gone in one with
-`receive backlog stopped draining — jumped to live … dropped_frames=37`. So `latch_pts_offset`
-takes only the first value after each `clear_pts_offset` (the sink's own anchor resets: hold
-resume, pacing off→on edge), and `play_audio` additionally floors every stamp at the previous
-one. Both guards are needed — the floor alone would leave audio stalled at a flat timestamp.
-
-⚠ The audio-enabled load returns success even on a TV that then dies silently, so **no runtime
-probe can distinguish the two** — if a model regresses, the `NDL load state:`
-(`LOADCOMPLETED`/`PLAYING`) log is the signal for whether the present pipeline ever starts, and
-turning Experimental → "Hardware audio decode" back off is the way out.
+⚠ The audio-enabled load returns success even on a TV that then plays nothing, so **no runtime
+probe can distinguish the two**. If a model regresses, the `NDL load state:`
+(`LOADCOMPLETED`/`PLAYING`) log says whether the pipeline ever started, and turning Experimental →
+"Audio offload" off is the way out of the hardware-decode half.
 
 ## ABR startup probe: 2 Gbps, upstream-hardcoded
 

--- a/src/app/view/experimental.rs
+++ b/src/app/view/experimental.rs
@@ -36,13 +36,13 @@ pub fn rows(settings: &Settings, rooted: bool) -> Vec<FocusRow> {
     rows.push(
         FocusRow::toggle(
             crate::app::view::icons::ICON_MEMORY,
-            "Hardware audio decode",
+            "Audio offload",
             settings.ndl_audio_offload,
         )
         .with_subtext(ui::widgets::RowSubtext::hint(if settings.ndl_audio_offload {
-            "Opus decoded by NDL"
+            "Turn off for decoding Opus in software"
         } else {
-            "Opus on the CPU — turn on to let NDL decode it"
+            "Offload Opus decode to NDL"
         })),
     );
     // Driving the TV's Game picture/sound modes needs the Homebrew Channel's root helper — the

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -243,15 +243,16 @@ pub struct Settings {
     /// stream start (SDR "game" / HDR "hdrGame" per the negotiated colour path) and reverted
     /// on stream exit.
     pub game_mode: bool,
-    /// Ask NDL to decode Opus itself instead of running the software decoder
-    /// (`session::ndl_audio_config`). Takes effect on the next stream.
+    /// Whether the real Opus stream rides NDL's audio plane (hardware decode) instead of the
+    /// software decoder. Takes effect on the next stream.
     ///
-    /// **Off by default, and opt-in for now.** The audio-enabled load is rejected on at least
-    /// some webOS 5+ sets (an OLED65CX): `NDL_DirectMediaLoad` returns 0 but the pipeline never
-    /// reports `LOADCOMPLETED`, and while the audio plane does play, the video plane never
-    /// starts — an entire session of black picture with sound. Until that is understood, the
-    /// software path is the one that always works, so it is the default and this row is the
-    /// escape hatch rather than the other way round.
+    /// **This does not decide whether the plane exists** — every accepted V2 load has one, since
+    /// NDL only paces the picture against a fed plane. Off, it carries `run_clock_plane`'s silent
+    /// metronome and software decode serves the speakers.
+    ///
+    /// Off by default: the audio-enabled load is rejected on some webOS 5+ sets, and a set that
+    /// accepts it can still play nothing, which no runtime probe detects. 5.1/7.1 stay on the
+    /// software decoder regardless — NDL's Opus struct has no multistream mapping field.
     pub ndl_audio_offload: bool,
     /// Resolve the Magic Remote's OK button into left click / right click / drag by how long
     /// it's held (see `platform::webos::mouse::RemoteButtons`). Off by default — with it

--- a/src/platform/webos/audio.rs
+++ b/src/platform/webos/audio.rs
@@ -216,9 +216,14 @@ impl AudioFeed {
         // empty input) interpolates a frame; the alternative is a hard gap, i.e. a click.
         for _ in 0..self.gaps.missing_before(seq) {
             let mut pcm = [0f32; SAMPLES_PER_FRAME * MAX_CHANNELS];
+            // One frame, not the whole scratch buffer: with no packet to describe it, libopus
+            // takes `out.len() / channels` as the frame size and rejects one that isn't legal —
+            // 5.1 gives 1920/6 = 320. A decode WITH a packet tolerates the oversized buffer,
+            // which is why only concealment failed.
+            let out = &mut pcm[..SAMPLES_PER_FRAME * self.channels];
             let n = self
                 .decoder
-                .decode_float(&[], &mut pcm, false)
+                .decode_float(&[], out, false)
                 .map_err(|e| anyhow::anyhow!("opus PLC decode: {e}"))?;
             self.push(&pcm[..n * self.channels]);
         }

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -95,7 +95,9 @@ pub struct NdlVideo {
     /// `wait_load_completed` blocked. Only [`FEED_ANYWAY_AFTER`] is measured from it; the PTS
     /// domain stays on `load_instant`.
     load_requested: Instant,
-    audio_offloaded: bool,
+    /// Whether the load asked for — and confirmed — an audio plane. What RIDES that plane (the
+    /// real Opus stream, or [`Self::play_silence`]'s metronome) is the caller's choice.
+    has_audio_plane: bool,
     /// Host-PTS → NDL-player-clock offset in ns, republished by the video plane on every fed
     /// frame (`session::sink`) and read by [`Self::play_audio`] so both planes land in ONE
     /// timeline. [`NO_PTS_OFFSET`] until the first frame is fed.
@@ -174,7 +176,7 @@ impl NdlVideo {
         fns: &'static ffi::V2,
         video: ffi::VideoInfo,
         audio: ffi::AudioUnion,
-        audio_offloaded: bool,
+        with_audio: bool,
     ) -> Result<Self> {
         let mut info = ffi::DataInfo { video, audio };
         arm_load();
@@ -187,7 +189,7 @@ impl NdlVideo {
         // `ret == 0` is "request accepted", not "pipeline ready" — the first feed still needs
         // LOADCOMPLETED, and an audio-enabled load will not report it until its audio plane has
         // seen a packet, which is what the prime supplies.
-        let (primed_pts_ms, confirmed) = if audio_offloaded {
+        let (primed_pts_ms, confirmed) = if with_audio {
             Self::prime_audio(fns)
         } else {
             (0, wait_load_completed())
@@ -196,7 +198,7 @@ impl NdlVideo {
             fns,
             load_instant: Instant::now(),
             load_requested,
-            audio_offloaded,
+            has_audio_plane: with_audio,
             pts_offset_ns: AtomicI64::new(NO_PTS_OFFSET),
             last_audio_pts_ms: AtomicI64::new(primed_pts_ms),
             load_confirmed: AtomicBool::new(confirmed),
@@ -231,8 +233,9 @@ impl NdlVideo {
                 );
                 return (pts_ms, false);
             }
-            // Stamps track wall-clock, PRIME_LEAD packets ahead. A fixed count per gap advances
-            // them at ~2x real time, and this ceiling is the floor real audio is pinned to.
+            // Stamps track wall-clock, topped up to PRIME_LEAD packets ahead of it — so the burst
+            // per gap is however many 5 ms packets that gap consumed, and the ceiling stays a
+            // fixed lead over real time. That ceiling is the floor real audio is pinned to.
             let target_ms = start.elapsed().as_millis() as i64 + PRIME_LEAD * PRIME_PACKET_MS;
             {
                 let _ffi = lock_ffi();
@@ -264,10 +267,11 @@ impl NdlVideo {
         (pts_ms, true)
     }
 
-    /// Whether NDL accepted the Opus config and is decoding audio itself — if false the
-    /// caller must run the software Opus path.
-    pub fn audio_offloaded(&self) -> bool {
-        self.audio_offloaded
+    /// Whether this load has an audio plane. It always does when the load confirmed, since NDL
+    /// only paces the picture against a fed audio plane — see [`Self::play_silence`]. False means
+    /// the audio-enabled load was rejected and `load()` fell back to video-only.
+    pub fn has_audio_plane(&self) -> bool {
+        self.has_audio_plane
     }
 
     /// Latch the video plane's host-PTS → player-clock offset so [`play_audio`](Self::play_audio)
@@ -299,13 +303,13 @@ impl NdlVideo {
         self.pts_offset_ns.store(NO_PTS_OFFSET, Ordering::Relaxed);
     }
 
-    /// Feed one Opus packet to NDL (only when `audio_offloaded`). `host_pts_ns` is the packet's
-    /// own host capture timestamp, NOT arrival time.
+    /// Feed one Opus packet to NDL (only when the real stream rides the plane). `host_pts_ns` is
+    /// the packet's own host capture timestamp, NOT arrival time.
     ///
     /// **Both planes must be stamped in one time base** — NDL runs its own A/V synchronisation
     /// against these values, and regulating a video plane on host-capture cadence against an audio
-    /// plane on arrival wall-clock is what froze the picture on webOS 10.3 (docs/NOTES.md § "Opus
-    /// offload to NDL"). So the host PTS goes through the video plane's own offset
+    /// plane on arrival wall-clock is what froze the picture on webOS 10.3 (docs/NOTES.md § "NDL's
+    /// audio plane"). So the host PTS goes through the video plane's own offset
     /// ([`latch_pts_offset`](Self::latch_pts_offset)).
     ///
     /// Returns `Ok(())` having fed nothing while no offset is latched: audio before the first
@@ -321,14 +325,58 @@ impl NdlVideo {
             return Ok(());
         }
         let raw_ms = (host_pts_ns as i64).saturating_add(offset_ns).max(0) / 1_000_000;
-        let pts_ms = self.last_audio_pts_ms.fetch_max(raw_ms, Ordering::Relaxed).max(raw_ms) as c_longlong;
+        self.feed_audio(packet, raw_ms)
+    }
+
+    /// The audio plane's only feed point. The monotonic floor is load-bearing: NDL reads a
+    /// backwards stamp as a rewind and mutes for the rest of the session, and both callers can
+    /// produce one (a receive-backlog jump; the prime's ceiling).
+    fn feed_audio(&self, data: &[u8], pts_ms: i64) -> Result<()> {
+        let pts_ms = self.last_audio_pts_ms.fetch_max(pts_ms, Ordering::Relaxed).max(pts_ms) as c_longlong;
         let _ffi = lock_ffi();
         // SAFETY: NDL reads `size` bytes synchronously and does not retain the pointer.
-        let ret = unsafe { (self.fns.audio_play)(packet.as_ptr() as *mut c_void, packet.len() as c_uint, pts_ms) };
+        let ret = unsafe { (self.fns.audio_play)(data.as_ptr() as *mut c_void, data.len() as c_uint, pts_ms) };
         if ret != 0 {
             bail!("NDL_DirectAudioPlay failed: ret={ret} error={}", ffi::last_error());
         }
         Ok(())
+    }
+
+    /// One silent frame for the clock plane. Stamped in the player-clock domain and not through
+    /// `pts_offset_ns`: this plane is a metronome, not content, so it has no host timeline to
+    /// join. Why it exists at all: docs/NOTES.md § "NDL's audio plane".
+    fn play_silence(&self, pts_ms: i64) -> Result<()> {
+        self.feed_audio(&OPUS_SILENCE, pts_ms)
+    }
+
+    /// Run the clock plane until `stop`, for a session whose real audio is decoded in software.
+    /// Blocks, so the caller gives it a thread.
+    ///
+    /// Same burst shape as [`Self::prime_audio`], topped up to `PRIME_LEAD` packets ahead so the
+    /// plane stays fed. Bursting keeps it to ~50 wakeups/s instead of 200, on a `SoC` whose video
+    /// feed shares `lock_ffi` with it.
+    pub fn run_clock_plane(&self, stop: &std::sync::atomic::AtomicBool) {
+        // Continue the prime's stamps instead of restarting from the player clock: the prime runs
+        // BEFORE `load_instant`, so its ceiling already sits a whole prime ahead, and targeting the
+        // raw clock would feed nothing until it caught up — dead exactly at session start. The
+        // resulting constant offset from the video timeline costs a metronome nothing.
+        let base_ms = self.last_audio_pts_ms.load(Ordering::Relaxed);
+        let mut pts_ms = base_ms;
+        while !stop.load(Ordering::Relaxed) {
+            let elapsed_ms = (self.elapsed_ns() / 1_000_000) as i64;
+            let target_ms = base_ms + elapsed_ms + PRIME_LEAD * PRIME_PACKET_MS;
+            while pts_ms < target_ms {
+                pts_ms += PRIME_PACKET_MS;
+                if let Err(e) = self.play_silence(pts_ms) {
+                    // Dead for the session; the picture keeps running unpaced, as it did before
+                    // the clock plane existed.
+                    tracing::warn!("NDL clock plane stopping at {pts_ms}ms: {e:#}");
+                    return;
+                }
+            }
+            std::thread::sleep(PRIME_RETRY);
+        }
+        tracing::info!("NDL clock plane ending at {pts_ms}ms");
     }
 
     /// Nanoseconds since `load()` (NDL PTS domain). `video_pump`'s pacer clamps its accumulator around this.

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -37,9 +37,12 @@ pub struct Connected {
     pub stats: Arc<StreamStats>,
     /// Kept alive so `shutdown()` can join and ensure QUIC close frame is sent before exit.
     video_thread: std::thread::JoinHandle<()>,
-    /// Dedicated NDL audio-drain thread (present only when `audio_offloaded`).
+    /// The NDL audio plane's pump, on every V2 load that got a plane: `ndl_audio_pump` when the
+    /// real stream rides it (`audio_offloaded`), `NdlVideo::run_clock_plane`'s metronome otherwise.
+    /// `None` only when the load has no audio plane at all (V1, SMP, or a rejected audio load).
     audio_thread: Option<std::thread::JoinHandle<()>>,
-    /// True when NDL accepted Opus config; prevents opening SDL2 audio device.
+    /// True when the REAL Opus stream rides NDL's audio plane; prevents opening the SDL2 audio
+    /// device. False on a clock-plane session, which still has a plane but decodes in software.
     pub audio_offloaded: bool,
     /// Whether HDR mastering metadata is being applied this session (negotiated codec is
     /// HEVC *and* the host signalled HDR). Drives which Game picture mode the runtime asks
@@ -185,31 +188,6 @@ impl Connected {
         );
         clean
     }
-}
-
-/// Whether NDL should decode Opus itself, and with what configuration — `None` puts the session
-/// on the software decoder (`platform::webos::audio`).
-///
-/// Software decode is the default, and hardware offload is **opt-in** (`offload`, the
-/// Experimental screen's "Hardware audio decode"). The audio-enabled load is rejected on at least
-/// some webOS 5+ sets — `NDL_DirectMediaLoad` returns 0, `LOADCOMPLETED` never arrives, the audio
-/// plane plays and the video plane never starts, so the session is black with sound. Until that is
-/// understood the offload cannot be the default, whatever it saves.
-///
-/// Software decode is also the only answer on three routes this function never sees — NDL v1 (no
-/// Opus audio type), SMP (loads video-only), and an audio-enabled load NDL refuses outright.
-/// **Stereo only**: NDL's struct has no multistream mapping field, so 5.1/7.1 would decode as
-/// noise.
-fn ndl_audio_config(resolved_channels: u8, offload: bool) -> Option<crate::platform::webos::ndl::NdlAudioConfig> {
-    if !offload {
-        return None;
-    }
-    (resolved_channels == 2).then_some(crate::platform::webos::ndl::NdlAudioConfig {
-        channels: 2,
-        // kHz, not Hz — NDL's own unit, and what ss4s passes (`info->sampleRate / 1000.0`).
-        // punktfunk's audio plane is fixed at 48 kHz (see `audio.rs`'s SAMPLE_RATE).
-        sample_rate: 48.0,
-    })
 }
 
 /// Default HDR10 mastering metadata for the LG CX OLED panel.
@@ -391,7 +369,17 @@ pub fn connect(
         height,
         fps,
         codec,
-        ndl_audio_config(client.audio_channels, ndl_audio_offload),
+        // Every V2 load asks for a plane: a fed one is what makes NDL pace the picture at all
+        // (docs/NOTES.md § "NDL's audio plane"). What rides it is decided below, at the pump.
+        // Stereo either way — the silent frame's TOC declares stereo, and a software-decode
+        // session's plane never sees the real stream. A set that refuses the load falls back to
+        // video-only in `NdlVideo::load`, and gives up pacing with it.
+        Some(crate::platform::webos::ndl::NdlAudioConfig {
+            channels: 2,
+            // kHz, not Hz — NDL's own unit, and what ss4s passes (`info->sampleRate / 1000.0`).
+            // punktfunk's audio plane is fixed at 48 kHz (see `audio.rs`'s SAMPLE_RATE).
+            sample_rate: 48.0,
+        }),
     )?;
     tracing::info!(
         "{} loaded ({codec:?} {}x{}@{fps}fps)",
@@ -426,18 +414,24 @@ pub fn connect(
     }
 
     let ndl_audio = player.ndl_audio_handle();
+    // Whether the REAL stream rides the plane. `ndl_audio.is_some()` is a different question —
+    // it only says the load HAS a plane, which every accepted V2 load does now.
+    let audio_offloaded = ndl_audio.is_some() && ndl_audio_offload && client.audio_channels == 2;
+
     // Naming the REASON matters: "software Opus" is the correct outcome on four different
     // routes plus the user's own override, and a silent session looks identical on all of
     // them. Without this the first debugging question has no answer in the log.
-    let path = match (&ndl_audio, ndl_audio_offload, &player) {
-        (Some(_), _, _) => "NDL hardware Opus decode",
-        (None, false, _) => "software Opus decode -> SDL2 (default; Experimental setting opts in)",
-        (None, _, VideoPlayer::V1(_)) => "software Opus decode -> SDL2 (NDL v1 has no Opus audio type)",
-        (None, _, VideoPlayer::Smp(_)) => "software Opus decode -> SDL2 (SMP loads video-only)",
-        (None, _, VideoPlayer::V2(_)) if client.audio_channels != 2 => {
-            "software Opus decode -> SDL2 (NDL Opus is stereo-only)"
-        }
-        (None, _, VideoPlayer::V2(_)) => "software Opus decode -> SDL2 (NDL rejected the audio-enabled load)",
+    let path = match (&ndl_audio, &player) {
+        _ if audio_offloaded => "NDL hardware Opus decode",
+        // A plane the real stream is not using is the pacing metronome — see
+        // `NdlVideo::run_clock_plane`.
+        (Some(_), _) if !ndl_audio_offload => "software Opus decode -> SDL2 + NDL clock plane (offload not opted in)",
+        (Some(_), _) => "software Opus decode -> SDL2 + NDL clock plane (NDL Opus is stereo-only)",
+        (None, VideoPlayer::V1(_)) => "software Opus decode -> SDL2, no clock plane (NDL v1 has no Opus audio type)",
+        (None, VideoPlayer::Smp(_)) => "software Opus decode -> SDL2, no clock plane (SMP loads video-only)",
+        // No plane on a V2 load means the audio-enabled attempt did not confirm and `load()` fell
+        // back to video-only, so this session has no pacing reference either.
+        (None, VideoPlayer::V2(_)) => "software Opus decode -> SDL2, no clock plane (NDL rejected the audio load)",
     };
     tracing::info!(
         "audio path: {path} (host resolved {} channel(s))",
@@ -466,9 +460,8 @@ pub fn connect(
             video_pump(video_client, sink, video_stop, video_stats, is_hdr)
         })
         .context("spawn video thread")?;
-    let audio_offloaded = ndl_audio.is_some();
-    let audio_thread = match ndl_audio {
-        Some(ndl) => {
+    let audio_thread = match (ndl_audio, audio_offloaded) {
+        (Some(ndl), true) => {
             let audio_client = client.clone();
             let audio_stop = stop.clone();
             Some(
@@ -478,7 +471,19 @@ pub fn connect(
                     .context("spawn audio thread")?,
             )
         }
-        None => None,
+        // Software decode owns the speakers, so this plane is a metronome. Nothing is consumed
+        // twice: the real packets still go to `audio_feed_pump`, and this pump generates its own
+        // cadence off the player clock.
+        (Some(ndl), false) => {
+            let clock_stop = stop.clone();
+            Some(
+                std::thread::Builder::new()
+                    .name("punktfunk-webos-clock".into())
+                    .spawn(move || ndl.run_clock_plane(&clock_stop))
+                    .context("spawn clock plane thread")?,
+            )
+        }
+        (None, _) => None,
     };
 
     Ok(Connected {

--- a/src/session/sink.rs
+++ b/src/session/sink.rs
@@ -205,9 +205,11 @@ impl VideoPlayer {
     /// `base_ns` is the *unpaced* reference — the pacer's ±half-frame smoothing is video-only
     /// jitter compensation and must not be projected onto the audio timeline.
     ///
-    /// V2 only, and only when audio is offloaded; no other backend feeds audio through NDL.
+    /// V2 only, and only when the load has an audio plane; no other backend feeds audio through
+    /// NDL. Harmless on a clock-plane session — nothing reads the offset there, since
+    /// `run_clock_plane` stamps in the player clock directly.
     fn latch_pts_offset(&self, frame_pts_ns: u64, base_ns: u64) {
-        if let Some(ndl) = self.offloaded_ndl() {
+        if let Some(ndl) = self.audio_plane_ndl() {
             ndl.latch_pts_offset(base_ns as i64 - frame_pts_ns as i64);
         }
     }
@@ -215,16 +217,16 @@ impl VideoPlayer {
     /// Decouple the audio plane from a timeline that no longer holds — the anchor it was
     /// derived from is being reset. Audio holds until the next fed frame republishes.
     fn clear_pts_offset(&self) {
-        if let Some(ndl) = self.offloaded_ndl() {
+        if let Some(ndl) = self.audio_plane_ndl() {
             ndl.clear_pts_offset();
         }
     }
 
-    /// The NDL handle the audio plane shares, or `None` on every backend/load that decodes Opus
-    /// in software — the gate both offset calls above answer to.
-    fn offloaded_ndl(&self) -> Option<&NdlVideo> {
+    /// The NDL handle the audio plane shares, or `None` on every backend/load without one — the
+    /// gate both offset calls above answer to.
+    fn audio_plane_ndl(&self) -> Option<&NdlVideo> {
         match self {
-            Self::V2(ndl) => ndl.audio_offloaded().then(|| ndl.as_ref()),
+            Self::V2(ndl) => ndl.has_audio_plane().then(|| ndl.as_ref()),
             Self::V1(_) | Self::Smp(_) => None,
         }
     }
@@ -247,11 +249,12 @@ impl VideoPlayer {
         }
     }
 
-    /// Shared NDL handle when audio-offloaded; None on a video-only load or any other backend.
+    /// Shared NDL handle when the load has an audio plane; None on a video-only load (the
+    /// audio-enabled one was rejected) or any other backend.
     /// V2 only: V1's `NDL_DirectAudio*` has no Opus source type, and SMP loads `needAudio: false`.
     pub fn ndl_audio_handle(&self) -> Option<Arc<NdlVideo>> {
         match self {
-            Self::V2(ndl) => ndl.audio_offloaded().then(|| ndl.clone()),
+            Self::V2(ndl) => ndl.has_audio_plane().then(|| ndl.clone()),
             Self::V1(_) | Self::Smp(_) => None,
         }
     }


### PR DESCRIPTION
NDL only paces the picture when its audio plane is fed. On a video-only load it ignores `pauseAtDecodeTime` and presents at feed cadence, which beats against a 120Hz panel — invisible at 1080p60, where the interval is twice as long. That's the stutter above 1080p120, and it's why the hardware Opus offload appeared to fix it: not because it moved decoding off the CPU, but because it happened to feed the plane.

What settled it: frames stamped ~60ms ahead of the player clock still left `render_buffer_length` at 0-1 and still stuttered; the same session with the plane fed was smooth.

Every accepted V2 load now asks for a stereo plane. Hardware decode rides it when opted in (unchanged, still off by default); otherwise `NdlVideo::run_clock_plane` feeds a silent metronome while software decode serves the speakers. Covers 5.1/7.1, which can never offload. Doesn't cover NDL v1 or SMP — no Opus audio type — so webOS 4 still has no pacing reference.

Also:

- 5.1 loss concealment failed on every concealed packet: with no packet to describe the frame, libopus takes the size from `out.len() / channels`, and the full scratch buffer gives an illegal 320.
- `audio_offloaded()` → `has_audio_plane()`, which is what it means now; session's `audio_offloaded` keeps the old meaning.
- `play_audio` and `play_silence` share one `feed_audio`, so the monotonic stamp floor (a backwards stamp mutes NDL for the session) lives in one place.
- NOTES.md rewritten around the root cause, listing the ruled-out theories: cushion depth, feed lateness, decode cost, HDR re-entry.

Tested on a CX at 4K120 5.1 and 1440p120. Worth more launches — this failure has been per-session random throughout.