### PR TITLE
Fade overlong labels instead of ellipsizing them

### DIFF
--- a/src/app/view/settings.rs
+++ b/src/app/view/settings.rs
@@ -297,14 +297,14 @@ pub(crate) fn render(c: &mut Canvas, set: SettingsScope, suffix: Option<&str>, h
             ui::style::theme().muted,
         );
         let used = title_w + (2 * SEP_DOT_GAP + 2 * SEP_DOT_R) as u32;
-        // Ellipsized rather than clipped: a long game name must not run under the close button.
+        // Faded rather than clipped: a long game name must not run under the close button.
         let avail = column.width().saturating_sub(used + CLOSE_RESERVE);
-        let suffix = ui::text::ellipsize(c.fonts.raster, font, suffix, avail);
-        c.text(
+        c.text_faded(
             font,
-            &suffix,
+            suffix,
             column.x() + used as i32,
             baseline,
+            avail,
             ui::style::theme().muted,
         )?;
     }

--- a/src/platform/webos/text_sdl.rs
+++ b/src/platform/webos/text_sdl.rs
@@ -118,7 +118,7 @@ impl TextRaster for SdlTextRaster<'_> {
 
     /// Memoized, because `size_of` is a full freetype glyph-metrics walk and this UI asks for
     /// the same measurement constantly: `wrap_text` measures every word of every string it
-    /// wraps (and words repeat), `ellipsize` binary-searches over prefixes of one title,
+    /// wraps (and words repeat), every label measures itself against its width budget,
     /// `Layout::total_length` probes a stack before placing it, and all of that happens again
     /// on the next tile rebuild. None of it can change — a loaded font's metrics are fixed.
     fn measure(&self, font: FontId, text: &str) -> (u32, u32) {

--- a/src/ui/painter.rs
+++ b/src/ui/painter.rs
@@ -394,6 +394,42 @@ impl Painter {
         });
     }
 
+    /// [`draw_pixmap`](Self::draw_pixmap) cut to `max_w`, its last [`FADE_EDGE_W`] px ramped
+    /// out — how an overlong label says "this continues" without spending width on an
+    /// ellipsis. A `src` that already fits is drawn untouched.
+    ///
+    /// Smoothstep, premultiplied and rounded for the reasons on
+    /// [`fill_vertical_fade`](Self::fill_vertical_fade), which it can't share: this modulates
+    /// the buffer rather than filling it.
+    pub fn draw_pixmap_faded(&mut self, x: i32, y: i32, src: &Pixmap, max_w: u32) {
+        if src.width() <= max_w {
+            self.draw_pixmap(x, y, src);
+            return;
+        }
+        let Some(mut cut) = Pixmap::new(max_w, src.height()) else {
+            return;
+        };
+        // Identity blit into a narrower buffer: the crop is the clip.
+        cut.draw_pixmap(0, 0, src.as_ref(), &PixmapPaint::default(), Transform::identity(), None);
+        let w = max_w as usize;
+        let fade = (FADE_EDGE_W as usize).min(w);
+        // Per column, not per pixel: the ramp doesn't vary down the line.
+        let ramp: Vec<u16> = (0..fade)
+            .map(|i| {
+                let eased = crate::ui::animation::smoothstep((fade - i) as f32 / fade as f32);
+                (eased * 255.0).round().clamp(0.0, 255.0) as u16
+            })
+            .collect();
+        for row in cut.data_mut().chunks_exact_mut(w * 4) {
+            for (pixel, &k) in row[(w - fade) * 4..].chunks_exact_mut(4).zip(&ramp) {
+                for b in pixel {
+                    *b = ((u16::from(*b) * k + 127) / 255) as u8;
+                }
+            }
+        }
+        self.draw_pixmap(x, y, &cut);
+    }
+
     pub fn draw_pixmap(&mut self, x: i32, y: i32, src: &Pixmap) {
         self.pixmap.draw_pixmap(
             x - self.origin.0,
@@ -469,6 +505,10 @@ impl Painter {
             .fill_path(&path, &paint, FillRule::Winding, Transform::identity(), None);
     }
 }
+
+/// Width of [`Painter::draw_pixmap_faded`]'s ramp: wide enough not to read as a hard cut,
+/// narrow enough to eat no more of the line than an ellipsis would.
+pub const FADE_EDGE_W: u32 = 28;
 
 /// How far a shadow's blur extends past the shape casting it, in px — a fixed
 /// constant (not derived from anything) picked to read as a soft TV-scale shadow.

--- a/src/ui/text.rs
+++ b/src/ui/text.rs
@@ -92,6 +92,19 @@ impl Canvas<'_, '_> {
         Ok(width)
     }
 
+    /// [`text`](Self::text), except an overlong line is cut at `max_w` and faded rather than
+    /// ellipsized — see
+    /// [`Painter::draw_pixmap_faded`](crate::ui::painter::Painter::draw_pixmap_faded).
+    pub fn text_faded(&mut self, font: FontId, s: &str, x: i32, y: i32, max_w: u32, color: Color) -> Result<u32> {
+        if s.is_empty() || max_w == 0 {
+            return Ok(0);
+        }
+        let pixmap = self.text_cache.get_or_create(self.fonts.raster, font, s, color)?;
+        let width = pixmap.width().min(max_w);
+        self.painter.draw_pixmap_faded(x, y, pixmap, max_w);
+        Ok(width)
+    }
+
     /// Renders one line of text WITHOUT touching [`TextCache`] — for text that is
     /// unique per line and scrolled past once, where caching is pure loss.
     ///
@@ -194,36 +207,27 @@ impl Canvas<'_, '_> {
     }
 }
 
