### PR TITLE
Keep per-game overrides until they're cleared

### DIFF
--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -4,8 +4,11 @@
 //! *widgets*, not this app's menus.
 use crate::core::caps::video_caps;
 use crate::core::event::MenuEvent;
-use crate::services::store::{CodecPref, GamepadType, LogLevelOverride, Settings, SettingsOverride, VideoBackend};
+use crate::services::store::{
+    CodecPref, GamepadType, LogLevelOverride, OverrideField, Settings, SettingsOverride, VideoBackend,
+};
 use crate::ui::focus::Dir;
+use crate::ui::widgets::{FocusRow, RowSubtext};
 
 /// This app's input vocabulary mapped onto `ui`'s spatial one. `ui` navigates by
 /// direction; deciding that "Up" means a d-pad press is the app's business, and this is
@@ -262,58 +265,69 @@ pub fn toggle_value(settings: &Settings, row: usize) -> Option<bool> {
     }
 }
 
-/// Whether `row` currently overrides the global value — what decides that the row gets a
-/// "use global" delete affordance.
-pub fn override_is_set(over: &SettingsOverride, row: usize) -> bool {
+/// The override fields a settings row owns — one table for both the mark and the capture, so
+/// a row can't show a dot for a field it doesn't record. The Cursor *link* row owns both
+/// toggles behind it, or a game overriding only a cursor one shows a dot on its card and
+/// nothing on the list saying where it came from.
+fn row_fields(row: usize) -> &'static [OverrideField] {
     match row {
-        ROW_RESOLUTION => over.mode.is_some(),
-        ROW_FRAMERATE => over.refresh_hz.is_some(),
-        ROW_BITRATE => over.bitrate_kbps.is_some(),
-        ROW_HDR => over.hdr_enabled.is_some(),
-        ROW_CODEC => over.codec.is_some(),
-        ROW_AUDIO => over.audio_channels.is_some(),
-        ROW_GAMEPAD => over.gamepad_type.is_some(),
-        ROW_CURSOR_CAPTURE => over.cursor_capture.is_some(),
-        ROW_CURSOR_GESTURES => over.cursor_gestures.is_some(),
-        // The link row stands in for the two toggles behind it — without this a game whose
-        // only override is a cursor one shows a dot on its card and nothing on the list that
-        // says where it came from.
-        ROW_CURSOR => over.cursor_capture.is_some() || over.cursor_gestures.is_some(),
-        _ => false,
+        ROW_RESOLUTION => &[OverrideField::Mode],
+        ROW_FRAMERATE => &[OverrideField::RefreshHz],
+        ROW_BITRATE => &[OverrideField::BitrateKbps],
+        ROW_HDR => &[OverrideField::HdrEnabled],
+        ROW_CODEC => &[OverrideField::Codec],
+        ROW_AUDIO => &[OverrideField::AudioChannels],
+        ROW_GAMEPAD => &[OverrideField::GamepadKind],
+        ROW_CURSOR_CAPTURE => &[OverrideField::CursorCapture],
+        ROW_CURSOR_GESTURES => &[OverrideField::CursorGestures],
+        ROW_CURSOR => &[OverrideField::CursorCapture, OverrideField::CursorGestures],
+        _ => &[],
     }
 }
 
