### PR TITLE
Re-poll gamepad type on every add; bound HDR stray-cursor re-assert

### DIFF
--- a/src/platform/webos/cursor.rs
+++ b/src/platform/webos/cursor.rs
@@ -6,8 +6,10 @@
 //! it stops drawing. But starving only stops *future* draws: an arrow already on screen when the
 //! stream starts stays painted until something retracts it, which is why the hide is also
 //! requested outright on each [`Cursor::apply`] and again once the grab is actually in place
-//! ([`Cursor::reassert_hidden`]). The 4 Hz re-assert *loop* stays off, see
-//! [`COMPOSITOR_REASSERT`].
+//! ([`Cursor::reassert_hidden`]), and on a 4 Hz loop bounded to the start of a capture
+//! ([`Cursor::tick`]). An *unbounded* version of that loop was tried and dropped: verified on
+//! webOS 26 the compositor re-shows its arrow on pointer activity regardless, so past the panel
+//! mode switch it only spent Wayland requests. See [`STARTUP_REASSERT`].
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
@@ -19,14 +21,14 @@ use sdl2::sys::SDL_bool;
 
 use super::sdl_webos;
 
-/// Polling re-assert is off: verified on webOS 26 the compositor re-shows its arrow regardless,
-/// so the loop only spent Wayland requests. Kept, not deleted, in case a firmware/SDL-fork fix
-/// makes flipping this worth it. The one-shot retracts are unconditional — a different question
-/// from whether the hide *sticks* against later pointer activity.
-const COMPOSITOR_REASSERT: bool = false;
+/// How long after a capture the hide keeps being re-issued. The compositor repaints its arrow
+/// when the panel changes mode — entering HDR is the case that bites, the arrow coming back for
+/// as long as the TV's HDR badge is up, well after the one-shot retracts have run. Bounded rather
+/// than the always-on loop: this covers the mode switch without spending requests all stream.
+const STARTUP_REASSERT: Duration = Duration::from_secs(10);
 
-/// Compositor gives no "took the pointer back" event, so re-hiding just polls on activity,
-/// capped here at 4 Wayland requests/sec.
+/// Compositor gives no "took the pointer back" event, so re-hiding just polls, capped here at
+/// 4 Wayland requests/sec however often [`Cursor::tick`] runs.
 const REASSERT_INTERVAL: Duration = Duration::from_millis(250);
 
 /// Global: shared with the panic hook, which has no [`Cursor`] to reach for.
@@ -40,6 +42,8 @@ pub struct Cursor {
     last_assert: Instant,
     captured: bool,
     sdl_relative: bool,
+    /// End of the post-capture [`STARTUP_REASSERT`] window.
+    reassert_until: Instant,
 }
 
 impl Cursor {
@@ -49,6 +53,7 @@ impl Cursor {
             last_assert: Instant::now(),
             captured: false,
             sdl_relative: true,
+            reassert_until: Instant::now(),
         }
     }
 
@@ -79,6 +84,21 @@ impl Cursor {
         set_compositor_visible(!self.captured);
         COMPOSITOR_HIDDEN.store(self.captured, Ordering::Relaxed);
         self.last_assert = Instant::now();
+        // Anchored at the capture, not advanced by the re-asserts themselves (`last_assert` is).
+        // Releasing arms nothing: there is no hide to keep re-issuing.
+        self.reassert_until = if self.captured {
+            self.last_assert + STARTUP_REASSERT
+        } else {
+            self.last_assert
+        };
+    }
+
+    /// Drive once per frame: keeps re-issuing the hide for [`STARTUP_REASSERT`] after a capture,
+    /// so a panel mode switch mid-startup (HDR) can't leave the compositor's arrow on screen.
+    pub fn tick(&mut self) {
+        if Instant::now() < self.reassert_until {
+            self.reassert_hidden();
+        }
     }
 
     /// Asks the compositor once more to drop its pointer. For the point where the evdev grab has
@@ -94,21 +114,6 @@ impl Cursor {
         }
         set_compositor_visible(false);
         self.last_assert = Instant::now();
