### PR TITLE
Per-game settings overrides

### DIFF
--- a/packaging/description.html
+++ b/packaging/description.html
@@ -12,12 +12,26 @@
   </p>
 
   <ul style="padding-left: 1.2em; margin: 0 0 20px;">
-    <li style="margin-bottom: 6px;">Find hosts on your network automatically, or add one by IP; pair once with a PIN.</li>
-    <li style="margin-bottom: 6px;">Choose resolution (1080p/1440p/4K), frame rate, bitrate, and HDR.</li>
-    <li style="margin-bottom: 6px;">Browse the host's game library with cover art and launch straight into a game.</li>
-    <li style="margin-bottom: 6px;">Smooth hardware-accelerated video with low latency.</li>
-    <li style="margin-bottom: 6px;">Control it with the Magic Remote, a gamepad, keyboard, or mouse.</li>
+    <li style="margin-bottom: 6px;"><b>Up to 4K120 with HDR.</b> Hardware HEVC or H.264 decode straight on the TV's
+      media pipeline — no browser, no transcode in the middle.</li>
+    <li style="margin-bottom: 6px;"><b>Adaptive bitrate.</b> Leave it on Automatic and the stream tracks your link as
+      it changes, backing off on loss and climbing again when it clears — or pin it anywhere from 10 to 200 Mbps.</li>
+    <li style="margin-bottom: 6px;"><b>Per-game settings.</b> Hold a game's cover to give it its own resolution,
+      frame rate, bitrate, codec, HDR, audio or controller. Anything you don't set follows your global settings,
+      and a game reverts the moment you set a value back.</li>
+    <li style="margin-bottom: 6px;"><b>Your library, on the TV.</b> Games are listed with their cover art and launch
+      with one press; pin the ones you play to the top row.</li>
+    <li style="margin-bottom: 6px;"><b>Surround audio.</b> Stereo, 5.1 or 7.1, decoded client-side.</li>
+    <li style="margin-bottom: 6px;"><b>Every input the TV has.</b> Magic Remote pointer, gamepad (with DualSense
+      adaptive triggers), USB keyboard and mouse — with pointer capture for games and absolute pointing for the
+      desktop.</li>
+    <li style="margin-bottom: 6px;"><b>Set up once.</b> Hosts are found on your network automatically, paired with a
+      PIN, and can be woken from sleep over Wake-on-LAN when you pick them.</li>
   </ul>
+
+  <p style="margin: 0 0 12px;">
+    Works on webOS 5 and later, with a fallback decode path for webOS 3.5&ndash;4.x.
+  </p>
 
   <p style="margin: 0 0 12px;">
     Needs a <a href="https://git.unom.io/unom/punktfunk" style="color: #6c5bf3;">punktfunk</a> host

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -4,7 +4,7 @@
 //! *widgets*, not this app's menus.
 use crate::core::caps::video_caps;
 use crate::core::event::MenuEvent;
-use crate::services::store::{CodecPref, GamepadType, LogLevelOverride, Settings, VideoBackend};
+use crate::services::store::{CodecPref, GamepadType, LogLevelOverride, Settings, SettingsOverride, VideoBackend};
 use crate::ui::focus::Dir;
 
 /// This app's input vocabulary mapped onto `ui`'s spatial one. `ui` navigates by
@@ -82,6 +82,39 @@ pub const ROW_DIAGNOSTICS: usize = 10;
 /// `RowKind::Action` row costs nothing extra to render.
 pub const ROW_ABOUT: usize = 11;
 pub const SETTINGS_ROW_COUNT: usize = 12;
+/// The two Cursor toggles, as logical ids for [`override_is_set`] and friends. They are on no
+/// row list — both screens reach them through [`ROW_CURSOR`]'s sub-screen, which has its own
+/// `CURSOR_ROW_*` indices. Past [`SETTINGS_ROW_COUNT`] on purpose: these key dropdown and row
+/// tiles, so they must never shift the ones above them.
+pub const ROW_CURSOR_CAPTURE: usize = 12;
+pub const ROW_CURSOR_GESTURES: usize = 13;
+/// Not a setting — the action row at the foot of the *per-game* list only. It drops every
+/// override, putting the game back to what its screen inherits. The global list has no
+/// counterpart: there is nothing above it to fall back to.
+pub const ROW_RESET: usize = 14;
+
+/// Which rows a settings-shaped screen shows — the scope its screen carries (see
+/// [`crate::core::screen::Screen::Settings`]). Both scopes share every `ROW_*` index and
+/// therefore every mutator, dropdown list and lock in this module.
+pub use crate::core::screen::SettingsScope;
+
+/// The per-game list. No `ROW_VIDEO_BACKEND` (`caps::set_backend` is a process-global, so a
+/// per-game backend would need an apply/restore around every launch) and no links out — the
+/// Experimental and Diagnostics are device-wide, so neither they nor anything behind them
+/// appears. Cursor keeps its link row and its sub-screen, exactly as on the global list — it holds two
+/// toggles either way, and duplicating that layout only for this screen would make the same
+/// settings look like two different things. See `store::SettingsOverride`.
+const GAME_ROWS: [usize; 9] = [
+    ROW_RESOLUTION,
+    ROW_FRAMERATE,
+    ROW_BITRATE,
+    ROW_CODEC,
+    ROW_HDR,
+    ROW_AUDIO,
+    ROW_GAMEPAD,
+    ROW_CURSOR,
+    ROW_RESET,
+];
 
 /// Experimental modal row indices (see `app::view::experimental::rows`).
 pub const EXP_ROW_HW_AUDIO: usize = 0;
@@ -92,6 +125,16 @@ pub const EXP_ROW_GAME_MODE: usize = 1;
 pub const CURSOR_ROW_CAPTURE: usize = 0;
 pub const CURSOR_ROW_GESTURES: usize = 1;
 pub const CURSOR_ROW_COUNT: usize = 2;
+
+/// A Cursor sub-screen row's logical `ROW_*` id — what the per-game override table is keyed
+/// by. The sub-screen has its own dense indices, so this is the one place the two spaces meet.
+pub fn cursor_logical_row(cursor_row: usize) -> usize {
+    debug_assert!((CURSOR_ROW_CAPTURE..CURSOR_ROW_COUNT).contains(&cursor_row));
+    match cursor_row {
+        CURSOR_ROW_GESTURES => ROW_CURSOR_GESTURES,
+        _ => ROW_CURSOR_CAPTURE,
+    }
+}
 
 /// Diagnostics modal row indices (see `app::view::diagnostics::rows`). Log level keeps
 /// index 0 so its dropdown's `(Screen, row)` tile key stays stable.
