### PR TITLE
Run the NDL clock plane on every V2 load with an audio plane

### DIFF
--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -144,6 +144,10 @@ question:
   feeds a silent Opus metronome stamped in NDL's own player-clock domain, while
   `platform::webos::audio` decodes the real audio to SDL as before. Confirmed at 4K120 5.1.
 
+`run_clock_plane` runs on **both** routes (`session::connect::spawn_plane_threads`): under offload
+it yields to the real stream and only fills in after 300 ms with no packet, since a host that stops
+sending would otherwise starve the plane and freeze the picture.
+
 A set that refuses the audio-enabled load falls back to video-only inside `NdlVideo::load` and
 gives up pacing with it; the session log names which of the routes it took. **NDL v1 and SMP have
 no Opus audio type at all**, so webOS 4 has no pacing reference — the lever there would be gating
@@ -180,8 +184,10 @@ anyway, so the flush was never doing work. `NDL_DirectAudioPlay` returns 0 eithe
 no error to find on the audio side, so do not go looking for one.
 
 ⚠ **Audio stamps must never go backwards — NDL reads a rewind as a mute for the rest of the
-session**, and does not resync. `NdlVideo::feed_audio` is the single feed point for both riders
-and floors every stamp at the previous one. For hardware decode the offset is additionally
+session**, and does not resync. `NdlVideo::play_audio` and `NdlVideo::burst_silence` are the only
+feed points, both serialised under `lock_ffi` and both flooring at `last_audio_pts_ms` — the floor
+must be read under that guard, or a packet measured against an older ceiling blocks on the lock and
+then hands NDL the stale stamp. For hardware decode the offset is additionally
 **latched, not recomputed per frame**: a receive-backlog flush jumps host PTS forward while the
 player clock does not, and a re-derived offset would drag the audio stamp backwards by the size of
 the jump. `latch_pts_offset` takes only the first value after each `clear_pts_offset` (hold

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -44,6 +44,12 @@ const PRIME_LEAD: i64 = 8;
 /// and this is launch-path time, i.e. black screen.
 const PRIME_RETRY: Duration = Duration::from_millis(20);
 
+/// How long the clock plane waits for the real stream before feeding the plane itself.
+///
+/// The test is "no packets at all", never amplitude: a silent game still streams, since the host
+/// encodes silence into the same continuous 5 ms datagrams. Only a dead host capture gaps this wide.
+const REAL_FEED_GRACE_MS: i64 = 300;
+
 /// [`NdlVideo::play`] refusing a frame because `LOADCOMPLETED` hasn't landed. A distinct type
 /// because the caller must NOT respond to it the way it responds to a decode error: the usual
 /// answer is `NDL_DirectVideoFlushRenderBuffer`, and issuing that against a pipeline NDL has not
@@ -96,7 +102,7 @@ pub struct NdlVideo {
     /// domain stays on `load_instant`.
     load_requested: Instant,
     /// Whether the load asked for — and confirmed — an audio plane. What RIDES that plane (the
-    /// real Opus stream, or [`Self::play_silence`]'s metronome) is the caller's choice.
+    /// real Opus stream, or [`Self::run_clock_plane`]'s metronome) is the caller's choice.
     has_audio_plane: bool,
     /// Host-PTS → NDL-player-clock offset in ns, republished by the video plane on every fed
     /// frame (`session::sink`) and read by [`Self::play_audio`] so both planes land in ONE
@@ -106,6 +112,14 @@ pub struct NdlVideo {
     /// timestamp going backwards. Never reset — the ceiling has to survive a re-latch, which is
     /// exactly the case that would otherwise rewind it.
     last_audio_pts_ms: AtomicI64,
+    /// Player-clock ms at the last REAL packet fed by [`Self::play_audio`].
+    /// [`Self::run_clock_plane`] reads it to stay off the plane while the real stream carries it.
+    ///
+    /// Starts at 0 (the load instant), NOT a sentinel: the grace then runs from session start, so
+    /// an offloaded session whose audio arrives normally never feeds a single silent packet. The
+    /// sentinel made every such session open by bursting silence to a ceiling a whole prime ahead
+    /// of the real timeline, and the real packets that followed were all floored onto it.
+    last_real_feed_ms: AtomicI64,
     /// `false` while `LOADCOMPLETED` still hasn't been seen for this load. Latched once, so the
     /// steady-state feed path costs one relaxed load.
     ///
@@ -201,6 +215,7 @@ impl NdlVideo {
             has_audio_plane: with_audio,
             pts_offset_ns: AtomicI64::new(NO_PTS_OFFSET),
             last_audio_pts_ms: AtomicI64::new(primed_pts_ms),
+            last_real_feed_ms: AtomicI64::new(0),
             load_confirmed: AtomicBool::new(confirmed),
             pending_hdr: Mutex::new(None),
             applied_hdr: Mutex::new(None),
@@ -268,7 +283,7 @@ impl NdlVideo {
     }
 
     /// Whether this load has an audio plane. It always does when the load confirmed, since NDL
-    /// only paces the picture against a fed audio plane — see [`Self::play_silence`]. False means
+    /// only paces the picture against a fed audio plane — see [`Self::run_clock_plane`]. False means
     /// the audio-enabled load was rejected and `load()` fell back to video-only.
     pub fn has_audio_plane(&self) -> bool {
         self.has_audio_plane
@@ -325,49 +340,105 @@ impl NdlVideo {
             return Ok(());
         }
         let raw_ms = (host_pts_ns as i64).saturating_add(offset_ns).max(0) / 1_000_000;
-        self.feed_audio(packet, raw_ms)
-    }
-
-    /// The audio plane's only feed point. The monotonic floor is load-bearing: NDL reads a
-    /// backwards stamp as a rewind and mutes for the rest of the session, and both callers can
-    /// produce one (a receive-backlog jump; the prime's ceiling).
-    fn feed_audio(&self, data: &[u8], pts_ms: i64) -> Result<()> {
-        let pts_ms = self.last_audio_pts_ms.fetch_max(pts_ms, Ordering::Relaxed).max(pts_ms) as c_longlong;
-        let _ffi = lock_ffi();
-        // SAFETY: NDL reads `size` bytes synchronously and does not retain the pointer.
-        let ret = unsafe { (self.fns.audio_play)(data.as_ptr() as *mut c_void, data.len() as c_uint, pts_ms) };
+        // Floor under the guard, never before it: flooring first lets a packet measured against an
+        // older ceiling block here while `burst_silence` feeds higher, then hand NDL the stale
+        // stamp — a rewind, which mutes the session for good.
+        let ret = {
+            let _ffi = lock_ffi();
+            let pts_ms = self.last_audio_pts_ms.fetch_max(raw_ms, Ordering::Relaxed).max(raw_ms);
+            // SAFETY: NDL reads `size` bytes synchronously and does not retain the pointer.
+            unsafe {
+                (self.fns.audio_play)(
+                    packet.as_ptr() as *mut c_void,
+                    packet.len() as c_uint,
+                    pts_ms as c_longlong,
+                )
+            }
+        };
         if ret != 0 {
             bail!("NDL_DirectAudioPlay failed: ret={ret} error={}", ffi::last_error());
         }
+        // Player clock, not the packet's domain: the reader asks "how long since a packet ARRIVED".
+        self.last_real_feed_ms
+            .store((self.elapsed_ns() / 1_000_000) as i64, Ordering::Relaxed);
         Ok(())
     }
 
-    /// One silent frame for the clock plane. Stamped in the player-clock domain and not through
-    /// `pts_offset_ns`: this plane is a metronome, not content, so it has no host timeline to
-    /// join. Why it exists at all: docs/NOTES.md § "NDL's audio plane".
-    fn play_silence(&self, pts_ms: i64) -> Result<()> {
-        self.feed_audio(&OPUS_SILENCE, pts_ms)
+    /// Feed silence from `from_ms` up to `target_ms`, returning the last stamp fed.
+    ///
+    /// One `lock_ffi` for the whole burst, like [`prime_audio`](Self::prime_audio) — the video feed
+    /// shares that guard, so per-packet acquires would be up to 60 of them in the picture's way.
+    ///
+    /// The floor is read under the guard, which is also the whole race story: `lock_ffi` is the
+    /// audio plane's only feed path, so no real packet can land mid-burst and read a stale ceiling
+    /// — it either precedes this and is picked up by the floor, or follows the final publish.
+    fn burst_silence(&self, from_ms: i64, target_ms: i64) -> Result<i64> {
+        let _ffi = lock_ffi();
+        let mut pts_ms = from_ms.max(self.last_audio_pts_ms.load(Ordering::Relaxed));
+        while pts_ms < target_ms {
+            pts_ms += PRIME_PACKET_MS;
+            // SAFETY: NDL reads `size` bytes synchronously and does not retain the pointer.
+            let ret = unsafe {
+                (self.fns.audio_play)(
+                    OPUS_SILENCE.as_ptr() as *mut c_void,
+                    OPUS_SILENCE.len() as c_uint,
+                    pts_ms as c_longlong,
+                )
+            };
+            if ret != 0 {
+                // Publish before unwinding: this burst has already handed NDL stamps above the old
+                // ceiling, and leaving it stale lets the next real packet floor below them — a
+                // rewind, which mutes the session for good.
+                self.last_audio_pts_ms.fetch_max(pts_ms, Ordering::Relaxed);
+                bail!("NDL_DirectAudioPlay failed: ret={ret} error={}", ffi::last_error());
+            }
+        }
+        self.last_audio_pts_ms.fetch_max(pts_ms, Ordering::Relaxed);
+        Ok(pts_ms)
     }
 
-    /// Run the clock plane until `stop`, for a session whose real audio is decoded in software.
-    /// Blocks, so the caller gives it a thread.
+    /// Keep the audio plane fed until `stop`. Blocks, so the caller gives it a thread.
     ///
-    /// Same burst shape as [`Self::prime_audio`], topped up to `PRIME_LEAD` packets ahead so the
-    /// plane stays fed. Bursting keeps it to ~50 wakeups/s instead of 200, on a `SoC` whose video
-    /// feed shares `lock_ffi` with it.
-    pub fn run_clock_plane(&self, stop: &std::sync::atomic::AtomicBool) {
+    /// **A fed audio plane is what makes NDL pace the picture at all** (docs/NOTES.md § "NDL's
+    /// audio plane"), so every V2 load with a plane runs this — the invariant is the decoder's, not
+    /// whichever session-layer pump happens to exist.
+    ///
+    /// `yields_to_real` is the whole difference between the two audio paths. Off (software decode):
+    /// a pure metronome, the only feed. On (NDL offload): the real stream is the metronome, and
+    /// this fills in only after [`REAL_FEED_GRACE_MS`] without a packet — a dead host capture,
+    /// which would otherwise starve the plane and freeze the picture.
+    pub fn run_clock_plane(&self, stop: &std::sync::atomic::AtomicBool, yields_to_real: bool) {
         // Continue the prime's stamps instead of restarting from the player clock: the prime runs
         // BEFORE `load_instant`, so its ceiling already sits a whole prime ahead, and targeting the
         // raw clock would feed nothing until it caught up — dead exactly at session start. The
         // resulting constant offset from the video timeline costs a metronome nothing.
-        let base_ms = self.last_audio_pts_ms.load(Ordering::Relaxed);
+        let mut base_ms = self.last_audio_pts_ms.load(Ordering::Relaxed);
         let mut pts_ms = base_ms;
+        let mut filling = false;
         while !stop.load(Ordering::Relaxed) {
-            let elapsed_ms = (self.elapsed_ns() / 1_000_000) as i64;
-            let target_ms = base_ms + elapsed_ms + PRIME_LEAD * PRIME_PACKET_MS;
-            while pts_ms < target_ms {
-                pts_ms += PRIME_PACKET_MS;
-                if let Err(e) = self.play_silence(pts_ms) {
+            let now_ms = (self.elapsed_ns() / 1_000_000) as i64;
+            if yields_to_real && now_ms - self.last_real_feed_ms.load(Ordering::Relaxed) < REAL_FEED_GRACE_MS {
+                if filling {
+                    tracing::info!("NDL clock plane: host audio resumed at {now_ms}ms — yielding");
+                    filling = false;
+                }
+                std::thread::sleep(PRIME_RETRY);
+                continue;
+            }
+            if yields_to_real && !filling {
+                // Rebase onto where the real stream left the ceiling: the start-of-session base
+                // would re-add the prime's whole lead on top of it, and recovered audio then floors
+                // to that jumped ceiling — pinned to one stamp for the length of the jump.
+                base_ms = self.last_audio_pts_ms.load(Ordering::Relaxed) - now_ms;
+                tracing::warn!(
+                    "NDL clock plane: no host audio for {REAL_FEED_GRACE_MS}ms — filling silence \
+                     to keep the picture paced (host capture is likely dead)"
+                );
+                filling = true;
+            }
+            match self.burst_silence(pts_ms, base_ms + now_ms + PRIME_LEAD * PRIME_PACKET_MS) {
+                Ok(fed_to) => pts_ms = fed_to,
+                Err(e) => {
                     // Dead for the session; the picture keeps running unpaced, as it did before
                     // the clock plane existed.
                     tracing::warn!("NDL clock plane stopping at {pts_ms}ms: {e:#}");

--- a/src/session/connect.rs
+++ b/src/session/connect.rs
@@ -28,10 +28,11 @@ pub struct Connected {
     pub stats: Arc<StreamStats>,
     /// Kept alive so `shutdown()` can join and ensure QUIC close frame is sent before exit.
     video_thread: std::thread::JoinHandle<()>,
-    /// The NDL audio plane's pump, on every V2 load that got a plane: `ndl_audio_pump` when the
-    /// real stream rides it (`audio_offloaded`), `NdlVideo::run_clock_plane`'s metronome otherwise.
-    /// `None` only when the load has no audio plane at all (V1, SMP, or a rejected audio load).
+    /// Forwards the real Opus stream onto NDL's audio plane. `Some` only on the offloaded path.
     audio_thread: Option<std::thread::JoinHandle<()>>,
+    /// `NdlVideo::run_clock_plane`, on every V2 load that got a plane. `None` only when the load
+    /// has no audio plane at all (V1, SMP, or a rejected audio load).
+    clock_thread: Option<std::thread::JoinHandle<()>>,
     /// True when the REAL Opus stream rides NDL's audio plane; prevents opening the SDL2 audio
     /// device. False on a clock-plane session, which still has a plane but decodes in software.
     pub audio_offloaded: bool,
@@ -46,14 +47,17 @@ impl Connected {
     /// graceful shutdown. Returns `false` if any step didn't finish within
     /// `SHUTDOWN_JOIN_TIMEOUT` — the caller must then skip `ndl::quit()`, since the thread
     /// still running may still be inside an NDL FFI call that a concurrent unload would race. A
-    /// wedged video/audio join additionally refuses new loads until it finishes — those two are the
-    /// threads that touch NDL.
+    /// wedged video/audio/clock join additionally refuses new loads until it finishes — those three
+    /// are the threads that touch NDL.
     pub fn shutdown(self) -> bool {
         use crate::platform::webos::ndl::poison;
         self.stop.store(true, Ordering::Relaxed);
         let mut clean = join_with_timeout(self.video_thread, SHUTDOWN_JOIN_TIMEOUT, "video", poison);
         if let Some(audio) = self.audio_thread {
             clean &= join_with_timeout(audio, SHUTDOWN_JOIN_TIMEOUT, "audio", poison);
+        }
+        if let Some(clock) = self.clock_thread {
+            clean &= join_with_timeout(clock, SHUTDOWN_JOIN_TIMEOUT, "clock", poison);
         }
         // `NativeClient::drop` joins its own QUIC-close worker thread internally — bound
         // that the same way, on its own thread, rather than blocking here directly. Doesn't
@@ -313,7 +317,7 @@ fn load_player(params: &ConnectParams, client: &NativeClient) -> Result<(VideoPl
 /// this the first debugging question has no answer in the log.
 fn audio_path_label(player: &VideoPlayer, has_plane: bool, offload_opt_in: bool, offloaded: bool) -> &'static str {
     match (has_plane, player) {
-        _ if offloaded => "NDL hardware Opus decode",
+        _ if offloaded => "NDL hardware Opus decode (+ clock plane standing by)",
         // A plane the real stream is not using is the pacing metronome — see
         // `NdlVideo::run_clock_plane`.
         (true, _) if !offload_opt_in => "software Opus decode -> SDL2 + NDL clock plane (offload not opted in)",
@@ -356,8 +360,8 @@ pub fn connect(params: ConnectParams) -> Result<Connected> {
     // Failing here after the video thread is already up would otherwise detach it: `Connected` is
     // never built, so nothing ever sets `stop`, and a thread still feeding NDL outlives the error
     // the caller sees — which then races the `ndl::quit()` the failed connect leads to.
-    let audio_thread = match spawn_audio_thread(&client, ndl_audio, &stop, audio_offloaded) {
-        Ok(handle) => handle,
+    let (audio_thread, clock_thread) = match spawn_plane_threads(&client, ndl_audio, &stop, audio_offloaded) {
+        Ok(handles) => handles,
         Err(e) => {
             stop.store(true, Ordering::Relaxed);
             join_with_timeout(
@@ -376,6 +380,7 @@ pub fn connect(params: ConnectParams) -> Result<Connected> {
         stats,
         video_thread,
         audio_thread,
+        clock_thread,
         audio_offloaded,
         hdr: is_hdr,
     })
@@ -406,30 +411,53 @@ fn spawn_video_thread(
         .context("spawn video thread")
 }
 
-/// The thread on NDL's audio plane, if this load got one: the real Opus stream when it is
-/// offloaded, the pacing metronome otherwise.
-fn spawn_audio_thread(
+/// `(audio pump, clock plane)`.
+type PlaneThreads = (Option<std::thread::JoinHandle<()>>, Option<std::thread::JoinHandle<()>>);
+
+/// The threads on NDL's audio plane, if this load got one: the clock plane always, plus the real
+/// Opus stream's pump when it is offloaded.
+///
+/// The clock plane runs on EVERY session with a plane — NDL paces the picture against a fed plane
+/// regardless of which pump the audio path uses. Offloaded, it yields to the real stream and only
+/// fills in once the host stops sending.
+fn spawn_plane_threads(
     client: &Arc<NativeClient>,
     ndl_audio: Option<Arc<NdlVideo>>,
     stop: &Arc<AtomicBool>,
     audio_offloaded: bool,
-) -> Result<Option<std::thread::JoinHandle<()>>> {
+) -> Result<PlaneThreads> {
     let Some(ndl) = ndl_audio else {
-        return Ok(None);
+        return Ok((None, None));
     };
-    let stop = stop.clone();
-    let handle = if audio_offloaded {
-        let client = client.clone();
+    let clock_thread = {
+        let (ndl, stop) = (ndl.clone(), stop.clone());
+        std::thread::Builder::new()
+            .name("punktfunk-webos-clock".into())
+            .spawn(move || ndl.run_clock_plane(&stop, audio_offloaded))
+            .context("spawn clock plane thread")?
+    };
+    if !audio_offloaded {
+        return Ok((None, Some(clock_thread)));
+    }
+    let audio_thread = {
+        let (client, stop) = (client.clone(), stop.clone());
         std::thread::Builder::new()
             .name("punktfunk-webos-audio".into())
             .spawn(move || ndl_audio_pump(&client, &ndl, &stop))
-    } else {
-        // Software decode owns the speakers, so this plane is a metronome. Nothing is consumed
-        // twice: the real packets still go to the audio feed pump, and this one generates its
-        // own cadence off the player clock.
-        std::thread::Builder::new()
-            .name("punktfunk-webos-clock".into())
-            .spawn(move || ndl.run_clock_plane(&stop))
     };
-    handle.map(Some).context("spawn audio plane thread")
+    match audio_thread {
+        Ok(handle) => Ok((Some(handle), Some(clock_thread))),
+        // Same reason `connect` unwinds its video thread on failure: a detached thread still
+        // feeding NDL would outlive the error and race the `ndl::quit()` that follows it.
+        Err(e) => {
+            stop.store(true, Ordering::Relaxed);
+            join_with_timeout(
+                clock_thread,
+                SHUTDOWN_JOIN_TIMEOUT,
+                "clock",
+                crate::platform::webos::ndl::poison,
+            );
+            Err(e).context("spawn audio pump thread")
+        }
+    }
 }

--- a/src/session/pump.rs
+++ b/src/session/pump.rs
@@ -261,6 +261,8 @@ fn audio_drain(client: &NativeClient, stop: &AtomicBool, what: &str, mut play: i
 /// process-global NDL unload in `NdlVideo::drop` cannot run until this thread has
 /// exited — `NDL_DirectAudioPlay` can never race the unload, whichever thread
 /// `Connected::shutdown` happens to join first.
+/// A gap starves NDL's pacing clock, but `run_clock_plane` watches the same plane and fills in —
+/// see its `yields_to_real`.
 pub(super) fn ndl_audio_pump(client: &NativeClient, ndl: &NdlVideo, stop: &AtomicBool) {
     audio_drain(client, stop, "audio pump", |packet| {
         if let Err(e) = ndl.play_audio(&packet.data, packet.pts_ns) {


### PR DESCRIPTION
NDL only paces the picture against a *fed* audio plane. Off-offload that was handled — `run_clock_plane` ran as a permanent silent metronome. On-offload it wasn't: real Opus packets were the only thing feeding the plane, so a host that stopped sending starved it and the picture froze for as long as the host's audio stayed dead.

Rather than bolt stall detection onto the offload pump, the clock plane now runs on every V2 load that has a plane, with one flag for the difference:

- **software decode** — pure metronome, the only feed. Unchanged behaviour.
- **NDL offload** — yields while real packets arrive, fills silence only after 300ms without one.

The test is packet arrival, never amplitude. A silent game still streams (the host encodes silence into the same continuous 5ms datagrams), so quiet content never trips it — only a host whose capture actually died.

Also in here:

- Fixes a latent permanent-mute on the shared feed path. The monotonic floor was computed *outside* `lock_ffi`, so a packet could floor against an old ceiling, block on the lock while silence fed higher stamps, then hand NDL a backwards stamp — which mutes the session for good. Floor and feed are now one step under the guard.
- Hoists `lock_ffi` out of the per-packet silence loop. It was up to 60 acquire/release pairs per top-up on the guard the video feed shares, on a 2-3 core SoC.
- Folds the two silence-feeding loops into one `burst_silence` helper.

## Testing

Builds clean (`docker:check`, `docker:lint`, `fmt`). **Not yet verified on device** — the offload path now spawns a second thread, so the `clock` teardown join is the thing to watch on a first real run.

Context: this came out of a user report of no audio plus a slow stream start. The host logs showed the host's own capture device had died (`delivered_pct=0`, `peak_db=-120` for minutes), and that user was on software decode, so **this is not a fix for that report** — the starvation gap it closes is on the offload path, which nobody has hit yet. The `lock_ffi` mute fix does apply to both paths. The slow start remains unexplained and needs a client-side log.