-/// The row's override mark, for [`ui::widgets::FocusRow::mark`] — amber when this row
-/// differs from the global, nothing when it doesn't. The colour lives here rather than in
-/// `ui`, which knows only that some rows carry a mark.
-pub fn override_mark(over: &SettingsOverride, row: usize) -> Option<crate::ui::render::Color> {
-    override_is_set(over, row).then(|| crate::ui::style::theme().warning)
+/// Whether `row` currently overrides the global value — what decides that the row gets a
+/// "use global" delete affordance.
+pub fn override_is_set(over: &SettingsOverride, row: usize) -> bool {
+    row_fields(row).iter().any(|&f| over.is_set(f))
 }
 
-/// Records `row`'s value from `edited` — a scratch `Settings` one of the mutators above has
-/// just been run against. Only the edited row is captured, so touching Bitrate never silently
-/// pins Resolution to whatever the global happened to be.
+/// Marks `row` as overriding the global and, on the focused row, names the gesture that
+/// clears it. Every settings-shaped screen goes through here, so the mark and the affordance
+/// explaining it can't drift apart or be forgotten by a new sub-screen.
 ///
-/// `ROW_CODEC` is the one row that writes two fields: an H.264 pick forces HDR off (see
-/// [`apply_dropdown_choice`]), and that consequence has to be recorded or the merge would put
-/// the global's HDR back on top of a codec that can't carry it.
-pub fn override_capture(over: &mut SettingsOverride, row: usize, edited: &Settings) {
-    match row {
-        ROW_RESOLUTION => over.mode = Some((edited.width, edited.height)),
-        ROW_FRAMERATE => over.refresh_hz = Some(edited.refresh_hz),
-        ROW_BITRATE => over.bitrate_kbps = Some(edited.bitrate_kbps),
-        ROW_HDR => over.hdr_enabled = Some(edited.hdr_enabled),
-        ROW_CODEC => {
-            over.codec = Some(edited.codec);
-            if edited.codec == CodecPref::H264 {
-                over.hdr_enabled = Some(false);
-            }
-        }
-        ROW_AUDIO => over.audio_channels = Some(edited.audio_channels),
-        ROW_GAMEPAD => over.gamepad_type = Some(edited.gamepad_type),
-        ROW_CURSOR_CAPTURE => over.cursor_capture = Some(edited.cursor_capture),
-        ROW_CURSOR_GESTURES => over.cursor_gestures = Some(edited.cursor_gestures),
-        _ => {}
+/// Focused only because subtext renders nowhere else; a caption the row already carries wins,
+/// since a lock explains why the row can't be used at all. The colour lives here rather than
+/// in `ui`, which knows only that some rows carry a mark.
+pub fn decorate_override(row: &mut FocusRow, over: &SettingsOverride, logical: usize, focused: bool) {
+    row.mark = override_is_set(over, logical).then(|| crate::ui::style::theme().warning);
+    if row.mark.is_some() && focused && row.subtext.is_none() {
+        row.subtext = Some(RowSubtext::hint("Delete to use the global setting"));
+    }
+}
+
+/// Drops `row` back to inheriting the global — every field it owns, so clearing the Cursor
+/// link row clears both toggles behind it.
+pub fn override_clear(over: &mut SettingsOverride, row: usize) {
+    for &field in row_fields(row) {
+        over.clear(field);
+    }
+}
+
+/// Records `row`'s value from `edited` against the `global` the game inherits from — a pick
+/// landing on the global's own value stores nothing (see [`SettingsOverride::capture`]).
+///
+/// Strictly the fields the row owns: an H.264 pick's effect on HDR is
+/// `Settings::presentable`'s job, not a second override written behind the user's back and
+/// stranded the moment they clear the Codec row.
+pub fn override_capture(over: &mut SettingsOverride, row: usize, edited: &Settings, global: &Settings) {
+    // An adjustable row owning no field would have its edit silently reverted by
+    // `edit_game_override`'s re-merge. Unreachable today (link rows don't adjust).
+    debug_assert!(
+        !row_fields(row).is_empty(),
+        "settings row {row} is adjustable but overrides nothing"
+    );
+    for &field in row_fields(row) {
+        over.capture(field, edited, global);
     }
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -641,16 +641,29 @@ impl App {
             .map(HostEntry::name)
     }
 
-    /// Which row list the settings screen that is up shows — its own scope, and off it the
-    /// scope of the flow that is running. The Cursor sub-screen is reachable from either, so
-    /// there it comes from the scratch copy: `game_settings` is `Some` for exactly the
-    /// per-game flow, for as long as it lasts (`persist_game_settings` takes it on the way
-    /// out). `Global` is the answer everywhere else, where nothing reads it.
-    pub(crate) fn row_set(&self) -> menu::SettingsScope {
+    /// Which document the settings-shaped screen that is up is editing. Read off the screen
+    /// itself — it and the Cursor sub-screen both carry their scope — so a scratch copy that
+    /// outlives its flow can't redirect the global screen's edits into it.
+    pub(crate) fn settings_scope(&self) -> menu::SettingsScope {
         match self.screen {
-            Screen::Settings(set) => set,
-            _ if self.game_settings.is_some() => menu::SettingsScope::Game,
+            Screen::Settings(scope) | Screen::CursorSettings(scope) => scope,
             _ => menu::SettingsScope::Global,
+        }
+    }
+
+    /// The per-game scratch state, but only while a per-game screen is actually up — the one
+    /// gate every accessor below shares, in the two forms borrowck needs.
+    pub(crate) fn editing_game(&self) -> Option<&state::gamesettings::GameSettingsState> {
+        match self.settings_scope() {
+            menu::SettingsScope::Game => self.game_settings.as_ref(),
+            menu::SettingsScope::Global => None,
+        }
+    }
+
+    pub(crate) fn editing_game_mut(&mut self) -> Option<&mut state::gamesettings::GameSettingsState> {
+        match self.settings_scope() {
+            menu::SettingsScope::Game => self.game_settings.as_mut(),
+            menu::SettingsScope::Global => None,
         }
     }
 
@@ -658,31 +671,33 @@ impl App {
     /// per-game scratch copy. One accessor so every mutator, lock check and dropdown lookup
     /// in `menu` sees the same value the rows were built from.
     pub(crate) fn settings_target(&self) -> &Settings {
-        match &self.game_settings {
+        match self.editing_game() {
             Some(gs) => &gs.merged,
             None => &self.settings,
         }
     }
 
+    /// Spells `editing_game_mut`'s gate out rather than calling it: the fallback arm needs
+    /// `self` back, which borrowck won't grant while a returned `Option<&mut _>` is in scope.
     pub(crate) fn settings_target_mut(&mut self) -> &mut Settings {
+        let scope = self.settings_scope();
         match &mut self.game_settings {
-            Some(gs) => &mut gs.merged,
-            None => &mut self.settings,
+            Some(gs) if scope == menu::SettingsScope::Game => &mut gs.merged,
+            _ => &mut self.settings,
         }
     }
 
     /// This game's overrides while the per-game screen is up — what decides which rows wear
     /// a "use global" button. Empty everywhere else, so the global screen shows none.
     pub(crate) fn editing_override(&self) -> store::SettingsOverride {
-        self.game_settings
-            .as_ref()
+        self.editing_game()
             .map_or_else(store::SettingsOverride::default, |gs| gs.over)
     }
 
     /// The settings rows, with the platform/hardware facts the view can't reach folded in,
     /// plus the override dot on every row this game differs from the global on.
     pub(crate) fn settings_rows(&self) -> Vec<ui::widgets::FocusRow> {
-        let set = self.row_set();
+        let set = self.settings_scope();
         let settings = self.settings_target();
         let effective = if settings.gamepad_type == store::GamepadType::Auto {
             self.detected_gamepad_type.unwrap_or_default()
@@ -699,15 +714,20 @@ impl App {
             webos_major,
         );
         let over = self.editing_override();
-        for (row, logical) in rows.iter_mut().zip(menu::settings_visible_logical_rows(set)) {
-            row.mark = menu::override_mark(&over, logical);
+        let focused = self.settings_focused;
+        for (display, (row, logical)) in rows
+            .iter_mut()
+            .zip(menu::settings_visible_logical_rows(set))
+            .enumerate()
+        {
+            menu::decorate_override(row, &over, logical, display == focused);
         }
         rows
     }
 
     /// Scrolls `settings_focused` into view.
     pub(crate) fn scroll_settings_into_view(&mut self, screen_h: u32) {
-        let set = self.row_set();
+        let set = self.settings_scope();
         let visible = view::settings::visible_rows(set, screen_h);
         self.scroll
             .scroll_into_view(self.settings_focused, menu::settings_row_count(set), visible);
@@ -867,7 +887,14 @@ impl App {
     pub(crate) fn wake_succeeded(&mut self, host: String, port: u16, mgmt_port: Option<u16>, source: &str) {
         tracing::info!("wake succeeded: {host}:{port} back ({source})");
         let name = self.wake.take().map(|w| w.name);
-        self.screen = Screen::Home;
+        // A wake ends on its own timing, not a keypress, so it dismisses its own modal and
+        // nothing else. The selection still moves — that is what the wait was for. Safe under
+        // an open modal: the one that writes per-host state off the selection pins its target
+        // at open time (`GameSettingsState::host`), and the rest key off `host_menu_index`,
+        // which nothing in the background reorders (`drain_discovery` only appends).
+        if matches!(self.screen, Screen::Wake) {
+            self.screen = Screen::Home;
+        }
         self.select_host(host, port, mgmt_port);
         // Overrides `select_host`'s plain "Loading library…": after a wait that may
         // have run for minutes with no modal up, the bar's job is to report that the
@@ -1027,9 +1054,13 @@ impl App {
         self.known_host(host, *port)
     }
 
+    pub(crate) fn known_host_mut(&mut self, host: &str, port: u16) -> Option<&mut KnownHost> {
+        self.known_hosts.iter_mut().find(|h| h.host == host && h.port == port)
+    }
+
     pub(crate) fn selected_known_host_mut(&mut self) -> Option<&mut KnownHost> {
         let (host, port) = self.selected_host.clone()?;
-        self.known_hosts.iter_mut().find(|h| h.host == host && h.port == port)
+        self.known_host_mut(&host, port)
     }
 
     /// The title of grid card `idx` (see `grid_card_at`) and its cover art, if

--- a/src/app/pointer.rs
+++ b/src/app/pointer.rs
@@ -154,7 +154,7 @@ impl App {
                 changed
             }
             // Identical row-list geometry; only which focus field they carry differs.
-            Screen::Diagnostics | Screen::Experimental | Screen::CursorSettings => {
+            Screen::Diagnostics | Screen::Experimental | Screen::CursorSettings(_) => {
                 let Some(row) = self.modal_list_row_at(x, y, screen_w, screen_h, fonts) else {
                     return false;
                 };
@@ -234,7 +234,7 @@ impl App {
         if !content.contains_point((x, y)) {
             return None;
         }
-        let total = menu::settings_row_count(self.row_set());
+        let total = menu::settings_row_count(self.settings_scope());
         (0..total).find(|&r| {
             let rect = ui::widgets::focus_row_rect_at_px(content, r, scroll_px);
             // Clipped edge rows aren't hoverable: a focused row composites on its own
@@ -247,7 +247,7 @@ impl App {
     /// geometry `settings_row_at`'s hit test and `settings_row_rect`'s lookup both index
     /// into, so a scrolled list can't put them at odds.
     fn settings_content_scroll(&self, screen_w: u32, screen_h: u32) -> (Rect, i32) {
-        let set = self.row_set();
+        let set = self.settings_scope();
         let (_, content) = view::settings::layout(set, screen_w, screen_h);
         let stride = ui::widgets::focus_row_stride() as i32;
         let total = menu::settings_row_count(set);
@@ -458,7 +458,7 @@ impl App {
                 // arms the drag (see `handle_mouse_motion`) instead of nudging one notch the
                 // way `Confirm` below would — a slider is for landing on a value, not stepping
                 // to it one click at a time.
-                if menu::settings_logical_row(self.row_set(), self.settings_focused) == menu::ROW_BITRATE
+                if menu::settings_logical_row(self.settings_scope(), self.settings_focused) == menu::ROW_BITRATE
                     && menu::row_lock(menu::ROW_BITRATE, self.settings_target(), self.detected_gamepad_type).is_none()
                 {
                     let (row_rect, track) = self.bitrate_row_and_track(screen_w, screen_h);
@@ -494,7 +494,7 @@ impl App {
                 }
             }
             // Identical row-list geometry; only which focus field they carry differs.
-            Screen::Diagnostics | Screen::Experimental | Screen::CursorSettings => {
+            Screen::Diagnostics | Screen::Experimental | Screen::CursorSettings(_) => {
                 let row = self.modal_list_row_at(x, y, screen_w, screen_h, fonts)?;
                 *self.list_modal_focused_mut()? = row;
             }

--- a/src/app/press.rs
+++ b/src/app/press.rs
@@ -38,7 +38,7 @@ impl App {
             Screen::PinLimit => self.handle_pin_limit_event(ev),
             Screen::Diagnostics => self.handle_diagnostics_event(ev),
             Screen::Experimental => self.handle_experimental_event(ev),
-            Screen::CursorSettings => self.handle_cursor_settings_event(ev),
+            Screen::CursorSettings(_) => self.handle_cursor_settings_event(ev),
             Screen::SendLogs => self.handle_send_logs_event(ev),
         }
         None
@@ -99,7 +99,7 @@ impl App {
             | Screen::PinLimit
             | Screen::Diagnostics
             | Screen::Experimental
-            | Screen::CursorSettings => false,
+            | Screen::CursorSettings(_) => false,
         }
     }
 

--- a/src/app/render/geometry.rs
+++ b/src/app/render/geometry.rs
@@ -39,7 +39,7 @@ impl App {
     ) -> Option<(usize, usize, Rect, Rect)> {
         match screen {
             Screen::Settings(_) => {
-                let set = self.row_set();
+                let set = self.settings_scope();
                 let (card, content) = view::settings::layout(set, screen_w, screen_h);
                 let visible = view::settings::visible_rows(set, screen_h);
                 Some((menu::settings_row_count(set), visible, card, content))
@@ -311,7 +311,7 @@ impl App {
             | Screen::WakeSettings
             | Screen::Diagnostics
             | Screen::Experimental
-            | Screen::CursorSettings => self.list_modal_focus_rect(screen_w, screen_h, fonts),
+            | Screen::CursorSettings(_) => self.list_modal_focus_rect(screen_w, screen_h, fonts),
             Screen::Home | Screen::AddHost | Screen::EditHost | Screen::About | Screen::PinLimit => None,
         }
     }
@@ -325,7 +325,7 @@ impl App {
             Screen::WakeSettings => self.wake_settings_focused,
             Screen::Diagnostics => self.diagnostics_focused,
             Screen::Experimental => self.experimental_focused,
-            Screen::CursorSettings => self.cursor_settings_focused,
+            Screen::CursorSettings(_) => self.cursor_settings_focused,
             _ => return None,
         })
     }
@@ -338,7 +338,7 @@ impl App {
             Screen::WakeSettings => &mut self.wake_settings_focused,
             Screen::Diagnostics => &mut self.diagnostics_focused,
             Screen::Experimental => &mut self.experimental_focused,
-            Screen::CursorSettings => &mut self.cursor_settings_focused,
+            Screen::CursorSettings(_) => &mut self.cursor_settings_focused,
             _ => return None,
         })
     }
@@ -355,7 +355,7 @@ impl App {
     pub(crate) fn dropdown_options_len(&self, row: usize) -> usize {
         match self.screen {
             Screen::Diagnostics => menu::LOG_LEVEL_OPTIONS.len(),
-            _ => menu::dropdown_option_count(menu::settings_logical_row(self.row_set(), row)),
+            _ => menu::dropdown_option_count(menu::settings_logical_row(self.settings_scope(), row)),
         }
     }
 
@@ -373,7 +373,7 @@ impl App {
             // one adds, and it comes from the scratch copy that scope implies.
             Screen::Settings(set) => f(&view::settings::Modal {
                 set,
-                game: self.game_settings.as_ref().map(|gs| gs.title.as_str()),
+                game: self.editing_game().map(|gs| gs.title.as_str()),
             }),
             Screen::Pairing => f(&view::pairing::Modal {
                 pin_digits: &self.pin_digits,
@@ -419,7 +419,7 @@ impl App {
                 settings: &self.settings,
                 rooted: self.rooted,
             }),
-            Screen::CursorSettings => f(&view::cursorsettings::Modal {
+            Screen::CursorSettings(_) => f(&view::cursorsettings::Modal {
                 settings: self.settings_target(),
                 over: &self.editing_override(),
             }),

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -522,7 +522,7 @@ impl App {
         // `content_dirty` tick, same as every modal did before this split.
         let modal_shell_key = match self.screen {
             Screen::Settings(_) => Some(ModalShellKey::Settings {
-                game: self.game_settings.as_ref().map(|gs| gs.title.clone()),
+                game: self.editing_game().map(|gs| gs.title.clone()),
                 hover_close: self.hover_close,
             }),
             Screen::Wake => self.wake.as_ref().map(|w| ModalShellKey::Wake {
@@ -576,7 +576,7 @@ impl App {
                 rooted: self.rooted,
                 hover_close: self.hover_close,
             }),
-            Screen::CursorSettings => Some(ModalShellKey::CursorSettings {
+            Screen::CursorSettings(_) => Some(ModalShellKey::CursorSettings {
                 cursor_capture: self.settings_target().cursor_capture,
                 cursor_gestures: self.settings_target().cursor_gestures,
                 over: self.editing_override(),
@@ -659,7 +659,7 @@ impl App {
                 self.settings.game_mode,
                 self.rooted,
             )),
-            Screen::CursorSettings => Some(ModalFocusKey::CursorSettingsRow(
+            Screen::CursorSettings(_) => Some(ModalFocusKey::CursorSettingsRow(
                 self.cursor_settings_focused,
                 self.settings_target().cursor_capture,
                 self.settings_target().cursor_gestures,
@@ -679,7 +679,7 @@ impl App {
             if stale {
                 let tile = match self.screen {
                     Screen::Settings(_) => {
-                        let (_, content) = view::settings::layout(self.row_set(), screen_w, screen_h);
+                        let (_, content) = view::settings::layout(self.settings_scope(), screen_w, screen_h);
                         let rows = self.settings_rows();
                         let dropdown_open = self.dropdown.as_ref().is_some_and(|dd| dd.row == self.settings_focused);
                         let target_on = rows.get(self.settings_focused).is_some_and(|r| r.value == "On");
@@ -757,14 +757,18 @@ impl App {
                     }
                     // The plain list modals: same tile, same geometry, built from whichever
                     // rows this screen shows. Only Diagnostics can have a dropdown open.
-                    Screen::WakeSettings | Screen::Diagnostics | Screen::Experimental | Screen::CursorSettings => {
+                    Screen::WakeSettings | Screen::Diagnostics | Screen::Experimental | Screen::CursorSettings(_) => {
                         let rows = match self.screen {
                             Screen::WakeSettings => {
                                 view::wakesettings::rows(self.wake_settings_host().is_some_and(|h| h.wol_auto))
                             }
                             Screen::Diagnostics => view::diagnostics::rows(&self.settings),
                             Screen::Experimental => view::experimental::rows(&self.settings, self.rooted),
-                            _ => view::cursorsettings::rows(self.settings_target(), &self.editing_override()),
+                            _ => view::cursorsettings::rows(
+                                self.settings_target(),
+                                &self.editing_override(),
+                                Some(self.cursor_settings_focused),
+                            ),
                         };
                         let focused = self
                             .list_modal_focused()
@@ -812,8 +816,8 @@ impl App {
                     (menu::log_level_dropdown_options(), content.width())
                 }
                 _ => {
-                    let (_, content) = view::settings::layout(self.row_set(), screen_w, screen_h);
-                    let logical = menu::settings_logical_row(self.row_set(), dd.row);
+                    let (_, content) = view::settings::layout(self.settings_scope(), screen_w, screen_h);
+                    let logical = menu::settings_logical_row(self.settings_scope(), dd.row);
                     (
                         menu::dropdown_options(logical, self.detected_gamepad_type),
                         content.width(),
@@ -926,7 +930,7 @@ impl App {
                         // Settings' whole row list always fits one tile — no windowing.
                         self.content_window = ui::scroll::ContentWindow {
                             start: 0,
-                            len: menu::settings_row_count(self.row_set()),
+                            len: menu::settings_row_count(self.settings_scope()),
                         };
                         updated.push(tile::SCROLL_CONTENT);
                     }

--- a/src/app/state/cursorsettings.rs
+++ b/src/app/state/cursorsettings.rs
@@ -8,15 +8,16 @@ use std::time::Instant;
 
 impl App {
     /// Opens the Cursor screen (Settings → `menu::ROW_CURSOR`). Holds the two pointer
-    /// toggles: capture mode and the OK-button gestures.
-    pub(crate) fn open_cursor_settings(&mut self) {
+    /// toggles: capture mode and the OK-button gestures. `scope` is the caller's, carried on
+    /// the screen so the sub-screen keeps editing the same document.
+    pub(crate) fn open_cursor_settings(&mut self, scope: menu::SettingsScope) {
         self.cursor_settings_focused = 0;
-        self.screen = Screen::CursorSettings;
+        self.screen = Screen::CursorSettings(scope);
     }
 
     /// All rows are plain Left/Right/Confirm toggles. Back saves and returns to whichever
     /// settings screen opened it — the per-game one keeps editing its own copy while here
-    /// (see `App::settings_target`), so this handler needs no branch of its own for it.
+    /// (see `App::settings_target`), so only where the save lands differs.
     pub(crate) fn handle_cursor_settings_event(&mut self, ev: MenuEvent) {
         if ui::widgets::list_nav(
             &mut self.cursor_settings_focused,
@@ -42,16 +43,17 @@ impl App {
                     }
                 }
             }
+            // Same clear gesture as the parent list: these rows are on it in every way but
+            // which screen draws them.
+            (_, MenuEvent::Secondary) => self.clear_focused_override(),
             (_, MenuEvent::Back) => {
-                match self.game_settings {
-                    // The per-game copy is saved once, on the way out of its own screen —
-                    // this is a step back into it, not out of the flow.
-                    Some(_) => self.screen = Screen::Settings(menu::SettingsScope::Game),
-                    None => {
-                        self.persist();
-                        self.screen = Screen::Settings(menu::SettingsScope::Global);
-                    }
+                let scope = self.settings_scope();
+                // The per-game copy is saved once, on the way out of its own screen — this
+                // is a step back into it, not out of the flow.
+                if scope == menu::SettingsScope::Global {
+                    self.persist();
                 }
+                self.screen = Screen::Settings(scope);
             }
             _ => {}
         }

--- a/src/app/state/gamesettings.rs
+++ b/src/app/state/gamesettings.rs
@@ -10,12 +10,17 @@ use crate::services::store::{Settings, SettingsOverride};
 /// What the per-game settings screen is editing. Set alongside `Screen::Settings(Game)`
 /// and cleared on the way out, so `Some` and the screen being up mean the same thing.
 pub(crate) struct GameSettingsState {
+    /// The write-back key, pinned at open time rather than re-read from `selected_host`: the
+    /// selection can move under an open modal (a wake completing), and the edits belong to
+    /// the host they were made on.
+    pub host: (String, u16),
     /// The `KnownHost::games` key: a `GameEntry::id`, or `store::DESKTOP_PIN_ID`.
     pub pin_id: String,
     /// The game's name, shown dimmer after "Settings" in the title.
     pub title: String,
-    /// The global settings with `over` applied — what every row renders from and what the
-    /// shared `menu::*` mutators edit. Only the edited row is copied back into `over`.
+    /// The global settings with `over` applied, then `Settings::presentable` — what every row
+    /// renders from and what the shared `menu::*` mutators edit, so a row shows the value the
+    /// stream will actually use. The clamp never reaches `over`.
     pub merged: Settings,
     pub over: SettingsOverride,
 }
@@ -23,14 +28,17 @@ pub(crate) struct GameSettingsState {
 impl App {
     /// Opens the per-game screen for `pin_id`. Only the card submenu calls this.
     pub(crate) fn open_game_settings(&mut self, pin_id: &str, title: &str) {
+        let Some(host) = self.selected_host.clone() else {
+            return;
+        };
         let over = self
-            .selected_known_host()
-            .map(|h| h.overrides(pin_id))
-            .unwrap_or_default();
+            .known_host(&host.0, host.1)
+            .map_or_else(SettingsOverride::default, |h| h.overrides(pin_id));
         self.game_settings = Some(GameSettingsState {
+            host,
             pin_id: pin_id.to_string(),
             title: title.to_string(),
-            merged: over.merge_into(self.settings),
+            merged: over.merge_into(self.settings).presentable(),
             over,
         });
         self.settings_focused = 0;
@@ -45,18 +53,39 @@ impl App {
     /// row whose value the merge would clamp (HDR under an H.264 pick) shows what will
     /// actually be used.
     ///
-    /// A value set back to what the global screen says stops being an override here rather
-    /// than needing a separate "use global" gesture: `drop_matching` clears it, the row's dot
-    /// goes out, and once nothing differs the game's whole record leaves the document (see
-    /// `KnownHost::edit_overrides`). There is deliberately no other way to clear one row.
+    /// A pick that lands on the global's own current value stores nothing; a row that
+    /// genuinely differs is cleared by `clear_game_override` instead. Both rules, and why
+    /// only *this* row is judged against the global, are on `store::SettingsOverride`.
     pub(crate) fn capture_game_override(&mut self, row: usize) {
         let global = self.settings;
-        let Some(gs) = self.game_settings.as_mut() else {
+        self.edit_game_override(|over, merged| menu::override_capture(over, row, merged, &global));
+    }
+
+    /// Drops the focused row back to inheriting the global — the Secondary key, and the only
+    /// way a single override goes away (the Reset row drops them all). A no-op outside the
+    /// per-game scope and on a row that overrides nothing, so the key is safe to lean on.
+    ///
+    /// Resolves the row here rather than at each binding: separate index spaces are the only
+    /// thing the flow's two screens would differ in.
+    pub(crate) fn clear_focused_override(&mut self) {
+        let row = match self.screen {
+            Screen::CursorSettings(_) => menu::cursor_logical_row(self.cursor_settings_focused),
+            _ => menu::settings_logical_row(self.settings_scope(), self.settings_focused),
+        };
+        self.edit_game_override(|over, _| menu::override_clear(over, row));
+    }
+
+    /// Runs one edit against the open game's override, handing it the scratch `merged` the row
+    /// mutators just ran against, then re-derives `merged`. The one place the two halves of
+    /// the scratch state are kept in step, and gated by `editing_game_mut`.
+    fn edit_game_override(&mut self, edit: impl FnOnce(&mut SettingsOverride, &Settings)) {
+        let global = self.settings;
+        let Some(gs) = self.editing_game_mut() else {
             return;
         };
-        menu::override_capture(&mut gs.over, row, &gs.merged);
-        gs.over.drop_matching(&global);
-        gs.merged = gs.over.merge_into(global);
+        let merged = gs.merged;
+        edit(&mut gs.over, &merged);
+        gs.merged = gs.over.merge_into(global).presentable();
     }
 
     /// Writes the edited override back onto the host record and persists. Called on the way
@@ -65,7 +94,7 @@ impl App {
         let Some(gs) = self.game_settings.take() else {
             return;
         };
-        let Some(known) = self.selected_known_host_mut() else {
+        let Some(known) = self.known_host_mut(&gs.host.0, gs.host.1) else {
             return;
         };
         known.edit_overrides(&gs.pin_id, |over| *over = gs.over);

--- a/src/app/state/settings.rs
+++ b/src/app/state/settings.rs
@@ -16,7 +16,7 @@ impl App {
     /// Handles one menu event on the settings modal. `screen_h` is only used by
     /// `Up`/`Down` to keep `self.scroll` following `settings_focused`.
     pub fn handle_settings_event(&mut self, ev: MenuEvent, screen_h: u32) {
-        let set = self.row_set();
+        let set = self.settings_scope();
         // An open Resolution/Frame rate dropdown intercepts all input until it's
         // closed (by picking an option or backing out) — it's a modal overlay on
         // top of the settings row list.
@@ -82,7 +82,7 @@ impl App {
                     if set == menu::SettingsScope::Global {
                         self.persist();
                     }
-                    self.open_cursor_settings();
+                    self.open_cursor_settings(set);
                 }
                 menu::ROW_EXPERIMENTAL => {
                     self.persist();
@@ -125,15 +125,14 @@ impl App {
             // once per Settings visit.
             MenuEvent::Back => {
                 match set {
-                    // One save per visit, not one per keystroke — `StateWriter` queues the
-                    // write off-thread either way, but there's no reason to touch disk more
-                    // often than that.
                     menu::SettingsScope::Global => self.persist(),
                     menu::SettingsScope::Game => self.persist_game_settings(),
                 }
                 self.screen = Screen::Home;
             }
-            MenuEvent::Secondary => {}
+            // Per-game only — there is nothing above the global document to fall back to,
+            // and `clear_focused_override` gates on the scope anyway.
+            MenuEvent::Secondary => self.clear_focused_override(),
         }
     }
 
@@ -143,9 +142,10 @@ impl App {
     /// Per-game only: the row appears on `SettingsScope::Game` alone (see
     /// `menu::settings_visible_logical_rows`), so a global screen can never reach here.
     fn reset_settings(&mut self) {
-        if let Some(gs) = self.game_settings.as_mut() {
+        let inherited = self.settings.presentable();
+        if let Some(gs) = self.editing_game_mut() {
             gs.over = crate::services::store::SettingsOverride::default();
-            gs.merged = self.settings;
+            gs.merged = inherited;
         }
     }
 
@@ -155,7 +155,7 @@ impl App {
     /// No focus re-anchoring afterwards: which rows are shown depends on the environment only
     /// (see `menu::row_shown`), so no adjustment can renumber the list under the cursor.
     pub(crate) fn apply_setting_adjust(&mut self, display_row: usize, forward: bool) {
-        let row = menu::settings_logical_row(self.row_set(), display_row);
+        let row = menu::settings_logical_row(self.settings_scope(), display_row);
         let toggled_from = menu::toggle_value(self.settings_target(), row);
         let detected = self.detected_gamepad_type;
         if menu::adjust_setting(self.settings_target_mut(), row, forward, detected) {

--- a/src/app/view/cursorsettings.rs
+++ b/src/app/view/cursorsettings.rs
@@ -15,8 +15,9 @@ pub const SUBTITLE: &str = "How the pointer behaves in a stream.";
 /// Order must match `menu::CURSOR_ROW_*`.
 ///
 /// `over` is the per-game override this screen is editing (empty on the global one) — a row
-/// it sets wears the same dot the per-game row list gives its own rows.
-pub fn rows(settings: &Settings, over: &SettingsOverride) -> Vec<FocusRow> {
+/// it sets wears the same dot the per-game row list gives its own rows. `focused` is `None` for
+/// the shell, which draws every row unfocused.
+pub fn rows(settings: &Settings, over: &SettingsOverride, focused: Option<usize>) -> Vec<FocusRow> {
     let mut rows = vec![
         FocusRow::toggle(crate::app::view::icons::ICON_MOUSE, "Capture", settings.cursor_capture).with_subtext(
             ui::widgets::RowSubtext::hint(if settings.cursor_capture {
@@ -35,7 +36,12 @@ pub fn rows(settings: &Settings, over: &SettingsOverride) -> Vec<FocusRow> {
         )),
     ];
     for (cursor_row, row) in rows.iter_mut().enumerate() {
-        row.mark = menu::override_mark(over, menu::cursor_logical_row(cursor_row));
+        menu::decorate_override(
+            row,
+            over,
+            menu::cursor_logical_row(cursor_row),
+            focused == Some(cursor_row),
+        );
     }
     rows
 }
@@ -60,12 +66,20 @@ impl ModalScreen for Modal<'_> {
             card,
             fonts,
             SUBTITLE,
-            rows(self.settings, self.over).len(),
+            menu::CURSOR_ROW_COUNT,
         ))
     }
 
     fn render(&self, c: &mut Canvas, hover_close: bool) -> Result<()> {
         let card = self.card_rect(c.screen_w, c.screen_h, c.fonts);
-        c.list_modal_screen(card, TITLE, SUBTITLE, &rows(self.settings, self.over), hover_close)
+        // Always unfocused: the focused row is composited from its own tile, and
+        // `ModalShellKey` carries no focus to invalidate on.
+        c.list_modal_screen(
+            card,
+            TITLE,
+            SUBTITLE,
+            &rows(self.settings, self.over, None),
+            hover_close,
+        )
     }
 }

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -59,103 +59,114 @@ impl GamePrefs {
     }
 }
 
-/// A sparse [`Settings`] diff: `Some` overrides the global value for one game, `None` inherits it.
-///
-/// Deliberately *not* every field. The experimental and diagnostics toggles are device-wide
-/// and stay global-only, as does `video_backend` — it is a process-global
-/// (`core::caps::set_backend`, which both `session::connect`'s clamp and the caps-derived row
-/// locks read), so a per-game value would need an apply/restore around every launch.
-///
-/// `Copy + Hash + Eq` because it rides the render cache keys next to `Settings`.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(default)]
-pub struct SettingsOverride {
+/// The one table every per-game override derives from — the struct, [`OverrideField`] and all
+/// the merge/capture/clear logic are generated from it, so a new overridable setting is one
+/// line here plus one row mapping in `app::menu::row_fields`.
+macro_rules! settings_override {
+    ($(
+        $(#[$attr:meta])*
+        $field:ident: $ty:ty as $variant:ident,
+        |$get:ident| $read:expr,
+        |$set:ident, $val:ident| $write:expr;
+    )*) => {
+        /// A sparse [`Settings`] diff: `Some` overrides the global value for one game, `None`
+        /// inherits it.
+        ///
+        /// A field starts overriding when the user picks a value the global doesn't have, and
+        /// stops two ways, both done *on this screen*: picking the global's own value back
+        /// ([`SettingsOverride::capture`] stores nothing) or clearing the row
+        /// ([`SettingsOverride::clear`]). The global later drifting onto the value does
+        /// **not** clear it — "pinned to 60 Hz" must survive the global moving away again.
+        ///
+        /// Deliberately *not* every field. Experimental and diagnostics toggles are
+        /// device-wide, and `video_backend` is a process-global (`core::caps::set_backend`,
+        /// read by `session::connect`'s clamp and the row locks), so a per-game value would
+        /// need an apply/restore around every launch.
+        ///
+        /// `Copy + Hash + Eq` because it rides the render cache keys next to `Settings`.
+        #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(default)]
+        pub struct SettingsOverride {
+            $(
+                $(#[$attr])*
+                #[serde(skip_serializing_if = "Option::is_none")]
+                pub $field: Option<$ty>,
+            )*
+        }
+
+        /// One overridable field, as a value — what `app::menu` keys its row mapping by, so
+        /// "which rows carry a mark" and "what an edited row records" read the same table.
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+        pub enum OverrideField {
+            $($variant,)*
+        }
+
+        impl SettingsOverride {
+            /// Whether this field overrides the global — what puts the mark on its row.
+            pub fn is_set(&self, field: OverrideField) -> bool {
+                match field {
+                    $(OverrideField::$variant => self.$field.is_some(),)*
+                }
+            }
+
+            /// Records `field` from `edited` unless that is what `global` says right now, in
+            /// which case it goes back to inheriting (see [`SettingsOverride`]).
+            ///
+            /// Only the named field: editing Bitrate must neither pin Resolution to whatever
+            /// the global happened to be, nor clear an override the global has drifted onto.
+            pub fn capture(&mut self, field: OverrideField, edited: &Settings, global: &Settings) {
+                match field {
+                    $(OverrideField::$variant => {
+                        let value = { let $get = edited; $read };
+                        let inherited = { let $get = global; $read };
+                        self.$field = (value != inherited).then_some(value);
+                    })*
+                }
+            }
+
+            /// Drops `field` back to inheriting the global, for a value that genuinely
+            /// differs — the other way an override ends (see [`SettingsOverride`]).
+            pub fn clear(&mut self, field: OverrideField) {
+                match field {
+                    $(OverrideField::$variant => self.$field = None,)*
+                }
+            }
+
+            /// `base` with every set field applied. The result still needs
+            /// [`Settings::clamp_to_caps`] before it reaches the wire, exactly like a
+            /// global value.
+            #[must_use]
+            pub fn merge_into(&self, mut base: Settings) -> Settings {
+                $(
+                    if let Some($val) = self.$field {
+                        let $set = &mut base;
+                        $write;
+                    }
+                )*
+                base
+            }
+        }
+    };
+}
+
+settings_override! {
     /// Width and height move together — they are one Resolution row.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mode: Option<(u32, u32)>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub refresh_hz: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bitrate_kbps: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hdr_enabled: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub codec: Option<CodecPref>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub audio_channels: Option<u8>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub gamepad_type: Option<GamepadType>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cursor_capture: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cursor_gestures: Option<bool>,
+    mode: (u32, u32) as Mode,
+        |s| (s.width, s.height),
+        |s, v| { s.width = v.0; s.height = v.1; };
+    refresh_hz: u32 as RefreshHz, |s| s.refresh_hz, |s, v| s.refresh_hz = v;
+    bitrate_kbps: u32 as BitrateKbps, |s| s.bitrate_kbps, |s, v| s.bitrate_kbps = v;
+    hdr_enabled: bool as HdrEnabled, |s| s.hdr_enabled, |s, v| s.hdr_enabled = v;
+    codec: CodecPref as Codec, |s| s.codec, |s, v| s.codec = v;
+    audio_channels: u8 as AudioChannels, |s| s.audio_channels, |s, v| s.audio_channels = v;
+    gamepad_type: GamepadType as GamepadKind, |s| s.gamepad_type, |s, v| s.gamepad_type = v;
+    cursor_capture: bool as CursorCapture, |s| s.cursor_capture, |s, v| s.cursor_capture = v;
+    cursor_gestures: bool as CursorGestures, |s| s.cursor_gestures, |s, v| s.cursor_gestures = v;
 }
 
 impl SettingsOverride {
     pub fn is_empty(&self) -> bool {
         *self == Self::default()
-    }
-
-    /// `base` with every set field applied. The result still needs
-    /// [`Settings::clamp_to_caps`] before it reaches the wire, exactly like a global value.
-    /// Clears every field that already equals `global` — a value the user has just set back
-    /// to what the global screen says is not an override, and must not linger in the
-    /// document. Run after every edit, so the record stays minimal (and disappears
-    /// entirely, via [`KnownHost::edit_overrides`], once nothing differs).
-    pub fn drop_matching(&mut self, global: &Settings) {
-        // Field by field against the global, not against the merge: a field is an override
-        // exactly when it is set *and* differs, and an unset one has nothing to drop.
-        macro_rules! drop_if_global {
-            ($($field:ident => $global:expr),* $(,)?) => {
-                $(if self.$field == Some($global) {
-                    self.$field = None;
-                })*
-            };
-        }
-        drop_if_global! {
-            mode => (global.width, global.height),
-            refresh_hz => global.refresh_hz,
-            bitrate_kbps => global.bitrate_kbps,
-            hdr_enabled => global.hdr_enabled,
-            codec => global.codec,
-            audio_channels => global.audio_channels,
-            gamepad_type => global.gamepad_type,
-            cursor_capture => global.cursor_capture,
-            cursor_gestures => global.cursor_gestures,
-        }
-    }
-
-    #[must_use]
-    pub fn merge_into(&self, mut base: Settings) -> Settings {
-        if let Some((w, h)) = self.mode {
-            base.width = w;
-            base.height = h;
-        }
-        if let Some(v) = self.refresh_hz {
-            base.refresh_hz = v;
-        }
-        if let Some(v) = self.bitrate_kbps {
-            base.bitrate_kbps = v;
-        }
-        if let Some(v) = self.hdr_enabled {
-            base.hdr_enabled = v;
-        }
-        if let Some(v) = self.codec {
-            base.codec = v;
-        }
-        if let Some(v) = self.audio_channels {
-            base.audio_channels = v;
-        }
-        if let Some(v) = self.gamepad_type {
-            base.gamepad_type = v;
-        }
-        if let Some(v) = self.cursor_capture {
-            base.cursor_capture = v;
-        }
-        if let Some(v) = self.cursor_gestures {
-            base.cursor_gestures = v;
-        }
-        base
     }
 }
 
@@ -256,9 +267,10 @@ pub fn pinned_only(id: &str) -> BTreeMap<String, GamePrefs> {
 /// for the games that are the common case and the desktop is the one card where the host's own
 /// pointer should stay visible. Doubles as the shipped demo of per-game overrides.
 ///
-/// `None` when the global value is already off — an override equal to the global reads as noise
-/// (matching [`SettingsOverride::drop_matching`]). The one place this default lives: new hosts
-/// get it from [`new_host_games`], existing ones from `store`'s version bootstrap.
+/// `None` when the global is already off: a seeded default has no business pinning a value the
+/// user would then have to find and clear (a *user-set* override equal to the global is kept —
+/// see [`SettingsOverride`]). The one place this default lives: new hosts get it from
+/// [`new_host_games`], existing ones from `store`'s version bootstrap.
 pub fn desktop_capture_override(global: &Settings) -> Option<bool> {
     global.cursor_capture.then_some(false)
 }
@@ -499,31 +511,59 @@ impl Default for Settings {
 }
 
 impl Settings {
-    /// Normalise to what the active backend can present (`core::caps`). Called on load and
-    /// whenever the backend row changes, so the document never holds a *set* value whose row
-    /// the UI has just hidden. `session::connect` clamps the wire regardless.
+    /// Normalise to what the active backend can present (`core::caps`), plus the one
+    /// cross-field rule: HDR needs HEVC, so an explicit H.264 pick turns it off. Called on
+    /// load and on every backend change, so the document never holds a *set* value whose row
+    /// the UI has just hidden or locked. `session::connect` clamps the wire regardless.
+    ///
+    /// Neither this nor [`Settings::presentable`] ever rewrites an override: one a current
+    /// global pick shadows stays in the document, unused, and applies again once it doesn't.
     pub fn clamp_to_caps(&mut self) {
+        self.clamp(true);
+    }
+
+    /// [`Settings::clamp_to_caps`] as a value, and silent — the per-game screen re-derives its
+    /// merged copy on every keystroke, which is no place to log the same clamp repeatedly.
+    #[must_use]
+    pub fn presentable(mut self) -> Self {
+        self.clamp(false);
+        self
+    }
+
+    fn clamp(&mut self, log: bool) {
+        // Only ever narrows, so `log` gating a line can't gate a mutation with it.
+        macro_rules! note {
+            ($($arg:tt)*) => { if log { tracing::info!($($arg)*); } };
+        }
         let backend = crate::core::caps::effective_backend(self.video_backend);
         if backend != self.video_backend {
-            tracing::info!("settings: SMP isn't offerable on this TV — using NDL");
+            note!("settings: SMP isn't offerable on this TV — using NDL");
             self.video_backend = backend;
         }
         let caps = crate::core::caps::video_caps();
+        // Before the HDR rules below: which codec is in force is what decides them.
         let codecs = caps.codec_prefs();
         if !codecs.contains(&self.codec) {
-            tracing::info!(
+            note!(
                 "settings: {:?} isn't offerable on this video backend — using {:?}",
                 self.codec,
                 codecs[0],
             );
             self.codec = codecs[0];
         }
-        if !caps.hdr && self.hdr_enabled {
-            tracing::info!("settings: HDR isn't presentable on this video backend — turning it off");
+        if self.hdr_enabled && !caps.hdr {
+            note!("settings: HDR isn't presentable on this video backend — turning it off");
+            self.hdr_enabled = false;
+        }
+        if self.hdr_enabled && self.codec == CodecPref::H264 {
+            // Mirrors `session::connect`'s own gate and `menu::RowLock::HdrNeedsHevc`: a
+            // session pinned to H.264 never resolves HDR. Reachable through the merge, where
+            // a game's HDR override can meet a global codec pick made after it.
+            note!("settings: HDR needs HEVC — an explicit H.264 pick turns it off");
             self.hdr_enabled = false;
         }
         if self.audio_channels > caps.max_channels {
-            tracing::info!(
+            note!(
                 "settings: {} audio channels exceeds this backend's {} — clamping",
                 self.audio_channels,
                 caps.max_channels,
@@ -609,23 +649,70 @@ mod tests {
     }
 
     #[test]
-    fn a_value_set_back_to_the_global_stops_being_an_override() {
+    fn picking_the_globals_own_value_stores_no_override() {
         let global = Settings::default();
-        let mut over = SettingsOverride {
-            refresh_hz: Some(120),
-            bitrate_kbps: Some(50_000),
-            ..SettingsOverride::default()
-        };
-        over.drop_matching(&global);
-        assert_eq!(over.refresh_hz, Some(120), "still differs");
+        let mut over = SettingsOverride::default();
+        over.capture(
+            OverrideField::RefreshHz,
+            &Settings {
+                refresh_hz: 120,
+                ..global
+            },
+            &global,
+        );
+        assert_eq!(
+            over.refresh_hz,
+            Some(120),
+            "differs from the global, so it is an override"
+        );
+        // Picking the global's own value back is the "use global" gesture.
+        over.capture(OverrideField::RefreshHz, &global, &global);
+        assert!(over.is_empty(), "nothing differs, so nothing is stored");
+    }
+
+    #[test]
+    fn an_override_survives_the_global_moving_onto_it_and_past_it() {
+        let mut global = Settings::default();
+        let mut over = SettingsOverride::default();
+        over.capture(
+            OverrideField::RefreshHz,
+            &Settings {
+                refresh_hz: 120,
+                ..global
+            },
+            &global,
+        );
+        // The global drifts onto the same value — a coincidence, not a gesture.
+        global.refresh_hz = 120;
+        assert_eq!(
+            over.refresh_hz,
+            Some(120),
+            "an override the user never touched is left alone"
+        );
+        global.refresh_hz = 30;
+        assert_eq!(over.merge_into(global).refresh_hz, 120);
+        // Only an explicit clear inherits again.
+        over.clear(OverrideField::RefreshHz);
+        assert!(over.is_empty());
+        assert_eq!(over.merge_into(global).refresh_hz, 30);
+    }
+
+    #[test]
+    fn editing_one_row_leaves_an_unrelated_override_alone() {
+        let global = Settings::default();
+        let mut over = SettingsOverride::default();
+        over.capture(
+            OverrideField::BitrateKbps,
+            &Settings {
+                bitrate_kbps: 50_000,
+                ..global
+            },
+            &global,
+        );
+        // A second row set to the global's own value must not drag the first one out with it.
+        over.capture(OverrideField::RefreshHz, &global, &global);
         assert_eq!(over.bitrate_kbps, Some(50_000));
-        // The user picks the global's own value back.
-        over.refresh_hz = Some(global.refresh_hz);
-        over.drop_matching(&global);
-        assert_eq!(over.refresh_hz, None, "matching the global is not an override");
-        over.bitrate_kbps = Some(global.bitrate_kbps);
-        over.drop_matching(&global);
-        assert!(over.is_empty(), "nothing differs, so nothing is persisted");
+        assert_eq!(over.refresh_hz, None);
     }
 
     #[test]
@@ -633,7 +720,7 @@ mod tests {
         let mut h = host();
         h.edit_overrides("steam:1", |o| o.refresh_hz = Some(120));
         assert!(h.games.contains_key("steam:1"));
-        h.edit_overrides("steam:1", |o| o.refresh_hz = None);
+        h.edit_overrides("steam:1", |o| o.clear(OverrideField::RefreshHz));
         assert!(!h.games.contains_key("steam:1"), "an empty record is dropped");
     }
 

--- a/src/core/screen.rs
+++ b/src/core/screen.rs
@@ -31,7 +31,9 @@ pub enum Screen {
     /// Experimental/unstable toggles (see `app/experimental.rs`).
     Experimental,
     /// Pointer/cursor behaviour, grouped off Settings (see `app/cursorsettings.rs`).
-    CursorSettings,
+    /// Carries the scope of the settings screen that opened it, so the sub-screen edits the
+    /// same document its parent does and Back knows where to return.
+    CursorSettings(SettingsScope),
     /// "Send logs to developer" confirmation (see `app/sendlogs.rs`).
     SendLogs,
 }

--- a/src/runtime/input.rs
+++ b/src/runtime/input.rs
@@ -598,7 +598,7 @@ pub(super) fn handle_ui_event(
             | Screen::WakeSettings
             | Screen::Diagnostics
             | Screen::Experimental
-            | Screen::CursorSettings
+            | Screen::CursorSettings(_)
                 if wheel_y != 0 =>
             {
                 let menu_ev = if wheel_y > 0 { MenuEvent::Up } else { MenuEvent::Down };

--- a/src/services/store/mod.rs
+++ b/src/services/store/mod.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 
 pub use crate::core::model::{
     desktop_capture_override, new_host_games, upsert_known_host, CodecPref, GamepadType, KnownHost, LogLevelOverride,
-    Persisted, Settings, SettingsOverride, VideoBackend, DESKTOP_PIN_ID,
+    OverrideField, Persisted, Settings, SettingsOverride, VideoBackend, DESKTOP_PIN_ID,
 };
 pub use crate::services::paths::app_dir;
 pub use identity::load_or_create_identity;


### PR DESCRIPTION
Per-game overrides used to delete themselves whenever their value matched the global's, which meant a deliberate pin vanished the moment the global happened to drift onto it. Now an override is what the user picked, and it stays until they say otherwise.

- A pick that lands on the global's current value stores nothing — that's the "use global" gesture. A row that genuinely differs is cleared with Delete (Y on a pad), or all of them at once with Reset.
- The old sweep cleared *every* matching field on every keystroke, so editing Bitrate could silently drop an unrelated Refresh override. Only the edited row is judged now.
- Overrides a global pick shadows stay in the document, unused. `clamp_to_caps` grew the HDR-needs-HEVC rule, so an HDR override survives a global switch to H.264 and applies again on the way back. The per-game screen shows the clamped value and locks the row, same as the global screen does.

Two bugs found along the way:

- The per-game scratch copy was only cleared on the way out of its own screen. A wake completing under an open modal jumped to Home without clearing it, so the *global* settings screen would then render and edit the leftover game copy while saving the untouched global document. `Screen::CursorSettings` now carries its scope like `Screen::Settings` already did, and every accessor reads the scope off the screen.
- `wake_succeeded` took down whatever screen was up. It only dismisses the wake modal now.
- The write-back keyed off `selected_host`, which a wake can move under the open modal. The screen pins its host at open time instead.

Refactor: the override field list existed in four hand-maintained copies (struct, merge, drop, capture) with no compiler help. One table generates all of it, plus the row→field mapping in `menu.rs` that both the mark and the capture read.

Not tested on device yet — the Delete binding and the override dots are worth a look on the TV.