-    }
-
-    /// Re-asserts the hide when due; no-op unless hidden and [`COMPOSITOR_REASSERT`] is on.
-    pub fn on_pointer_activity(&mut self) {
-        if !COMPOSITOR_REASSERT {
-            return;
-        }
-        if !COMPOSITOR_HIDDEN.load(Ordering::Relaxed) {
-            return;
-        }
-        if self.last_assert.elapsed() < REASSERT_INTERVAL {
-            return;
-        }
-        self.last_assert = Instant::now();
-        set_compositor_visible(false);
     }
 }
 

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -321,6 +321,9 @@ pub(super) fn run_inner() -> Result<()> {
                 connected.disconnect_quit();
                 break 'running StreamOutcome::Quit;
             }
+            // Bounded post-capture re-assert — the compositor repaints its arrow when the panel
+            // switches into HDR, after the one-shot retracts below have already run.
+            cursor.tick();
             if settings.cursor_capture
                 && !hid_device_seen
                 && hid
@@ -456,7 +459,6 @@ pub(super) fn run_inner() -> Result<()> {
                     // Magic Remote pointer mode surfaces as plain SDL2 mouse events, forwarded
                     // to the host instead of driving local UI focus (see `mouse.rs`).
                     Event::MouseMotion { x, y, xrel, yrel, .. } => {
-                        cursor.on_pointer_activity();
                         if !hid_motion {
                             // Relative only for the remote alone: SDL's warp emulation is off
                             // whenever the evdev reader owns motion, so the remote sends

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -65,10 +65,8 @@ pub(super) fn run_ui_flow(
     const TICK_BUDGET: Duration = Duration::from_millis(16);
     canvas.window_mut().show();
     let mut app = App::new(identity.clone());
-    // `app` is rebuilt per menu entry but `controller` outlives it, and `ControllerDeviceAdded`
-    // fires only once per physical connect — so poll the subsystem here instead of relying on
-    // an event that already fired during the last menu or mid-stream. Without this the
-    // Controller row is locked on every menu entry after the first.
+    // `ControllerDeviceAdded` fires once per connect, not per menu entry, so re-poll here
+    // or the Controller row stays stale after the first menu.
     app.detected_gamepad_type = gamepad::detect_type(game_controller);
     // The GPU tile cache is the render loop's, not App's — App holds only screen state
     // Recreated per menu entry, same as `app`.
@@ -274,15 +272,19 @@ pub(super) fn run_ui_flow(
                     tracing::info!("quit during UI");
                     return Ok(None);
                 }
-                Event::ControllerDeviceAdded { which, .. } if controller.is_none() => {
-                    match game_controller.open(which) {
-                        Ok(c) => {
-                            tracing::info!("controller connected: {}", c.name());
-                            *controller = Some(c);
-                            app.detected_gamepad_type = gamepad::detect_type(game_controller);
+                Event::ControllerDeviceAdded { which, .. } => {
+                    if controller.is_none() {
+                        match game_controller.open(which) {
+                            Ok(c) => {
+                                tracing::info!("controller connected: {}", c.name());
+                                *controller = Some(c);
+                            }
+                            Err(e) => tracing::warn!("controller open failed: {e}"),
                         }
-                        Err(e) => tracing::warn!("controller open failed: {e}"),
                     }
+                    // Outside the open: only the first pad becomes `controller`, but a second one
+                    // plugged in after it can still be the pad `detect_type` names.
+                    app.detected_gamepad_type = gamepad::detect_type(game_controller);
                     continue;
                 }
                 Event::ControllerDeviceRemoved { .. } => {


### PR DESCRIPTION
## Summary
- Gamepad: `ControllerDeviceAdded` re-poll was gated on `controller.is_none()`, so only the first pad refreshed the Controller settings row. Guard moved inside the arm so every connect re-polls, matching the removal path.
- Cursor: with cursor capture on, an HDR-starting stream showed the system pointer for as long as the TV's HDR badge overlay was up. The compositor repaints its arrow on panel mode switch; the old hide request was one-shot at capture time, before the switch. `Cursor::tick()` now re-issues the hide at 4 Hz for 10s after each capture (armed only on capture, window anchored at capture). Deleted the dead always-on `COMPOSITOR_REASSERT` flag, `on_pointer_activity()`, and its call site.

## Test plan
- [ ] `task docker:lint` (passes)
- [ ] Device: plug Xbox pad then DualSense, confirm Controller row updates on each
- [ ] Device: start an HDR stream with cursor capture on, confirm no stray arrow during the HDR badge