### PR TITLE
Fix root detection on rooted TVs

### DIFF
--- a/src/app/state/experimental.rs
+++ b/src/app/state/experimental.rs
@@ -14,11 +14,6 @@ impl App {
         if self.rooted.is_some() || self.rooted_rx.is_some() {
             return;
         }
-        // No Homebrew Channel, no root, no thread — the answer is a stat away.
-        if !crate::platform::webos::game_mode::hbchannel_installed() {
-            self.settle_rooted(false);
-            return;
-        }
         let (tx, rx) = std::sync::mpsc::channel();
         match std::thread::Builder::new().name("root-probe".into()).spawn(move || {
             let _ = tx.send(crate::platform::webos::game_mode::probe_rooted());

--- a/src/platform/webos/game_mode.rs
+++ b/src/platform/webos/game_mode.rs
@@ -16,22 +16,14 @@ use serde_json::Value;
 use std::time::Duration;
 
 const URI_EXEC: &str = "luna://org.webosbrew.hbchannel.service/exec";
-/// The Homebrew Channel's elevated helper — [`enter`] can only reach `settingsservice` by having
-/// this service run `luna-send` as root (see the module docs).
-const HBCHANNEL_SERVICE: &str = "/media/developer/apps/usr/palm/services/org.webosbrew.hbchannel.service";
-
-/// Whether the Homebrew Channel's elevated service is installed at all — free, and false rules
-/// root out without paying for [`probe_rooted`]'s round-trip.
-pub fn hbchannel_installed() -> bool {
-    std::path::Path::new(HBCHANNEL_SERVICE).is_dir()
-}
 
 /// Probes whether this TV can actually run privileged commands through the Homebrew Channel.
-/// [`hbchannel_installed`] is not enough — a non-rooted TV has the service but the call comes
-/// back permission-denied, so a harmless `true` has to make the round-trip for real.
+/// Only the round-trip is trustworthy: the service's install path varies (`/media/developer` vs
+/// `/media/cryptofs`, depending on how the Homebrew Channel was installed), and even when it is
+/// present a non-rooted TV answers permission-denied. So a harmless `true` is run for real.
 pub fn probe_rooted() -> bool {
     if let Err(e) = exec(PROBE_TIMEOUT, "true") {
-        tracing::info!("hbchannel service present but root exec failed — TV is not rooted: {e:#}");
+        tracing::info!("hbchannel root exec failed — TV is not rooted: {e:#}");
         return false;
     }
     true
@@ -40,8 +32,9 @@ pub fn probe_rooted() -> bool {
 /// Generous: the outer call forks `luna-send` as root on the TV, which itself round-trips to
 /// `settingsservice`. Passed through as `luna-send-pub -w` and the process kill deadline.
 const EXEC_TIMEOUT: Duration = Duration::from_millis(4000);
-/// The probe runs a bare `true` — no `settingsservice` hop — so it needn't wait as long.
-const PROBE_TIMEOUT: Duration = Duration::from_millis(1500);
+/// The probe runs a bare `true` — no `settingsservice` hop — but the Homebrew Channel's service
+/// is launched on demand, so a cold first call pays for that start-up before it answers.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(4000);
 
 /// One setting we changed, plus the value to put back on exit (`None` = nothing to restore:
 /// couldn't read the prior value, or it already equalled what we set).

--- a/src/platform/webos/luna.rs
+++ b/src/platform/webos/luna.rs
@@ -91,14 +91,24 @@ pub fn call_capture(uri: &str, payload: &str, timeout: Duration) -> anyhow::Resu
 /// reaping on timeout so no zombie is left). Returns its stdout when `capture` is set, else an
 /// empty string. Shared by [`call`] and [`call_capture`] — the only differences between them are
 /// the args, `capture`, and the deadline.
+///
+/// **Why a temp file and not a pipe.** `luna-send-pub` leaves stdout fully buffered when it is
+/// not a tty and exits without flushing, so a piped reply arrives empty every time (verified
+/// on-device: the same call redirected to a file prints its JSON). A regular file is the one
+/// non-tty destination that survives that, since the buffer is flushed by the kernel on exit.
 fn run_bounded(args: &[&str], timeout: Duration, capture: bool) -> anyhow::Result<String> {
     if !available() {
         anyhow::bail!("luna-send-pub unavailable");
     }
+    let reply = capture.then(ReplyFile::new);
+    let stdout = match &reply {
+        Some(reply) => Stdio::from(std::fs::File::create(&reply.0)?),
+        None => Stdio::null(),
+    };
     let mut child = Command::new(LUNA_SEND_PUB)
         .args(args)
         .stdin(Stdio::null())
-        .stdout(if capture { Stdio::piped() } else { Stdio::null() })
+        .stdout(stdout)
         .stderr(Stdio::null())
         .spawn()?;
 
@@ -106,12 +116,10 @@ fn run_bounded(args: &[&str], timeout: Duration, capture: bool) -> anyhow::Resul
     loop {
         match child.try_wait()? {
             Some(status) if status.success() => {
-                let out = if capture {
-                    String::from_utf8_lossy(&child.wait_with_output()?.stdout).into_owned()
-                } else {
-                    String::new()
+                return match &reply {
+                    Some(reply) => reply.read(),
+                    None => Ok(String::new()),
                 };
-                return Ok(out);
             }
             Some(status) => anyhow::bail!("luna-send-pub exited {status}"),
             None if Instant::now() >= deadline => {
@@ -123,5 +131,30 @@ fn run_bounded(args: &[&str], timeout: Duration, capture: bool) -> anyhow::Resul
             }
             None => std::thread::sleep(Duration::from_millis(10)),
         }
+    }
+}
+
+/// The file one call's reply is written to, unlinked on drop so every way out of
+/// [`run_bounded`] — including ones added later — cleans up without having to remember to.
+///
+/// The path is unique per process AND per call: calls can be in flight from several threads
+/// (feedback sends, the root probe), and a shared path would let one truncate another's reply.
+struct ReplyFile(std::path::PathBuf);
+
+impl ReplyFile {
+    fn new() -> Self {
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let n = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Self(std::env::temp_dir().join(format!("pf-luna-{}-{n}.json", std::process::id())))
+    }
+
+    fn read(&self) -> anyhow::Result<String> {
+        Ok(std::fs::read_to_string(&self.0)?)
+    }
+}
+
+impl Drop for ReplyFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
     }
 }


### PR DESCRIPTION
Game mode said "not rooted" on a rooted TV. Two separate causes.

- `luna-send-pub` leaves stdout fully buffered when it is not a tty and exits without flushing, so every reply captured through a pipe came back empty — verified on-device, the same call redirected to a file prints its JSON. Capture now goes to a temp file (`ReplyFile`, unlinked on drop). This broke `call_capture` for all callers, not just the root probe.
- Root detection gated on stat'ing the Homebrew Channel service under `/media/developer/...`, which is not where it always lives. Dropped the gate; the real exec probe is the only verdict now.
- Probe timeout raised to 4s since the hbchannel service launches on demand and a cold first call pays for the start-up.

Confirmed working on a rooted CX.