### PR TITLE
fix: probe actual root access for game mode

### DIFF
--- a/packaging/description.html
+++ b/packaging/description.html
@@ -25,6 +25,9 @@
     <li style="margin-bottom: 6px;"><b>Every input the TV has.</b> Magic Remote pointer, gamepad (with DualSense
       adaptive triggers), USB keyboard and mouse — with pointer capture for games and absolute pointing for the
       desktop.</li>
+    <li style="margin-bottom: 6px;"><b>Game mode.</b> An optional Experimental setting on rooted TVs: it switches picture and
+      sound to Game mode for the lowest input lag while streaming, then puts your previous
+      settings back on exit.</li>
     <li style="margin-bottom: 6px;"><b>Set up once.</b> Hosts are found on your network automatically, paired with a
       PIN, and can be woken from sleep over Wake-on-LAN when you pick them.</li>
   </ul>

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -118,8 +118,10 @@ const GAME_ROWS: [usize; 9] = [
 
 /// Experimental modal row indices (see `app::view::experimental::rows`).
 pub const EXP_ROW_HW_AUDIO: usize = 0;
-/// Only present on rooted TVs, so it's the last row when shown.
+/// Locked whenever [`exp_row_lock`] returns a reason.
 pub const EXP_ROW_GAME_MODE: usize = 1;
+/// Fixed: the Game mode row is always listed, locked rather than hidden when it can't be used.
+pub const EXP_ROW_COUNT: usize = 2;
 
 /// Cursor modal row indices (see `app::view::cursorsettings::rows`).
 pub const CURSOR_ROW_CAPTURE: usize = 0;
@@ -185,6 +187,24 @@ pub(crate) enum RowLock {
     StereoOnly,
     /// Nothing is plugged into the TV, so there is no controller to describe to the host.
     NoGamepad,
+}
+
+/// Why an Experimental row can't be changed. Same contract as [`RowLock`]: the predicate that
+/// greys the row is the one that rejects the keypress, so the two can't disagree.
+pub(crate) enum ExpRowLock {
+    /// The root probe hasn't answered yet.
+    RootUnknown,
+    /// Not a rooted TV, so Game mode has no way to reach `settingsservice`.
+    NotRooted,
+}
+
+/// `rooted` is the root-probe verdict, `None` while it is still running.
+pub(crate) fn exp_row_lock(row: usize, rooted: Option<bool>) -> Option<ExpRowLock> {
+    match (row, rooted) {
+        (EXP_ROW_GAME_MODE, None) => Some(ExpRowLock::RootUnknown),
+        (EXP_ROW_GAME_MODE, Some(false)) => Some(ExpRowLock::NotRooted),
+        _ => None,
+    }
 }
 
 /// `detected` is the attached pad per `gamepad::detect_type` — `None` with nothing attached

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -207,6 +207,9 @@ pub struct App {
     pub(crate) discovery: Option<crate::services::discovery::Discovery>,
     pub entries: Vec<HostEntry>,
     pub home_focus: HomeFocus,
+    /// Whether this TV is webosbrew-rooted — `None` until [`App::start_root_probe`] answers.
+    pub(crate) rooted: Option<bool>,
+    pub(crate) rooted_rx: Option<std::sync::mpsc::Receiver<bool>>,
     /// Where the grid is re-entered from the sidebar. Only ever consulted through the
     /// focus map, which drops it when it no longer names a real card, so reorders and
     /// library reloads need no invalidation of their own.
@@ -520,6 +523,8 @@ impl App {
             discovery,
             entries,
             home_focus: HomeFocus::Sidebar(0),
+            rooted: None,
+            rooted_rx: None,
             grid_focus_last: 0,
             selected_host: None,
             games: Vec::new(),
@@ -627,12 +632,6 @@ impl App {
         }
         std::thread::spawn(crate::assets::spinner_frames);
         app
-    }
-
-    /// Whether this TV is rooted — gates the Experimental screen's Game mode row, and so
-    /// that screen's row count and card height.
-    pub(crate) fn rooted() -> bool {
-        crate::platform::webos::game_mode::is_rooted()
     }
 
     /// Name of the host whichever host-scoped modal (Forget, Wake settings) is acting on.

--- a/src/app/render/geometry.rs
+++ b/src/app/render/geometry.rs
@@ -417,7 +417,7 @@ impl App {
             }),
             Screen::Experimental => f(&view::experimental::Modal {
                 settings: &self.settings,
-                rooted: Self::rooted(),
+                rooted: self.rooted,
             }),
             Screen::CursorSettings => f(&view::cursorsettings::Modal {
                 settings: self.settings_target(),

--- a/src/app/render/key.rs
+++ b/src/app/render/key.rs
@@ -28,7 +28,7 @@ pub enum ModalFocusKey {
     MenuRow(usize, String, bool),
     /// (focused row, log level, stats-overlay on, show-logs on) — any change invalidates the tile.
     DiagnosticsRow(usize, LogLevelOverride, bool, bool),
-    ExperimentalRow(usize, bool, bool),
+    ExperimentalRow(usize, bool, bool, Option<bool>),
     /// (focused row, cursor-capture on, cursor-gestures on, which rows are overridden) — any
     /// change invalidates the tile.
     CursorSettingsRow(usize, bool, bool, SettingsOverride),
@@ -103,6 +103,8 @@ pub enum ModalShellKey {
     Experimental {
         ndl_audio_offload: bool,
         game_mode: bool,
+        /// The root-probe verdict — it locks the Game mode row and rewrites its caption.
+        rooted: Option<bool>,
         hover_close: bool,
     },
     CursorSettings {

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -573,6 +573,7 @@ impl App {
             Screen::Experimental => Some(ModalShellKey::Experimental {
                 ndl_audio_offload: self.settings.ndl_audio_offload,
                 game_mode: self.settings.game_mode,
+                rooted: self.rooted,
                 hover_close: self.hover_close,
             }),
             Screen::CursorSettings => Some(ModalShellKey::CursorSettings {
@@ -656,6 +657,7 @@ impl App {
                 self.experimental_focused,
                 self.settings.ndl_audio_offload,
                 self.settings.game_mode,
+                self.rooted,
             )),
             Screen::CursorSettings => Some(ModalFocusKey::CursorSettingsRow(
                 self.cursor_settings_focused,
@@ -761,7 +763,7 @@ impl App {
                                 view::wakesettings::rows(self.wake_settings_host().is_some_and(|h| h.wol_auto))
                             }
                             Screen::Diagnostics => view::diagnostics::rows(&self.settings),
-                            Screen::Experimental => view::experimental::rows(&self.settings, Self::rooted()),
+                            Screen::Experimental => view::experimental::rows(&self.settings, self.rooted),
                             _ => view::cursorsettings::rows(self.settings_target(), &self.editing_override()),
                         };
                         let focused = self

--- a/src/app/state/experimental.rs
+++ b/src/app/state/experimental.rs
@@ -7,16 +7,70 @@ use crate::ui;
 use std::time::Instant;
 
 impl App {
+    /// Probes root access for the Game mode row, once per launch — rooting can come and go
+    /// between boots, so it is never persisted, and no screen but this one needs the answer.
+    /// Off-thread: a luna round-trip has no business blocking the modal's open frame.
+    fn start_root_probe(&mut self) {
+        if self.rooted.is_some() || self.rooted_rx.is_some() {
+            return;
+        }
+        // No Homebrew Channel, no root, no thread — the answer is a stat away.
+        if !crate::platform::webos::game_mode::hbchannel_installed() {
+            self.settle_rooted(false);
+            return;
+        }
+        let (tx, rx) = std::sync::mpsc::channel();
+        match std::thread::Builder::new().name("root-probe".into()).spawn(move || {
+            let _ = tx.send(crate::platform::webos::game_mode::probe_rooted());
+        }) {
+            Ok(_) => self.rooted_rx = Some(rx),
+            // Nothing will ever answer, so settle on "not rooted" rather than leaving the row
+            // stuck on its checking caption.
+            Err(e) => {
+                tracing::warn!("root probe thread: {e}");
+                self.settle_rooted(false);
+            }
+        }
+    }
+
+    /// Records the probe's verdict. A `game_mode` left on from when this TV *was* rooted has to
+    /// go with it: the row is locked once the verdict is in, so nothing could switch it off
+    /// again, and every stream start would keep paying for luna calls that can only fail.
+    fn settle_rooted(&mut self, rooted: bool) {
+        self.rooted = Some(rooted);
+        if !rooted && self.settings.game_mode {
+            self.settings.game_mode = false;
+            self.persist();
+        }
+    }
+
+    /// Picks up the probe's verdict, unlocking the Game mode row (or explaining why not).
+    /// Reports whether anything changed, so the open screen redraws.
+    pub(crate) fn drain_rooted(&mut self) -> bool {
+        let Some(rx) = &self.rooted_rx else { return false };
+        let rooted = match rx.try_recv() {
+            Ok(rooted) => rooted,
+            // A probe thread that died without sending would otherwise leave the row on its
+            // checking caption forever, so a dead channel settles like a failed spawn.
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => false,
+            Err(std::sync::mpsc::TryRecvError::Empty) => return false,
+        };
+        self.rooted_rx = None;
+        self.settle_rooted(rooted);
+        true
+    }
+
     /// Opens the Experimental screen (Settings → `menu::ROW_EXPERIMENTAL`). Holds unstable,
     /// off-by-default toggles (the software-audio override, Game mode on rooted sets).
     pub(crate) fn open_experimental(&mut self) {
+        self.start_root_probe();
         self.experimental_focused = 0;
         self.screen = Screen::Experimental;
     }
 
     /// All rows are plain Left/Right/Confirm toggles. Back saves and returns to Settings.
     pub(crate) fn handle_experimental_event(&mut self, ev: MenuEvent) {
-        let len = crate::app::view::experimental::rows(&self.settings, Self::rooted()).len();
+        let len = menu::EXP_ROW_COUNT;
         if ui::widgets::list_nav(&mut self.experimental_focused, len, menu::nav_dir(ev)) {
             self.modal_focus_anim = Some(Instant::now());
             return;
@@ -27,7 +81,11 @@ impl App {
                 self.settings.ndl_audio_offload = !from;
                 self.switch_anim = Some((Instant::now(), from, self.experimental_focused));
             }
-            (menu::EXP_ROW_GAME_MODE, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
+            // A locked row (see `menu::exp_row_lock`) rejects the press — the greyed control
+            // already says the value is fixed.
+            (menu::EXP_ROW_GAME_MODE, MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm)
+                if menu::exp_row_lock(menu::EXP_ROW_GAME_MODE, self.rooted).is_none() =>
+            {
                 let from = self.settings.game_mode;
                 self.settings.game_mode = !from;
                 self.switch_anim = Some((Instant::now(), from, self.experimental_focused));

--- a/src/app/view/experimental.rs
+++ b/src/app/view/experimental.rs
@@ -1,8 +1,8 @@
 //! Experimental: unstable features, off by default. Logic lives in `app::state::experimental`.
 //!
 //! `rooted` reaches every entry point rather than being read here, so this module stays
-//! platform-neutral — the Game mode row only exists on a rooted TV, which changes the row
-//! count and so the card's height.
+//! platform-neutral.
+use crate::app::menu::{self, ExpRowLock, EXP_ROW_COUNT};
 use crate::services::store::Settings;
 use crate::ui;
 use crate::ui::render::Rect;
@@ -15,9 +15,9 @@ use anyhow::Result;
 pub const TITLE: &str = "Experimental";
 pub const SUBTITLE: &str = "Unstable, off by default.";
 
-/// The software-audio override, and Game mode on rooted sets. All off by default.
-/// Order must match `menu::EXP_ROW_*`.
-pub fn rows(settings: &Settings, rooted: bool) -> Vec<FocusRow> {
+/// The software-audio override, and Game mode. All off by default. `rooted` is the root-probe
+/// verdict, `None` while it is still running.
+pub fn rows(settings: &Settings, rooted: Option<bool>) -> Vec<FocusRow> {
     // Opt-in, not the default: the audio-enabled load is rejected on at least some webOS 5+ sets
     // and takes the video plane down with it (black picture, sound fine — see
     // `Settings::ndl_audio_offload`). Software Opus is the path that always exists, so it stays
@@ -33,36 +33,39 @@ pub fn rows(settings: &Settings, rooted: bool) -> Vec<FocusRow> {
         "Offload Opus decode to NDL"
     }))];
     // Driving the TV's Game picture/sound modes needs the Homebrew Channel's root helper — the
-    // public bus is denied `settingsservice` outright (see `platform::webos::game_mode`). So the
-    // row only exists on a rooted set, where it's known to work.
-    if rooted {
-        rows.push(
-            FocusRow::toggle(crate::app::view::icons::ICON_GAMEPAD, "Game mode", settings.game_mode)
-                .with_subtext(ui::widgets::RowSubtext::hint("Your TV is rooted, you can use ALLM")),
-        );
-    }
+    // public bus is denied `settingsservice` outright (see `platform::webos::game_mode`). The row
+    // is always listed, but stays locked until the probe finds that helper actually reachable.
+    let game_mode = FocusRow::toggle(crate::app::view::icons::ICON_GAMEPAD, "Game mode", settings.game_mode)
+        .with_subtext(ui::widgets::RowSubtext::hint("Your TV is rooted, you can use ALLM"));
+    rows.push(match menu::exp_row_lock(menu::EXP_ROW_GAME_MODE, rooted) {
+        // The lock's caption replaces the row's own: a row the user can't change has nothing
+        // more useful to say than why.
+        Some(lock) => game_mode.locked(true).with_subtext(lock_caption(lock)),
+        None => game_mode,
+    });
     rows
 }
 
-/// Row count without building the `FocusRow` vec — for card sizing and hit-testing. The
-/// Game mode row is only offered on a rooted TV, so the screen is one row shorter otherwise.
-pub fn row_count(rooted: bool) -> usize {
-    1 + usize::from(rooted)
+fn lock_caption(lock: ExpRowLock) -> ui::widgets::RowSubtext {
+    match lock {
+        ExpRowLock::RootUnknown => ui::widgets::RowSubtext::hint("Checking whether your TV is rooted..."),
+        ExpRowLock::NotRooted => ui::widgets::RowSubtext::caution("Your TV is not rooted, Game mode is unavailable"),
+    }
 }
 
-pub fn card_rect(screen_w: u32, screen_h: u32, fonts: &Fonts, rooted: bool) -> Rect {
-    ui::widgets::list_modal_card_rect(screen_w, screen_h, fonts, SUBTITLE, row_count(rooted))
+pub fn card_rect(screen_w: u32, screen_h: u32, fonts: &Fonts) -> Rect {
+    ui::widgets::list_modal_card_rect(screen_w, screen_h, fonts, SUBTITLE, EXP_ROW_COUNT)
 }
 
 /// The experimental-features list as a [`ModalScreen`].
 pub(crate) struct Modal<'a> {
     pub settings: &'a Settings,
-    pub rooted: bool,
+    pub rooted: Option<bool>,
 }
 
 impl ModalScreen for Modal<'_> {
     fn card_rect(&self, screen_w: u32, screen_h: u32, fonts: &Fonts) -> Rect {
-        card_rect(screen_w, screen_h, fonts, self.rooted)
+        card_rect(screen_w, screen_h, fonts)
     }
 
     fn content_rect(&self, card: Rect, fonts: &Fonts) -> Option<Rect> {
@@ -70,7 +73,7 @@ impl ModalScreen for Modal<'_> {
             card,
             fonts,
             SUBTITLE,
-            rows(self.settings, self.rooted).len(),
+            EXP_ROW_COUNT,
         ))
     }
 

--- a/src/platform/webos/game_mode.rs
+++ b/src/platform/webos/game_mode.rs
@@ -13,26 +13,35 @@
 //! returns its stdout — reachable from the public bus. On a TV without the Homebrew Channel this
 //! simply fails and is logged; the feature stays behind the Experimental toggle for that reason.
 use serde_json::Value;
-use std::sync::OnceLock;
 use std::time::Duration;
 
 const URI_EXEC: &str = "luna://org.webosbrew.hbchannel.service/exec";
-/// The Homebrew Channel's elevated helper — its presence is our proxy for "this TV is rooted",
-/// since [`enter`] can only reach `settingsservice` by having this service run `luna-send` as
-/// root (see the module docs). No service dir → not rooted → the feature can't work.
+/// The Homebrew Channel's elevated helper — [`enter`] can only reach `settingsservice` by having
+/// this service run `luna-send` as root (see the module docs).
 const HBCHANNEL_SERVICE: &str = "/media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service";
 
-/// Whether this TV can drive picture/sound settings — i.e. it's webosbrew-rooted (the Homebrew
-/// Channel elevated service is installed) and `luna-send-pub` exists to reach it. Probed once;
-/// gates whether the Experimental "Game mode" row is offered at all.
-pub fn is_rooted() -> bool {
-    static ROOTED: OnceLock<bool> = OnceLock::new();
-    *ROOTED
-        .get_or_init(|| crate::platform::webos::luna::available() && std::path::Path::new(HBCHANNEL_SERVICE).is_dir())
+/// Whether the Homebrew Channel's elevated service is installed at all — free, and false rules
+/// root out without paying for [`probe_rooted`]'s round-trip.
+pub fn hbchannel_installed() -> bool {
+    std::path::Path::new(HBCHANNEL_SERVICE).is_dir()
 }
+
+/// Probes whether this TV can actually run privileged commands through the Homebrew Channel.
+/// [`hbchannel_installed`] is not enough — a non-rooted TV has the service but the call comes
+/// back permission-denied, so a harmless `true` has to make the round-trip for real.
+pub fn probe_rooted() -> bool {
+    if let Err(e) = exec(PROBE_TIMEOUT, "true") {
+        tracing::info!("hbchannel service present but root exec failed — TV is not rooted: {e:#}");
+        return false;
+    }
+    true
+}
+
 /// Generous: the outer call forks `luna-send` as root on the TV, which itself round-trips to
 /// `settingsservice`. Passed through as `luna-send-pub -w` and the process kill deadline.
 const EXEC_TIMEOUT: Duration = Duration::from_millis(4000);
+/// The probe runs a bare `true` — no `settingsservice` hop — so it needn't wait as long.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(1500);
 
 /// One setting we changed, plus the value to put back on exit (`None` = nothing to restore:
 /// couldn't read the prior value, or it already equalled what we set).
@@ -53,14 +62,14 @@ fn picture_mode(hdr: bool) -> &'static str {
     }
 }
 
-/// Runs `luna-send-cmd` as root through the Homebrew Channel's `exec` and returns the wrapped
-/// command's stdout (the inner `luna-send`'s reply JSON). Errors if the exec service is absent
-/// (non-rooted TV) or itself reports failure.
-fn exec_root(luna_send_cmd: &str) -> anyhow::Result<String> {
-    // serde_json builds the outer payload so `luna_send_cmd` (which contains quotes) is escaped
+/// Runs `command` as root through the Homebrew Channel's `exec` and returns its stdout (for a
+/// wrapped `luna-send`, the inner reply JSON). Errors if the exec service is absent (non-rooted
+/// TV) or itself reports failure.
+fn exec(timeout: Duration, command: &str) -> anyhow::Result<String> {
+    // serde_json builds the outer payload so `command` (which contains quotes) is escaped
     // correctly regardless of the inner JSON.
-    let payload = serde_json::json!({ "command": luna_send_cmd }).to_string();
-    let reply = crate::platform::webos::luna::call_capture(URI_EXEC, &payload, EXEC_TIMEOUT)?;
+    let payload = serde_json::json!({ "command": command }).to_string();
+    let reply = crate::platform::webos::luna::call_capture(URI_EXEC, &payload, timeout)?;
     let parsed: Value = serde_json::from_str(&reply).map_err(|e| anyhow::anyhow!("exec reply parse: {e}"))?;
     if parsed.get("returnValue").and_then(Value::as_bool) != Some(true) {
         anyhow::bail!("hbchannel exec failed: {reply}");
@@ -72,7 +81,7 @@ fn exec_root(luna_send_cmd: &str) -> anyhow::Result<String> {
         .to_owned())
 }
 
-/// The privileged `luna-send` for one settingsservice method, as a shell string for `exec_root`.
+/// The privileged `luna-send` for one settingsservice method, as a shell string for `exec`.
 /// `body` is serialized by `serde_json` (like the outer payload) then single-quoted for the
 /// shell; its own double quotes sit inside untouched.
 fn luna_send(method: &str, body: &Value) -> String {
@@ -82,7 +91,7 @@ fn luna_send(method: &str, body: &Value) -> String {
 /// Reads one setting's current string value so it can be put back on stream exit.
 fn get_setting(category: &str, key: &str) -> Option<String> {
     let body = serde_json::json!({ "category": category, "keys": [key] });
-    let out = exec_root(&luna_send("getSystemSettings", &body))
+    let out = exec(EXEC_TIMEOUT, &luna_send("getSystemSettings", &body))
         .map_err(|e| tracing::warn!("game mode: read {category}.{key} failed: {e:#}"))
         .ok()?;
     serde_json::from_str::<Value>(&out)
@@ -95,10 +104,10 @@ fn get_setting(category: &str, key: &str) -> Option<String> {
 
 /// Sets one setting for the current source. No `dimension` — a native app is not an HDMI input,
 /// so this targets the app/current context rather than a specific `hdmiN`. Confirms the inner
-/// call's own `returnValue`, which `exec_root`'s success does not imply.
+/// call's own `returnValue`, which `exec`'s success does not imply.
 fn set_setting(category: &str, key: &str, value: &str) -> anyhow::Result<()> {
     let body = serde_json::json!({ "category": category, "settings": { key: value } });
-    let out = exec_root(&luna_send("setSystemSettings", &body))?;
+    let out = exec(EXEC_TIMEOUT, &luna_send("setSystemSettings", &body))?;
     let ok = serde_json::from_str::<Value>(&out)
         .ok()
         .and_then(|v| v.get("returnValue").and_then(Value::as_bool))

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -183,6 +183,7 @@ pub(super) fn run_ui_flow(
         dirty |= app.drain_art();
         dirty |= app.drain_games();
         dirty |= app.drain_pairing();
+        dirty |= app.drain_rooted();
         dirty |= app.drain_speed_test();
         dirty |= app.drain_send_logs();
         app.tick_reachability();


### PR DESCRIPTION
## Problem

The old `is_rooted()` only checked that the Homebrew Channel service directory existed and `luna-send-pub` was executable. On a non-rooted TV with HBC installed those files are present but `luna-send` itself is permission-denied — the check passed, the Game mode toggle showed up in Experimental, and it did nothing on stream.

## Fix

`probe_rooted()` runs a harmless `true` through the HBC exec service and only reports rooted if the round-trip actually succeeds.

That is a luna round-trip, so it doesn't sit on the startup path. The probe starts when the Experimental screen opens (once per launch, skipped entirely when the HBC service isn't installed) and its verdict lands through the menu tick like the other `drain_*` results.

The Game mode row is always listed now instead of appearing and disappearing. It stays locked until the answer arrives, with a caption for each state:

- checking — "Checking whether your TV is rooted..."
- not rooted — "Your TV is not rooted, Game mode is unavailable"
- rooted — "Your TV is rooted, you can use ALLM"

One predicate, `menu::exp_row_lock`, both greys the row and rejects the keypress, matching how the Settings screen's `row_lock` works. A `game_mode` left enabled from when the TV *was* rooted is cleared when the verdict says otherwise, so stream start stops paying for luna calls that can only fail.

Nothing about root is persisted — rooting can change between boots, so it is re-probed each launch.

Also adds a Game mode bullet to the packaging description.