@@ -161,18 +204,97 @@ pub(crate) fn row_lock(row: usize, settings: &Settings, detected: Option<Gamepad
 /// Logical `ROW_*` indices currently visible, in display order — the single source of truth
 /// every visibility-aware helper derives from. Settings-independent (see [`row_shown`]), so
 /// this mapping is fixed for the run.
-pub fn settings_visible_logical_rows() -> impl Iterator<Item = usize> {
-    (0..SETTINGS_ROW_COUNT).filter(|&row| row_shown(row))
+pub fn settings_visible_logical_rows(set: SettingsScope) -> impl Iterator<Item = usize> {
+    const GLOBAL_ROWS: [usize; SETTINGS_ROW_COUNT] = {
+        let mut rows = [0; SETTINGS_ROW_COUNT];
+        let mut i = 0;
+        while i < SETTINGS_ROW_COUNT {
+            rows[i] = i;
+            i += 1;
+        }
+        rows
+    };
+    let rows: &'static [usize] = match set {
+        SettingsScope::Global => &GLOBAL_ROWS,
+        SettingsScope::Game => &GAME_ROWS,
+    };
+    rows.iter().copied().filter(|&row| row_shown(row))
 }
 
 /// Live row count (vs. `SETTINGS_ROW_COUNT`, the maximum).
-pub fn settings_row_count() -> usize {
-    settings_visible_logical_rows().count()
+pub fn settings_row_count(set: SettingsScope) -> usize {
+    settings_visible_logical_rows(set).count()
 }
 
 /// On-screen row position -> logical `ROW_*` index, skipping past any hidden rows.
-pub fn settings_logical_row(display: usize) -> usize {
-    settings_visible_logical_rows().nth(display).unwrap_or(display)
+pub fn settings_logical_row(set: SettingsScope, display: usize) -> usize {
+    settings_visible_logical_rows(set).nth(display).unwrap_or(display)
+}
+
+/// Current value of `row` if it is a toggle — the start point the switch slide animates
+/// from. `None` for every other row kind.
+pub fn toggle_value(settings: &Settings, row: usize) -> Option<bool> {
+    match row {
+        ROW_HDR => Some(settings.hdr_enabled),
+        ROW_CURSOR_CAPTURE => Some(settings.cursor_capture),
+        ROW_CURSOR_GESTURES => Some(settings.cursor_gestures),
+        _ => None,
+    }
+}
+
+/// Whether `row` currently overrides the global value — what decides that the row gets a
+/// "use global" delete affordance.
+pub fn override_is_set(over: &SettingsOverride, row: usize) -> bool {
+    match row {
+        ROW_RESOLUTION => over.mode.is_some(),
+        ROW_FRAMERATE => over.refresh_hz.is_some(),
+        ROW_BITRATE => over.bitrate_kbps.is_some(),
+        ROW_HDR => over.hdr_enabled.is_some(),
+        ROW_CODEC => over.codec.is_some(),
+        ROW_AUDIO => over.audio_channels.is_some(),
+        ROW_GAMEPAD => over.gamepad_type.is_some(),
+        ROW_CURSOR_CAPTURE => over.cursor_capture.is_some(),
+        ROW_CURSOR_GESTURES => over.cursor_gestures.is_some(),
+        // The link row stands in for the two toggles behind it — without this a game whose
+        // only override is a cursor one shows a dot on its card and nothing on the list that
+        // says where it came from.
+        ROW_CURSOR => over.cursor_capture.is_some() || over.cursor_gestures.is_some(),
+        _ => false,
+    }
+}
+
+/// The row's override mark, for [`ui::widgets::FocusRow::mark`] — amber when this row
+/// differs from the global, nothing when it doesn't. The colour lives here rather than in
+/// `ui`, which knows only that some rows carry a mark.
+pub fn override_mark(over: &SettingsOverride, row: usize) -> Option<crate::ui::render::Color> {
+    override_is_set(over, row).then(|| crate::ui::style::theme().warning)
+}
+
+/// Records `row`'s value from `edited` — a scratch `Settings` one of the mutators above has
+/// just been run against. Only the edited row is captured, so touching Bitrate never silently
+/// pins Resolution to whatever the global happened to be.
+///
+/// `ROW_CODEC` is the one row that writes two fields: an H.264 pick forces HDR off (see
+/// [`apply_dropdown_choice`]), and that consequence has to be recorded or the merge would put
+/// the global's HDR back on top of a codec that can't carry it.
+pub fn override_capture(over: &mut SettingsOverride, row: usize, edited: &Settings) {
+    match row {
+        ROW_RESOLUTION => over.mode = Some((edited.width, edited.height)),
+        ROW_FRAMERATE => over.refresh_hz = Some(edited.refresh_hz),
+        ROW_BITRATE => over.bitrate_kbps = Some(edited.bitrate_kbps),
+        ROW_HDR => over.hdr_enabled = Some(edited.hdr_enabled),
+        ROW_CODEC => {
+            over.codec = Some(edited.codec);
+            if edited.codec == CodecPref::H264 {
+                over.hdr_enabled = Some(false);
+            }
+        }
+        ROW_AUDIO => over.audio_channels = Some(edited.audio_channels),
+        ROW_GAMEPAD => over.gamepad_type = Some(edited.gamepad_type),
+        ROW_CURSOR_CAPTURE => over.cursor_capture = Some(edited.cursor_capture),
+        ROW_CURSOR_GESTURES => over.cursor_gestures = Some(edited.cursor_gestures),
+        _ => {}
+    }
 }
 
 pub fn cycle_index(current: usize, len: usize, forward: bool) -> usize {
@@ -466,6 +588,14 @@ pub fn adjust_setting(settings: &mut Settings, row_index: usize, forward: bool, 
         }
         ROW_HDR => {
             settings.hdr_enabled = !settings.hdr_enabled;
+            true
+        }
+        ROW_CURSOR_CAPTURE => {
+            settings.cursor_capture = !settings.cursor_capture;
+            true
+        }
+        ROW_CURSOR_GESTURES => {
+            settings.cursor_gestures = !settings.cursor_gestures;
             true
         }
         row => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -222,6 +222,12 @@ pub struct App {
     pub(crate) launch_anim: Option<Instant>,
     pub(crate) launch_anim_idx: Option<usize>,
     pub settings: Settings,
+    /// What `Screen::GameSettings` is editing, `None` when it isn't up — see
+    /// `app::state::gamesettings`.
+    pub(crate) game_settings: Option<state::gamesettings::GameSettingsState>,
+    /// The submenu raised over a held grid card's title strip (Pin/Unpin + Settings), and
+    /// the only way to `Screen::GameSettings`. `None` when no card is held open.
+    pub card_menu: Option<state::cardmenu::CardMenu>,
     /// Persists settings off UI thread to avoid blocking.
     pub(crate) state_writer: store::StateWriter,
     /// The attached pad's type per `gamepad::detect_type`, refreshed on hotplug in
@@ -482,6 +488,7 @@ impl App {
             settings,
             known_hosts,
             selected_host,
+            version: _,
         } = loaded;
         let entries = known_entries(&known_hosts);
 
@@ -514,6 +521,8 @@ impl App {
             launch_anim: None,
             launch_anim_idx: None,
             settings,
+            game_settings: None,
+            card_menu: None,
             state_writer,
             detected_gamepad_type: None,
             settings_focused: 0,
@@ -617,28 +626,76 @@ impl App {
             .map(HostEntry::name)
     }
 
-    /// The settings rows, with the platform/hardware facts the view can't reach folded in.
+    /// Which row list the settings screen that is up shows — its own scope, and off it the
+    /// scope of the flow that is running. The Cursor sub-screen is reachable from either, so
+    /// there it comes from the scratch copy: `game_settings` is `Some` for exactly the
+    /// per-game flow, for as long as it lasts (`persist_game_settings` takes it on the way
+    /// out). `Global` is the answer everywhere else, where nothing reads it.
+    pub(crate) fn row_set(&self) -> menu::SettingsScope {
+        match self.screen {
+            Screen::Settings(set) => set,
+            _ if self.game_settings.is_some() => menu::SettingsScope::Game,
+            _ => menu::SettingsScope::Global,
+        }
+    }
+
+    /// The `Settings` the open settings screen is editing: the global document, or the
+    /// per-game scratch copy. One accessor so every mutator, lock check and dropdown lookup
+    /// in `menu` sees the same value the rows were built from.
+    pub(crate) fn settings_target(&self) -> &Settings {
+        match &self.game_settings {
+            Some(gs) => &gs.merged,
+            None => &self.settings,
+        }
+    }
+
+    pub(crate) fn settings_target_mut(&mut self) -> &mut Settings {
+        match &mut self.game_settings {
+            Some(gs) => &mut gs.merged,
+            None => &mut self.settings,
+        }
+    }
+
+    /// This game's overrides while the per-game screen is up — what decides which rows wear
+    /// a "use global" button. Empty everywhere else, so the global screen shows none.
+    pub(crate) fn editing_override(&self) -> store::SettingsOverride {
+        self.game_settings
+            .as_ref()
+            .map_or_else(store::SettingsOverride::default, |gs| gs.over)
+    }
+
+    /// The settings rows, with the platform/hardware facts the view can't reach folded in,
+    /// plus the override dot on every row this game differs from the global on.
     pub(crate) fn settings_rows(&self) -> Vec<ui::widgets::FocusRow> {
-        let effective = if self.settings.gamepad_type == store::GamepadType::Auto {
+        let set = self.row_set();
+        let settings = self.settings_target();
+        let effective = if settings.gamepad_type == store::GamepadType::Auto {
             self.detected_gamepad_type.unwrap_or_default()
         } else {
-            self.settings.gamepad_type
+            settings.gamepad_type
         };
         let dualsense_limited = effective.is_dualsense() && !crate::platform::webos::dualsense::hid_playstation_bound();
         let webos_major = crate::platform::webos::device::sdk_version().map(|(major, _)| major);
-        view::settings::rows(
-            &self.settings,
+        let mut rows = view::settings::rows(
+            set,
+            settings,
             self.detected_gamepad_type,
             dualsense_limited,
             webos_major,
-        )
+        );
+        let over = self.editing_override();
+        for (row, logical) in rows.iter_mut().zip(menu::settings_visible_logical_rows(set)) {
+            row.mark = menu::override_mark(&over, logical);
+        }
+        rows
     }
 
     /// Scrolls `settings_focused` into view.
     pub(crate) fn scroll_settings_into_view(&mut self, screen_h: u32) {
-        let visible = view::settings::visible_rows(screen_h);
+        let set = self.row_set();
+        let visible = view::settings::visible_rows(set, screen_h);
         self.scroll
-            .scroll_into_view(self.settings_focused, menu::settings_row_count(), visible);
+            .scroll_into_view(self.settings_focused, menu::settings_row_count(set), visible);
     }
 
     /// `(row, focused, alpha)` for the open dropdown or its close-fade; `None` if neither.
@@ -842,6 +899,11 @@ impl App {
         // host sidebar first. Only a Back from the sidebar itself is a no-op here
         // — the menu loop turns that into the quit dialog.
         if matches!(self.screen, Screen::Home) {
+            // A held card's submenu is up: Back dismisses it rather than stepping focus
+            // out from under it.
+            if self.card_menu.take().is_some() {
+                return None;
+            }
             match self.home_focus {
                 HomeFocus::Grid(_) => {
                     self.home_focus = HomeFocus::Sidebar(self.sidebar_index_for_selected());
@@ -860,42 +922,10 @@ impl App {
     /// loop keeps rendering while true). Expired animations report one final
     /// `true` so their end state gets drawn.
     pub fn tick_animations(&mut self) -> bool {
-        let mut animating = false;
-        let d = self.grid_scroll_target - self.grid_scroll;
-        if d != 0 {
-            // Exponential ease-out: cover ~35% of the remaining distance per
-            // tick, snapping when close so it terminates.
-            let step = if d.abs() <= 3 {
-                d
-            } else {
-                let s = (f64::from(d) * 0.35) as i32;
-                if s == 0 {
-                    d.signum()
-                } else {
-                    s
-                }
-            };
-            self.grid_scroll += step;
-            animating = true;
-        }
-        // The scrolling modal's viewport, on the same ease-out as the grid above so both
-        // lists feel identical. `scroll.offset` has already jumped to its new row; this is
-        // only the rendered crop catching up.
-        let d = self.modal_scroll_target_px - self.modal_scroll_px;
-        if d != 0 {
-            let step = if d.abs() <= 3 {
-                d
-            } else {
-                let s = (f64::from(d) * 0.35) as i32;
-                if s == 0 {
-                    d.signum()
-                } else {
-                    s
-                }
-            };
-            self.modal_scroll_px += step;
-            animating = true;
-        }
+        let mut animating = ui::animation::ease_scroll(&mut self.grid_scroll, self.grid_scroll_target);
+        // The scrolling modal's viewport, on the same ease-out as the grid. `scroll.offset`
+        // has already jumped to its new row; this is only the rendered crop catching up.
+        animating |= ui::animation::ease_scroll(&mut self.modal_scroll_px, self.modal_scroll_target_px);
         if let Some(t) = self.focus_anim {
             if t.elapsed() >= ui::animation::CARD_FOCUS_POP {
                 self.focus_anim = None;
@@ -938,6 +968,13 @@ impl App {
             }
             animating = true;
         }
+        // The held card's submenu: its rise, and the selection band's slide between rows.
+        // Both run off clocks on `CardMenu`, not off `focus_anim` — without reporting them
+        // here the loop parks in `wait_for_event` mid-rise (the auto-repeat KeyDowns the
+        // hold swallows set no `dirty`), and the panel finishes only when OK is released.
+        if self.card_menu.as_mut().is_some_and(state::cardmenu::CardMenu::tick) {
+            animating = true;
+        }
         // A scan, not one clock: every card zooms on its own (see `card_pop`).
         if self.card_pop.values().any(|t| t.elapsed() < CARD_POP) {
             animating = true;
@@ -952,14 +989,22 @@ impl App {
             settings: self.settings,
             known_hosts: self.known_hosts.clone(),
             selected_host: self.selected_host.clone(),
+            // Always this build's version: whatever wrote the document last is what a future
+            // migration needs to know, and that is now us.
+            version: Some(store::VERSION.to_string()),
         });
+    }
+
+    /// The known-host record for an address — the one place `(host, port)` is matched.
+    pub(crate) fn known_host(&self, host: &str, port: u16) -> Option<&KnownHost> {
+        self.known_hosts.iter().find(|h| h.host == host && h.port == port)
     }
 
     /// The `KnownHost` record backing `selected_host`, if any — shared by every
     /// pin-related lookup (the focused card's badge, `toggle_focused_pin`).
     pub(crate) fn selected_known_host(&self) -> Option<&KnownHost> {
         let (host, port) = self.selected_host.as_ref()?;
-        self.known_hosts.iter().find(|h| h.host == *host && h.port == *port)
+        self.known_host(host, *port)
     }
 
     pub(crate) fn selected_known_host_mut(&mut self) -> Option<&mut KnownHost> {

--- a/src/app/pointer.rs
+++ b/src/app/pointer.rs
@@ -103,6 +103,17 @@ impl App {
             return false;
         }
         match self.screen {
+            // The held card's submenu takes hover whole, like an open dropdown does — the
+            // grid behind it must not steal focus out from under an open menu.
+            Screen::Home if self.card_menu.is_some() => {
+                let Some(row) = self.card_menu_row_at(x, y, screen_w, fonts) else {
+                    return false;
+                };
+                let menu = self.card_menu.as_mut().expect("guarded by the arm");
+                let changed = menu.focused != row;
+                menu.focus(row);
+                changed
+            }
             Screen::Home => {
                 // The ⋯ button sits inside its row, so it's tested first — same order
                 // as `handle_mouse_click`, so hover previews exactly what a click hits.
@@ -133,7 +144,7 @@ impl App {
                 false
             }
             // Dropdown case already handled above.
-            Screen::Settings => {
+            Screen::Settings(_) => {
                 let Some(row) = self.settings_row_at(x, y, screen_w, screen_h) else {
                     return false;
                 };
@@ -155,10 +166,10 @@ impl App {
                 let Some(row) = self.modal_list_row_at(x, y, screen_w, screen_h, fonts) else {
                     return false;
                 };
-                let focused = match self.screen {
-                    Screen::Diagnostics => &mut self.diagnostics_focused,
-                    Screen::CursorSettings => &mut self.cursor_settings_focused,
-                    _ => &mut self.experimental_focused,
+                // Same per-screen field table the keyboard path indexes, so hover and
+                // D-pad focus can never name different fields.
+                let Some(focused) = self.list_modal_focused_mut() else {
+                    return false;
                 };
                 let changed = *focused != row;
                 *focused = row;
@@ -214,17 +225,9 @@ impl App {
     /// exactly where options are drawn. `None` for a screen with no dropdown.
     pub(crate) fn dropdown_geom(&self, screen_w: u32, screen_h: u32, fonts: &ui::text::Fonts) -> Option<(Rect, i32)> {
         match self.screen {
-            Screen::Settings => {
-                let (_, content) = view::settings::layout(screen_w, screen_h);
-                let stride = ui::widgets::focus_row_stride() as i32;
-                let total = menu::settings_row_count();
-                // Anchor to the animated offset so an open dropdown stays attached to
-                // its row while the list is still settling.
-                let px = self
-                    .modal_scroll_px
-                    .clamp(0, Self::max_scroll_px(total, stride, content.height()));
-                Some((content, px))
-            }
+            // Anchored to the animated offset (`settings_content_scroll`) so an open
+            // dropdown stays attached to its row while the list is still settling.
+            Screen::Settings(_) => Some(self.settings_content_scroll(screen_w, screen_h)),
             // Diagnostics doesn't scroll, so 0.
             Screen::Diagnostics => Some((self.modal_list_geometry(screen_w, screen_h, fonts)?.1, 0)),
             _ => None,
@@ -239,7 +242,7 @@ impl App {
         if !content.contains_point((x, y)) {
             return None;
         }
-        let total = menu::settings_row_count();
+        let total = menu::settings_row_count(self.row_set());
         (0..total).find(|&r| {
             let rect = ui::widgets::focus_row_rect_at_px(content, r, scroll_px);
             // Clipped edge rows aren't hoverable: a focused row composites on its own
@@ -252,9 +255,10 @@ impl App {
     /// geometry `settings_row_at`'s hit test and `settings_row_rect`'s lookup both index
     /// into, so a scrolled list can't put them at odds.
     fn settings_content_scroll(&self, screen_w: u32, screen_h: u32) -> (Rect, i32) {
-        let (_, content) = view::settings::layout(screen_w, screen_h);
+        let set = self.row_set();
+        let (_, content) = view::settings::layout(set, screen_w, screen_h);
         let stride = ui::widgets::focus_row_stride() as i32;
-        let total = menu::settings_row_count();
+        let total = menu::settings_row_count(set);
         let scroll_px = self
             .modal_scroll_px
             .clamp(0, Self::max_scroll_px(total, stride, content.height()));
@@ -273,7 +277,10 @@ impl App {
     /// click and every later drag motion need.
     fn bitrate_row_and_track(&self, screen_w: u32, screen_h: u32) -> (Rect, Rect) {
         let row_rect = self.settings_row_rect(self.settings_focused, screen_w, screen_h);
-        (row_rect, ui::widgets::slider_track_rect(row_rect))
+        // A marked row's track shifts left (see `row_layout`), so the drag reads the same
+        // geometry the draw did rather than deriving its own.
+        let marked = menu::override_is_set(&self.editing_override(), menu::ROW_BITRATE);
+        (row_rect, ui::widgets::row_layout(row_rect, marked).track)
     }
 
     /// Sets the Bitrate row from the pointer's current x against its track — shared by the
@@ -281,7 +288,8 @@ impl App {
     /// all) and every drag motion after it.
     fn set_bitrate_from_x(&mut self, x: i32, track: Rect) {
         let fraction = (x - track.x()) as f32 / track.width() as f32;
-        menu::set_bitrate_fraction(&mut self.settings, fraction);
+        menu::set_bitrate_fraction(self.settings_target_mut(), fraction);
+        self.capture_game_override(menu::ROW_BITRATE);
     }
 
     /// Drags the Bitrate slider to `x`.
@@ -415,6 +423,17 @@ impl App {
         // *places* focus (or bails on a click that landed on nothing); the shared
         // `press` below is what confirms it, so a click and an OK press act alike.
         match self.screen {
+            Screen::Home if self.card_menu.is_some() => {
+                // The held card's submenu is over the grid: a click either picks one of its
+                // rows or dismisses it. Nothing underneath is reachable while it is up.
+                let Some(row) = self.card_menu_row_at(x, y, screen_w, fonts) else {
+                    self.close_card_menu();
+                    return None;
+                };
+                if let Some(menu) = self.card_menu.as_mut() {
+                    menu.focus(row);
+                }
+            }
             Screen::Home => {
                 // The ⋯ button sits inside its row, so it has to be tested first or the
                 // click just reads as a click on the host.
@@ -447,7 +466,7 @@ impl App {
                     self.home_focus = HomeFocus::Grid(idx);
                 }
             }
-            Screen::Settings => {
+            Screen::Settings(_) => {
                 // `?` bails if the click hit the gap between rows or outside the
                 // viewport — nothing to focus or confirm.
                 self.settings_focused = self.settings_row_at(x, y, screen_w, screen_h)?;
@@ -455,8 +474,8 @@ impl App {
                 // arms the drag (see `handle_mouse_motion`) instead of nudging one notch the
                 // way `Confirm` below would — a slider is for landing on a value, not stepping
                 // to it one click at a time.
-                if menu::settings_logical_row(self.settings_focused) == menu::ROW_BITRATE
-                    && menu::row_lock(menu::ROW_BITRATE, &self.settings, self.detected_gamepad_type).is_none()
+                if menu::settings_logical_row(self.row_set(), self.settings_focused) == menu::ROW_BITRATE
+                    && menu::row_lock(menu::ROW_BITRATE, self.settings_target(), self.detected_gamepad_type).is_none()
                 {
                     let (row_rect, track) = self.bitrate_row_and_track(screen_w, screen_h);
                     // Full row height, not just the thin track — vertical precision on a

--- a/src/app/press.rs
+++ b/src/app/press.rs
@@ -26,7 +26,7 @@ impl App {
         match self.screen {
             Screen::Home => return self.handle_home_event(ev, screen_w, screen_h),
             Screen::Pairing => self.handle_pairing_event(ev),
-            Screen::Settings => self.handle_settings_event(ev, screen_h),
+            Screen::Settings(_) => self.handle_settings_event(ev, screen_h),
             Screen::AddHost => self.handle_add_host_event(ev),
             Screen::Wake => self.handle_wake_event(ev),
             Screen::ForgetHost => self.handle_forget_host_event(ev),
@@ -90,7 +90,7 @@ impl App {
             Screen::Pairing => matches!(self.pairing_focus, PairingFocus::RequestAccess),
             Screen::Wake | Screen::ForgetHost | Screen::SpeedTest | Screen::SendLogs => true,
             // Rows, not buttons.
-            Screen::Settings
+            Screen::Settings(_)
             | Screen::AddHost
             | Screen::EditHost
             | Screen::About

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -351,8 +351,9 @@ impl App {
                 let popped = |base: Rect| ui::animation::pop_in_rect(base, pop, CARD_POP_SHRINK);
                 // The card's total scale, for anything composited on top of it that has to
                 // fold in the same transform about the card's centre rather than its own.
-                let card_scale =
-                    ui::animation::zoom_scale(f, CARD_GROWTH) * ui::animation::pop_in_scale(pop, CARD_POP_SHRINK);
+                // Shared with the pointer path (`card_menu_rows_rect`), so a click can't land
+                // on a row other than the one drawn under it.
+                let card_scale = self.focused_card_scale(pin_id);
                 // Glow first — a halo behind the card, not an outline on top of it. Its
                 // alpha rides the same eased `f` as the zoom, so it blooms over the whole
                 // travel instead of snapping on ahead of it. No fade-out to match: focus
@@ -385,18 +386,108 @@ impl App {
                 // Sliding the whole tile dragged that baked cover fragment up with it,
                 // reading as the card shifting under the glass. `r` is the pivot: a band
                 // scaled about its own center drifts off the edge it sits flush to.
-                if let Some(strip_h) = tiles.get(tile::CARD_TITLE).map(ui::Painter::height) {
-                    let wipe = ui::animation::anim_frac(self.focus_anim, ui::animation::CARD_FOCUS_POP);
-                    let shown = (strip_h as f32 * wipe) as u32;
-                    if shown > 0 {
-                        let visible = Rect::new(r.x(), r.bottom() - shown as i32, r.width(), shown);
+                // A held card's submenu grows the same frost into a taller panel, and its
+                // title and rows are separate transparent tiles (see `render_card_menu_tile`)
+                // so they can ride the growing window's top edge. Falls back to the plain
+                // strip until all three are built, which is what the first frames after
+                // launch see.
+                let menu = self.card_menu.as_ref().and_then(|_| {
+                    tiles.get(tile::CARD_MENU_TITLE)?;
+                    Some((
+                        tiles.get(tile::CARD_MENU).map(ui::Painter::height)?,
+                        tiles.get(tile::CARD_MENU_ROWS).map(ui::Painter::height)?,
+                    ))
+                });
+                let title_h = tiles.get(tile::CARD_TITLE).map(ui::Painter::height);
+                match (menu, title_h) {
+                    // Menu open: the window grows from the title strip's height — already on
+                    // screen and already focused — up to the full panel, rather than
+                    // restarting from the card's bottom edge.
+                    (Some((panel_h, rows_h)), Some(title_h)) if panel_h > title_h => {
+                        // On its own clock: `focus_anim` is re-armed by every focus move, so
+                        // the panel would pop open the instant the menu is dismissed by
+                        // moving off the card.
+                        let clock = self.card_menu.as_ref().map_or(self.focus_anim, |m| Some(m.since));
+                        // Smoothstep, not the cubic ease-out the plain strip's short wipe
+                        // uses: over a whole panel's travel `1-(1-t)³` is 87% done at the
+                        // halfway point, so the tail reads as a small late move after the
+                        // panel has apparently stopped. Same reason `CARD_FOCUS_POP`'s zoom
+                        // is on `anim_frac_smooth` (see `ui::animation`).
+                        let wipe = ui::animation::anim_frac_smooth(clock, ui::animation::CARD_MENU_RISE);
+                        let shown = title_h + ((panel_h - title_h) as f32 * wipe) as u32;
+                        // Panel-local coordinates throughout: local y maps to
+                        // `r.bottom() - (panel_h - y)`, and the revealed window is
+                        // `[panel_h - shown, panel_h]`.
+                        let window_top = (panel_h - shown) as i32;
+                        // The frost can only wipe — it carries a fragment of the card's cover
+                        // baked in for the blur, and translating that reads as the card
+                        // sliding under the glass.
                         cmds.push(DrawCmd::TexCropped {
-                            tile: tile::CARD_TITLE,
-                            src: Rect::new(0, (strip_h - shown) as i32, r.width(), shown),
-                            dst: ui::animation::scale_about(visible, r, card_scale),
+                            tile: tile::CARD_MENU,
+                            src: Rect::new(0, window_top, r.width(), shown),
+                            dst: ui::animation::scale_about(
+                                Rect::new(r.x(), r.bottom() - shown as i32, r.width(), shown),
+                                r,
+                                card_scale,
+                            ),
                             alpha: (255.0 * pop) as u8,
                         });
+                        // Title and rows both hang off the window's top edge, so the title
+                        // continues upward from exactly where the plain strip had it and the
+                        // rows follow it in. Nothing restarts from the bottom.
+                        cmds.push(DrawCmd::Tex {
+                            tile: tile::CARD_MENU_TITLE,
+                            dst: ui::animation::scale_about(
+                                Rect::new(r.x(), r.bottom() - shown as i32, r.width(), title_h),
+                                r,
+                                card_scale,
+                            ),
+                            alpha: (255.0 * pop) as u8,
+                        });
+                        let rows_top = window_top + title_h as i32;
+                        // The selection sits under the row text, not over it: the band is a
+                        // darkening, so a label drawn beneath it would dim with the frost.
+                        // It rides `rows_top` too, staying on its row for the whole rise.
+                        if let Some(band) = self.card_menu_band(r, panel_h, shown, rows_top) {
+                            cmds.push(DrawCmd::Fill {
+                                rect: ui::animation::scale_about(band, r, card_scale),
+                                color: ui::widgets::CARD_MENU_ROW_FOCUS,
+                            });
+                        }
+                        let vis_bottom = (rows_top + rows_h as i32).min(panel_h as i32);
+                        if vis_bottom > rows_top {
+                            let visible_h = (vis_bottom - rows_top) as u32;
+                            cmds.push(DrawCmd::TexCropped {
+                                tile: tile::CARD_MENU_ROWS,
+                                src: Rect::new(0, 0, r.width(), visible_h),
+                                dst: ui::animation::scale_about(
+                                    Rect::new(r.x(), r.bottom() - (panel_h as i32 - rows_top), r.width(), visible_h),
+                                    r,
+                                    card_scale,
+                                ),
+                                alpha: (255.0 * pop) as u8,
+                            });
+                        }
                     }
+                    // No menu: the plain title strip, wiping up from the card's bottom edge
+                    // on the card's own focus clock.
+                    (_, Some(strip_h)) => {
+                        let wipe = ui::animation::anim_frac(self.focus_anim, ui::animation::CARD_FOCUS_POP);
+                        let shown = (strip_h as f32 * wipe) as u32;
+                        if shown > 0 {
+                            cmds.push(DrawCmd::TexCropped {
+                                tile: tile::CARD_TITLE,
+                                src: Rect::new(0, (strip_h - shown) as i32, r.width(), shown),
+                                dst: ui::animation::scale_about(
+                                    Rect::new(r.x(), r.bottom() - shown as i32, r.width(), shown),
+                                    r,
+                                    card_scale,
+                                ),
+                                alpha: (255.0 * pop) as u8,
+                            });
+                        }
+                    }
+                    (_, None) => {}
                 }
                 // The lit edge last, over the art *and* the strip, so the card ends on one
                 // unbroken line. It gives the glow behind a hard boundary to end on, so

--- a/src/app/render/geometry.rs
+++ b/src/app/render/geometry.rs
@@ -38,10 +38,11 @@ impl App {
         fonts: &ui::text::Fonts,
     ) -> Option<(usize, usize, Rect, Rect)> {
         match screen {
-            Screen::Settings => {
-                let (card, content) = view::settings::layout(screen_w, screen_h);
-                let visible = view::settings::visible_rows(screen_h);
-                Some((menu::settings_row_count(), visible, card, content))
+            Screen::Settings(_) => {
+                let set = self.row_set();
+                let (card, content) = view::settings::layout(set, screen_w, screen_h);
+                let visible = view::settings::visible_rows(set, screen_h);
+                Some((menu::settings_row_count(set), visible, card, content))
             }
             Screen::About => {
                 let card = view::about::card_rect(screen_w, screen_h);
@@ -143,7 +144,7 @@ impl App {
         // (see `view::settings::PEEK`). The clamps then pin the first and last positions flush,
         // where there is genuinely nothing beyond the edge to hint at.
         let bias = match screen {
-            Screen::Settings => view::settings::PEEK as i32,
+            Screen::Settings(_) => view::settings::PEEK as i32,
             _ => 0,
         };
         let target = (offset as i32 * stride - bias)
@@ -166,7 +167,7 @@ impl App {
     /// Same as `scroll_stride`, but for an explicit screen — see `scroll_geometry_for`.
     pub(crate) fn scroll_stride_for(&self, screen: Screen, fonts: &ui::text::Fonts) -> i32 {
         match screen {
-            Screen::Settings => ui::widgets::FOCUS_ROW_H as i32 + ui::widgets::FOCUS_ROW_GAP,
+            Screen::Settings(_) => ui::widgets::FOCUS_ROW_H as i32 + ui::widgets::FOCUS_ROW_GAP,
             Screen::About => view::about::line_stride(fonts.raster, fonts.value),
             _ => 1,
         }
@@ -276,7 +277,7 @@ impl App {
         fonts: &ui::text::Fonts,
     ) -> Option<Rect> {
         match screen {
-            Screen::Settings => {
+            Screen::Settings(_) => {
                 let (total, _, _, content) = self.scroll_geometry_for(screen, screen_w, screen_h, fonts)?;
                 // Positioned from the animated pixel offset, not the row index: the baked
                 // list is cropped at that offset, and the focus tile *is* the focused row
@@ -354,7 +355,7 @@ impl App {
     pub(crate) fn dropdown_options_len(&self, row: usize) -> usize {
         match self.screen {
             Screen::Diagnostics => menu::LOG_LEVEL_OPTIONS.len(),
-            _ => menu::dropdown_option_count(menu::settings_logical_row(row)),
+            _ => menu::dropdown_option_count(menu::settings_logical_row(self.row_set(), row)),
         }
     }
 
@@ -368,7 +369,12 @@ impl App {
     pub(crate) fn with_modal_screen<R>(&self, f: impl FnOnce(&dyn ui::ModalScreen) -> R) -> Option<R> {
         Some(match self.screen {
             Screen::Home => return None,
-            Screen::Settings => f(&view::settings::Modal),
+            // One screen, two scopes: the dim title suffix is the only thing the per-game
+            // one adds, and it comes from the scratch copy that scope implies.
+            Screen::Settings(set) => f(&view::settings::Modal {
+                set,
+                game: self.game_settings.as_ref().map(|gs| gs.title.as_str()),
+            }),
             Screen::Pairing => f(&view::pairing::Modal {
                 pin_digits: &self.pin_digits,
                 status: self.pairing_status.as_ref(),
@@ -414,7 +420,8 @@ impl App {
                 rooted: Self::rooted(),
             }),
             Screen::CursorSettings => f(&view::cursorsettings::Modal {
-                settings: &self.settings,
+                settings: self.settings_target(),
+                over: &self.editing_override(),
             }),
             Screen::SendLogs => f(&view::sendlogs::Modal),
         })

--- a/src/app/render/key.rs
+++ b/src/app/render/key.rs
@@ -6,7 +6,7 @@
 //!
 //! App-side on purpose: they name this app's screens and its `Settings`, which is exactly
 //! what a widget library must not know.
-use crate::core::model::{GamepadType, LogLevelOverride, Settings};
+use crate::core::model::{GamepadType, LogLevelOverride, Settings, SettingsOverride};
 
 /// Focused widget in the open modal. Each variant carries its content,
 /// so value changes (not just focus moves) invalidate the tile.
@@ -14,7 +14,9 @@ use crate::core::model::{GamepadType, LogLevelOverride, Settings};
 pub enum ModalFocusKey {
     /// The detected pad type rides along because the Controller row's "Automatic (...)" value
     /// depends on it, not just on `Settings` — a hotplug alone doesn't touch `Settings` at all.
-    SettingsRow(usize, Settings, Option<GamepadType>),
+    /// The override rides along because it decides which rows wear a "use global" button —
+    /// a change there moves no value in `Settings` at all.
+    SettingsRow(usize, Settings, SettingsOverride, Option<GamepadType>),
     WakeToggle(bool),
     WakeButton(usize),
     PairingDigit(usize, u8),
@@ -27,8 +29,9 @@ pub enum ModalFocusKey {
     /// (focused row, log level, stats-overlay on, show-logs on) — any change invalidates the tile.
     DiagnosticsRow(usize, LogLevelOverride, bool, bool),
     ExperimentalRow(usize, bool, bool),
-    /// (focused row, cursor-capture on, cursor-gestures on) — any change invalidates the tile.
-    CursorSettingsRow(usize, bool, bool),
+    /// (focused row, cursor-capture on, cursor-gestures on, which rows are overridden) — any
+    /// change invalidates the tile.
+    CursorSettingsRow(usize, bool, bool, SettingsOverride),
     /// Which `Screen::SendLogs` button is focused (0 = Cancel, 1 = Send).
     SendLogsButton(usize),
 }
@@ -37,7 +40,7 @@ pub enum ModalFocusKey {
 #[derive(PartialEq, Eq, Hash)]
 pub enum ScrollContentKey {
     /// Settings row list + open dropdown row + detected pad type (see `ModalFocusKey::SettingsRow`).
-    Settings(Settings, Option<usize>, Option<GamepadType>),
+    Settings(Settings, SettingsOverride, Option<usize>, Option<GamepadType>),
     /// About window's start line.
     About(usize),
 }
@@ -52,6 +55,9 @@ pub enum ModalShellKey {
     // row content, not even the Bitrate caution — that's the focus tile's job),
     // so the only thing that can actually change it is the close-button hover.
     Settings {
+        /// The per-game screen's dim title suffix — `None` on the global one. The only thing
+        /// separating the two shells.
+        game: Option<String>,
         hover_close: bool,
     },
     Wake {
@@ -102,6 +108,7 @@ pub enum ModalShellKey {
     CursorSettings {
         cursor_capture: bool,
         cursor_gestures: bool,
+        over: SettingsOverride,
         hover_close: bool,
     },
     /// Fixed warning copy + two buttons; only the close (X) hover varies.

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -268,11 +268,63 @@ impl App {
                     let (title, art) = self.grid_card_content(idx, columns);
                     // Keyed by card identity like the card tiles themselves (`CardIds`),
                     // not by title — two games can share one.
-                    let version = cache::version(&(pin_id, card_w, card_h, art.is_some()));
+                    let overridden = self.game_has_overrides(pin_id);
+                    let version = cache::version(&(pin_id, card_w, card_h, art.is_some(), overridden));
                     if tiles.ensure(tile::CARD_TITLE, version, || {
-                        ui::tiles::render_card_title_tile(text_cache, fonts, card_w, card_h, title, art)
+                        ui::tiles::render_card_title_tile(text_cache, fonts, card_w, card_h, title, art, overridden)
                     })? {
                         updated.push(tile::CARD_TITLE);
+                    }
+
+                    // The submenu panel a hold raises: the same strip grown to carry the
+                    // rows (see `render_card_menu_tile`), on the same wipe.
+                    //
+                    // Built when the card takes focus, not when the menu opens — it costs a
+                    // full-card art rescale plus a radius-6 blur, and paying that on the
+                    // frame the rise starts is what made the panel appear to wait for the
+                    // button to come back up. Held off until the grid has settled so a fast
+                    // scroll doesn't pay it per card, unless a menu is already up (which
+                    // can only happen on a settled grid anyway).
+                    let menu_open = self.card_menu.as_ref().is_some_and(|m| m.pin_id == pin_id);
+                    if menu_open || (self.grid_reveal_ready && !pending) {
+                        let rows = self.card_menu_rows(pin_id);
+                        // No focused row in the key: the selection is a `DrawCmd::Fill` laid
+                        // over this tile, so moving between the menu's rows rebuilds nothing.
+                        let version = cache::version(&(pin_id, card_w, card_h, art.is_some(), &rows, overridden));
+                        if tiles.ensure(tile::CARD_MENU, version, || {
+                            ui::tiles::render_card_menu_tile(
+                                text_cache,
+                                fonts,
+                                ui::tiles::CardMenuTile {
+                                    card_w,
+                                    card_h,
+                                    title,
+                                    art,
+                                    rows: &rows,
+                                },
+                            )
+                        })? {
+                            updated.push(tile::CARD_MENU);
+                        }
+                        if tiles.ensure(tile::CARD_MENU_ROWS, version, || {
+                            ui::tiles::render_card_menu_rows_tile(
+                                text_cache,
+                                fonts,
+                                card_w,
+                                card_h,
+                                &rows,
+                                // The dot follows what owns it: the title while the strip is
+                                // collapsed, the Settings row once the panel is up.
+                                overridden.then_some(crate::app::state::cardmenu::ROW_SETTINGS),
+                            )
+                        })? {
+                            updated.push(tile::CARD_MENU_ROWS);
+                        }
+                        if tiles.ensure(tile::CARD_MENU_TITLE, version, || {
+                            ui::tiles::render_card_menu_title_tile(text_cache, fonts, card_w, card_h, title)
+                        })? {
+                            updated.push(tile::CARD_MENU_TITLE);
+                        }
                     }
                 }
             }
@@ -448,7 +500,8 @@ impl App {
         // (no split focus tile to protect) and just redraws on any
         // `content_dirty` tick, same as every modal did before this split.
         let modal_shell_key = match self.screen {
-            Screen::Settings => Some(ModalShellKey::Settings {
+            Screen::Settings(_) => Some(ModalShellKey::Settings {
+                game: self.game_settings.as_ref().map(|gs| gs.title.clone()),
                 hover_close: self.hover_close,
             }),
             Screen::Wake => self.wake.as_ref().map(|w| ModalShellKey::Wake {
@@ -502,8 +555,9 @@ impl App {
                 hover_close: self.hover_close,
             }),
             Screen::CursorSettings => Some(ModalShellKey::CursorSettings {
-                cursor_capture: self.settings.cursor_capture,
-                cursor_gestures: self.settings.cursor_gestures,
+                cursor_capture: self.settings_target().cursor_capture,
+                cursor_gestures: self.settings_target().cursor_gestures,
+                over: self.editing_override(),
                 hover_close: self.hover_close,
             }),
             Screen::SendLogs => Some(ModalShellKey::SendLogs {
@@ -540,9 +594,10 @@ impl App {
         // (Home, AddHost) or when Wake has nothing to focus (no MAC on record,
         // see `handle_wake_event`'s matching guard).
         let focus_key = match self.screen {
-            Screen::Settings => Some(ModalFocusKey::SettingsRow(
+            Screen::Settings(_) => Some(ModalFocusKey::SettingsRow(
                 self.settings_focused,
-                self.settings,
+                *self.settings_target(),
+                self.editing_override(),
                 self.detected_gamepad_type,
             )),
             Screen::Wake => self
@@ -583,8 +638,9 @@ impl App {
             )),
             Screen::CursorSettings => Some(ModalFocusKey::CursorSettingsRow(
                 self.cursor_settings_focused,
-                self.settings.cursor_capture,
-                self.settings.cursor_gestures,
+                self.settings_target().cursor_capture,
+                self.settings_target().cursor_gestures,
+                self.editing_override(),
             )),
             Screen::SendLogs => Some(ModalFocusKey::SendLogsButton(self.send_logs_focused)),
             // Neither has a single focused widget: the address form is one always-active
@@ -599,8 +655,8 @@ impl App {
             let stale = self.switch_anim.is_some() || !tiles.is_fresh(tile::MODAL_FOCUS, cache::version(&key));
             if stale {
                 let tile = match self.screen {
-                    Screen::Settings => {
-                        let (_, content) = view::settings::layout(screen_w, screen_h);
+                    Screen::Settings(_) => {
+                        let (_, content) = view::settings::layout(self.row_set(), screen_w, screen_h);
                         let rows = self.settings_rows();
                         let dropdown_open = self.dropdown.as_ref().is_some_and(|dd| dd.row == self.settings_focused);
                         let target_on = rows.get(self.settings_focused).is_some_and(|r| r.value == "On");
@@ -685,7 +741,7 @@ impl App {
                             }
                             Screen::Diagnostics => view::diagnostics::rows(&self.settings),
                             Screen::Experimental => view::experimental::rows(&self.settings, Self::rooted()),
-                            _ => view::cursorsettings::rows(&self.settings),
+                            _ => view::cursorsettings::rows(self.settings_target(), &self.editing_override()),
                         };
                         let focused = self
                             .list_modal_focused()
@@ -733,8 +789,8 @@ impl App {
                     (menu::log_level_dropdown_options(), content.width())
                 }
                 _ => {
-                    let (_, content) = view::settings::layout(screen_w, screen_h);
-                    let logical = menu::settings_logical_row(dd.row);
+                    let (_, content) = view::settings::layout(self.row_set(), screen_w, screen_h);
+                    let logical = menu::settings_logical_row(self.row_set(), dd.row);
                     (
                         menu::dropdown_options(logical, self.detected_gamepad_type),
                         content.width(),
@@ -823,11 +879,16 @@ impl App {
             self.sync_modal_scroll(self.screen, total, visible, content.height(), stride);
 
             match self.screen {
-                Screen::Settings => {
+                Screen::Settings(_) => {
                     let dropdown_row = self.dropdown.as_ref().map(|dd| dd.row);
                     let key = cache::version(&(
-                        Screen::Settings,
-                        ScrollContentKey::Settings(self.settings, dropdown_row, self.detected_gamepad_type),
+                        self.screen,
+                        ScrollContentKey::Settings(
+                            *self.settings_target(),
+                            self.editing_override(),
+                            dropdown_row,
+                            self.detected_gamepad_type,
+                        ),
                     ));
                     if !tiles.is_fresh(tile::SCROLL_CONTENT, key) {
                         let rows = self.settings_rows();
@@ -842,7 +903,7 @@ impl App {
                         // Settings' whole row list always fits one tile — no windowing.
                         self.content_window = ui::scroll::ContentWindow {
                             start: 0,
-                            len: menu::settings_row_count(),
+                            len: menu::settings_row_count(self.row_set()),
                         };
                         updated.push(tile::SCROLL_CONTENT);
                     }
@@ -893,9 +954,11 @@ impl App {
         let mut scratch = Painter::new(screen_w, screen_h);
         view::settings::render(
             &mut ui::Canvas::new(&mut scratch, text_cache, fonts, screen_w, screen_h),
+            menu::SettingsScope::Global,
+            None,
             self.hover_close,
         )?;
-        let (_, content) = view::settings::layout(screen_w, screen_h);
+        let (_, content) = view::settings::layout(menu::SettingsScope::Global, screen_w, screen_h);
         let rows = self.settings_rows();
         let _ = ui::widgets::render_focus_rows_tile(text_cache, fonts, &rows, content.width(), None)?;
         let _ = ui::widgets::render_focus_row_tile(text_cache, fonts, &rows, content.width(), 0, false, 0.0)?;

--- a/src/app/render/tile.rs
+++ b/src/app/render/tile.rs
@@ -63,6 +63,18 @@ pub const MODAL_PREV: TileId = TileId(23);
 /// That snapshot's scrolled content, for a leaving modal whose body lives in
 /// [`SCROLL_CONTENT`] rather than in its shell (Settings, About).
 pub const MODAL_PREV_CONTENT: TileId = TileId(24);
+/// The focused card's submenu panel — [`CARD_TITLE`] grown to carry the Pin/Settings rows.
+/// Its own slot rather than a second shape for `CARD_TITLE`, so it can be baked *ahead* of
+/// the hold that shows it: it costs a full-card art rescale plus a blur, and paying that at
+/// the moment the panel starts rising is what made the rise stutter.
+pub const CARD_MENU: TileId = TileId(25);
+/// That panel's row icons and labels, on their own transparent tile. Composited *after* the
+/// selection band, which is a translucent darkening: baked into [`CARD_MENU`] the text would
+/// be dimmed along with the frost, and the band is meant to slide under it.
+pub const CARD_MENU_ROWS: TileId = TileId(26);
+/// That panel's title line, likewise on its own transparent tile — it rides the top edge of
+/// the opening window, continuing up from where [`CARD_TITLE`] already had it.
+pub const CARD_MENU_TITLE: TileId = TileId(27);
 
 /// First id of the spinner band. One per frame, so animation is a swap not an upload.
 const SPINNER_BASE: u32 = 64;

--- a/src/app/state/about.rs
+++ b/src/app/state/about.rs
@@ -2,7 +2,7 @@
 use crate::app::view;
 use crate::app::App;
 use crate::core::event::MenuEvent;
-use crate::core::screen::Screen;
+use crate::core::screen::{Screen, SettingsScope};
 use crate::ui;
 
 impl App {
@@ -36,7 +36,7 @@ impl App {
             }
             // Return to Settings (not Home) to preserve settings context
             MenuEvent::Back | MenuEvent::Confirm => {
-                self.screen = Screen::Settings;
+                self.screen = Screen::Settings(SettingsScope::Global);
                 self.scroll = self.settings_scroll;
             }
             MenuEvent::Secondary => {}

--- a/src/app/state/addhost.rs
+++ b/src/app/state/addhost.rs
@@ -44,7 +44,7 @@ impl App {
                 // Only reaches a genuinely new host: `upsert_known_host` keeps an existing
                 // record's pins, wol_auto and fingerprint, so re-adding a paired host neither
                 // unpairs it nor resets its preferences.
-                pinned: vec![store::DESKTOP_PIN_ID.to_string()],
+                games: store::pinned_only(store::DESKTOP_PIN_ID),
                 ..KnownHost::default()
             },
         );

--- a/src/app/state/cardmenu.rs
+++ b/src/app/state/cardmenu.rs
@@ -1,0 +1,138 @@
+//! The submenu a held grid card raises over its own title strip: Pin/Unpin, and Settings.
+//!
+//! It is not a `Screen` — it lives on Home, over one card, and Home's own navigation is
+//! simply suspended while it is up (see `App::handle_home_event`). That keeps the card, its
+//! focus ring and its frosted title strip on screen underneath, which is the whole point:
+//! the menu belongs to *that* card, not to a modal that happens to know its id.
+use std::time::{Duration, Instant};
+
+use crate::app::menu::nav_dir;
+use crate::app::{view, App};
+use crate::core::event::MenuEvent;
+use crate::core::screen::HomeFocus;
+use crate::ui;
+
+/// How long the selection band takes to travel from one row to the next. Short: the band is
+/// the only thing that says which row is picked, so the move has to finish inside a keypress.
+pub(crate) const MENU_FOCUS_SLIDE: Duration = Duration::from_millis(120);
+
+/// Rows, in order. Two, and both always shown — an unpinnable card still shows Pin and
+/// answers with the pin-limit alert, which says more than a missing row would.
+pub(crate) const ROW_PIN: usize = 0;
+pub(crate) const ROW_SETTINGS: usize = 1;
+pub(crate) const ROW_COUNT: usize = 2;
+
+/// The open card submenu. `Some` exactly while it is up.
+pub struct CardMenu {
+    /// The card it belongs to (a `GameEntry::id`, or `store::DESKTOP_PIN_ID`).
+    pub pin_id: String,
+    /// That card's title — reused as the per-game settings screen's dim title suffix.
+    pub title: String,
+    pub focused: usize,
+    /// The row focus just left, and when — where the band slides *from* (see
+    /// [`MENU_FOCUS_SLIDE`]). `None` while it is settled on `focused`.
+    pub leaving: Option<(usize, Instant)>,
+    /// When it opened, for the panel's rise. Its own clock, not `focus_anim`: that one is
+    /// re-armed by every focus move, and the panel must not restart with the card's zoom.
+    pub since: Instant,
+    /// The rise has had its final frame drawn (see [`CardMenu::tick`]).
+    risen: bool,
+}
+
+impl CardMenu {
+    /// Moves focus and arms the band's slide. No-op when `row` is already focused, so a
+    /// pointer resting on a row can't restart a slide that goes nowhere.
+    pub(crate) fn focus(&mut self, row: usize) {
+        if row != self.focused {
+            self.leaving = Some((self.focused, Instant::now()));
+            self.focused = row;
+        }
+    }
+
+    /// Whether the panel still owes frames — the rise, and the band's slide between rows.
+    ///
+    /// Both report `true` on the tick their clock *expires*, not just while it runs. That
+    /// last tick is the one that draws the animation at its final value: report `false`
+    /// there and the render loop parks in `wait_for_event` one frame short, leaving the
+    /// panel a percent below its resting place until some unrelated event sets `dirty` —
+    /// which, during a hold, is the button coming back up. It reads as the panel stalling
+    /// just before the end and then finishing on release. `focus_anim` and friends avoid it
+    /// by clearing their `Option` on the expiring tick and still reporting that tick.
+    pub fn tick(&mut self) -> bool {
+        let mut owed = false;
+        if !self.risen {
+            self.risen = self.since.elapsed() >= ui::animation::CARD_MENU_RISE;
+            owed = true;
+        }
+        match self.leaving {
+            Some((_, t)) if t.elapsed() < MENU_FOCUS_SLIDE => owed = true,
+            Some(_) => {
+                self.leaving = None;
+                owed = true;
+            }
+            None => {}
+        }
+        owed
+    }
+}
+
+impl App {
+    /// Raises the submenu over the focused card. The long-hold's whole effect — see
+    /// `runtime::ui_flow`.
+    pub(crate) fn open_card_menu(&mut self, screen_w: u32) {
+        let columns = view::home::grid_columns(screen_w.saturating_sub(ui::widgets::SIDEBAR_W));
+        let HomeFocus::Grid(idx) = self.home_focus else {
+            return;
+        };
+        let Some(pin_id) = self.pin_id_at_grid_idx(idx, columns).map(str::to_string) else {
+            return;
+        };
+        let title = self.grid_card_content(idx, columns).0.to_string();
+        self.card_menu = Some(CardMenu {
+            pin_id,
+            title,
+            focused: ROW_PIN,
+            leaving: None,
+            since: Instant::now(),
+            risen: false,
+        });
+    }
+
+    pub(crate) fn close_card_menu(&mut self) {
+        self.card_menu = None;
+    }
+
+    /// Handles one menu event while the submenu is up. Returns `false` when it isn't, so
+    /// Home's own handler runs instead.
+    pub(crate) fn handle_card_menu_event(&mut self, ev: MenuEvent, screen_w: u32, screen_h: u32) -> bool {
+        let Some(menu) = self.card_menu.as_mut() else {
+            return false;
+        };
+        // Wraps, like every other row list in the app (`list_nav`); `focus` is what arms the
+        // band's slide, so the move goes through it rather than writing `focused` directly.
+        let mut next = menu.focused;
+        if ui::widgets::list_nav(&mut next, ROW_COUNT, nav_dir(ev)) {
+            menu.focus(next);
+            return true;
+        }
+        match ev {
+            MenuEvent::Confirm => match menu.focused {
+                ROW_PIN => {
+                    self.close_card_menu();
+                    // Keeps the pin-limit alert and the reorder animation it already owns.
+                    self.toggle_focused_pin(screen_w, screen_h);
+                }
+                ROW_SETTINGS => {
+                    let (pin_id, title) = (menu.pin_id.clone(), menu.title.clone());
+                    self.close_card_menu();
+                    self.open_game_settings(&pin_id, &title);
+                }
+                _ => {}
+            },
+            // Left/Right have nothing to move to, and Secondary would otherwise forget a
+            // host from under an open menu.
+            _ => self.close_card_menu(),
+        }
+        true
+    }
+}

--- a/src/app/state/cursorsettings.rs
+++ b/src/app/state/cursorsettings.rs
@@ -14,7 +14,9 @@ impl App {
         self.screen = Screen::CursorSettings;
     }
 
-    /// All rows are plain Left/Right/Confirm toggles. Back saves and returns to Settings.
+    /// All rows are plain Left/Right/Confirm toggles. Back saves and returns to whichever
+    /// settings screen opened it — the per-game one keeps editing its own copy while here
+    /// (see `App::settings_target`), so this handler needs no branch of its own for it.
     pub(crate) fn handle_cursor_settings_event(&mut self, ev: MenuEvent) {
         if ui::widgets::list_nav(
             &mut self.cursor_settings_focused,
@@ -24,20 +26,32 @@ impl App {
             self.modal_focus_anim = Some(Instant::now());
             return;
         }
-        match (self.cursor_settings_focused, ev) {
-            (menu::CURSOR_ROW_CAPTURE, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
-                let from = self.settings.cursor_capture;
-                self.settings.cursor_capture = !from;
-                self.switch_anim = Some((Instant::now(), from, self.cursor_settings_focused));
-            }
-            (menu::CURSOR_ROW_GESTURES, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
-                let from = self.settings.cursor_gestures;
-                self.settings.cursor_gestures = !from;
-                self.switch_anim = Some((Instant::now(), from, self.cursor_settings_focused));
+        let row = self.cursor_settings_focused;
+        match (row, ev) {
+            // Both rows are plain toggles, so they go through the same mutator every
+            // settings row uses — `cursor_logical_row` is where the dense `CURSOR_ROW_*`
+            // indices meet the logical `ROW_*` ids the override table is keyed by.
+            (_, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
+                let logical = menu::cursor_logical_row(row);
+                let from = menu::toggle_value(self.settings_target(), logical);
+                let detected = self.detected_gamepad_type;
+                if menu::adjust_setting(self.settings_target_mut(), logical, true, detected) {
+                    self.capture_game_override(logical);
+                    if let Some(from) = from {
+                        self.switch_anim = Some((Instant::now(), from, row));
+                    }
+                }
             }
             (_, MenuEvent::Back) => {
-                self.persist();
-                self.screen = Screen::Settings;
+                match self.game_settings {
+                    // The per-game copy is saved once, on the way out of its own screen —
+                    // this is a step back into it, not out of the flow.
+                    Some(_) => self.screen = Screen::Settings(menu::SettingsScope::Game),
+                    None => {
+                        self.persist();
+                        self.screen = Screen::Settings(menu::SettingsScope::Global);
+                    }
+                }
             }
             _ => {}
         }

--- a/src/app/state/diagnostics.rs
+++ b/src/app/state/diagnostics.rs
@@ -3,7 +3,7 @@ use crate::app::menu;
 use crate::app::App;
 use crate::app::DropdownState;
 use crate::core::event::MenuEvent;
-use crate::core::screen::Screen;
+use crate::core::screen::{Screen, SettingsScope};
 use crate::services::store;
 use crate::ui;
 use std::time::Instant;
@@ -74,7 +74,7 @@ impl App {
             }
             (_, MenuEvent::Back) => {
                 self.persist();
-                self.screen = Screen::Settings;
+                self.screen = Screen::Settings(SettingsScope::Global);
             }
             _ => {}
         }

--- a/src/app/state/edithost.rs
+++ b/src/app/state/edithost.rs
@@ -62,7 +62,7 @@ impl App {
                 mgmt_port: old.mgmt_port,
                 mac: old.mac.clone(),
                 wol_auto: old.wol_auto,
-                pinned: old.pinned.clone(),
+                games: old.games.clone(),
             },
         );
         // The address is the cache key, so the old one's art is now orphaned.

--- a/src/app/state/experimental.rs
+++ b/src/app/state/experimental.rs
@@ -2,7 +2,7 @@
 use crate::app::menu;
 use crate::app::App;
 use crate::core::event::MenuEvent;
-use crate::core::screen::Screen;
+use crate::core::screen::{Screen, SettingsScope};
 use crate::ui;
 use std::time::Instant;
 
@@ -34,7 +34,7 @@ impl App {
             }
             (_, MenuEvent::Back) => {
                 self.persist();
-                self.screen = Screen::Settings;
+                self.screen = Screen::Settings(SettingsScope::Global);
             }
             _ => {}
         }

--- a/src/app/state/gamesettings.rs
+++ b/src/app/state/gamesettings.rs
@@ -1,0 +1,83 @@
+//! The per-game settings screen's logic: opening it against one game, and folding an edit
+//! back into that game's sparse override. The rows themselves, their navigation and their
+//! dropdowns are the global Settings screen's — see `app::state::settings`, which both
+//! screens share via `menu::SettingsScope`.
+use crate::app::menu;
+use crate::app::App;
+use crate::core::screen::Screen;
+use crate::services::store::{Settings, SettingsOverride};
+
+/// What the per-game settings screen is editing. Set alongside `Screen::Settings(Game)`
+/// and cleared on the way out, so `Some` and the screen being up mean the same thing.
+pub(crate) struct GameSettingsState {
+    /// The `KnownHost::games` key: a `GameEntry::id`, or `store::DESKTOP_PIN_ID`.
+    pub pin_id: String,
+    /// The game's name, shown dimmer after "Settings" in the title.
+    pub title: String,
+    /// The global settings with `over` applied — what every row renders from and what the
+    /// shared `menu::*` mutators edit. Only the edited row is copied back into `over`.
+    pub merged: Settings,
+    pub over: SettingsOverride,
+}
+
+impl App {
+    /// Opens the per-game screen for `pin_id`. Only the card submenu calls this.
+    pub(crate) fn open_game_settings(&mut self, pin_id: &str, title: &str) {
+        let over = self
+            .selected_known_host()
+            .map(|h| h.overrides(pin_id))
+            .unwrap_or_default();
+        self.game_settings = Some(GameSettingsState {
+            pin_id: pin_id.to_string(),
+            title: title.to_string(),
+            merged: over.merge_into(self.settings),
+            over,
+        });
+        self.settings_focused = 0;
+        self.dropdown = None;
+        // Its own scroll position, like every other modal list — and Settings' is stashed
+        // the same way About stashes it.
+        self.scroll = crate::ui::scroll::ScrollWindow::new();
+        self.screen = Screen::Settings(menu::SettingsScope::Game);
+    }
+
+    /// Records `row`'s freshly edited value into the override, then re-derives `merged` so a
+    /// row whose value the merge would clamp (HDR under an H.264 pick) shows what will
+    /// actually be used.
+    ///
+    /// A value set back to what the global screen says stops being an override here rather
+    /// than needing a separate "use global" gesture: `drop_matching` clears it, the row's dot
+    /// goes out, and once nothing differs the game's whole record leaves the document (see
+    /// `KnownHost::edit_overrides`). There is deliberately no other way to clear one row.
+    pub(crate) fn capture_game_override(&mut self, row: usize) {
+        let global = self.settings;
+        let Some(gs) = self.game_settings.as_mut() else {
+            return;
+        };
+        menu::override_capture(&mut gs.over, row, &gs.merged);
+        gs.over.drop_matching(&global);
+        gs.merged = gs.over.merge_into(global);
+    }
+
+    /// Writes the edited override back onto the host record and persists. Called on the way
+    /// out, like the global screen's single save per visit.
+    pub(crate) fn persist_game_settings(&mut self) {
+        let Some(gs) = self.game_settings.take() else {
+            return;
+        };
+        let Some(known) = self.selected_known_host_mut() else {
+            return;
+        };
+        known.edit_overrides(&gs.pin_id, |over| *over = gs.over);
+        self.persist();
+    }
+}
+
+impl App {
+    /// Whether `pin_id` carries any settings override on the selected host — what puts the
+    /// amber dot in front of its card title, before anything is held.
+    pub(crate) fn game_has_overrides(&self, pin_id: &str) -> bool {
+        self.selected_known_host()
+            .is_some_and(|h| !h.overrides(pin_id).is_empty())
+    }
+}

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -6,7 +6,7 @@ use crate::app::view;
 use crate::app::App;
 use crate::app::{ConnectTarget, GridCard, GridLayout};
 use crate::core::event::MenuEvent;
-use crate::core::screen::{HomeFocus, Screen};
+use crate::core::screen::{HomeFocus, Screen, SettingsScope};
 use crate::services::store::{self};
 use crate::ui;
 use std::time::Instant;
@@ -185,6 +185,11 @@ impl App {
         let available_w = screen_w.saturating_sub(ui::widgets::SIDEBAR_W);
         let columns = view::home::grid_columns(available_w);
 
+        // The held card's submenu owns every key while it is up — it sits over one card,
+        // so moving Home's focus underneath it would leave it pointing at another game.
+        if self.handle_card_menu_event(ev, screen_w, screen_h) {
+            return None;
+        }
         if let Some(dir) = crate::app::menu::nav_dir(ev) {
             self.navigate_home(dir, screen_w, screen_h);
             return None;
@@ -199,7 +204,7 @@ impl App {
                     self.screen = Screen::AddHost;
                 }
                 HomeFocus::Sidebar(_) => {
-                    self.screen = Screen::Settings;
+                    self.screen = Screen::Settings(SettingsScope::Global);
                     self.dropdown = None;
                     self.settings_focused = 0;
                     self.scroll = ui::scroll::ScrollWindow::new();
@@ -293,38 +298,53 @@ impl App {
         }
     }
 
-    /// Re-sorts games: pinned first (in pin order), rest untouched. Also prunes
-    /// `known_hosts`' persisted pins for games the host no longer lists — otherwise
-    /// a removed game keeps counting toward `MAX_PINNED_GAMES` forever.
+    /// Re-sorts games: pinned first (in pin order), rest untouched. A pin for a game
+    /// not currently listed just doesn't sort — it is *not* dropped here, because this
+    /// runs on every pin toggle and a host that failed to answer has an empty
+    /// `self.games`. Dropping is [`App::prune_stale_game_prefs`]'s job.
     pub(crate) fn reorder_games_by_pin(&mut self) {
-        let Some(known_idx) = self
-            .selected_host
-            .as_ref()
-            .and_then(|(h, p)| self.known_hosts.iter().position(|k| k.host == *h && k.port == *p))
-        else {
+        let Some(known_idx) = self.selected_known_host_idx() else {
             self.pinned_count = 0;
             return;
         };
-        let pinned_ids = self.known_hosts[known_idx].pinned.clone();
+        let pinned_ids: Vec<String> = self.known_hosts[known_idx]
+            .pinned_ids()
+            .into_iter()
+            .map(str::to_string)
+            .collect();
         let mut pinned = Vec::new();
-        let mut still_pinned = Vec::new();
         for id in &pinned_ids {
-            if id == store::DESKTOP_PIN_ID {
-                // Desktop isn't in `self.games`, so it's never "missing".
-                still_pinned.push(id.clone());
-            } else if let Some(pos) = self.games.iter().position(|g| &g.id == id) {
+            // Desktop isn't in `self.games`, so it never sorts here.
+            if let Some(pos) = self.games.iter().position(|g| &g.id == id) {
                 pinned.push(self.games.remove(pos));
-                still_pinned.push(id.clone());
             }
         }
         self.pinned_count = pinned.len();
         pinned.append(&mut self.games);
         self.games = pinned;
+    }
 
-        if still_pinned != pinned_ids {
-            self.known_hosts[known_idx].pinned = still_pinned;
+    /// Drops per-game state (pins *and* settings overrides) for games the host no longer
+    /// lists — otherwise a removed game keeps counting toward `MAX_PINNED_GAMES` and its
+    /// overrides linger forever.
+    ///
+    /// Call only from the success arm of [`App::drain_games`]: `self.games` is empty
+    /// whenever a fetch failed or a host is unreachable, and pruning against that would
+    /// wipe everything the user configured the moment their host went to sleep.
+    pub(crate) fn prune_stale_game_prefs(&mut self) {
+        let Some(known_idx) = self.selected_known_host_idx() else {
+            return;
+        };
+        let live: std::collections::HashSet<&str> = self.games.iter().map(|g| g.id.as_str()).collect();
+        if self.known_hosts[known_idx].prune_games(|id| live.contains(id)) {
             self.persist();
         }
+    }
+
+    fn selected_known_host_idx(&self) -> Option<usize> {
+        self.selected_host
+            .as_ref()
+            .and_then(|(h, p)| self.known_hosts.iter().position(|k| k.host == *h && k.port == *p))
     }
 
     /// Eased 0..=1 progress of pin id `id`'s zoom-in (see `card_pop`)
@@ -516,6 +536,7 @@ impl App {
                 if !self.home_status_sticky {
                     self.home_status = None;
                 }
+                self.prune_stale_game_prefs();
                 self.reorder_games_by_pin();
             }
             Err(e) => {

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -3,11 +3,13 @@
 //! Rendering counterparts live in `app::view`.
 mod about;
 pub(crate) mod addhost;
+pub(crate) mod cardmenu;
 mod cursorsettings;
 pub(crate) mod diagnostics;
 mod edithost;
 mod experimental;
 mod forget;
+pub(crate) mod gamesettings;
 mod home;
 pub(crate) mod hostmenu;
 mod pairing;

--- a/src/app/state/pairing.rs
+++ b/src/app/state/pairing.rs
@@ -146,7 +146,7 @@ impl App {
                         mac: outcome.mac,
                         // Only reaches a genuinely new host — `upsert_known_host` keeps an
                         // existing record's pins and wol_auto.
-                        pinned: vec![store::DESKTOP_PIN_ID.to_string()],
+                        games: store::pinned_only(store::DESKTOP_PIN_ID),
                         ..KnownHost::default()
                     },
                 );

--- a/src/app/state/settings.rs
+++ b/src/app/state/settings.rs
@@ -1,5 +1,11 @@
 //! The settings modal's logic: row navigation, dropdown, persistence. Rendering
 //! (row list layout, dropdown overlay geometry) lives in `app::view::settings`.
+//!
+//! Shared by both settings screens. `Screen::Settings` edits the global document;
+//! `Screen::GameSettings` edits a scratch copy for one game and records each touched row
+//! into that game's sparse override (`app::state::gamesettings`). Which rows exist is
+//! `menu::SettingsScope`'s answer, and every mutator below is indexed by logical `ROW_*`, so the
+//! two screens can't drift apart.
 use crate::app::menu;
 use crate::app::{App, DropdownState};
 use crate::core::event::MenuEvent;
@@ -10,36 +16,39 @@ impl App {
     /// Handles one menu event on the settings modal. `screen_h` is only used by
     /// `Up`/`Down` to keep `self.scroll` following `settings_focused`.
     pub fn handle_settings_event(&mut self, ev: MenuEvent, screen_h: u32) {
+        let set = self.row_set();
         // An open Resolution/Frame rate dropdown intercepts all input until it's
         // closed (by picking an option or backing out) — it's a modal overlay on
         // top of the settings row list.
         if let Some(dd) = self.dropdown.as_mut() {
             // `dd.row` is the display position; setting lookups need the logical row.
             let row = dd.row;
-            let logical = menu::settings_logical_row(row);
+            let logical = menu::settings_logical_row(set, row);
             let len = menu::dropdown_option_count(logical).max(1);
             match ev {
                 MenuEvent::Up | MenuEvent::Down => {
                     crate::ui::widgets::list_nav(&mut dd.focused, len, menu::nav_dir(ev));
                 }
-                MenuEvent::Confirm => {
-                    let choice = dd.focused;
-                    // Not persisted here — `MenuEvent::Back` below (leaving the
-                    // whole Settings screen) saves once for every change made
-                    // during this visit, not per-row.
-                    menu::apply_dropdown_choice(&mut self.settings, logical, choice, self.detected_gamepad_type);
+                // Applied after the borrow ends: the pick has to reach `self` beyond
+                // `self.dropdown`, and the fade needs `dd.focused` either way.
+                MenuEvent::Confirm | MenuEvent::Back => {
+                    let choice = (ev == MenuEvent::Confirm).then_some(dd.focused);
                     self.dropdown_fade.close((row, dd.focused));
                     self.dropdown = None;
-                }
-                MenuEvent::Back => {
-                    self.dropdown_fade.close((row, dd.focused));
-                    self.dropdown = None;
+                    if let Some(choice) = choice {
+                        let detected = self.detected_gamepad_type;
+                        // Not persisted here — `MenuEvent::Back` on the row list (leaving
+                        // the whole screen) saves once for every change made during this
+                        // visit, not per-row.
+                        menu::apply_dropdown_choice(self.settings_target_mut(), logical, choice, detected);
+                        self.capture_game_override(logical);
+                    }
                 }
                 MenuEvent::Left | MenuEvent::Right | MenuEvent::Secondary => {}
             }
             return;
         }
-        let total = menu::settings_row_count();
+        let total = menu::settings_row_count(set);
         match ev {
             // No wraparound here (unlike most other row lists) — wrapping a scrolled
             // list would silently jump the scroll position across the whole card.
@@ -59,7 +68,7 @@ impl App {
             }
             MenuEvent::Left => self.apply_setting_adjust(self.settings_focused, false),
             MenuEvent::Right => self.apply_setting_adjust(self.settings_focused, true),
-            MenuEvent::Confirm => match menu::settings_logical_row(self.settings_focused) {
+            MenuEvent::Confirm => match menu::settings_logical_row(set, self.settings_focused) {
                 // Not a setting — a link out to the About screen (see `menu::ROW_ABOUT`).
                 // Settings are saved on the way out so the visit's changes aren't lost
                 // behind the navigation.
@@ -67,8 +76,12 @@ impl App {
                     self.persist();
                     self.open_about();
                 }
+                // No save on the way in for the per-game flow: its copy is written once,
+                // when its own screen is left (see `persist_game_settings`).
                 menu::ROW_CURSOR => {
-                    self.persist();
+                    if set == menu::SettingsScope::Global {
+                        self.persist();
+                    }
                     self.open_cursor_settings();
                 }
                 menu::ROW_EXPERIMENTAL => {
@@ -79,6 +92,10 @@ impl App {
                     self.persist();
                     self.open_diagnostics();
                 }
+                // Puts the whole screen back: defaults on the global one, "inherit
+                // everything" on the per-game one. Both keep the row list and the focus
+                // where they are — nothing is shown or hidden by this (see `row_shown`).
+                menu::ROW_RESET => self.reset_settings(),
                 // A locked row (see `menu::row_lock`) never opens its dropdown — there is
                 // nothing to pick, which is exactly what the greyed row already says.
                 logical @ (menu::ROW_RESOLUTION
@@ -87,9 +104,9 @@ impl App {
                 | menu::ROW_CODEC
                 | menu::ROW_AUDIO
                 | menu::ROW_GAMEPAD)
-                    if menu::row_lock(logical, &self.settings, self.detected_gamepad_type).is_none() =>
+                    if menu::row_lock(logical, self.settings_target(), self.detected_gamepad_type).is_none() =>
                 {
-                    let focused = menu::dropdown_current_index(&self.settings, logical);
+                    let focused = menu::dropdown_current_index(self.settings_target(), logical);
                     // `row` is the display position (what the overlay is drawn against);
                     // the logical row is recovered on lookup via `settings_logical_row`.
                     self.dropdown = Some(DropdownState {
@@ -107,10 +124,28 @@ impl App {
             // its docs), but there's no reason to touch disk at all more than
             // once per Settings visit.
             MenuEvent::Back => {
-                self.persist();
+                match set {
+                    // One save per visit, not one per keystroke — `StateWriter` queues the
+                    // write off-thread either way, but there's no reason to touch disk more
+                    // often than that.
+                    menu::SettingsScope::Global => self.persist(),
+                    menu::SettingsScope::Game => self.persist_game_settings(),
+                }
                 self.screen = Screen::Home;
             }
             MenuEvent::Secondary => {}
+        }
+    }
+
+    /// The foot-of-the-list reset row (`menu::ROW_RESET`). Not persisted here — like every
+    /// other edit on these screens, it lands on the way out.
+    ///
+    /// Per-game only: the row appears on `SettingsScope::Game` alone (see
+    /// `menu::settings_visible_logical_rows`), so a global screen can never reach here.
+    fn reset_settings(&mut self) {
+        if let Some(gs) = self.game_settings.as_mut() {
+            gs.over = crate::services::store::SettingsOverride::default();
+            gs.merged = self.settings;
         }
     }
 
@@ -120,12 +155,11 @@ impl App {
     /// No focus re-anchoring afterwards: which rows are shown depends on the environment only
     /// (see `menu::row_shown`), so no adjustment can renumber the list under the cursor.
     pub(crate) fn apply_setting_adjust(&mut self, display_row: usize, forward: bool) {
-        let row = menu::settings_logical_row(display_row);
-        let toggled_from = match row {
-            menu::ROW_HDR => Some(self.settings.hdr_enabled),
-            _ => None,
-        };
-        if menu::adjust_setting(&mut self.settings, row, forward, self.detected_gamepad_type) {
+        let row = menu::settings_logical_row(self.row_set(), display_row);
+        let toggled_from = menu::toggle_value(self.settings_target(), row);
+        let detected = self.detected_gamepad_type;
+        if menu::adjust_setting(self.settings_target_mut(), row, forward, detected) {
+            self.capture_game_override(row);
             if let Some(from) = toggled_from {
                 // Scope the slide to the display row being rendered (see `toggle_frac`).
                 self.switch_anim = Some((Instant::now(), from, display_row));

--- a/src/app/view/cardmenu.rs
+++ b/src/app/view/cardmenu.rs
@@ -1,0 +1,106 @@
+//! The held card's submenu — presentation: its row labels, its screen-space geometry and
+//! the selection band the compose path lays over the panel. Logic lives in
+//! `app::state::cardmenu`.
+//!
+//! The panel itself is baked into one tile (`ui::tiles::render_card_menu_tile`) without any
+//! notion of focus, so everything the *selection* needs is here and nothing of it is in that
+//! tile's cache key: moving between rows rebuilds nothing.
+use crate::app::state::cardmenu::{MENU_FOCUS_SLIDE, ROW_COUNT};
+use crate::app::{view, App};
+use crate::ui;
+use crate::ui::render::Rect;
+
+impl App {
+    /// The submenu's rows for `pin_id`'s card. Takes the card rather than reading the open
+    /// menu: the panel is baked when the card takes focus, before there is a menu to ask.
+    /// Pin's label is the action it performs, not the state it reads.
+    pub(crate) fn card_menu_rows(&self, pin_id: &str) -> [(&'static str, &'static str); ROW_COUNT] {
+        let pinned = self.selected_known_host().is_some_and(|h| h.is_pinned(pin_id));
+        [
+            (view::icons::ICON_PIN, if pinned { "Unpin" } else { "Pin" }),
+            (view::icons::ICON_SETTINGS, "Settings"),
+        ]
+    }
+
+    /// The open submenu's rows band in screen space, and the card it hangs off — the
+    /// pointer's counterpart to the panel `render_card_menu_tile` bakes. Derived from the
+    /// same two heights the tile is, so a click lands on the row it can see.
+    ///
+    /// Scaled about the card exactly as `compose_grid` scales what it draws: a focused card
+    /// sits permanently at `1 + CARD_GROWTH`, so an unscaled band would sit several pixels
+    /// above the rows on screen — enough to mispick at a row boundary, and to drop clicks in
+    /// the panel's bottom edge (which read as "clicked outside" and dismiss the menu).
+    pub(crate) fn card_menu_rows_rect(&self, screen_w: u32, fonts: &ui::text::Fonts) -> Option<Rect> {
+        let menu = self.card_menu.as_ref()?;
+        let available_w = screen_w.saturating_sub(ui::widgets::SIDEBAR_W);
+        let columns = view::home::grid_columns(available_w);
+        let idx = self.grid_idx_for_pin_id(&menu.pin_id, columns)?;
+        let card = self.scrolled_card_rect(idx, columns, ui::widgets::SIDEBAR_W as i32, available_w);
+        let panel_h = ui::widgets::card_menu_strip_h(fonts.raster, fonts.value, card.height(), ROW_COUNT);
+        let title_h = ui::widgets::title_strip_h(fonts.raster, fonts.value, card.height());
+        let top = card.bottom() - panel_h as i32 + title_h as i32;
+        let band = Rect::new(card.x(), top, card.width(), panel_h.saturating_sub(title_h));
+        Some(ui::animation::scale_about(
+            band,
+            card,
+            self.focused_card_scale(&menu.pin_id),
+        ))
+    }
+
+    /// The transform `compose_grid` composites the focused card and everything on it with:
+    /// the focus zoom and the appear pop, both about the card's own centre.
+    pub(crate) fn focused_card_scale(&self, pin_id: &str) -> f32 {
+        let f = ui::animation::anim_frac_smooth(self.focus_anim, ui::animation::CARD_FOCUS_POP);
+        ui::animation::zoom_scale(f, crate::app::CARD_GROWTH)
+            * ui::animation::pop_in_scale(self.card_pop_frac(pin_id), crate::app::CARD_POP_SHRINK)
+    }
+
+    /// The submenu row under the pointer, if any.
+    pub(crate) fn card_menu_row_at(&self, x: i32, y: i32, screen_w: u32, fonts: &ui::text::Fonts) -> Option<usize> {
+        let band = self.card_menu_rows_rect(screen_w, fonts)?;
+        if !band.contains_point((x, y)) {
+            return None;
+        }
+        // Proportional, not by `CARD_MENU_ROW_H`: the band carries the focused card's scale
+        // (see `card_menu_rows_rect`), so its rows are that much taller on screen too.
+        let row = ((y - band.y()) as f32 / band.height().max(1) as f32 * ROW_COUNT as f32) as usize;
+        (row < ROW_COUNT).then_some(row)
+    }
+
+    /// The selection band in screen space, clipped to the part of the panel the wipe has
+    /// revealed — `None` when no menu is open on this card, or when the rise hasn't reached
+    /// the band yet.
+    ///
+    /// One band that *moves*, not one per row: on a focus change its top slides from the row
+    /// being left to the row arriving, so the selection reads as a single object travelling
+    /// the list rather than two darkenings trading places.
+    ///
+    /// `panel_h` is the panel tile's own height and `shown` how many of its bottom rows are
+    /// on screen, so the panel's local y maps to `card.bottom() - (panel_h - y)`. `rows_top`
+    /// is the rows overlay's current panel-local top — passed in rather than recomputed
+    /// because the overlay *slides* during the rise (see `compose_grid`), and the band has to
+    /// ride with it or it sits on the resting row while the labels are still travelling.
+    pub(crate) fn card_menu_band(&self, card: Rect, panel_h: u32, shown: u32, rows_top: i32) -> Option<Rect> {
+        let menu = self.card_menu.as_ref()?;
+        let row_h = ui::widgets::CARD_MENU_ROW_H as i32;
+        let row_top = |row: usize| (rows_top + row as i32 * row_h) as f32;
+        // Smoothstep, not the cubic ease-out: eased at both ends, a short travel of one row
+        // height reads as one motion instead of a jump that drifts to a stop.
+        let frac = ui::animation::anim_frac_smooth(menu.leaving.map(|(_, t)| t), MENU_FOCUS_SLIDE);
+        let from = menu
+            .leaving
+            .map_or_else(|| row_top(menu.focused), |(row, _)| row_top(row));
+        let top = (from + (row_top(menu.focused) - from) * frac) as i32;
+        let visible_top = top.max(panel_h as i32 - shown as i32);
+        let visible_bottom = (top + row_h).min(panel_h as i32);
+        if visible_bottom <= visible_top {
+            return None;
+        }
+        Some(Rect::new(
+            card.x(),
+            card.bottom() - (panel_h as i32 - visible_top),
+            card.width(),
+            (visible_bottom - visible_top) as u32,
+        ))
+    }
+}

--- a/src/app/view/cursorsettings.rs
+++ b/src/app/view/cursorsettings.rs
@@ -1,6 +1,6 @@
 //! Cursor: how the pointer behaves in a stream. Logic lives in `app::state::cursorsettings`.
 use crate::app::menu;
-use crate::services::store::Settings;
+use crate::services::store::{Settings, SettingsOverride};
 use crate::ui;
 use crate::ui::render::Rect;
 use crate::ui::text::Fonts;
@@ -13,8 +13,11 @@ pub const TITLE: &str = "Cursor";
 pub const SUBTITLE: &str = "How the pointer behaves in a stream.";
 
 /// Order must match `menu::CURSOR_ROW_*`.
-pub fn rows(settings: &Settings) -> Vec<FocusRow> {
-    vec![
+///
+/// `over` is the per-game override this screen is editing (empty on the global one) — a row
+/// it sets wears the same dot the per-game row list gives its own rows.
+pub fn rows(settings: &Settings, over: &SettingsOverride) -> Vec<FocusRow> {
+    let mut rows = vec![
         FocusRow::toggle(crate::app::view::icons::ICON_MOUSE, "Capture", settings.cursor_capture).with_subtext(
             ui::widgets::RowSubtext::hint(if settings.cursor_capture {
                 "Capture (games)"
@@ -30,7 +33,11 @@ pub fn rows(settings: &Settings) -> Vec<FocusRow> {
         .with_subtext(ui::widgets::RowSubtext::hint(
             "Hold OK to right-click or red remote button",
         )),
-    ]
+    ];
+    for (cursor_row, row) in rows.iter_mut().enumerate() {
+        row.mark = menu::override_mark(over, menu::cursor_logical_row(cursor_row));
+    }
+    rows
 }
 
 pub fn card_rect(screen_w: u32, screen_h: u32, fonts: &Fonts) -> Rect {
@@ -40,6 +47,7 @@ pub fn card_rect(screen_w: u32, screen_h: u32, fonts: &Fonts) -> Rect {
 /// The cursor settings list as a [`ModalScreen`].
 pub(crate) struct Modal<'a> {
     pub settings: &'a Settings,
+    pub over: &'a SettingsOverride,
 }
 
 impl ModalScreen for Modal<'_> {
@@ -52,12 +60,12 @@ impl ModalScreen for Modal<'_> {
             card,
             fonts,
             SUBTITLE,
-            rows(self.settings).len(),
+            rows(self.settings, self.over).len(),
         ))
     }
 
     fn render(&self, c: &mut Canvas, hover_close: bool) -> Result<()> {
         let card = self.card_rect(c.screen_w, c.screen_h, c.fonts);
-        c.list_modal_screen(card, TITLE, SUBTITLE, &rows(self.settings), hover_close)
+        c.list_modal_screen(card, TITLE, SUBTITLE, &rows(self.settings, self.over), hover_close)
     }
 }

--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -8,6 +8,7 @@
 //! carries no dependency on the app state machine.
 pub(crate) mod about;
 pub(crate) mod addhost;
+pub(crate) mod cardmenu;
 pub(crate) mod cursorsettings;
 pub(crate) mod diagnostics;
 pub(crate) mod experimental;

--- a/src/app/view/settings.rs
+++ b/src/app/view/settings.rs
@@ -1,6 +1,7 @@
 //! The settings modal — presentation: row list layout, dropdown overlay geometry, shell.
 //! Logic lives in `app::state::settings`.
 use crate::app::menu;
+use crate::app::menu::SettingsScope;
 use crate::core::VERSION;
 use crate::services::store::{GamepadType, Settings, VideoBackend};
 use crate::ui;
@@ -74,8 +75,8 @@ fn lock_caption(lock: menu::RowLock, webos_major: Option<u32>) -> String {
     }
 }
 
-/// One row per `menu::ROW_*`, in order, filtered by `menu::row_shown` and greyed by
-/// `menu::row_lock` (whose reason becomes the row's caption, see [`lock_caption`]).
+/// One row per `menu::ROW_*`, in order, filtered by `menu::settings_visible_logical_rows`
+/// (so `set` decides which list this is) and greyed by `menu::row_lock` (whose reason becomes the row's caption, see [`lock_caption`]).
 ///
 /// `detected_gamepad_type` is the attached pad per `gamepad::detect_type`, `None` with nothing
 /// attached or an unrecognized pad — it only changes what "Automatic" reads as.
@@ -85,6 +86,7 @@ fn lock_caption(lock: menu::RowLock, webos_major: Option<u32>) -> String {
 /// `hid-playstation` — see `platform::webos::dualsense::hid_playstation_bound`. Computed by
 /// the caller, like `webos_major`, so this module stays platform-neutral.
 pub(crate) fn rows(
+    set: SettingsScope,
     settings: &Settings,
     detected_gamepad_type: Option<GamepadType>,
     dualsense_limited: bool,
@@ -96,18 +98,18 @@ pub(crate) fn rows(
         (settings.bitrate_kbps.saturating_sub(menu::BITRATE_MIN_KBPS)) as f32
             / (menu::BITRATE_MAX_KBPS - menu::BITRATE_MIN_KBPS) as f32
     };
-    let rows = vec![
-        FocusRow::dropdown(
+    let row_for = |logical: usize| match logical {
+        menu::ROW_RESOLUTION => FocusRow::dropdown(
             crate::app::view::icons::ICON_MONITOR,
             "Resolution",
             menu::resolution_label(settings.width, settings.height),
         ),
-        FocusRow::dropdown(
+        menu::ROW_FRAMERATE => FocusRow::dropdown(
             crate::app::view::icons::ICON_SCHEDULE,
             "Frame rate",
             format!("{} Hz", settings.refresh_hz),
         ),
-        FocusRow::slider(
+        menu::ROW_BITRATE => FocusRow::slider(
             crate::app::view::icons::ICON_SIGNAL,
             "Bitrate",
             if settings.bitrate_kbps == menu::BITRATE_AUTOMATIC {
@@ -121,7 +123,7 @@ pub(crate) fn rows(
             (settings.bitrate_kbps > menu::BITRATE_WARN_KBPS)
                 .then(|| ui::widgets::RowSubtext::caution("May be unstable on Wi-Fi — try Ethernet")),
         ),
-        FocusRow::dropdown(
+        menu::ROW_VIDEO_BACKEND => FocusRow::dropdown(
             crate::app::view::icons::ICON_MEMORY,
             "Video backend",
             match settings.video_backend {
@@ -129,18 +131,18 @@ pub(crate) fn rows(
                 VideoBackend::Smp => "SMP",
             },
         ),
-        FocusRow::dropdown(
+        menu::ROW_CODEC => FocusRow::dropdown(
             crate::app::view::icons::ICON_MOVIE,
             "Codec",
             menu::codec_label(settings.codec),
         ),
-        FocusRow::toggle(crate::app::view::icons::ICON_SUN, "HDR", settings.hdr_enabled),
-        FocusRow::dropdown(
+        menu::ROW_HDR => FocusRow::toggle(crate::app::view::icons::ICON_SUN, "HDR", settings.hdr_enabled),
+        menu::ROW_AUDIO => FocusRow::dropdown(
             crate::app::view::icons::ICON_SIGNAL,
             "Audio",
             menu::audio_label(settings.audio_channels),
         ),
-        FocusRow::dropdown(
+        menu::ROW_GAMEPAD => FocusRow::dropdown(
             crate::app::view::icons::ICON_GAMEPAD,
             "Controller",
             if settings.gamepad_type == GamepadType::Auto {
@@ -152,37 +154,45 @@ pub(crate) fn rows(
         .with_subtext_opt(
             dualsense_limited.then(|| ui::widgets::RowSubtext::caution("Limited support by your WebOS version")),
         ),
-        FocusRow::action(crate::app::view::icons::ICON_MOUSE, "Cursor"),
-        FocusRow::action(crate::app::view::icons::ICON_BUG, "Experimental"),
-        FocusRow::action(crate::app::view::icons::ICON_WRENCH, "Diagnostics"),
+        menu::ROW_CURSOR => FocusRow::action(crate::app::view::icons::ICON_MOUSE, "Cursor"),
+        menu::ROW_EXPERIMENTAL => FocusRow::action(crate::app::view::icons::ICON_BUG, "Experimental"),
+        menu::ROW_DIAGNOSTICS => FocusRow::action(crate::app::view::icons::ICON_WRENCH, "Diagnostics"),
         // The build version rides along as this row's value, so it's visible without
         // opening the screen — matching where the other clients surface it.
-        FocusRow::action_with_value(
+        menu::ROW_ABOUT => FocusRow::action_with_value(
             crate::app::view::icons::ICON_INFO,
             "About & licenses",
             format!("v{VERSION}"),
         ),
-    ];
-    debug_assert_eq!(
-        rows.len(),
-        menu::SETTINGS_ROW_COUNT,
-        "one row per logical index, in order"
-    );
-    // Driven by the two predicates rather than repeating their conditions, so a row hidden or
-    // locked there can never disagree here. Index == logical row, guaranteed by the assert above.
-    rows.into_iter()
-        .enumerate()
-        .filter(|(logical, _)| menu::row_shown(*logical))
-        .map(
-            |(logical, row)| match menu::row_lock(logical, settings, detected_gamepad_type) {
+        // Marked destructive: it discards the whole screen's worth of choices in one press,
+        // and the red reads as that before it's pressed rather than after. Per-game only —
+        // the global list has nothing to fall back to (see `menu::ROW_RESET`).
+        menu::ROW_RESET => FocusRow::action(crate::app::view::icons::ICON_DELETE, "Reset")
+            .danger()
+            .with_subtext(ui::widgets::RowSubtext::hint("Use global settings for this game")),
+        // `ROW_CURSOR_CAPTURE`/`ROW_CURSOR_GESTURES` are logical ids only — both screens reach
+        // them through the Cursor link above, so they are on neither list and never asked for.
+        // Anything else means a row list gained an id without an arm here: fail loudly in
+        // debug rather than render a blank, focusable row.
+        _ => {
+            debug_assert!(false, "no settings row built for logical {logical}");
+            FocusRow::action("", "")
+        }
+    };
+    // Driven by the shared predicates rather than repeating their conditions, so a row hidden or
+    // locked there can never disagree here.
+    menu::settings_visible_logical_rows(set)
+        .map(|logical| {
+            let row = row_for(logical);
+            match menu::row_lock(logical, settings, detected_gamepad_type) {
                 // The lock's caption replaces whatever contextual one the row carried: a row the
                 // user can't change has nothing more useful to say than why.
                 Some(lock) => row
                     .locked(true)
                     .with_subtext(ui::widgets::RowSubtext::hint(lock_caption(lock, webos_major))),
                 None => row,
-            },
-        )
+            }
+        })
         .collect()
 }
 
@@ -193,9 +203,9 @@ pub(crate) fn rows(
 /// the partially-visible sliver the bottom fade dissolves. Computed without the peek first,
 /// because a list that fits entirely has nothing below to peek at and should not give up
 /// the space.
-pub(crate) fn visible_rows(screen_h: u32) -> usize {
+pub(crate) fn visible_rows(set: SettingsScope, screen_h: u32) -> usize {
     let stride = ui::widgets::focus_row_stride();
-    let total = menu::settings_row_count();
+    let total = menu::settings_row_count(set);
     let budget = screen_h.saturating_sub(CHROME_TOP + CHROME_BOTTOM + EDGE_MARGIN);
     if (budget / stride) as usize >= total {
         return total.max(1);
@@ -207,9 +217,9 @@ pub(crate) fn visible_rows(screen_h: u32) -> usize {
 /// Height of the scrolling viewport: the fully-visible rows plus a peek strip past each
 /// edge while the list overflows. Deliberately *not* a whole multiple of the row stride
 /// when scrolling — see [`PEEK`].
-pub(crate) fn content_h(screen_h: u32) -> u32 {
-    let visible = visible_rows(screen_h);
-    let peeks = if visible < menu::settings_row_count() {
+pub(crate) fn content_h(set: SettingsScope, screen_h: u32) -> u32 {
+    let visible = visible_rows(set, screen_h);
+    let peeks = if visible < menu::settings_row_count(set) {
         2 * PEEK
     } else {
         0
@@ -217,16 +227,20 @@ pub(crate) fn content_h(screen_h: u32) -> u32 {
     visible as u32 * ui::widgets::focus_row_stride() + peeks
 }
 
+/// Width the title line keeps clear on the right for the close button, which overhangs the
+/// content column (see `ui::widgets::modal_close_rect`).
+const CLOSE_RESERVE: u32 = 48;
+
 /// Left/right inset of the card's own content column — the title, the rule and the row
 /// list all start here.
 pub(crate) const SIDE_PAD: u32 = 40;
 
 /// Card and content rects, shared by render and hit-test. One split, read twice: the card's
 /// height is what its own stack adds up to, and the viewport is the middle slot of it.
-pub(crate) fn layout(screen_w: u32, screen_h: u32) -> (Rect, Rect) {
+pub(crate) fn layout(set: SettingsScope, screen_w: u32, screen_h: u32) -> (Rect, Rect) {
     let stack = ui::layout::Layout::vertical([
         ui::layout::Constraint::Length(CHROME_TOP),
-        ui::layout::Constraint::Length(content_h(screen_h)),
+        ui::layout::Constraint::Length(content_h(set, screen_h)),
         ui::layout::Constraint::Length(CHROME_BOTTOM),
     ]);
     // Widened from 0.56 to fit the scroll indicator on the right edge.
@@ -249,27 +263,68 @@ pub(crate) fn dropdown_overlay_rect_at_px(content: Rect, row: usize, scroll_px: 
     Rect::new(content.x(), y, content.width(), 0)
 }
 
+/// Radius of the dot separating the heading from the per-game title suffix, and the gap it
+/// keeps on each side.
+const SEP_DOT_R: i32 = 3;
+const SEP_DOT_GAP: i32 = 12;
+
 /// The shell only: card chrome, title and rule. The row list is its own scroll-content
 /// tile and the open dropdown its own overlay tile, so neither scrolling nor navigating
 /// options re-rasterizes this.
-pub(crate) fn render(c: &mut Canvas, hover_close: bool) -> Result<()> {
-    let (card, _content) = layout(c.screen_w, c.screen_h);
+///
+/// `suffix` is appended after the title in the muted text colour — the per-game screen names
+/// its game there, dimmer so "Settings" still reads as the heading.
+pub(crate) fn render(c: &mut Canvas, set: SettingsScope, suffix: Option<&str>, hover_close: bool) -> Result<()> {
+    let (card, _content) = layout(set, c.screen_w, c.screen_h);
     let column = content_column(card);
+    let baseline = card.y() + 36;
     c.modal_shell(card, hover_close)?;
-    c.text(c.fonts.label, TITLE, column.x(), card.y() + 36, ui::style::theme().text)?;
+    c.text(c.fonts.label, TITLE, column.x(), baseline, ui::style::theme().text)?;
+    if let Some(suffix) = suffix {
+        let font = c.fonts.label;
+        let title_w = c.fonts.raster.measure(font, TITLE).0;
+        // A dot between the heading and the game name: at this size a space reads as a line
+        // break waiting to happen, and the two words are not one phrase.
+        let dot_x = column.x() + title_w as i32 + SEP_DOT_GAP;
+        c.painter.fill_rounded_rect(
+            Rect::new(
+                dot_x,
+                baseline + c.fonts.raster.height(font) / 2 - SEP_DOT_R,
+                2 * SEP_DOT_R as u32,
+                2 * SEP_DOT_R as u32,
+            ),
+            SEP_DOT_R,
+            ui::style::theme().muted,
+        );
+        let used = title_w + (2 * SEP_DOT_GAP + 2 * SEP_DOT_R) as u32;
+        // Ellipsized rather than clipped: a long game name must not run under the close button.
+        let avail = column.width().saturating_sub(used + CLOSE_RESERVE);
+        let suffix = ui::text::ellipsize(c.fonts.raster, font, suffix, avail);
+        c.text(
+            font,
+            &suffix,
+            column.x() + used as i32,
+            baseline,
+            ui::style::theme().muted,
+        )?;
+    }
     c.painter.rule(column.x(), card.y() + 88, column.width());
     Ok(())
 }
 
-/// The settings modal as a [`ModalScreen`].
-pub(crate) struct Modal;
+/// The settings modal as a [`ModalScreen`]. `game` names the per-game variant's title suffix;
+/// `None` is the global screen.
+pub(crate) struct Modal<'a> {
+    pub set: SettingsScope,
+    pub game: Option<&'a str>,
+}
 
-impl ModalScreen for Modal {
+impl ModalScreen for Modal<'_> {
     fn card_rect(&self, screen_w: u32, screen_h: u32, _fonts: &ui::text::Fonts) -> Rect {
-        layout(screen_w, screen_h).0
+        layout(self.set, screen_w, screen_h).0
     }
 
     fn render(&self, c: &mut Canvas, hover_close: bool) -> Result<()> {
-        render(c, hover_close)
+        render(c, self.set, self.game, hover_close)
     }
 }

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -1,5 +1,5 @@
-/// How long a button must be held to take a gesture's long-press branch: pin/unpin
-/// instead of launch on a Home card (`runtime::input::PIN_HOLD`), right-click instead
+/// How long a button must be held to take a gesture's long-press branch: the card's own
+/// menu instead of launch on a Home card (`runtime::input::CARD_HOLD`), right-click instead
 /// of left on the Magic Remote's OK during a stream
 /// (`platform::webos::mouse::OkPress`). One value so a hold feels the same
 /// wherever the user learns it.

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -1,4 +1,6 @@
 //! Plain domain data. No I/O — persistence lives in `crate::services`.
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 /// Stream connection target.
@@ -29,14 +31,139 @@ pub struct KnownHost {
     pub mac: Vec<String>,
     /// Auto-wake on unreachable (per-host, off by default; lives in Wake settings).
     pub wol_auto: bool,
-    /// Pinned game IDs (up to `MAX_PINNED_GAMES`).
-    pub pinned: Vec<String>,
+    /// Per-game state for this host, keyed by `GameEntry::id` (or [`DESKTOP_PIN_ID`]) — pins
+    /// and settings overrides together, so one prune drops both when a game leaves the library.
+    /// A `BTreeMap` so the file's key order is stable and diffable.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub games: BTreeMap<String, GamePrefs>,
+}
+
+/// What one game carries on one host. Absent from `KnownHost::games` entirely when it holds
+/// nothing — an untouched game costs no bytes.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GamePrefs {
+    /// Pin slot — the ordering key of the pinned block. `None` = not pinned. Values are
+    /// monotonic per host, not dense: unpinning leaves a hole rather than renumbering.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pin: Option<u32>,
+    /// Settings this game overrides; every unset field falls through to the global [`Settings`].
+    #[serde(skip_serializing_if = "SettingsOverride::is_empty")]
+    pub over: SettingsOverride,
+}
+
+impl GamePrefs {
+    /// Nothing worth persisting — the prune drops these.
+    fn is_empty(&self) -> bool {
+        self.pin.is_none() && self.over.is_empty()
+    }
+}
+
+/// A sparse [`Settings`] diff: `Some` overrides the global value for one game, `None` inherits it.
+///
+/// Deliberately *not* every field. The experimental and diagnostics toggles are device-wide
+/// and stay global-only, as does `video_backend` — it is a process-global
+/// (`core::caps::set_backend`, which both `session::connect`'s clamp and the caps-derived row
+/// locks read), so a per-game value would need an apply/restore around every launch.
+///
+/// `Copy + Hash + Eq` because it rides the render cache keys next to `Settings`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(default)]
+pub struct SettingsOverride {
+    /// Width and height move together — they are one Resolution row.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<(u32, u32)>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_hz: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bitrate_kbps: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hdr_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub codec: Option<CodecPref>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio_channels: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gamepad_type: Option<GamepadType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor_capture: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor_gestures: Option<bool>,
+}
+
+impl SettingsOverride {
+    pub fn is_empty(&self) -> bool {
+        *self == Self::default()
+    }
+
+    /// `base` with every set field applied. The result still needs
+    /// [`Settings::clamp_to_caps`] before it reaches the wire, exactly like a global value.
+    /// Clears every field that already equals `global` — a value the user has just set back
+    /// to what the global screen says is not an override, and must not linger in the
+    /// document. Run after every edit, so the record stays minimal (and disappears
+    /// entirely, via [`KnownHost::edit_overrides`], once nothing differs).
+    pub fn drop_matching(&mut self, global: &Settings) {
+        // Field by field against the global, not against the merge: a field is an override
+        // exactly when it is set *and* differs, and an unset one has nothing to drop.
+        macro_rules! drop_if_global {
+            ($($field:ident => $global:expr),* $(,)?) => {
+                $(if self.$field == Some($global) {
+                    self.$field = None;
+                })*
+            };
+        }
+        drop_if_global! {
+            mode => (global.width, global.height),
+            refresh_hz => global.refresh_hz,
+            bitrate_kbps => global.bitrate_kbps,
+            hdr_enabled => global.hdr_enabled,
+            codec => global.codec,
+            audio_channels => global.audio_channels,
+            gamepad_type => global.gamepad_type,
+            cursor_capture => global.cursor_capture,
+            cursor_gestures => global.cursor_gestures,
+        }
+    }
+
+    #[must_use]
+    pub fn merge_into(&self, mut base: Settings) -> Settings {
+        if let Some((w, h)) = self.mode {
+            base.width = w;
+            base.height = h;
+        }
+        if let Some(v) = self.refresh_hz {
+            base.refresh_hz = v;
+        }
+        if let Some(v) = self.bitrate_kbps {
+            base.bitrate_kbps = v;
+        }
+        if let Some(v) = self.hdr_enabled {
+            base.hdr_enabled = v;
+        }
+        if let Some(v) = self.codec {
+            base.codec = v;
+        }
+        if let Some(v) = self.audio_channels {
+            base.audio_channels = v;
+        }
+        if let Some(v) = self.gamepad_type {
+            base.gamepad_type = v;
+        }
+        if let Some(v) = self.cursor_capture {
+            base.cursor_capture = v;
+        }
+        if let Some(v) = self.cursor_gestures {
+            base.cursor_gestures = v;
+        }
+        base
+    }
 }
 
 /// Max games pinned to one host's always-visible grid row at once.
 pub const MAX_PINNED_GAMES: usize = 5;
 
-/// Pin ID for "Desktop" card (stored in pinned like games; counts toward `MAX_PINNED_GAMES`).
+/// Pin ID for the "Desktop" card — a `games` key like any other, and it counts toward
+/// `MAX_PINNED_GAMES`. Never pruned, since no library listing contains it.
 pub const DESKTOP_PIN_ID: &str = "__desktop__";
 
 impl KnownHost {
@@ -45,31 +172,92 @@ impl KnownHost {
     }
 
     pub fn is_pinned(&self, id: &str) -> bool {
-        self.pinned.iter().any(|p| p == id)
+        self.games.get(id).is_some_and(|g| g.pin.is_some())
+    }
+
+    /// Pinned ids, in pin order.
+    pub fn pinned_ids(&self) -> Vec<&str> {
+        let mut pinned: Vec<(u32, &str)> = self
+            .games
+            .iter()
+            .filter_map(|(id, g)| g.pin.map(|p| (p, id.as_str())))
+            .collect();
+        pinned.sort_unstable();
+        pinned.into_iter().map(|(_, id)| id).collect()
+    }
+
+    pub fn pinned_count(&self) -> usize {
+        self.games.values().filter(|g| g.pin.is_some()).count()
     }
 
     /// Whether toggling id would do anything (unpin always ok, pin only if under `MAX_PINNED_GAMES`).
     pub fn can_toggle_pin(&self, id: &str) -> bool {
-        self.is_pinned(id) || self.pinned.len() < MAX_PINNED_GAMES
+        self.is_pinned(id) || self.pinned_count() < MAX_PINNED_GAMES
     }
 
     /// Toggles `id`'s pinned state (a `GameEntry::id`, or `DESKTOP_PIN_ID`) —
     /// a no-op when `can_toggle_pin` is false.
     pub fn toggle_pin(&mut self, id: &str) {
-        match self.pinned.iter().position(|p| p == id) {
-            Some(i) => drop(self.pinned.remove(i)),
-            None if self.can_toggle_pin(id) => self.pinned.push(id.to_string()),
-            None => {}
+        if self.is_pinned(id) {
+            if let Some(g) = self.games.get_mut(id) {
+                g.pin = None;
+            }
+            self.drop_if_empty(id);
+        } else if self.can_toggle_pin(id) {
+            // Monotonic, never renumbered: a re-pin lands at the end of the block, which is
+            // where someone who just pinned it expects to find it.
+            let next = self.games.values().filter_map(|g| g.pin).max().map_or(0, |m| m + 1);
+            self.games.entry(id.to_string()).or_default().pin = Some(next);
         }
     }
+
+    /// This game's overrides, or the empty set — reading never creates an entry.
+    pub fn overrides(&self, id: &str) -> SettingsOverride {
+        self.games.get(id).map_or_else(SettingsOverride::default, |g| g.over)
+    }
+
+    /// Runs `edit` against this game's overrides, creating the entry only if needed and
+    /// dropping it again when the edit leaves nothing behind.
+    pub fn edit_overrides(&mut self, id: &str, edit: impl FnOnce(&mut SettingsOverride)) {
+        edit(&mut self.games.entry(id.to_string()).or_default().over);
+        self.drop_if_empty(id);
+    }
+
+    fn drop_if_empty(&mut self, id: &str) {
+        if self.games.get(id).is_some_and(GamePrefs::is_empty) {
+            self.games.remove(id);
+        }
+    }
+
+    /// Drops per-game state for ids the host no longer lists. `live` must come from a
+    /// *successful* library fetch — an error or an offline host would otherwise wipe
+    /// everything. [`DESKTOP_PIN_ID`] is always kept: it is never in a library listing.
+    /// Returns whether anything was removed.
+    pub fn prune_games(&mut self, live: impl Fn(&str) -> bool) -> bool {
+        let before = self.games.len();
+        self.games.retain(|id, _| id == DESKTOP_PIN_ID || live(id));
+        self.games.len() != before
+    }
+}
+
+/// A fresh host's per-game map: just `id` pinned. What every add/pair flow seeds
+/// [`KnownHost::games`] with, so the Desktop card starts in the pinned block.
+pub fn pinned_only(id: &str) -> BTreeMap<String, GamePrefs> {
+    BTreeMap::from([(
+        id.to_string(),
+        GamePrefs {
+            pin: Some(0),
+            ..GamePrefs::default()
+        },
+    )])
 }
 
 /// Upserts by `(host, port)`, keeping the existing fingerprint if the new record is unpaired
 /// (a fresh mDNS discovery shouldn't clobber a paired host) — same reasoning for `mac`,
 /// learned separately (see `App::drain_discovery`) and not necessarily known again at the
-/// point something else re-upserts this host. `pinned` and `wol_auto` are *always* kept from the
-/// existing record: only [`KnownHost::toggle_pin`] and the Wake screen change them, so no
-/// add/edit/re-pair flow may clobber either.
+/// point something else re-upserts this host. `games` and `wol_auto` are *always* kept from the
+/// existing record: only [`KnownHost::toggle_pin`], the per-game settings screen and the Wake
+/// screen change them, so no add/edit/re-pair flow may clobber any of it.
 pub fn upsert_known_host(hosts: &mut Vec<KnownHost>, mut new: KnownHost) {
     let Some(existing) = hosts.iter_mut().find(|h| h.host == new.host && h.port == new.port) else {
         hosts.push(new);
@@ -81,7 +269,7 @@ pub fn upsert_known_host(hosts: &mut Vec<KnownHost>, mut new: KnownHost) {
     if new.mac.is_empty() {
         new.mac.clone_from(&existing.mac);
     }
-    new.pinned.clone_from(&existing.pinned);
+    new.games.clone_from(&existing.games);
     new.wol_auto = existing.wol_auto;
     *existing = new;
 }
@@ -340,6 +528,11 @@ pub struct Persisted {
     /// grid instead of an unfocused sidebar. `(host, port)`, not an index: `known_hosts` order
     /// isn't stable across a forget/re-add.
     pub selected_host: Option<(String, u16)>,
+    /// The app version that last wrote this document (`CARGO_PKG_VERSION`). `None` means it
+    /// was written before versioning existed — the only signal a future migration gets about
+    /// which shape it is reading. `store::load` stamps it on first sight.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
 }
 
 /// Cover-art paths for a title (host-relative, fetched via mTLS). Cards prefer
@@ -360,4 +553,101 @@ pub struct GameEntry {
     pub title: String,
     #[serde(default)]
     pub art: Artwork,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn host() -> KnownHost {
+        KnownHost {
+            games: pinned_only(DESKTOP_PIN_ID),
+            ..KnownHost::default()
+        }
+    }
+
+    #[test]
+    fn merge_leaves_unset_fields_at_the_global_value() {
+        let global = Settings {
+            width: 1920,
+            height: 1080,
+            bitrate_kbps: 20_000,
+            ..Settings::default()
+        };
+        let over = SettingsOverride {
+            bitrate_kbps: Some(50_000),
+            ..SettingsOverride::default()
+        };
+        let merged = over.merge_into(global);
+        assert_eq!(merged.bitrate_kbps, 50_000);
+        assert_eq!((merged.width, merged.height), (1920, 1080));
+        assert_eq!(merged.refresh_hz, global.refresh_hz);
+    }
+
+    #[test]
+    fn a_value_set_back_to_the_global_stops_being_an_override() {
+        let global = Settings::default();
+        let mut over = SettingsOverride {
+            refresh_hz: Some(120),
+            bitrate_kbps: Some(50_000),
+            ..SettingsOverride::default()
+        };
+        over.drop_matching(&global);
+        assert_eq!(over.refresh_hz, Some(120), "still differs");
+        assert_eq!(over.bitrate_kbps, Some(50_000));
+        // The user picks the global's own value back.
+        over.refresh_hz = Some(global.refresh_hz);
+        over.drop_matching(&global);
+        assert_eq!(over.refresh_hz, None, "matching the global is not an override");
+        over.bitrate_kbps = Some(global.bitrate_kbps);
+        over.drop_matching(&global);
+        assert!(over.is_empty(), "nothing differs, so nothing is persisted");
+    }
+
+    #[test]
+    fn an_edit_that_undoes_itself_leaves_no_entry_behind() {
+        let mut h = host();
+        h.edit_overrides("steam:1", |o| o.refresh_hz = Some(120));
+        assert!(h.games.contains_key("steam:1"));
+        h.edit_overrides("steam:1", |o| o.refresh_hz = None);
+        assert!(!h.games.contains_key("steam:1"), "an empty record is dropped");
+    }
+
+    #[test]
+    fn pins_keep_their_order_and_respect_the_limit() {
+        let mut h = host();
+        for i in 0..MAX_PINNED_GAMES {
+            h.toggle_pin(&format!("g{i}"));
+        }
+        // Desktop was already pinned, so the last one had no slot left.
+        assert_eq!(h.pinned_count(), MAX_PINNED_GAMES);
+        assert_eq!(h.pinned_ids()[0], DESKTOP_PIN_ID);
+        assert!(!h.is_pinned(&format!("g{}", MAX_PINNED_GAMES - 1)));
+        // Unpinning frees a slot, and a re-pin lands at the end of the block.
+        h.toggle_pin("g0");
+        assert!(!h.is_pinned("g0"));
+        h.toggle_pin("g0");
+        assert_eq!(*h.pinned_ids().last().expect("just pinned"), "g0");
+    }
+
+    #[test]
+    fn pruning_drops_vanished_games_but_never_desktop() {
+        let mut h = host();
+        h.toggle_pin("steam:gone");
+        h.edit_overrides("steam:here", |o| o.hdr_enabled = Some(false));
+        assert!(h.prune_games(|id| id == "steam:here"));
+        assert!(h.games.contains_key(DESKTOP_PIN_ID));
+        assert!(h.games.contains_key("steam:here"));
+        assert!(!h.games.contains_key("steam:gone"));
+        assert!(!h.prune_games(|id| id == "steam:here"), "a second pass is a no-op");
+    }
+
+    #[test]
+    fn upsert_keeps_per_game_state() {
+        let mut hosts = vec![host()];
+        hosts[0].edit_overrides("steam:1", |o| o.codec = Some(CodecPref::Hevc));
+        upsert_known_host(&mut hosts, KnownHost::default());
+        assert_eq!(hosts[0].overrides("steam:1").codec, Some(CodecPref::Hevc));
+        assert!(hosts[0].is_pinned(DESKTOP_PIN_ID));
+    }
 }

--- a/src/core/screen.rs
+++ b/src/core/screen.rs
@@ -1,8 +1,22 @@
+/// Which settings document a settings-shaped screen edits. The per-game scope shows the
+/// overridable rows only (see `app::menu::settings_visible_logical_rows`) and edits a scratch
+/// copy of the global document; both share every row mutator, so a row behaves identically
+/// wherever it appears.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub enum SettingsScope {
+    Global,
+    Game,
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Screen {
     Home,
     Pairing,
-    Settings,
+    /// The settings list, in one of two scopes: the global document, or one game's
+    /// overrides of it (`SettingsScope::Game`, reached only by holding that game's card —
+    /// there is no path to it from the global screen). One variant, because the two are the
+    /// same screen with a different row list: every dispatch site treats them alike.
+    Settings(SettingsScope),
     AddHost,
     Wake,
     ForgetHost,

--- a/src/runtime/input.rs
+++ b/src/runtime/input.rs
@@ -16,14 +16,14 @@ use super::*;
 pub(super) const EXIT_HOLD: Duration = Duration::from_millis(1000);
 
 /// How long OK must be held on a focused Home game card to pin/unpin it instead
-/// of launching it — see `pin_hold_gate`.
-pub(super) const PIN_HOLD: Duration = crate::core::event::LONG_PRESS;
+/// of launching it — see `card_hold_gate`.
+pub(super) const CARD_HOLD: Duration = crate::core::event::LONG_PRESS;
 
 /// An in-flight hold-to-pin gesture: OK is down on a pinnable Home card. The
-/// toggle fires the moment `PIN_HOLD` elapses (so the pin visibly lands under
+/// toggle fires the moment `CARD_HOLD` elapses (so the pin visibly lands under
 /// the still-held button), and `fired` then makes the release a no-op instead
 /// of the launch a quick tap would have dispatched.
-pub(super) struct PinHold {
+pub(super) struct CardHold {
     pub(super) since: Instant,
     pub(super) focus: HomeFocus,
     pub(super) fired: bool,
@@ -382,8 +382,8 @@ pub(super) struct UiInput {
     /// dispatches Back exactly once no matter how SDL reports (or misreports)
     /// repeats for it.
     menu_back_down: bool,
-    /// Hold-to-pin on Home (see `PIN_HOLD`), while OK is held on a pinnable card.
-    pub(super) pin_held: Option<PinHold>,
+    /// Hold-to-pin on Home (see `CARD_HOLD`), while OK is held on a pinnable card.
+    pub(super) card_held: Option<CardHold>,
     stick_nav: crate::platform::webos::input::StickMenuNav,
 }
 
@@ -395,12 +395,28 @@ pub(super) enum EventAction {
     Launch,
 }
 
-/// Hold-to-pin arbitration (see `PIN_HOLD`). `MenuEvent` has no press/release
+/// Hold-to-pin arbitration (see `CARD_HOLD`). `MenuEvent` has no press/release
 /// notion, so the gesture works off raw SDL events: OK down on a pinnable Home
 /// card starts the hold and is swallowed, and the launch can only ever come
 /// from the release. `Some` means the event was the gesture's and goes no
 /// further.
-fn pin_hold_gate(
+/// Starts a hold on the focused grid card, if the focus is on one. Both the pointer press
+/// and the OK press arm through here so the two gestures can never disagree about what a
+/// hold is; `screen_w` is the full screen width, the sidebar taken off inside.
+fn arm_card_hold(input: &mut UiInput, app: &App, screen_w: u32) -> bool {
+    let columns = crate::app::view::home::grid_columns(screen_w.saturating_sub(crate::ui::widgets::SIDEBAR_W));
+    if app.focused_pin_id(columns).is_none() {
+        return false;
+    }
+    input.card_held = Some(CardHold {
+        since: Instant::now(),
+        focus: app.home_focus,
+        fired: false,
+    });
+    true
+}
+
+fn card_hold_gate(
     app: &mut App,
     event: &sdl2::event::Event,
     input: &mut UiInput,
@@ -410,12 +426,11 @@ fn pin_hold_gate(
 ) -> Option<EventAction> {
     use sdl2::event::Event;
     let (w, h) = (display_mode.w as u32, display_mode.h as u32);
-    // The Magic Remote's pointer delivers OK as a left mouse button, so give it
-    // the same hold-to-pin gesture the D-pad's Confirm has: a press on a hovered
-    // pinnable Home card starts the hold and is swallowed (the pin fires on the
-    // hold-elapsed tick, same as `PIN_HOLD` above), and the tap/launch comes only
-    // from the release. A press on anything else falls through to the normal
-    // click path.
+    // The Magic Remote's pointer delivers OK as a left mouse button, so give it the same
+    // hold gesture the D-pad's Confirm has: a press on a hovered Home card starts the hold
+    // and is swallowed (the card's menu opens on the hold-elapsed tick, same as `CARD_HOLD`
+    // above), and the tap/launch comes only from the release. A press on anything else falls
+    // through to the normal click path.
     if let Event::MouseButtonDown {
         mouse_btn: sdl2::mouse::MouseButton::Left,
         x,
@@ -423,28 +438,25 @@ fn pin_hold_gate(
         ..
     } = *event
     {
-        if !matches!(app.screen, Screen::Home) {
+        // A press while the menu is up belongs to the menu, not to a fresh gesture — the
+        // hold fires on elapsed (see `ui_flow`'s `CARD_HOLD` check), so the panel is already
+        // open with OK still down, and re-arming here would re-open it from row 0.
+        if !matches!(app.screen, Screen::Home) || app.card_menu.is_some() {
             return None;
         }
         // Land hover focus on the press point first — a button press can jostle the
         // remote off the last motion position.
         *dirty |= app.handle_mouse_motion(x, y, w, h, fonts);
-        if input.pin_held.is_some() {
+        if input.card_held.is_some() {
             return Some(EventAction::Next);
         }
-        let columns = crate::app::view::home::grid_columns(w.saturating_sub(crate::ui::widgets::SIDEBAR_W));
-        if app.focused_pin_id(columns).is_some() {
-            input.pin_held = Some(PinHold {
-                since: Instant::now(),
-                focus: app.home_focus,
-                fired: false,
-            });
+        if arm_card_hold(input, app, w) {
             return Some(EventAction::Next);
         }
         return None;
     }
-    // Release of a pointer OK: resolve whatever the matching press started. A fired
-    // hold already pinned (swallow); a quick tap confirms whatever's under the
+    // Release of a pointer OK: resolve whatever the matching press started. A fired hold has
+    // already opened the card's menu (swallow); a quick tap confirms whatever's under the
     // pointer now, exactly as an immediate click would have.
     if let Event::MouseButtonUp {
         mouse_btn: sdl2::mouse::MouseButton::Left,
@@ -453,7 +465,7 @@ fn pin_hold_gate(
         ..
     } = *event
     {
-        let hold = input.pin_held.take()?;
+        let hold = input.card_held.take()?;
         *dirty = true;
         if hold.fired {
             return Some(EventAction::Next);
@@ -476,21 +488,16 @@ fn pin_hold_gate(
             if crate::platform::webos::input::menu_event_for_button(button) == Some(MenuEvent::Confirm)
     );
     if confirm_down {
-        // OK stays the gesture's until released, whatever the toggle put on
-        // screen: a hold that hit the pin limit opens the `PinLimit` alert
-        // *under the still-held button*, and the next auto-repeat KeyDown would
-        // otherwise dispatch Confirm to it and dismiss it instantly.
-        if input.pin_held.is_some() {
+        // OK stays the gesture's until released, whatever the hold put on screen: the
+        // card menu opens *under the still-held button*, and the next auto-repeat KeyDown
+        // would otherwise dispatch Confirm straight into it.
+        if input.card_held.is_some() {
             return Some(EventAction::Next);
         }
-        let columns =
-            crate::app::view::home::grid_columns((display_mode.w as u32).saturating_sub(crate::ui::widgets::SIDEBAR_W));
-        if matches!(app.screen, Screen::Home) && app.focused_pin_id(columns).is_some() {
-            input.pin_held = Some(PinHold {
-                since: Instant::now(),
-                focus: app.home_focus,
-                fired: false,
-            });
+        if matches!(app.screen, Screen::Home)
+            && app.card_menu.is_none()
+            && arm_card_hold(input, app, display_mode.w as u32)
+        {
             return Some(EventAction::Next);
         }
         return None;
@@ -505,11 +512,10 @@ fn pin_hold_gate(
             if crate::platform::webos::input::menu_event_for_button(button) == Some(MenuEvent::Confirm)
     );
     // This press was ours (tap or hold) — swallow the release.
-    let hold = ends_hold.then(|| input.pin_held.take()).flatten()?;
+    let hold = ends_hold.then(|| input.card_held.take()).flatten()?;
     *dirty = true;
-    // A quick tap: the press never dispatched, so do it now. A hold that already
-    // toggled, or one whose screen/focus moved out from under it, resolves to
-    // nothing.
+    // A quick tap: the press never dispatched, so do it now. A hold that already opened its
+    // menu, or one whose screen/focus moved out from under it, resolves to nothing.
     let tapped = !hold.fired && matches!(app.screen, Screen::Home) && hold.focus == app.home_focus;
     let launched = tapped && app.press(display_mode.w as u32, display_mode.h as u32, fonts).is_some();
     Some(if launched {
@@ -587,7 +593,7 @@ pub(super) fn handle_ui_event(
             }
             // List-modal screens (row-per-page, not pixel scroll): one detent
             // moves focus exactly one row, same as an Up/Down key press.
-            Screen::Settings
+            Screen::Settings(_)
             | Screen::HostMenu
             | Screen::WakeSettings
             | Screen::Diagnostics
@@ -602,7 +608,7 @@ pub(super) fn handle_ui_event(
         }
         return EventAction::Next;
     }
-    if let Some(action) = pin_hold_gate(app, &event, input, display_mode, fonts, dirty) {
+    if let Some(action) = card_hold_gate(app, &event, input, display_mode, fonts, dirty) {
         return action;
     }
     // Any other event might change what's on screen (focus/hover, a typed

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -16,6 +16,23 @@ fn upload_spinner(
     Ok(())
 }
 
+/// The settings one launch runs with: the global document with `target`'s per-game
+/// overrides applied. The single merge point — everything downstream (`spawn_connect`,
+/// `session::connect`, the stream loop) reads this one copy.
+///
+/// Clamped to caps afterwards exactly like a global value, so an override a TV can't
+/// satisfy degrades instead of reaching the wire.
+fn launch_settings(app: &App, target: &crate::core::model::ConnectTarget) -> crate::services::store::Settings {
+    use crate::services::store::{SettingsOverride, DESKTOP_PIN_ID};
+    let id = target.launch.as_deref().unwrap_or(DESKTOP_PIN_ID);
+    let over = app
+        .known_host(&target.host, target.port)
+        .map_or_else(SettingsOverride::default, |h| h.overrides(id));
+    let mut settings = over.merge_into(app.settings);
+    settings.clamp_to_caps();
+    settings
+}
+
 /// Runs the UI (host list -> pairing -> settings) until the user confirms a
 /// connect target or the system asks the app to close (`None`). A plain
 /// function, not a closure — a closure capturing `canvas`/`events` by
@@ -173,14 +190,16 @@ pub(super) fn run_ui_flow(
         dirty |= app.tick_wake();
         // Fire on hold elapsed, not release, so user sees it before letting go.
         if let Some(hold) = input
-            .pin_held
+            .card_held
             .as_mut()
-            .filter(|h| !h.fired && h.since.elapsed() >= PIN_HOLD)
+            .filter(|h| !h.fired && h.since.elapsed() >= CARD_HOLD)
         {
             hold.fired = true;
             let still_there = matches!(app.screen, Screen::Home) && hold.focus == app.home_focus;
             if still_there {
-                app.toggle_focused_pin(display_mode.w as u32, display_mode.h as u32);
+                // The hold's whole effect. It no longer pins — pinning is one of the two
+                // rows the menu it raises offers, and the only way to reach it.
+                app.open_card_menu(display_mode.w as u32);
             }
             dirty = true;
         }
@@ -193,7 +212,11 @@ pub(super) fn run_ui_flow(
                 // toggle (e.g. audio offload) is persisted asynchronously by
                 // `StateWriter`, so re-reading disk here could race the write and
                 // connect with the stale value. `app.settings` is updated synchronously.
-                let settings = resolve_gamepad_type(app.settings, game_controller);
+                // Per-game overrides merge over the global document here — the single
+                // point where the game being launched is known and the settings copy that
+                // rides the whole session is made. Clamped to caps like any global value.
+                let mut settings = launch_settings(&app, &target);
+                settings = resolve_gamepad_type(settings, game_controller);
                 let handle = spawn_connect(identity.clone(), target, settings)?;
                 connect_handle = Some((handle, settings));
             }

--- a/src/services/store/legacy.rs
+++ b/src/services/store/legacy.rs
@@ -20,6 +20,7 @@ pub(super) fn migrate(settings: Settings) -> Persisted {
         settings,
         known_hosts,
         selected_host: None,
+        version: None,
     };
     if present.is_empty() {
         return state;

--- a/src/services/store/mod.rs
+++ b/src/services/store/mod.rs
@@ -13,8 +13,8 @@ use anyhow::{Context, Result};
 use serde_json::Value;
 
 pub use crate::core::model::{
-    upsert_known_host, CodecPref, GamepadType, KnownHost, LogLevelOverride, Persisted, Settings, VideoBackend,
-    DESKTOP_PIN_ID,
+    pinned_only, upsert_known_host, CodecPref, GamepadType, KnownHost, LogLevelOverride, Persisted, Settings,
+    SettingsOverride, VideoBackend, DESKTOP_PIN_ID,
 };
 pub use crate::services::paths::app_dir;
 pub use identity::load_or_create_identity;
@@ -43,6 +43,7 @@ pub fn load() -> Persisted {
         None => legacy::migrate(Settings::default()),
     };
     apply_launch_overrides(&mut state);
+    stamp_version(&mut state);
     // A document written on a more capable TV can hold HEVC, HDR and 7.1 on a device with none
     // of them — leaving a *set* value whose row the UI hides.
     state.settings.clamp_to_caps();
@@ -61,6 +62,49 @@ pub fn persisted_video_backend() -> VideoBackend {
         .get("video_backend")
         .and_then(|v| serde_json::from_value(v.clone()).ok())
         .unwrap_or_default()
+}
+
+/// The version this build writes into the document.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Stamps [`Persisted::version`] the first time a document is read without one, and takes the
+/// one chance that gives us to seed a demo per-game override — an upgrade from a pre-versioning
+/// build has no overrides at all, so the feature is invisible until someone finds the card menu.
+///
+/// Only the Desktop card is seeded, only where it exists (is pinned), and only with cursor
+/// capture off: harmless if left alone, and the row it lights up explains itself.
+///
+/// Written synchronously so it happens once — `StateWriter`'s baseline is taken after this,
+/// and an unstamped document that never gets saved would seed again on every launch.
+fn stamp_version(state: &mut Persisted) {
+    if state.version.is_some() {
+        return;
+    }
+    state.version = Some(VERSION.to_string());
+    // Nothing to demo on a fresh install (no hosts), and nothing to demo *with* if the global
+    // value already is off — the override would equal the global and read as noise.
+    if !state.known_hosts.is_empty() && state.settings.cursor_capture {
+        seed_demo_overrides(state);
+    }
+    if let Err(e) = save(state) {
+        tracing::warn!("could not stamp document version: {e:#}");
+        return;
+    }
+    tracing::info!("stamped settings.json with version {VERSION}");
+}
+
+/// Gives every host whose Desktop card is pinned, and which carries no overrides yet, a
+/// cursor-capture-off override on that card. A host that already overrides something is left
+/// alone — the user has found the feature.
+fn seed_demo_overrides(state: &mut Persisted) {
+    for host in &mut state.known_hosts {
+        let untouched = host.games.values().all(|g| g.over.is_empty());
+        if !untouched || !host.is_pinned(DESKTOP_PIN_ID) {
+            continue;
+        }
+        host.edit_overrides(DESKTOP_PIN_ID, |over| over.cursor_capture = Some(false));
+        tracing::info!("seeded demo Desktop override on {}", host.name);
+    }
 }
 
 pub fn save(state: &Persisted) -> Result<()> {

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -9,6 +9,33 @@ pub const FOCUS_POP: Duration = Duration::from_millis(140);
 /// driving them (`App::focus_anim`) is cleared on it, so nothing may outlast it.
 pub const CARD_FOCUS_POP: Duration = Duration::from_millis(160);
 
+/// How long a held card's submenu panel takes to climb the card. Named separately from
+/// [`CARD_FOCUS_POP`] (which it currently matches) because it answers a different question:
+/// the panel covers several times the title strip's travel, so if the rise ever needs its
+/// own timing this is the knob. Eased at both ends ([`anim_frac_smooth`]) so the long travel
+/// reads as one motion.
+pub const CARD_MENU_RISE: Duration = CARD_FOCUS_POP;
+
+/// Advances an eased scroll one tick: cover ~35% of the remaining distance, snapping when
+/// close so it terminates. Returns whether anything moved. Shared by the card grid and the
+/// scrolling modals' viewports so both lists feel identical.
+pub fn ease_scroll(current: &mut i32, target: i32) -> bool {
+    let d = target - *current;
+    if d == 0 {
+        return false;
+    }
+    let step = if d.abs() <= 3 {
+        d
+    } else {
+        match (f64::from(d) * 0.35) as i32 {
+            0 => d.signum(),
+            s => s,
+        }
+    };
+    *current += step;
+    true
+}
+
 /// How long a pressed button takes to spring back out of its dip.
 pub const PRESS_POP: Duration = Duration::from_millis(120);
 

--- a/src/ui/tiles.rs
+++ b/src/ui/tiles.rs
@@ -79,13 +79,107 @@ pub fn render_card_title_tile(
     card_h: u32,
     title: &str,
     art: Option<&Pixmap>,
+    overridden: bool,
 ) -> Result<Painter> {
     let strip_h = title_strip_h(fonts.raster, fonts.value, card_h);
     let mut p = Painter::new(card_w.max(1), strip_h);
     let mut c = Canvas::tile(&mut p, text_cache, fonts);
     let strip = Rect::new(0, 0, card_w, strip_h);
     c.poster_art(Rect::new(0, -((card_h - strip_h) as i32), card_w, card_h), title, art);
-    c.poster_title_strip(strip, title)?;
+    c.poster_title_strip(strip, title, overridden)?;
+    Ok(p)
+}
+
+/// One held card's frost panel, as [`render_card_menu_tile`] takes it. `title` and `rows` are
+/// here for the *sizing* they imply (the placeholder poster's text, the panel's height), not
+/// to be drawn — both have their own tiles.
+pub struct CardMenuTile<'a> {
+    pub card_w: u32,
+    pub card_h: u32,
+    pub title: &'a str,
+    pub art: Option<&'a Pixmap>,
+    /// `(icon glyph, label)` per row.
+    pub rows: &'a [(&'a str, &'a str)],
+}
+
+/// The frosted glass a held card raises, and nothing else — no title, no row text.
+///
+/// The panel is composited from four pieces (this, [`render_card_menu_title_tile`], the
+/// selection band, [`render_card_menu_rows_tile`]) rather than baked whole, because each has
+/// to move differently while it opens:
+///
+/// - the frost can only *wipe*: it carries a fragment of the card's cover baked in for the
+///   blur to work on, and translating that reads as the card sliding under the glass;
+/// - the title and the rows have to *travel*, riding the top edge of the growing window —
+///   the title is already on screen at the card's bottom before the menu opens, so it
+///   continues upward from there rather than restarting;
+/// - the band is a translucent darkening, so text baked under it would dim with the frost.
+///
+/// See `app::render::compose`, which is the one place those four motions are reconciled.
+pub fn render_card_menu_tile(text_cache: &mut TextCache, fonts: &Fonts, card: CardMenuTile<'_>) -> Result<Painter> {
+    let CardMenuTile {
+        card_w,
+        card_h,
+        title,
+        art,
+        rows,
+    } = card;
+    let panel_h = card_menu_strip_h(fonts.raster, fonts.value, card_h, rows.len());
+    let mut p = Painter::new(card_w.max(1), panel_h);
+    let mut c = Canvas::tile(&mut p, text_cache, fonts);
+    // Same trick as the title strip: the card's art re-drawn translated up by everything
+    // above the panel, so the frost blurs the cover it actually sits on.
+    c.poster_art(
+        Rect::new(0, -((card_h.saturating_sub(panel_h)) as i32), card_w, card_h),
+        title,
+        art,
+    );
+    c.poster_frost_panel(Rect::new(0, 0, card_w, panel_h));
+    Ok(p)
+}
+
+/// The panel's title line alone, on a transparent tile — drawn at the same inset and
+/// baseline [`render_card_title_tile`] uses, so the moment the menu opens and this takes
+/// over, the name does not shift by a pixel.
+///
+/// No override dot here, unlike the collapsed strip: with the panel open the mark moves down
+/// onto the Settings row that owns it (see [`Canvas::poster_menu_rows`]).
+pub fn render_card_menu_title_tile(
+    text_cache: &mut TextCache,
+    fonts: &Fonts,
+    card_w: u32,
+    card_h: u32,
+    title: &str,
+) -> Result<Painter> {
+    let title_h = title_strip_h(fonts.raster, fonts.value, card_h);
+    let mut p = Painter::new(card_w.max(1), title_h.max(1));
+    let mut c = Canvas::tile(&mut p, text_cache, fonts);
+    c.poster_strip_label(Rect::new(0, 0, card_w, title_h), title, false)?;
+    Ok(p)
+}
+
+/// Height of [`render_card_menu_rows_tile`]'s output — the panel's rows band, i.e. what is
+/// left of it under the title line.
+fn card_menu_rows_h(raster: &dyn TextRaster, font: FontId, card_h: u32, rows: usize) -> u32 {
+    card_menu_strip_h(raster, font, card_h, rows).saturating_sub(title_strip_h(raster, font, card_h))
+}
+
+/// The submenu's icons and labels alone, on a transparent tile the width of the card — laid
+/// over the selection band so the band darkens the frost and nothing else. Every row draws
+/// identically (see [`Canvas::poster_menu_rows`]), so which row is focused is in no tile's
+/// cache key and moving between them rebuilds nothing.
+pub fn render_card_menu_rows_tile(
+    text_cache: &mut TextCache,
+    fonts: &Fonts,
+    card_w: u32,
+    card_h: u32,
+    rows: &[(&str, &str)],
+    marked: Option<usize>,
+) -> Result<Painter> {
+    let rows_h = card_menu_rows_h(fonts.raster, fonts.value, card_h, rows.len());
+    let mut p = Painter::new(card_w.max(1), rows_h.max(1));
+    let mut c = Canvas::tile(&mut p, text_cache, fonts);
+    c.poster_menu_rows(Rect::new(0, 0, card_w, rows_h), rows, marked)?;
     Ok(p)
 }
 

--- a/src/ui/widgets/cards.rs
+++ b/src/ui/widgets/cards.rs
@@ -117,6 +117,28 @@ pub fn title_strip_h(raster: &dyn TextRaster, font: FontId, card_h: u32) -> u32 
     (raster.height(font) + TITLE_STRIP_PAD).min(card_h as i32 / 3).max(1) as u32
 }
 
+/// Height of one row of the submenu a held card raises over its title strip.
+pub const CARD_MENU_ROW_H: u32 = 46;
+
+/// Gap between the title strip's "this game has settings overrides" dot and the title. The
+/// dot itself is [`super::rows::MARK_DOT_R`] — the same mark the settings rows wear.
+const TITLE_DOT_GAP: i32 = 8;
+
+/// The focused submenu row's band: a darkening of the frost rather than a fill over it, and
+/// edge to edge with square corners so it reads as a band across the panel rather than a pill
+/// floating on the card's art. Composited by `app::render::compose`, not baked — see
+/// [`Canvas::poster_menu_rows`].
+pub const CARD_MENU_ROW_FOCUS: Color = Color::RGBA(0x00, 0x00, 0x00, 0x9a);
+
+/// Height of the whole frosted panel when `rows` submenu entries sit under the title.
+/// Shared by the tile builder and the compose geometry, like [`title_strip_h`] — and it
+/// deliberately ignores that function's third-of-a-card cap: the panel is meant to climb
+/// the card, which is what says the menu belongs to it.
+pub fn card_menu_strip_h(raster: &dyn TextRaster, font: FontId, card_h: u32, rows: usize) -> u32 {
+    let panel = title_strip_h(raster, font, card_h) + rows as u32 * CARD_MENU_ROW_H;
+    panel.min(card_h.max(1))
+}
+
 /// Vertical breathing room around the title strip's single line.
 const TITLE_STRIP_PAD: i32 = 16;
 /// Left/right inset of the strip's label, doubled when measuring the space it has.
@@ -184,7 +206,15 @@ impl Canvas<'_, '_> {
 
     /// The frosted title strip overlaying a focused card's bottom edge, drawn over a copy
     /// of the art beneath it so the blur is real frost rather than a flat scrim.
-    pub fn poster_title_strip(&mut self, strip: Rect, title: &str) -> Result<()> {
+    pub fn poster_title_strip(&mut self, strip: Rect, title: &str, overridden: bool) -> Result<()> {
+        self.poster_frost_panel(strip);
+        self.poster_strip_label(strip, title, overridden)
+    }
+
+    /// The frosted glass alone: blur, tint, and the bottom-rounded clip. Split out because
+    /// the held-card submenu frosts a much taller panel than the one line its title
+    /// occupies, and both must end on the same rounded edge as the card's art.
+    pub fn poster_frost_panel(&mut self, strip: Rect) {
         self.painter.blur_rect(strip, TITLE_STRIP_BLUR);
         // Rounded at the bottom only, to sit inside the card's own rounded corners rather
         // than jutting out square past the art. One rounded rect grown upward by its
@@ -202,11 +232,74 @@ impl Canvas<'_, '_> {
         // it back out into those corners — trim everything to the shape once, so art and
         // frost end on the same rounded edge.
         self.painter.clip_to_rounded_rect(shaped, CARD_RADIUS);
+    }
+
+    /// The title line itself, centred in `band`.
+    ///
+    /// `overridden` puts an amber dot in front of the name — the same mark an overridden
+    /// settings row wears, so "this game does not use the global settings" reads the same
+    /// on the grid as it does inside the screen that made it true.
+    pub fn poster_strip_label(&mut self, band: Rect, title: &str, overridden: bool) -> Result<()> {
         let font = self.fonts.value;
-        let avail = strip.width().saturating_sub(2 * TITLE_STRIP_INSET as u32);
+        let mut x = band.x() + TITLE_STRIP_INSET;
+        let y = band.y() + (band.height() as i32 - self.fonts.raster.height(font)) / 2;
+        if overridden {
+            self.mark_dot(x, y + self.fonts.raster.height(font) / 2, theme().warning);
+            x += 2 * super::rows::MARK_DOT_R + TITLE_DOT_GAP;
+        }
+        let avail = band
+            .width()
+            .saturating_sub((x - band.x()) as u32 + TITLE_STRIP_INSET as u32);
         let label = ellipsize(self.fonts.raster, font, title, avail);
-        let y = strip.y() + (strip.height() as i32 - self.fonts.raster.height(font)) / 2;
-        self.text(font, &label, strip.x() + TITLE_STRIP_INSET, y, theme().text)?;
+        self.text(font, &label, x, y, theme().text)?;
+        Ok(())
+    }
+
+    /// The submenu rows under a held card's title, inside the frost [`poster_title_strip`]
+    /// has already laid down (which is why this takes the rows' band rather than drawing
+    /// its own background).
+    ///
+    /// Deliberately focus-free: every row is drawn identically, and the selection is a
+    /// translucent [`crate::ui::render::DrawCmd::Fill`] the compose path lays over this tile
+    /// (see [`CARD_MENU_ROW_FOCUS`]). Baking it in instead would put this whole panel — a
+    /// full-card art rescale plus a blur of it — on the rebuild path of every row move,
+    /// which is exactly the work the tile cache exists to avoid repeating.
+    /// `marked` is the row that wears the override dot. It sits at the same x the collapsed
+    /// title's dot does ([`Canvas::poster_strip_label`]), so raising the panel moves the mark
+    /// straight down its own column onto the Settings row that owns it — the title is left
+    /// carrying only the name.
+    pub fn poster_menu_rows(&mut self, band: Rect, rows: &[(&str, &str)], marked: Option<usize>) -> Result<()> {
+        let font = self.fonts.value;
+        let icon = 22u32;
+        for (i, (glyph, label)) in rows.iter().enumerate() {
+            let row = Rect::new(
+                band.x(),
+                band.y() + i as i32 * CARD_MENU_ROW_H as i32,
+                band.width(),
+                CARD_MENU_ROW_H,
+            );
+            let fg = theme().text;
+            // Clear of the mark's column (`marked`, at one inset in): the rows start past
+            // where a dot can be, so a marked and an unmarked panel read the same.
+            let icon_x = row.x() + 4 * TITLE_STRIP_INSET;
+            self.icon(
+                Rect::new(icon_x, row.y() + (row.height() as i32 - icon as i32) / 2, icon, icon),
+                glyph,
+                fg,
+            )?;
+            let text_x = icon_x + icon as i32 + 10;
+            let avail = row.right().saturating_sub(text_x + 2 * TITLE_STRIP_INSET).max(0) as u32;
+            let label = ellipsize(self.fonts.raster, font, label, avail);
+            let y = row.y() + (row.height() as i32 - self.fonts.raster.height(font)) / 2;
+            self.text(font, &label, text_x, y, fg)?;
+            if marked == Some(i) {
+                self.mark_dot(
+                    row.x() + TITLE_STRIP_INSET,
+                    row.y() + row.height() as i32 / 2,
+                    theme().warning,
+                );
+            }
+        }
         Ok(())
     }
 }

--- a/src/ui/widgets/confirm.rs
+++ b/src/ui/widgets/confirm.rs
@@ -1,0 +1,125 @@
+//! The two-button confirm modal's buttons — a primary action plus Cancel, shared by every
+//! confirm screen (forget host, send logs, stop streaming, quit app) so their geometry and
+//! their focus treatment can't drift apart.
+use crate::ui::prelude::*;
+use anyhow::Result;
+
+/// Confirm button with identity color (full when focused, dimmed when not).
+pub struct ConfirmButton<'a> {
+    pub icon: Option<&'a str>,
+    pub label: &'a str,
+    pub color: Color,
+}
+
+/// A primary action button plus a Cancel — the pair every confirm modal shares
+/// (forget host, send logs, stop streaming, quit app), so their `ConfirmButton`
+/// data can't drift apart. Index 0 is the action, index 1 is Cancel (the safe
+/// default focus).
+pub fn confirm_buttons(icon: Option<&'static str>, label: &'static str, color: Color) -> [ConfirmButton<'static>; 2] {
+    [
+        ConfirmButton { icon, label, color },
+        ConfirmButton {
+            icon: None,
+            label: "Cancel",
+            color: theme().text,
+        },
+    ]
+}
+
+/// Gap between the two buttons in a [`ConfirmButtons`] row.
+const CONFIRM_BUTTON_GAP: i32 = 20;
+
+/// Confirm button metrics derived from label font height — keeps sizing consistent
+/// between drawing and measurement.
+fn confirm_button_metrics(raster: &dyn TextRaster, font: FontId) -> (u32, i32, i32) {
+    let line_h = raster.height(font).max(1);
+    ((line_h * 2 / 3).max(1) as u32, (line_h / 3).max(1), (line_h / 2).max(1))
+}
+
+/// Button `index`'s rect within a confirm button row: two equal halves, one gap between.
+pub fn confirm_button_rect(content: Rect, index: usize) -> Rect {
+    Layout::horizontal([Constraint::Fill(1), Constraint::Fill(1)])
+        .gap(CONFIRM_BUTTON_GAP)
+        .split(content)[index.min(1)]
+}
+
+/// The pair of buttons every confirm modal ends with — see [`confirm_buttons`] for the
+/// pair itself. Renders both unfocused: the focused one composites over this from
+/// [`render_confirm_button_tile`], zoom-animated in `app::App`.
+pub struct ConfirmButtons<'a> {
+    buttons: &'a [ConfirmButton<'a>; 2],
+}
+
+impl<'a> ConfirmButtons<'a> {
+    pub fn new(buttons: &'a [ConfirmButton<'a>; 2]) -> Self {
+        Self { buttons }
+    }
+}
+
+impl Widget for ConfirmButtons<'_> {
+    fn render(self, area: Rect, c: &mut Canvas) -> Result<()> {
+        for (i, button) in self.buttons.iter().enumerate() {
+            c.confirm_button(button, false, confirm_button_rect(area, i))?;
+        }
+        Ok(())
+    }
+}
+
+/// Renders one focused button as a tile, composited over the shell.
+pub fn render_confirm_button_tile(
+    text_cache: &mut TextCache,
+    fonts: &Fonts,
+    button: &ConfirmButton<'_>,
+    w: u32,
+    h: u32,
+) -> Result<Painter> {
+    crate::ui::tiles::padded_widget_tile(text_cache, fonts, w, h, |c, rect| c.confirm_button(button, true, rect))
+}
+
+impl Canvas<'_, '_> {
+    /// Draws one confirm button at normal size, focused or not.
+    pub fn confirm_button(&mut self, button: &ConfirmButton<'_>, focused: bool, rect: Rect) -> Result<()> {
+        self.painter.selectable_fixed(rect, focused);
+        let color = if focused { button.color } else { theme().muted };
+
+        // Every inset here is derived from the label font's own line height, which
+        // `load_font` already scales by the panel's height — the button's width scales with
+        // the screen too, so a hardcoded icon inset does not stay in proportion to either.
+        // It used to be a fixed `20 + 26 + 12`, which left "Stop streaming" more label than
+        // button below 4K (~117px of room for ~154px of text at 720p) and ran it past the
+        // right edge, because nothing clamped the label either.
+        let font = self.fonts.label;
+        let line_h = self.fonts.raster.height(font).max(1);
+        let (icon_size, icon_gap, side_pad) = confirm_button_metrics(self.fonts.raster, font);
+
+        // Icon and label are centred as one group, the same way a label without an icon
+        // was already centred on its own — and the label is ellipsized to whatever the icon
+        // leaves, so no label can overflow the button regardless of resolution.
+        let leading = match button.icon {
+            Some(_) => icon_size + icon_gap as u32,
+            None => 0,
+        };
+        let budget = rect.width().saturating_sub(2 * side_pad as u32).saturating_sub(leading);
+        let label = ellipsize(self.fonts.raster, font, button.label, budget);
+        let label_w = self.fonts.raster.measure(font, &label).0;
+        let start_x = rect.x() + (rect.width() as i32 - (leading + label_w) as i32) / 2;
+
+        if let Some(icon) = button.icon {
+            let icon_rect = Rect::new(
+                start_x,
+                rect.y() + (rect.height() as i32 - icon_size as i32) / 2,
+                icon_size,
+                icon_size,
+            );
+            self.icon(icon_rect, icon, color)?;
+        }
+        self.text(
+            font,
+            &label,
+            start_x + leading as i32,
+            rect.y() + (rect.height() as i32 - line_h) / 2,
+            color,
+        )?;
+        Ok(())
+    }
+}

--- a/src/ui/widgets/dropdown.rs
+++ b/src/ui/widgets/dropdown.rs
@@ -1,0 +1,100 @@
+//! The expanded dropdown a [`RowKind::Dropdown`](super::RowKind) row opens: the option
+//! overlay, its option rows, and the popup chrome they sit on. The closed row's pill is the
+//! row's own business (see [`Canvas::focus_row`](super::Canvas)).
+use crate::ui::prelude::*;
+use anyhow::Result;
+
+/// Row height of one dropdown option — also `render_dropdown_option_tile`'s tile size.
+pub const DROPDOWN_OPTION_H: u32 = 56;
+
+/// The expanded dropdown: its options as an overlay list anchored below the opener row.
+/// One panel background+shadow instead of per-row cards, to avoid shadow smearing.
+/// Renders every option unfocused, like the row lists: the focused one composites over it
+/// from [`render_dropdown_option_tile`].
+pub struct DropdownOverlay<'a> {
+    options: &'a [String],
+}
+
+impl<'a> DropdownOverlay<'a> {
+    pub fn new(options: &'a [String]) -> Self {
+        Self { options }
+    }
+}
+
+impl Widget for DropdownOverlay<'_> {
+    fn render(self, area: Rect, c: &mut Canvas) -> Result<()> {
+        let bg_rect = Rect::new(
+            area.x(),
+            area.y(),
+            area.width(),
+            self.options.len() as u32 * DROPDOWN_OPTION_H,
+        );
+        c.painter.popup_panel(bg_rect, Color::RGBA(0xff, 0xff, 0xff, 0x20));
+        for (i, opt) in self.options.iter().enumerate() {
+            c.dropdown_option(opt, false, dropdown_option_rect(area, i))?;
+        }
+        Ok(())
+    }
+}
+
+/// Option `index`'s rect within a dropdown overlay.
+pub fn dropdown_option_rect(rect: Rect, index: usize) -> Rect {
+    Rect::new(
+        rect.x(),
+        rect.y() + index as i32 * DROPDOWN_OPTION_H as i32,
+        rect.width(),
+        DROPDOWN_OPTION_H,
+    )
+}
+
+/// Renders one focused dropdown option as a tile, composited over the overlay.
+/// Moving focus recomposites just this tile instead of re-rasterizing.
+pub fn render_dropdown_option_tile(
+    text_cache: &mut TextCache,
+    fonts: &Fonts,
+    option: &str,
+    width: u32,
+) -> Result<Painter> {
+    let mut p = Painter::new(width, DROPDOWN_OPTION_H);
+    let mut c = Canvas::tile(&mut p, text_cache, fonts);
+    c.dropdown_option(option, true, Rect::new(0, 0, width, DROPDOWN_OPTION_H))?;
+    Ok(p)
+}
+
+impl Canvas<'_, '_> {
+    /// Draws one dropdown option (highlighted if focused) at normal size.
+    pub fn dropdown_option(&mut self, option: &str, focused: bool, row_rect: Rect) -> Result<()> {
+        if focused {
+            let highlight = Rect::new(
+                row_rect.x() + 6,
+                row_rect.y() + 4,
+                row_rect.width().saturating_sub(12),
+                row_rect.height().saturating_sub(8),
+            );
+            self.painter.fill_rounded_rect(
+                highlight,
+                8,
+                Color::RGBA(theme().accent.r, theme().accent.g, theme().accent.b, 0x50),
+            );
+        }
+        let font = self.fonts.value;
+        let y = row_rect.y() + (row_rect.height() as i32 - self.fonts.raster.height(font)) / 2;
+        self.text(
+            font,
+            option,
+            row_rect.x() + 20,
+            y,
+            if focused { theme().text } else { theme().muted },
+        )?;
+        Ok(())
+    }
+}
+
+impl Painter {
+    /// Common popup panel chrome: shadowed dark background with colored border.
+    pub fn popup_panel(&mut self, rect: Rect, border_color: Color) {
+        self.card_shadow(rect, CARD_RADIUS);
+        self.fill_rounded_rect(rect, CARD_RADIUS, Color::RGBA(0x17, 0x11, 0x28, 0xf6));
+        self.stroke_rounded_rect(rect, CARD_RADIUS, border_color, 1.5);
+    }
+}

--- a/src/ui/widgets/mod.rs
+++ b/src/ui/widgets/mod.rs
@@ -5,15 +5,21 @@
 //! in the same breath, and the file a widget lives in is an implementation detail.
 
 mod cards;
+mod confirm;
+mod dropdown;
 mod listmodal;
 mod modal;
 mod notification;
 mod rows;
+mod scroll;
 mod sidebar;
 
 pub use cards::*;
+pub use confirm::*;
+pub use dropdown::*;
 pub use listmodal::*;
 pub use modal::*;
 pub use notification::*;
 pub use rows::*;
+pub use scroll::*;
 pub use sidebar::*;

--- a/src/ui/widgets/rows.rs
+++ b/src/ui/widgets/rows.rs
@@ -1,6 +1,8 @@
-//! The generic focusable-row list: `FocusRow`/`RowKind` plus every control
-//! (dropdown pill, slider, switch, confirm button) a row can carry.
-//!
+//! The generic focusable-row list: `FocusRow`/`RowKind`, the row geometry both the draw and
+//! the pointer index by ([`row_layout`]), and the controls a row itself draws — the dropdown
+//! pill, the slider and the switch. What sits *around* a row list lives beside it:
+//! [`super::dropdown`] (the expanded option overlay), [`super::scroll`] (scrollbar and edge
+//! fades) and [`super::confirm`] (the two-button modal's buttons).
 use crate::ui::prelude::*;
 use anyhow::Result;
 
@@ -22,6 +24,7 @@ pub enum RowKind {
 /// One focusable icon + label (+ dropdown pill / slider / switch) row, drawn by
 /// [`FocusRows`]/[`Canvas::focus_row`]. The lists themselves are built per screen in
 /// `app::view`.
+#[derive(Clone)]
 pub struct FocusRow {
     pub icon: &'static str,
     pub label: String,
@@ -45,6 +48,12 @@ pub struct FocusRow {
     /// Confirm can mean, reached with Right, so the row's own action stays a single
     /// press. `None` (the default) draws no button at all.
     pub menu: Option<bool>,
+    /// A small dot in the row's right gutter, in this colour — what marks a row as differing
+    /// from whatever it inherits (a per-game settings override, say). Purely an indicator:
+    /// not focusable, not clickable, carrying no action; what it means, and how it goes away,
+    /// is the caller's business. `None` (the default) draws nothing and leaves the row's
+    /// control the width the dot would have taken.
+    pub mark: Option<Color>,
     /// A small secondary line drawn under the row's label *only while the row is focused*
     /// (e.g. the high-bitrate "may be unstable on Wi-Fi" caution on the Bitrate row).
     /// Unfocused, the label stays vertically centred and nothing is drawn; on focus the
@@ -55,6 +64,7 @@ pub struct FocusRow {
 /// A small caption drawn under a row's label. The color is carried with the text so the
 /// drawing code stays generic — a neutral hint and a caution differ only by which
 /// constructor built them, not by any special-casing in [`Canvas::focus_row`].
+#[derive(Clone)]
 pub struct RowSubtext {
     pub text: String,
     pub color: Color,
@@ -104,6 +114,7 @@ impl FocusRow {
             danger: false,
             locked: false,
             menu: None,
+            mark: None,
             subtext: None,
         }
     }
@@ -200,19 +211,50 @@ pub const SLIDER_VALUE_SLOT_W: i32 = 150;
 /// Extra gap between the track's right edge and the value slot.
 const SLIDER_TRACK_GAP: i32 = 16;
 
-/// A slider row's track rect within `row_rect` — shared by [`Canvas::focus_row`]'s draw and
-/// the pointer path's click/drag hit-testing, so a dragged thumb always lands under the
-/// cursor exactly where the track was drawn.
-pub fn slider_track_rect(row_rect: Rect) -> Rect {
-    let control_pad = 28;
-    let slot_right = row_rect.right() - control_pad;
+/// Radius of a [`FocusRow::mark`] dot. A card's title strip wears the same mark.
+pub const MARK_DOT_R: i32 = 5;
+/// Gap between a row's right edge and whatever sits closest to it — the control on an
+/// unmarked row, the mark on a marked one, so both end on the same line.
+const CONTROL_PAD: i32 = 28;
+/// Gap between the mark and the control it displaces. Tighter than [`CONTROL_PAD`]: the dot
+/// belongs to the row's value, so it reads as part of that group rather than as a third
+/// column of its own.
+const MARK_GAP: i32 = 22;
+
+/// Where a focus row's pieces go: the right edge its control is laid out from, the slider
+/// track, and the mark's dot.
+///
+/// One function for all three, so [`Canvas::focus_row`]'s draw and the pointer path's
+/// click/drag hit-testing can't disagree — a dragged thumb lands under the cursor exactly
+/// where the track was drawn, marked row or not. A marked row gives the dot's width up off
+/// its right edge and every control shifts left by it, so the dot never lands on a dropdown
+/// pill, a slider's value slot or a toggle switch.
+pub struct RowGeom {
+    pub control_right: i32,
+    pub track: Rect,
+    pub mark: Rect,
+}
+
+pub fn row_layout(row_rect: Rect, marked: bool) -> RowGeom {
+    let reserve = if marked { 2 * MARK_DOT_R + MARK_GAP } else { 0 };
+    let control_right = row_rect.right() - CONTROL_PAD - reserve;
     let track_w = 220u32.min(row_rect.width() / 3);
-    Rect::new(
-        slot_right - SLIDER_VALUE_SLOT_W - SLIDER_TRACK_GAP - track_w as i32,
-        row_rect.y() + (row_rect.height() as i32 - 10) / 2,
-        track_w,
-        10,
-    )
+    let cy = row_rect.y() + row_rect.height() as i32 / 2;
+    RowGeom {
+        control_right,
+        track: Rect::new(
+            control_right - SLIDER_VALUE_SLOT_W - SLIDER_TRACK_GAP - track_w as i32,
+            cy - 5,
+            track_w,
+            10,
+        ),
+        mark: Rect::new(
+            row_rect.right() - CONTROL_PAD - 2 * MARK_DOT_R,
+            cy - MARK_DOT_R,
+            2 * MARK_DOT_R as u32,
+            2 * MARK_DOT_R as u32,
+        ),
+    }
 }
 
 /// A modal's focus-row list: icon + label left, control right, one row per
@@ -320,6 +362,16 @@ pub fn render_focus_rows_tile(
 }
 
 impl Canvas<'_, '_> {
+    /// A [`FocusRow::mark`]-sized dot, from its left edge and vertical centre — for callers
+    /// placing one outside a row (the card title strip), so the two marks can't drift apart.
+    pub fn mark_dot(&mut self, left: i32, cy: i32, color: Color) {
+        self.painter.fill_rounded_rect(
+            Rect::new(left, cy - MARK_DOT_R, 2 * MARK_DOT_R as u32, 2 * MARK_DOT_R as u32),
+            MARK_DOT_R,
+            color,
+        );
+    }
+
     /// Draws one focus row (icon + label + control per `RowKind`) at normal size.
     /// `dropdown_open` is independent of `focused` — a dropdown row's pill brightens while
     /// its overlay is expanded too, not only on row focus.
@@ -332,6 +384,12 @@ impl Canvas<'_, '_> {
         row_rect: Rect,
     ) -> Result<()> {
         self.painter.selectable_fixed(row_rect, focused);
+
+        // Past the row's control, on the right edge — the width `row_layout` took off it.
+        let geom = row_layout(row_rect, row.mark.is_some());
+        if let Some(color) = row.mark {
+            self.painter.fill_rounded_rect(geom.mark, MARK_DOT_R, color);
+        }
 
         let icon_pad = 24;
         let icon_rect = Rect::new(
@@ -367,31 +425,27 @@ impl Canvas<'_, '_> {
         };
         self.text(label_font, &row.label, label_x, label_y, fg)?;
 
-        let control_pad = 28;
         let value_y = row_rect.y() + (row_rect.height() as i32 - self.fonts.raster.height(value_font)) / 2;
         match row.kind {
             RowKind::Dropdown => {
-                let right_edge = row_rect.right() - control_pad;
                 let value_fg = locked_fg(row.locked, focused || dropdown_open, theme().text, theme().muted);
-                self.dropdown_value(row_rect, right_edge, &row.value, value_fg)?;
+                self.dropdown_value(row_rect, geom.control_right, &row.value, value_fg)?;
             }
             RowKind::Slider => {
                 let value_w = self.fonts.raster.measure(value_font, &row.value).0;
-                let slot_right = row_rect.right() - control_pad;
                 self.text(
                     value_font,
                     &row.value,
-                    slot_right - value_w as i32,
+                    geom.control_right - value_w as i32,
                     value_y,
                     locked_fg(row.locked, focused, theme().text, theme().muted),
                 )?;
-                let track = slider_track_rect(row_rect);
                 self.painter
-                    .slider_with_thumb(track, row.fraction, focused, !row.locked);
+                    .slider_with_thumb(geom.track, row.fraction, focused, !row.locked);
             }
             RowKind::Toggle => {
                 let switch = Rect::new(
-                    row_rect.right() - control_pad - 64,
+                    geom.control_right - 64,
                     row_rect.y() + (row_rect.height() as i32 - 34) / 2,
                     64,
                     34,
@@ -406,7 +460,7 @@ impl Canvas<'_, '_> {
                     self.text(
                         value_font,
                         &row.value,
-                        row_rect.right() - control_pad - menu_w - value_w as i32,
+                        geom.control_right - menu_w - value_w as i32,
                         value_y,
                         theme().muted,
                     )?;
@@ -507,290 +561,10 @@ impl Painter {
     }
 }
 
-/// Row height of one dropdown option — also `render_dropdown_option_tile`'s tile size.
-pub const DROPDOWN_OPTION_H: u32 = 56;
-
-/// Scrollbar track+thumb. Rendered as own tile so fade-in/out is alpha
-/// composite, not re-rasterization.
-const SCROLLBAR_TRACK_W: u32 = 6;
-
-pub fn render_list_scrollbar_tile(tile_w: u32, tile_h: u32, total: usize, visible: usize, scroll: usize) -> Painter {
-    let mut painter = Painter::new(tile_w, tile_h.max(1));
-    if total <= visible {
-        return painter;
-    }
-    let track_w = SCROLLBAR_TRACK_W.min(tile_w);
-    let track = Rect::new(tile_w as i32 - track_w as i32, 0, track_w, tile_h);
-    painter.fill_rounded_rect(track, track_w as i32 / 2, Color::RGBA(0xff, 0xff, 0xff, 0x14));
-
-    let thumb_h = ((visible as f32 / total as f32) * track.height() as f32).round() as u32;
-    let thumb_h = thumb_h.clamp(24, track.height());
-    let max_thumb_y = track.height().saturating_sub(thumb_h) as f32;
-    let max_scroll = (total - visible).max(1) as f32;
-    let thumb_y = track.y() + ((scroll as f32 / max_scroll) * max_thumb_y).round() as i32;
-    let thumb = Rect::new(track.x(), thumb_y, track_w, thumb_h);
-    painter.fill_rounded_rect(thumb, track_w as i32 / 2, Color::RGBA(0xff, 0xff, 0xff, 0x50));
-    painter
-}
-
 /// A settings row's on-screen rect at a pixel scroll offset — the smooth-scroll counterpart
 /// of [`focus_row_rect`], which indexes rows within the viewport instead. Can land partly (or
 /// wholly) outside `content_rect` while the viewport is gliding; callers clip.
 pub fn focus_row_rect_at_px(content_rect: Rect, index: usize, scroll_px: i32) -> Rect {
     let y = content_rect.y() + index as i32 * focus_row_stride() as i32 - scroll_px;
     Rect::new(content_rect.x(), y, content_rect.width(), FOCUS_ROW_H)
-}
-
-/// How tall an edge fade is: exactly one row.
-///
-/// Deliberately taller than the peek strip it dissolves (`view::settings::PEEK`), so the band
-/// reaches past the partial row and into the full row beyond it. Sized to the peek instead,
-/// the ramp only reached ~35% alpha by the time it crossed the partial row's text — enough to
-/// render, not enough to read as a fade. Being taller also means the dense end lands on the
-/// partial row while the row above it takes only the ramp's first, near-clear pixels.
-pub const SCROLL_FADE_H: u32 = FOCUS_ROW_H;
-
-/// Tile width for the scroll fade. The ramp is uniform horizontally, so the GPU stretches
-/// this to whatever the list's width is — a fixed narrow tile means one static texture for
-/// every modal instead of one per content width. Not 1px: under linear filtering a
-/// single-column texture has no interior samples to stretch from.
-const SCROLL_FADE_TILE_W: u32 = 8;
-
-/// Which edge of the viewport a fade tile dissolves into.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum FadeEdge {
-    /// Dense at the top, clear at the bottom — shown while content is scrolled off above.
-    Top,
-    /// Clear at the top, dense at the bottom — shown while content remains below.
-    Bottom,
-}
-
-/// An edge fade that signals "the list continues this way".
-///
-/// Exists because the scrollbar alone doesn't answer the question on arrival: it's
-/// hold-then-fade (see `SCROLL_INDICATOR_HOLD`), so a list that opens already overflowing
-/// shows nothing at all once the hold lapses, and the last row looks like the final row.
-///
-/// Fades to the modal card's own background (`theme().panel`), not to black: the band has to
-/// look like the card surface swallowing the row, and any other colour reads as a shadow
-/// sitting on top of the list.
-pub fn render_scroll_fade_tile(edge: FadeEdge) -> Painter {
-    let mut painter = Painter::new(SCROLL_FADE_TILE_W, SCROLL_FADE_H);
-    match edge {
-        FadeEdge::Top => painter.fill_vertical_fade(theme().panel, 0xff, 0x00),
-        FadeEdge::Bottom => painter.fill_vertical_fade(theme().panel, 0x00, 0xff),
-    }
-    painter
-}
-
-/// The expanded dropdown: its options as an overlay list anchored below the opener row.
-/// One panel background+shadow instead of per-row cards, to avoid shadow smearing.
-/// Renders every option unfocused, like the row lists: the focused one composites over it
-/// from [`render_dropdown_option_tile`].
-pub struct DropdownOverlay<'a> {
-    options: &'a [String],
-}
-
-impl<'a> DropdownOverlay<'a> {
-    pub fn new(options: &'a [String]) -> Self {
-        Self { options }
-    }
-}
-
-impl Widget for DropdownOverlay<'_> {
-    fn render(self, area: Rect, c: &mut Canvas) -> Result<()> {
-        let bg_rect = Rect::new(
-            area.x(),
-            area.y(),
-            area.width(),
-            self.options.len() as u32 * DROPDOWN_OPTION_H,
-        );
-        c.painter.popup_panel(bg_rect, Color::RGBA(0xff, 0xff, 0xff, 0x20));
-        for (i, opt) in self.options.iter().enumerate() {
-            c.dropdown_option(opt, false, dropdown_option_rect(area, i))?;
-        }
-        Ok(())
-    }
-}
-
-/// Option `index`'s rect within a dropdown overlay.
-pub fn dropdown_option_rect(rect: Rect, index: usize) -> Rect {
-    Rect::new(
-        rect.x(),
-        rect.y() + index as i32 * DROPDOWN_OPTION_H as i32,
-        rect.width(),
-        DROPDOWN_OPTION_H,
-    )
-}
-
-/// Renders one focused dropdown option as a tile, composited over the overlay.
-/// Moving focus recomposites just this tile instead of re-rasterizing.
-pub fn render_dropdown_option_tile(
-    text_cache: &mut TextCache,
-    fonts: &Fonts,
-    option: &str,
-    width: u32,
-) -> Result<Painter> {
-    let mut p = Painter::new(width, DROPDOWN_OPTION_H);
-    let mut c = Canvas::tile(&mut p, text_cache, fonts);
-    c.dropdown_option(option, true, Rect::new(0, 0, width, DROPDOWN_OPTION_H))?;
-    Ok(p)
-}
-
-impl Canvas<'_, '_> {
-    /// Draws one dropdown option (highlighted if focused) at normal size.
-    pub fn dropdown_option(&mut self, option: &str, focused: bool, row_rect: Rect) -> Result<()> {
-        if focused {
-            let highlight = Rect::new(
-                row_rect.x() + 6,
-                row_rect.y() + 4,
-                row_rect.width().saturating_sub(12),
-                row_rect.height().saturating_sub(8),
-            );
-            self.painter.fill_rounded_rect(
-                highlight,
-                8,
-                Color::RGBA(theme().accent.r, theme().accent.g, theme().accent.b, 0x50),
-            );
-        }
-        let font = self.fonts.value;
-        let y = row_rect.y() + (row_rect.height() as i32 - self.fonts.raster.height(font)) / 2;
-        self.text(
-            font,
-            option,
-            row_rect.x() + 20,
-            y,
-            if focused { theme().text } else { theme().muted },
-        )?;
-        Ok(())
-    }
-}
-
-impl Painter {
-    /// Common popup panel chrome: shadowed dark background with colored border.
-    pub fn popup_panel(&mut self, rect: Rect, border_color: Color) {
-        self.card_shadow(rect, CARD_RADIUS);
-        self.fill_rounded_rect(rect, CARD_RADIUS, Color::RGBA(0x17, 0x11, 0x28, 0xf6));
-        self.stroke_rounded_rect(rect, CARD_RADIUS, border_color, 1.5);
-    }
-}
-
-/// Confirm button with identity color (full when focused, dimmed when not).
-pub struct ConfirmButton<'a> {
-    pub icon: Option<&'a str>,
-    pub label: &'a str,
-    pub color: Color,
-}
-
-/// A primary action button plus a Cancel — the pair every confirm modal shares
-/// (forget host, send logs, stop streaming, quit app), so their `ConfirmButton`
-/// data can't drift apart. Index 0 is the action, index 1 is Cancel (the safe
-/// default focus).
-pub fn confirm_buttons(icon: Option<&'static str>, label: &'static str, color: Color) -> [ConfirmButton<'static>; 2] {
-    [
-        ConfirmButton { icon, label, color },
-        ConfirmButton {
-            icon: None,
-            label: "Cancel",
-            color: theme().text,
-        },
-    ]
-}
-
-/// Gap between the two buttons in a [`ConfirmButtons`] row.
-const CONFIRM_BUTTON_GAP: i32 = 20;
-
-/// Confirm button metrics derived from label font height — keeps sizing consistent
-/// between drawing and measurement.
-fn confirm_button_metrics(raster: &dyn TextRaster, font: FontId) -> (u32, i32, i32) {
-    let line_h = raster.height(font).max(1);
-    ((line_h * 2 / 3).max(1) as u32, (line_h / 3).max(1), (line_h / 2).max(1))
-}
-
-/// Button `index`'s rect within a confirm button row: two equal halves, one gap between.
-pub fn confirm_button_rect(content: Rect, index: usize) -> Rect {
-    Layout::horizontal([Constraint::Fill(1), Constraint::Fill(1)])
-        .gap(CONFIRM_BUTTON_GAP)
-        .split(content)[index.min(1)]
-}
-
-/// The pair of buttons every confirm modal ends with — see [`confirm_buttons`] for the
-/// pair itself. Renders both unfocused: the focused one composites over this from
-/// [`render_confirm_button_tile`], zoom-animated in `app::App`.
-pub struct ConfirmButtons<'a> {
-    buttons: &'a [ConfirmButton<'a>; 2],
-}
-
-impl<'a> ConfirmButtons<'a> {
-    pub fn new(buttons: &'a [ConfirmButton<'a>; 2]) -> Self {
-        Self { buttons }
-    }
-}
-
-impl Widget for ConfirmButtons<'_> {
-    fn render(self, area: Rect, c: &mut Canvas) -> Result<()> {
-        for (i, button) in self.buttons.iter().enumerate() {
-            c.confirm_button(button, false, confirm_button_rect(area, i))?;
-        }
-        Ok(())
-    }
-}
-
-/// Renders one focused button as a tile, composited over the shell.
-pub fn render_confirm_button_tile(
-    text_cache: &mut TextCache,
-    fonts: &Fonts,
-    button: &ConfirmButton<'_>,
-    w: u32,
-    h: u32,
-) -> Result<Painter> {
-    crate::ui::tiles::padded_widget_tile(text_cache, fonts, w, h, |c, rect| c.confirm_button(button, true, rect))
-}
-
-impl Canvas<'_, '_> {
-    /// Draws one confirm button at normal size, focused or not.
-    pub fn confirm_button(&mut self, button: &ConfirmButton<'_>, focused: bool, rect: Rect) -> Result<()> {
-        self.painter.selectable_fixed(rect, focused);
-        let color = if focused { button.color } else { theme().muted };
-
-        // Every inset here is derived from the label font's own line height, which
-        // `load_font` already scales by the panel's height — the button's width scales with
-        // the screen too, so a hardcoded icon inset does not stay in proportion to either.
-        // It used to be a fixed `20 + 26 + 12`, which left "Stop streaming" more label than
-        // button below 4K (~117px of room for ~154px of text at 720p) and ran it past the
-        // right edge, because nothing clamped the label either.
-        let font = self.fonts.label;
-        let line_h = self.fonts.raster.height(font).max(1);
-        let (icon_size, icon_gap, side_pad) = confirm_button_metrics(self.fonts.raster, font);
-
-        // Icon and label are centred as one group, the same way a label without an icon
-        // was already centred on its own — and the label is ellipsized to whatever the icon
-        // leaves, so no label can overflow the button regardless of resolution.
-        let leading = match button.icon {
-            Some(_) => icon_size + icon_gap as u32,
-            None => 0,
-        };
-        let budget = rect.width().saturating_sub(2 * side_pad as u32).saturating_sub(leading);
-        let label = ellipsize(self.fonts.raster, font, button.label, budget);
-        let label_w = self.fonts.raster.measure(font, &label).0;
-        let start_x = rect.x() + (rect.width() as i32 - (leading + label_w) as i32) / 2;
-
-        if let Some(icon) = button.icon {
-            let icon_rect = Rect::new(
-                start_x,
-                rect.y() + (rect.height() as i32 - icon_size as i32) / 2,
-                icon_size,
-                icon_size,
-            );
-            self.icon(icon_rect, icon, color)?;
-        }
-        self.text(
-            font,
-            &label,
-            start_x + leading as i32,
-            rect.y() + (rect.height() as i32 - line_h) / 2,
-            color,
-        )?;
-        Ok(())
-    }
 }

--- a/src/ui/widgets/scroll.rs
+++ b/src/ui/widgets/scroll.rs
@@ -1,0 +1,69 @@
+//! What a scrolling row list draws around its rows: the scrollbar, and the fades that
+//! dissolve a partially-scrolled row into the viewport's edges. Both are their own tiles so
+//! showing and hiding them is an alpha composite rather than a re-raster.
+use crate::ui::prelude::*;
+
+/// Scrollbar track+thumb. Rendered as own tile so fade-in/out is alpha
+/// composite, not re-rasterization.
+const SCROLLBAR_TRACK_W: u32 = 6;
+
+pub fn render_list_scrollbar_tile(tile_w: u32, tile_h: u32, total: usize, visible: usize, scroll: usize) -> Painter {
+    let mut painter = Painter::new(tile_w, tile_h.max(1));
+    if total <= visible {
+        return painter;
+    }
+    let track_w = SCROLLBAR_TRACK_W.min(tile_w);
+    let track = Rect::new(tile_w as i32 - track_w as i32, 0, track_w, tile_h);
+    painter.fill_rounded_rect(track, track_w as i32 / 2, Color::RGBA(0xff, 0xff, 0xff, 0x14));
+
+    let thumb_h = ((visible as f32 / total as f32) * track.height() as f32).round() as u32;
+    let thumb_h = thumb_h.clamp(24, track.height());
+    let max_thumb_y = track.height().saturating_sub(thumb_h) as f32;
+    let max_scroll = (total - visible).max(1) as f32;
+    let thumb_y = track.y() + ((scroll as f32 / max_scroll) * max_thumb_y).round() as i32;
+    let thumb = Rect::new(track.x(), thumb_y, track_w, thumb_h);
+    painter.fill_rounded_rect(thumb, track_w as i32 / 2, Color::RGBA(0xff, 0xff, 0xff, 0x50));
+    painter
+}
+
+/// How tall an edge fade is: exactly one row.
+///
+/// Deliberately taller than the peek strip it dissolves (`view::settings::PEEK`), so the band
+/// reaches past the partial row and into the full row beyond it. Sized to the peek instead,
+/// the ramp only reached ~35% alpha by the time it crossed the partial row's text — enough to
+/// render, not enough to read as a fade. Being taller also means the dense end lands on the
+/// partial row while the row above it takes only the ramp's first, near-clear pixels.
+pub const SCROLL_FADE_H: u32 = FOCUS_ROW_H;
+
+/// Tile width for the scroll fade. The ramp is uniform horizontally, so the GPU stretches
+/// this to whatever the list's width is — a fixed narrow tile means one static texture for
+/// every modal instead of one per content width. Not 1px: under linear filtering a
+/// single-column texture has no interior samples to stretch from.
+const SCROLL_FADE_TILE_W: u32 = 8;
+
+/// Which edge of the viewport a fade tile dissolves into.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum FadeEdge {
+    /// Dense at the top, clear at the bottom — shown while content is scrolled off above.
+    Top,
+    /// Clear at the top, dense at the bottom — shown while content remains below.
+    Bottom,
+}
+
+/// An edge fade that signals "the list continues this way".
+///
+/// Exists because the scrollbar alone doesn't answer the question on arrival: it's
+/// hold-then-fade (see `SCROLL_INDICATOR_HOLD`), so a list that opens already overflowing
+/// shows nothing at all once the hold lapses, and the last row looks like the final row.
+///
+/// Fades to the modal card's own background (`theme().panel`), not to black: the band has to
+/// look like the card surface swallowing the row, and any other colour reads as a shadow
+/// sitting on top of the list.
+pub fn render_scroll_fade_tile(edge: FadeEdge) -> Painter {
+    let mut painter = Painter::new(SCROLL_FADE_TILE_W, SCROLL_FADE_H);
+    match edge {
+        FadeEdge::Top => painter.fill_vertical_fade(theme().panel, 0xff, 0x00),
+        FadeEdge::Bottom => painter.fill_vertical_fade(theme().panel, 0x00, 0xff),
+    }
+    painter
+}


### PR DESCRIPTION
Certain settings can now be overridden per game. Holding a card raises a small menu on the frosted title panel with pin/unpin and settings; per-game settings are only reachable from there.

- Overrides are nested per game id inside the known-host record, so they're keyed by host + id. `pinned` is gone; pins are a slot on the same per-game record.
- The per-game screen is a scope of the global settings screen, not a copy, so every row behaves identically in both. Diagnostics, experimental and video backend stay global-only.
- An override is self-clearing: set a value back to the global one and the record leaves the JSON. Overridden rows wear an amber dot on the right; so does a card with any override.
- Global settings are merged with the overrides at launch, in one place, right before connect.
- Games that vanish from the host library have their overrides pruned, but only on a successful listing, so a sleeping host doesn't wipe them.

No migration: pins from older builds are dropped once.