-/// Truncates `text` with a trailing "…" so it fits within `max_w` pixels in `font`
-/// (moonlight-tv scroll-marquees long titles on focus instead — see the module docs
-/// on why this client keeps it simple).
-/// Binary-searches the character count rather than popping one at a time: a measurement is a
-/// freetype metrics walk, and a long title that has to lose most of itself was paying one per
-/// dropped character. Width is monotonic in the prefix length, which is what makes the search
-/// valid — the same negligible-kerning assumption every width budget in this UI already makes.
-pub fn ellipsize(raster: &dyn TextRaster, font: FontId, text: &str, max_w: u32) -> String {
-    if raster.measure(font, text).0 <= max_w {
-        return text.to_string();
-    }
-    let chars: Vec<char> = text.chars().collect();
-    let candidate = |take: usize| chars[..take].iter().collect::<String>() + "…";
-    // Invariant: `lo` always fits, `hi` never does. `lo = 0` is "…" alone, which is the
-    // documented last resort when even that overflows.
-    let (mut lo, mut hi) = (0usize, chars.len());
-    while hi - lo > 1 {
-        let mid = lo + (hi - lo) / 2;
-        if raster.measure(font, &candidate(mid)).0 <= max_w {
-            lo = mid;
-        } else {
-            hi = mid;
-        }
-    }
-    candidate(lo)
+/// Largest loaded font whose longest word in `text` fits `max_w` (smallest if none does).
+/// For wrapped blocks: wrapping never breaks inside a word, so one word wider than the box
+/// overflows at any fixed size.
+pub fn fitting_font(raster: &dyn TextRaster, text: &str, max_w: u32) -> FontId {
+    // Descending point size — see `SdlTextRaster::new`.
+    const LADDER: [FontId; 4] = [FontId::Title, FontId::Label, FontId::Value, FontId::Caption];
+    let longest_word = |f| {
+        text.split_whitespace()
+            .map(|w| raster.measure(f, w).0)
+            .max()
+            .unwrap_or(0)
+    };
+    LADDER
+        .into_iter()
+        .find(|&f| longest_word(f) <= max_w)
+        .unwrap_or(FontId::Caption)
 }
 
 /// Greedily word-wraps `text` into lines no wider than `max_w` px in `font` — for modal
-/// copy that's a full sentence or two (status/explanation text), unlike `ellipsize`'s
-/// single-line truncation for card titles.
+/// copy that's a full sentence or two (status/explanation text), unlike
+/// [`Canvas::text_faded`]'s single-line budget for card titles and row labels.
 ///
 /// Tracks the running line width instead of re-measuring the whole (growing) line on
 /// every word — the original did a full-prefix measure each time, which is O(line

--- a/src/ui/widgets/cards.rs
+++ b/src/ui/widgets/cards.rs
@@ -148,7 +148,7 @@ const TITLE_STRIP_PAD: i32 = 16;
 const TITLE_STRIP_INSET: i32 = 8;
 /// Inset of the override dot from the panel's right edge — deeper than the label's own, so
 /// the mark reads as sitting inside the frosted window rather than against its corner.
-const MARK_DOT_INSET: i32 = 22;
+const MARK_DOT_INSET: i32 = 16;
 /// Blur radius of the frost under the strip.
 const TITLE_STRIP_BLUR: usize = 6;
 /// Gap between a submenu row's icon and its label.
@@ -222,25 +222,27 @@ impl Canvas<'_, '_> {
     /// Cards only; hero art keeps its own (art-or-nothing) treatment.
     fn placeholder_poster(&mut self, r: Rect, title: &str) {
         self.painter.fill_rounded_rect(r, CARD_RADIUS, tint_for(title));
-        let font = self.fonts.title;
         let (raster, gap) = (self.fonts.raster, PLACEHOLDER_LINE_GAP);
-        let line_h = raster.height(font) + gap;
         let max_w = r.width().saturating_sub(2 * PLACEHOLDER_PAD as u32);
+        let font = fitting_font(raster, title, max_w);
+        let line_h = raster.height(font) + gap;
         let mut lines = wrap_text(raster, font, title, max_w);
-        // Keep the block inside the card even for a long title; the strip has the full
-        // text (ellipsized) anyway, so truncating here loses nothing.
+        // Keep the block inside the card even for a long title; the strip carries the whole
+        // title anyway, so dropping lines here loses nothing.
         let max_lines = ((r.height() as i32 - 2 * PLACEHOLDER_PAD) / line_h.max(1)).max(1) as usize;
         lines.truncate(max_lines);
-        if let Some(last) = lines.last_mut() {
-            *last = ellipsize(raster, font, last, max_w);
-        }
 
         let block_h = lines.len() as i32 * line_h - gap;
         let mut y = r.y() + (r.height() as i32 - block_h) / 2;
         for line in &lines {
+            // Centred on the width it actually gets: a word too long even for the smallest
+            // font still overflows its line, and must fade at the padding rather than spill
+            // out over the card's shadow.
+            let w = raster.measure(font, line).0.min(max_w);
+            let x = r.x() + (r.width() as i32 - w as i32) / 2;
             // Infallible in practice (glyphs come from the bundled font); a placeholder
             // that can't measure its own title just draws the tint.
-            let _ = self.text_centered(font, line, r, y, Color::RGBA(0xff, 0xff, 0xff, 0xd8));
+            let _ = self.text_faded(font, line, x, y, max_w, Color::RGBA(0xff, 0xff, 0xff, 0xd8));
             y += line_h;
         }
     }
@@ -285,8 +287,7 @@ impl Canvas<'_, '_> {
         let avail = band
             .width()
             .saturating_sub((TITLE_STRIP_INSET + label_right_pad(overridden)) as u32);
-        let label = ellipsize(self.fonts.raster, font, title, avail);
-        self.text(font, &label, x, y, theme().text)?;
+        self.text_faded(font, title, x, y, avail, theme().text)?;
         Ok(())
     }
 
@@ -324,9 +325,8 @@ impl Canvas<'_, '_> {
             let text_x = icon_x + icon as i32 + ICON_LABEL_GAP;
             let marked = marked == Some(i);
             let avail = row.right().saturating_sub(text_x + label_right_pad(marked)).max(0) as u32;
-            let label = ellipsize(self.fonts.raster, font, label, avail);
             let y = row.y() + (row.height() as i32 - self.fonts.raster.height(font)) / 2;
-            self.text(font, &label, text_x, y, fg)?;
+            self.text_faded(font, label, text_x, y, avail, fg)?;
             if marked {
                 self.mark_dot(mark_dot_x(row), row.y() + row.height() as i32 / 2, theme().warning);
             }

--- a/src/ui/widgets/confirm.rs
+++ b/src/ui/widgets/confirm.rs
@@ -93,15 +93,14 @@ impl Canvas<'_, '_> {
         let (icon_size, icon_gap, side_pad) = confirm_button_metrics(self.fonts.raster, font);
 
         // Icon and label are centred as one group, the same way a label without an icon
-        // was already centred on its own — and the label is ellipsized to whatever the icon
+        // was already centred on its own — and the label is held to whatever the icon
         // leaves, so no label can overflow the button regardless of resolution.
         let leading = match button.icon {
             Some(_) => icon_size + icon_gap as u32,
             None => 0,
         };
         let budget = rect.width().saturating_sub(2 * side_pad as u32).saturating_sub(leading);
-        let label = ellipsize(self.fonts.raster, font, button.label, budget);
-        let label_w = self.fonts.raster.measure(font, &label).0;
+        let label_w = self.fonts.raster.measure(font, button.label).0.min(budget);
         let start_x = rect.x() + (rect.width() as i32 - (leading + label_w) as i32) / 2;
 
         if let Some(icon) = button.icon {
@@ -113,11 +112,12 @@ impl Canvas<'_, '_> {
             );
             self.icon(icon_rect, icon, color)?;
         }
-        self.text(
+        self.text_faded(
             font,
-            &label,
+            button.label,
             start_x + leading as i32,
             rect.y() + (rect.height() as i32 - line_h) / 2,
+            budget,
             color,
         )?;
         Ok(())

--- a/src/ui/widgets/sidebar.rs
+++ b/src/ui/widgets/sidebar.rs
@@ -110,13 +110,12 @@ impl Widget for SidebarRow<'_> {
         let drawn = c.painter.selectable_with_selection(area, self.focused, self.selected);
         let color = if self.focused { theme().text } else { theme().muted };
         c.icon(sidebar_icon_rect(drawn), self.glyph, color)?;
-        // Ellipsized to prevent overflow; `reserve_right` keeps it clear of the ⋯ button.
+        // Faded rather than clipped; `reserve_right` keeps it clear of the ⋯ button.
         let text_x = SIDEBAR_ICON_PAD + SIDEBAR_ICON_SIZE as i32 + 16;
         let max_w = drawn.width().saturating_sub(text_x as u32 + 20 + self.reserve_right);
-        let label = ellipsize(c.fonts.raster, c.fonts.label, self.label, max_w);
         let font = c.fonts.label;
         let y = drawn.y() + (drawn.height() as i32 - c.fonts.raster.height(font)) / 2;
-        c.text(font, &label, drawn.x() + text_x, y, color)?;
+        c.text_faded(font, self.label, drawn.x() + text_x, y, max_w, color)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Trailing `…` on a cut-off game title never looked great, especially on the frosted strip under a focused card. Swapped it for a soft fade on the right edge — same "there's more text" signal, no glyph eating into the budget.

- New `Painter::draw_pixmap_faded` crops a label to its width budget and ramps the last 28px out to transparent. Smoothstep + rounded premultiply, same reasoning as `fill_vertical_fade`.
- `Canvas::text_faded` replaces `ellipsize` everywhere: card titles, card submenu rows, sidebar rows, confirm buttons, the per-game settings title. `ellipsize` is gone.
- Placeholder posters (cards with no cover art) now pick their font from the loaded ladder so the title's longest word fits, instead of always using the 40px title font and overflowing. New `ui::text::fitting_font`.
- Override dot in the title strip moved 6px right.

Not tested on a TV yet.