### PR TITLE
Poll mDNS from the menu tick and re-browse periodically

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -29,6 +29,7 @@ use crate::core::event::MenuEvent;
 pub use crate::core::model::ConnectTarget;
 use crate::core::model::GameEntry;
 pub use crate::core::screen::{HomeFocus, PairingFocus, Screen};
+use crate::services::discovery::Discovery;
 use crate::services::store::{self, KnownHost, Settings};
 use crate::ui;
 use crate::ui::render::TileId;
@@ -191,9 +192,8 @@ pub struct DropdownState {
 pub struct App {
     pub screen: Screen,
     pub known_hosts: Vec<KnownHost>,
-    pub discovered: std::sync::mpsc::Receiver<crate::services::discovery::DiscoveredHost>,
-    /// `None` if mDNS daemon didn't start. `Some` lets Drop shut it down explicitly.
-    pub(crate) discovery_daemon: Option<mdns_sd::ServiceDaemon>,
+    /// `None` if the mDNS daemon didn't start. Owned here so it stops with the menu.
+    pub(crate) discovery: Option<crate::services::discovery::Discovery>,
     pub entries: Vec<HostEntry>,
     pub home_focus: HomeFocus,
     /// Where the grid is re-entered from the sidebar. Only ever consulted through the
@@ -460,14 +460,6 @@ pub(crate) struct PairingOutcome {
     pub(crate) result: Result<[u8; 32], String>,
 }
 
-impl Drop for App {
-    fn drop(&mut self) {
-        if let Some(daemon) = &self.discovery_daemon {
-            let _ = daemon.shutdown();
-        }
-    }
-}
-
 /// The sidebar's saved-host rows.
 fn known_entries(known_hosts: &[store::KnownHost]) -> Vec<HostEntry> {
     known_hosts.iter().cloned().map(HostEntry::Known).collect()
@@ -488,15 +480,11 @@ impl App {
         // Catches hosts that left the list while the app was closed (migration, torn document);
         // in-session removals reconcile at their own sites.
         crate::services::art::reconcile_host_caches(&known_hosts);
-        let (discovered, discovery_daemon) = match crate::services::discovery::browse() {
-            Some((rx, daemon)) => (rx, Some(daemon)),
-            None => (std::sync::mpsc::channel().1, None),
-        };
+        let discovery = crate::services::discovery::Discovery::start();
         let mut app = Self {
             screen: Screen::Home,
             known_hosts,
-            discovered,
-            discovery_daemon,
+            discovery,
             entries,
             home_focus: HomeFocus::Sidebar(0),
             grid_focus_last: 0,
@@ -746,7 +734,8 @@ impl App {
         // `found.addr` throughout this loop is deliberate, not a typo for a nonexistent
         // `found.host` — `DiscoveredHost` (discovery.rs) only has `addr`, `WakeState`/
         // `KnownHost` only have `host`; both hold the same kind of value (network address).
-        while let Ok(found) = self.discovered.try_recv() {
+        let polled = self.discovery.as_mut().map(Discovery::poll).unwrap_or_default();
+        for found in polled {
             #[allow(clippy::suspicious_operation_groupings)]
             if let Some(w) = &self.wake {
                 if found.addr == w.host && found.port == w.port {

--- a/src/services/discovery.rs
+++ b/src/services/discovery.rs
@@ -49,50 +49,84 @@ fn parse_discovery(info: &mdns_sd::ResolvedService) -> Option<DiscoveredHost> {
     })
 }
 
-/// Browse continuously for punktfunk hosts; returns (Receiver, `ServiceDaemon`). Thread won't
-/// exit until `ServiceDaemon::shutdown()` called explicitly — mdns-sd's `SearchStarted` events
-/// loop forever. Failure points logged via tracing.
-pub fn browse() -> Option<(std::sync::mpsc::Receiver<DiscoveredHost>, ServiceDaemon)> {
-    let (tx, rx) = std::sync::mpsc::channel();
-    let daemon = ServiceDaemon::new()
-        .inspect_err(|e| {
-            tracing::error!("mdns: ServiceDaemon::new failed: {e}");
-        })
-        .ok()?;
-    let daemon_handle = daemon.clone();
-    std::thread::Builder::new()
-        .name("punktfunk-webos-mdns".into())
-        .spawn(move || {
-            // Blocking `recv` rather than a poll loop: it costs nothing while idle, where a
-            // timed poll would have to wake up forever.
-            let receiver = match daemon.browse(SERVICE_TYPE) {
-                Ok(r) => r,
-                Err(e) => {
-                    tracing::error!("mdns: browse({SERVICE_TYPE}) failed: {e}");
-                    let _ = daemon.shutdown();
-                    return;
-                }
-            };
-            tracing::debug!("mdns: browsing {SERVICE_TYPE}");
-            while let Ok(event) = receiver.recv() {
-                let info = match event {
-                    ServiceEvent::ServiceResolved(info) => info,
-                    other => {
-                        tracing::debug!("mdns: {other:?}");
-                        continue;
-                    }
-                };
-                let Some(host) = parse_discovery(&info) else {
-                    continue;
-                };
-                tracing::info!("mdns: resolved {} at {}:{}", host.name, host.addr, host.port);
-                if tx.send(host).is_err() {
-                    break; // receiver gone — stop browsing
-                }
+/// mdns-sd doubles its PTR re-query interval every round (1s, 2s ... capped at an hour) and
+/// discards a whole incoming message on any parse error, so answers lost inside one malformed
+/// packet can leave the list empty for minutes. Restarting resets that backoff, but also its
+/// traffic-quieting — hence this long, not shorter.
+const REBROWSE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// A running browse for punktfunk hosts, drained from the menu tick. No thread of its own —
+/// mdns-sd's daemon already runs one. That daemon re-queries on its own timers, so what keeps
+/// discovery off the network during a stream is `App` dropping this (and with it the daemon)
+/// when the menu loop exits, not the tick.
+pub struct Discovery {
+    daemon: ServiceDaemon,
+    events: mdns_sd::Receiver<ServiceEvent>,
+    last_browse: std::time::Instant,
+}
+
+impl Drop for Discovery {
+    fn drop(&mut self) {
+        let _ = self.daemon.shutdown();
+    }
+}
+
+impl Discovery {
+    /// `None` if the daemon or initial browse won't start — discovery is then simply absent.
+    pub fn start() -> Option<Self> {
+        let daemon = ServiceDaemon::new()
+            .inspect_err(|e| tracing::error!("mdns: ServiceDaemon::new failed: {e}"))
+            .ok()?;
+        let events = match daemon.browse(SERVICE_TYPE) {
+            Ok(events) => events,
+            Err(e) => {
+                // The daemon's thread outlives its handle, so a failed start still has to stop it.
+                tracing::error!("mdns: browse({SERVICE_TYPE}) failed: {e}");
+                let _ = daemon.shutdown();
+                return None;
             }
-            tracing::debug!("mdns: receiver loop ended, shutting down");
-            let _ = daemon.shutdown();
+        };
+        tracing::debug!("mdns: browsing {SERVICE_TYPE}");
+        Some(Self {
+            daemon,
+            events,
+            last_browse: std::time::Instant::now(),
         })
-        .expect("spawn mdns thread");
-    Some((rx, daemon_handle))
+    }
+
+    /// Hosts resolved since the last call, restarting the browse when due. Empty on almost
+    /// every tick, which costs no allocation.
+    pub fn poll(&mut self) -> Vec<DiscoveredHost> {
+        let mut found = Vec::new();
+        while let Ok(event) = self.events.try_recv() {
+            let ServiceEvent::ServiceResolved(info) = event else {
+                tracing::debug!("mdns: {event:?}");
+                continue;
+            };
+            let Some(host) = parse_discovery(&info) else {
+                continue;
+            };
+            tracing::info!("mdns: resolved {} at {}:{}", host.name, host.addr, host.port);
+            found.push(host);
+        }
+        // After the drain, not before: re-browsing swaps the receiver out and whatever it still
+        // held goes with it.
+        if self.last_browse.elapsed() >= REBROWSE_INTERVAL {
+            self.rebrowse();
+        }
+        found
+    }
+
+    fn rebrowse(&mut self) {
+        // Without the stop, the old retransmission chain keeps running and they stack one per
+        // interval. It also drops the cache, which is what makes hosts resolve from scratch.
+        let _ = self.daemon.stop_browse(SERVICE_TYPE);
+        match self.daemon.browse(SERVICE_TYPE) {
+            Ok(events) => self.events = events,
+            // The stop already removed the querier, so nothing more arrives until the
+            // next interval retries this.
+            Err(e) => tracing::error!("mdns: re-browse({SERVICE_TYPE}) failed: {e}"),
+        }
+        self.last_browse = std::time::Instant::now();
+    }
 }


### PR DESCRIPTION
Discovery used to run its own thread that blocked on the mdns-sd receiver and pushed hosts through an mpsc channel. Now it's a `Discovery` struct the menu loop drains each tick — mdns-sd's daemon already has a thread, so ours was just a relay.

The reason for the change is the re-browse. mdns-sd doubles its PTR re-query interval every round (1s, 2s, ... up to an hour) and throws away a whole incoming message on any parse error, so answers lost in one bad packet could leave the host list empty for minutes. Restarting the browse resets that backoff; 2 minutes is long enough not to undo its traffic quieting.

- `browse()` + the mDNS thread -> `Discovery::start()` / `Discovery::poll()`
- `Discovery` owns the daemon and shuts it down on drop, so `App`'s `Drop` impl goes away
- discovery now stops entirely during a stream, since `App` is dropped on menu exit