### PR TITLE
Fix DualSense gyro wire scale and split evdev pad handling

### DIFF
--- a/packaging/description.html
+++ b/packaging/description.html
@@ -22,9 +22,16 @@
     <li style="margin-bottom: 6px;"><b>Your library, on the TV.</b> Games are listed with their cover art and launch
       with one press; pin the ones you play to the top row.</li>
     <li style="margin-bottom: 6px;"><b>Surround audio.</b> Stereo, 5.1 or 7.1, decoded client-side.</li>
-    <li style="margin-bottom: 6px;"><b>Every input the TV has.</b> Magic Remote pointer, gamepad (with DualSense
-      adaptive triggers), USB keyboard and mouse — with pointer capture for games and absolute pointing for the
-      desktop.</li>
+    <li style="margin-bottom: 6px;"><b>Every input the TV has.</b> Magic Remote pointer, gamepads, USB keyboard and
+      mouse — with pointer capture for games and absolute pointing for the desktop.</li>
+    <li style="margin-bottom: 6px;"><b>The full DualSense.</b> Adaptive triggers, lightbar and player LEDs driven by
+      the game, plus the touchpad, the motion sensors for gyro aiming, and rumble. Connect the pad over Bluetooth;
+      on older webOS versions whose kernel predates the PlayStation driver, Settings says so and the pad still plays
+      as an ordinary controller.</li>
+    <li style="margin-bottom: 6px;"><b>Pick the controller the game sees.</b> Automatic mirrors whatever you're
+      holding, or present an Xbox, DualShock 4, DualSense, DualSense Edge or Switch Pro pad instead — per game if you
+      want. Games read the glyphs and the trigger effects from that choice, so a DualSense has to be a DualSense for
+      its triggers to do anything.</li>
     <li style="margin-bottom: 6px;"><b>Game mode.</b> An optional Experimental setting on rooted TVs: it switches picture and
       sound to Game mode for the lowest input lag while streaming, then puts your previous
       settings back on exit.</li>

--- a/packaging/description.html
+++ b/packaging/description.html
@@ -17,8 +17,7 @@
     <li style="margin-bottom: 6px;"><b>Adaptive bitrate.</b> Leave it on Automatic and the stream tracks your link as
       it changes, backing off on loss and climbing again when it clears — or pin it anywhere from 10 to 200 Mbps.</li>
     <li style="margin-bottom: 6px;"><b>Per-game settings.</b> Hold a game's cover to give it its own resolution,
-      frame rate, bitrate, codec, HDR, audio or controller. Anything you don't set follows your global settings,
-      and a game reverts the moment you set a value back.</li>
+      frame rate, bitrate, codec, HDR, audio or controller.</li>
     <li style="margin-bottom: 6px;"><b>Your library, on the TV.</b> Games are listed with their cover art and launch
       with one press; pin the ones you play to the top row.</li>
     <li style="margin-bottom: 6px;"><b>Surround audio.</b> Stereo, 5.1 or 7.1, decoded client-side.</li>
@@ -26,17 +25,10 @@
       mouse — with pointer capture for games and absolute pointing for the desktop.</li>
     <li style="margin-bottom: 6px;"><b>The full DualSense.</b> Adaptive triggers, lightbar and player LEDs driven by
       the game, plus the touchpad, the motion sensors for gyro aiming, and rumble. Connect the pad over Bluetooth;
-      on older webOS versions whose kernel predates the PlayStation driver, Settings says so and the pad still plays
-      as an ordinary controller.</li>
-    <li style="margin-bottom: 6px;"><b>Pick the controller the game sees.</b> Automatic mirrors whatever you're
-      holding, or present an Xbox, DualShock 4, DualSense, DualSense Edge or Switch Pro pad instead — per game if you
-      want. Games read the glyphs and the trigger effects from that choice, so a DualSense has to be a DualSense for
-      its triggers to do anything.</li>
+      on older webOS versions whose kernel predates the PlayStation driver, some features are limited.</li>
     <li style="margin-bottom: 6px;"><b>Game mode.</b> An optional Experimental setting on rooted TVs: it switches picture and
       sound to Game mode for the lowest input lag while streaming, then puts your previous
       settings back on exit.</li>
-    <li style="margin-bottom: 6px;"><b>Set up once.</b> Hosts are found on your network automatically, paired with a
-      PIN, and can be woken from sleep over Wake-on-LAN when you pick them.</li>
   </ul>
 
   <p style="margin: 0 0 12px;">

--- a/src/platform/webos/dualsense.rs
+++ b/src/platform/webos/dualsense.rs
@@ -88,10 +88,11 @@ struct State {
 
 /// CRC32 (IEEE 802.3, reflected) — the `crc32_le` variant `hid-playstation` signs Bluetooth
 /// output reports with. Computed bitwise: 78 bytes per report at human-paced update rates
-/// isn't worth a 1 KiB lookup table.
-fn crc32_le(bytes: &[u8]) -> u32 {
+/// isn't worth a 1 KiB lookup table. Over an iterator so the seed byte the signature covers
+/// chains onto the report without copying it into a buffer first.
+fn crc32_le(bytes: impl IntoIterator<Item = u8>) -> u32 {
     let mut crc = 0xFFFF_FFFFu32;
-    for &b in bytes {
+    for b in bytes {
         crc ^= u32::from(b);
         for _ in 0..8 {
             // 0xEDB88320 = reflected 0x04C11DB7.
@@ -113,18 +114,25 @@ fn crc32_le(bytes: &[u8]) -> u32 {
 /// (no `Uniq`), which is correct — this path is Bluetooth-only.
 pub fn find_address() -> Option<String> {
     let devices = std::fs::read_to_string("/proc/bus/input/devices").ok()?;
-    devices.split("\n\n").find_map(|block| {
-        let is_dualsense = block
-            .lines()
-            .any(|l| l.starts_with("N: Name=") && l.to_ascii_lowercase().contains("dualsense"));
-        if !is_dualsense {
-            return None;
-        }
+    // Bound rather than returned directly: the iterator borrows `devices`, and a tail-position
+    // temporary outlives the local it borrows from.
+    let address = dualsense_blocks(&devices).find_map(|block| {
         block
             .lines()
             .find_map(|l| l.strip_prefix("U: Uniq="))
             .map(|u| u.trim().to_ascii_lowercase())
             .filter(|u| !u.is_empty())
+    });
+    address
+}
+
+/// The `/proc/bus/input/devices` records of every connected `DualSense`, matched on the `N: Name=`
+/// line. One pad publishes three of them, and only some carry the field a caller wants.
+fn dualsense_blocks<'a>(devices: &'a str) -> impl Iterator<Item = &'a str> + 'a {
+    devices.split("\n\n").filter(|block| {
+        block
+            .lines()
+            .any(|l| l.starts_with("N: Name=") && l.to_ascii_lowercase().contains("dualsense"))
     })
 }
 
@@ -163,24 +171,17 @@ pub fn hid_playstation_bound() -> bool {
 /// The uncached probe behind [`hid_playstation_bound`].
 fn probe_hid_playstation_bound() -> bool {
     let devices = std::fs::read_to_string("/proc/bus/input/devices").unwrap_or_default();
-    devices.split("\n\n").any(|block| {
-        let is_dualsense = block
-            .lines()
-            .any(|l| l.starts_with("N: Name=") && l.to_ascii_lowercase().contains("dualsense"));
-        if !is_dualsense {
-            return false;
-        }
+    // Bound for the same reason as in `find_address`.
+    let bound = dualsense_blocks(&devices)
         // The evdev node's `Sysfs=` line points at `<hid-device>/input/inputN`; the driver
         // binding lives on the HID device itself, one level up.
-        let Some(sysfs) = block.lines().find_map(|l| l.strip_prefix("S: Sysfs=")) else {
-            return false;
-        };
-        let Some(device_dir) = sysfs.split("/input/input").next() else {
-            return false;
-        };
-        std::fs::read_link(format!("/sys{device_dir}/driver"))
-            .is_ok_and(|d| d.file_name().is_some_and(|f| f == "playstation"))
-    })
+        .filter_map(|block| block.lines().find_map(|l| l.strip_prefix("S: Sysfs=")))
+        .any(|sysfs| {
+            let device_dir = sysfs.split("/input/input").next().unwrap_or(sysfs);
+            std::fs::read_link(format!("/sys{device_dir}/driver"))
+                .is_ok_and(|d| d.file_name().is_some_and(|f| f == "playstation"))
+        });
+    bound
 }
 
 /// Owns the pad's feedback state and the thread that ships it.
@@ -287,14 +288,6 @@ impl Drop for Feedback {
     }
 }
 
-/// Monotonic report sequence, low 4 bits used — the pad expects a changing sequence number
-/// per report.
-fn seq_next() -> u8 {
-    use std::sync::atomic::{AtomicU8, Ordering};
-    static SEQ: AtomicU8 = AtomicU8::new(0);
-    SEQ.fetch_add(1, Ordering::Relaxed) & 0x0F
-}
-
 /// Builds one Bluetooth output report for `state`.
 ///
 /// Note which valid-flags are never set: not `0x01` (compatible vibration), so the motor
@@ -322,10 +315,9 @@ fn build_report(seq: u8, state: &State) -> [u8; REPORT_LEN] {
     }
     // CRC32 over a 0xA2 seed byte (the HIDP DATA/Output header the stack prepends) followed
     // by everything ahead of the CRC field itself.
-    let mut signed = Vec::with_capacity(REPORT_LEN);
-    signed.push(0xA2);
-    signed.extend_from_slice(&r[..REPORT_LEN - 4]);
-    r[REPORT_LEN - 4..].copy_from_slice(&crc32_le(&signed).to_le_bytes());
+    let signed = std::iter::once(0xA2).chain(r[..REPORT_LEN - 4].iter().copied());
+    let crc = crc32_le(signed);
+    r[REPORT_LEN - 4..].copy_from_slice(&crc.to_le_bytes());
     r
 }
 
@@ -378,11 +370,14 @@ fn sender_loop(address: &str, rx: &Receiver<State>) {
     let mut failing = false;
     let mut last_sent: Option<State> = None;
     let mut sends: u32 = 0;
+    // The pad expects a changing sequence number per report; low 4 bits, so it wraps freely.
+    let mut seq: u8 = 0;
     while let Ok(state) = rx.recv() {
         if last_sent == Some(state) {
             continue;
         }
-        match send_report(address, &build_report(seq_next(), &state)) {
+        seq = seq.wrapping_add(1);
+        match send_report(address, &build_report(seq, &state)) {
             Ok(()) => {
                 failing = false;
                 last_sent = Some(state);
@@ -414,7 +409,7 @@ mod tests {
     #[test]
     fn crc32_matches_known_vector() {
         // Standard IEEE CRC32 check value for "123456789".
-        assert_eq!(crc32_le(b"123456789"), 0xCBF4_3926);
+        assert_eq!(crc32_le(*b"123456789"), 0xCBF4_3926);
     }
 
     #[test]

--- a/src/platform/webos/evdev.rs
+++ b/src/platform/webos/evdev.rs
@@ -330,13 +330,14 @@ struct Device {
 /// its full rate forever.
 #[derive(Default)]
 struct Sensors {
-    /// Pitch/yaw/roll then accelerometer, in the pad's own units (`hid-playstation` keeps the
-    /// report's scale), as the wire orders them.
+    /// Pitch/yaw/roll then accelerometer, in the node's own units, as the wire orders them.
     axes: [i32; 6],
     /// A `SYN_REPORT` completed a sample since the last send.
     dirty: bool,
     /// Last sample actually sent, for the unchanged-sample skip.
     sent: Option<[i16; 6]>,
+    /// Per-axis node units → wire units, `SCALE_SHIFT` fixed point — see [`Sensors::new`].
+    scale: [i64; 6],
 }
 
 /// Multitouch decode state for a claimed pad touchpad, plus the axis ranges its coordinates are
@@ -474,7 +475,7 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
     if is_pad_touchpad(absolute_pointer, bit(&key, BTN_TOUCH), || device_vendor(fd)) {
         dev.touchpad = Some(Touchpad::new(fd));
     } else if is_pad_motion(&abs, bit(&key, BTN_TOUCH) || bit(&key, BTN_SOUTH), || device_vendor(fd)) {
-        dev.sensors = Some(Sensors::default());
+        dev.sensors = Some(Sensors::new(fd));
     }
     if !dev.mouse && !dev.keyboard && dev.touchpad.is_none() && dev.sensors.is_none() {
         // Not ours, or a pointer-only node in desktop mode — left with the compositor so the
@@ -538,6 +539,46 @@ fn is_pad_motion(abs: &[u8; 128], has_buttons: bool, vendor: impl FnOnce() -> u1
     (ABS_X..=ABS_RZ).all(|c| bit(abs, c)) && !has_buttons && vendor() == VENDOR_SONY
 }
 
+/// The units the wire carries: the raw `DualSense` report scale the host's *virtual* pad is
+/// calibrated for, since the host injects inputtino's fixed calibration blob. Same convention as
+/// the Linux and Apple clients.
+const WIRE_GYRO_LSB_PER_DEG_S: i32 = 20;
+const WIRE_ACCEL_LSB_PER_G: i32 = 10_000;
+
+/// `hid-playstation`'s own output scale, for a node that publishes no `resolution`.
+const DS_GYRO_RES_PER_DEG_S: i32 = 1024;
+const DS_ACC_RES_PER_G: i32 = 8192;
+
+/// Fixed-point fraction bits of [`Sensors::scale`]. Both real ratios (20/1024, 10000/8192) are
+/// exact at 16.
+const SCALE_SHIFT: u32 = 16;
+
+impl Sensors {
+    /// Builds the per-axis wire scale once, at open. The node's `resolution` is per device — the
+    /// driver derives it from *this* pad's factory calibration blob — so it is the only honest
+    /// answer to what a raw count here means. Reciprocal rather than a divisor: armv7 has no
+    /// 64-bit divide, and [`flush_sensors`] runs per read burst.
+    fn new(fd: RawFd) -> Self {
+        let scale = std::array::from_fn(|i| {
+            // Gyro axes first, then accelerometer — the order `read_sensors` fills.
+            let (code, wire, fallback) = if i < 3 {
+                (ABS_RX + i as u16, WIRE_GYRO_LSB_PER_DEG_S, DS_GYRO_RES_PER_DEG_S)
+            } else {
+                (ABS_X + (i - 3) as u16, WIRE_ACCEL_LSB_PER_G, DS_ACC_RES_PER_G)
+            };
+            let res = match abs_resolution(fd, code) {
+                r if r > 0 => r,
+                _ => fallback,
+            };
+            (i64::from(wire) << SCALE_SHIFT) / i64::from(res)
+        });
+        Self {
+            scale,
+            ..Default::default()
+        }
+    }
+}
+
 impl Touchpad {
     /// Reads the node's axis ranges once, at open. A node whose `ABS_MT_POSITION_*` ranges are
     /// unusable is still worth claiming (the compositor must not have it) — it just reports no
@@ -563,10 +604,9 @@ fn normalize(x: i32, y: i32, x_range: (i32, i32), y_range: (i32, i32)) -> Option
     Some((scale(x, x_range)?, scale(y, y_range)?))
 }
 
-/// `EVIOCGABS(code)`'s `(minimum, maximum)` out of `struct input_absinfo`
-/// (`value, minimum, maximum, fuzz, flat, resolution`). Falls back to `(0, 0)` when the ioctl
-/// fails, which [`normalize`] reads as "no usable range".
-fn abs_range(fd: RawFd, code: u16) -> (i32, i32) {
+/// `EVIOCGABS(code)` — `struct input_absinfo` as `value, minimum, maximum, fuzz, flat,
+/// resolution`. All zeroes when the ioctl fails, which every caller reads as "no usable value".
+fn abs_info(fd: RawFd, code: u16) -> [i32; 6] {
     let mut info = [0i32; 6];
     // SAFETY: as `event_bits` — length-encoding request, buffer of exactly that length.
     let rc = unsafe {
@@ -577,9 +617,22 @@ fn abs_range(fd: RawFd, code: u16) -> (i32, i32) {
         )
     };
     if rc < 0 {
-        return (0, 0);
+        return [0; 6];
     }
+    info
+}
+
+/// The axis's `(minimum, maximum)`; `(0, 0)` when unknown, which [`normalize`] reads as "no
+/// usable range".
+fn abs_range(fd: RawFd, code: u16) -> (i32, i32) {
+    let info = abs_info(fd, code);
     (info[1], info[2])
+}
+
+/// The axis's `resolution` — units per deg/s on a gyro axis, per g on an accelerometer one.
+/// `0` when the driver publishes none.
+fn abs_resolution(fd: RawFd, code: u16) -> i32 {
+    abs_info(fd, code)[5]
 }
 
 /// The vendor id out of `EVIOCGID`'s `struct input_id` (`bustype, vendor, product, version`) —
@@ -939,15 +992,19 @@ fn read_sensors(sensors: &mut Sensors, buf: &[u8], size: usize) {
 /// reports forever, and re-sending its resting attitude at 500 Hz would cost a datagram per
 /// sample to tell the host nothing.
 ///
-/// Clamped to `i16`: the wire carries the `DualSense` report's own signed-16 units, and
-/// `hid-playstation`'s calibration can push a sample a little past that at the extremes.
+/// Rescaled to the wire's units before the `i16` clamp: this node reports `hid-playstation`'s
+/// *calibrated* readings (~1024 counts per deg/s) where the wire wants the host virtual pad's raw
+/// report scale (~20), so forwarding them verbatim rails every axis on the slightest movement.
+/// The divide also quantizes a resting pad's bias jitter to a clean zero, which the skip below
+/// then stops sending.
 fn flush_sensors(sensors: &mut Sensors, sink: &impl Fn(HidReport)) {
     if !std::mem::take(&mut sensors.dirty) {
         return;
     }
-    let axes = sensors
-        .axes
-        .map(|v| v.clamp(i32::from(i16::MIN), i32::from(i16::MAX)) as i16);
+    let axes: [i16; 6] = std::array::from_fn(|i| {
+        ((i64::from(sensors.axes[i]) * sensors.scale[i]) >> SCALE_SHIFT)
+            .clamp(i64::from(i16::MIN), i64::from(i16::MAX)) as i16
+    });
     if sensors.sent == Some(axes) {
         return;
     }

--- a/src/platform/webos/evdev/mod.rs
+++ b/src/platform/webos/evdev/mod.rs
@@ -306,8 +306,6 @@ struct Device {
     pad: Option<Pad>,
 }
 
-
-
 impl Drop for Device {
     fn drop(&mut self) {
         // SAFETY: `fd` came from `open` in `open_mouse` and is owned solely by this struct.
@@ -765,5 +763,4 @@ mod tests {
         assert!(!is_tv_builtin("M720 Triathlon Mouse"));
         assert!(!is_tv_builtin("MX MCHNCL M Keyboard"));
     }
-
 }

--- a/src/platform/webos/evdev/mod.rs
+++ b/src/platform/webos/evdev/mod.rs
@@ -1,8 +1,9 @@
 //! Raw HID mouse **and keyboard** input straight from `/dev/input/event*`, bypassing SDL.
 //!
-//! **Also a pad's touchpad.** A `DualSense`'s touchpad is a third evdev node the compositor would
-//! otherwise turn into a cursor (see [`is_pad_touchpad`]); it's claimed here and decoded into
-//! rich-input contacts for the host's virtual pad, the only route a game's touchpad swipes have.
+//! **Also a pad's touchpad and motion sensors.** Those are two more evdev nodes the compositor
+//! would otherwise turn into cursors; this reader claims them and [`pad`] decodes them into rich
+//! input for the host's virtual pad — the only route a game's touchpad swipes and gyro aiming
+//! have.
 //!
 //! **Why.** SDL mouse events on webOS come from the compositor's pointer, smoothed/resampled
 //! for a wrist-waved remote rather than a 125–1000 Hz mouse — jittery deltas no matter what the
@@ -47,6 +48,10 @@ use std::time::{Duration, Instant};
 use punktfunk_core::input::InputEvent;
 use punktfunk_core::quic::RichInput;
 
+mod pad;
+
+use pad::Pad;
+
 use super::keyboard;
 use super::mouse;
 
@@ -55,23 +60,12 @@ const EV_KEY: u16 = 0x01;
 const EV_REL: u16 = 0x02;
 const EV_ABS: u16 = 0x03;
 
-/// End of one report — every `EV_ABS` since the last one describes the same instant, so touch
-/// contacts are only sent here (see [`read_touch`]).
+/// End of one report — every `EV_ABS` since the last one describes the same instant, so [`pad`]
+/// only sends contacts and motion samples here.
 const SYN_REPORT: u16 = 0x00;
 
 const ABS_X: u16 = 0x00;
 const ABS_Y: u16 = 0x01;
-/// The motion node's six axes, contiguous and in the `DualSense` report's own order: `ABS_X`..`_Z`
-/// accelerometer, `ABS_RX`..`_RZ` gyro (pitch/yaw/roll).
-const ABS_Z: u16 = 0x02;
-const ABS_RX: u16 = 0x03;
-const ABS_RZ: u16 = 0x05;
-/// Multitouch protocol B: which contact the following `ABS_MT_*` values belong to.
-const ABS_MT_SLOT: u16 = 0x2f;
-const ABS_MT_POSITION_X: u16 = 0x35;
-const ABS_MT_POSITION_Y: u16 = 0x36;
-/// `-1` lifts the slot's contact; anything else is a new or continuing one.
-const ABS_MT_TRACKING_ID: u16 = 0x39;
 const REL_X: u16 = 0x00;
 const REL_Y: u16 = 0x01;
 const REL_HWHEEL: u16 = 0x06;
@@ -82,17 +76,6 @@ const BTN_RIGHT: u16 = 0x111;
 const BTN_MIDDLE: u16 = 0x112;
 const BTN_SIDE: u16 = 0x113;
 const BTN_EXTRA: u16 = 0x114;
-/// Finger-on-surface, which only touch-class nodes carry — the pad's own node reports
-/// `BTN_SOUTH`/`BTN_EAST` and never this. See [`is_pad_touchpad`].
-const BTN_TOUCH: u16 = 0x14a;
-
-/// The pad's own south face button — what parts the gamepad node from the motion node, which
-/// advertises the same six absolute axes but no buttons at all. See [`is_pad_motion`].
-const BTN_SOUTH: u16 = 0x130;
-
-/// Sony's USB/BT vendor id. `hid-playstation` binds only Sony pads, and it's the split-node
-/// layout that creates the touchpad node this identifies.
-const VENDOR_SONY: u16 = 0x054c;
 
 const KEY_LEFTCTRL: u16 = 29;
 const KEY_A: u16 = 30;
@@ -317,57 +300,13 @@ struct Device {
     mouse: bool,
     /// Alphanumeric/modifier keys. Magic Remote nodes are excluded by [`open_hid`].
     keyboard: bool,
-    /// A pad's touchpad ([`is_pad_touchpad`]), claimed so the compositor can't make a cursor of
-    /// it and decoded into [`RichInput::Touchpad`] contacts instead. `None` on every other node.
-    touchpad: Option<Touchpad>,
-    /// A pad's motion sensors ([`is_pad_motion`]), on their own node — never set together with
-    /// [`Self::touchpad`]. `None` on every other node.
-    sensors: Option<Sensors>,
+    /// Set only on a `PlayStation` pad's touchpad or motion node, which this reader claims and
+    /// decodes into rich input rather than pointer events — see [`pad`]. `None` on every other
+    /// node.
+    pad: Option<Pad>,
 }
 
-/// Motion decode state. Sensor readings are levels, not deltas, so a read burst collapses to its
-/// newest sample and an unchanged sample is worth no datagram at all — a resting pad reports at
-/// its full rate forever.
-#[derive(Default)]
-struct Sensors {
-    /// Pitch/yaw/roll then accelerometer, in the node's own units, as the wire orders them.
-    axes: [i32; 6],
-    /// A `SYN_REPORT` completed a sample since the last send.
-    dirty: bool,
-    /// Last sample actually sent, for the unchanged-sample skip.
-    sent: Option<[i16; 6]>,
-    /// Per-axis node units → wire units, `SCALE_SHIFT` fixed point — see [`Sensors::new`].
-    scale: [i64; 6],
-}
 
-/// Multitouch decode state for a claimed pad touchpad, plus the axis ranges its coordinates are
-/// normalized against.
-///
-/// Protocol B (`ABS_MT_SLOT` + `ABS_MT_TRACKING_ID`), which is what `hid-playstation` reports and
-/// all the wire has room for: two contacts, matching the `finger` field's `0`/`1`.
-struct Touchpad {
-    /// The slot `ABS_MT_*` values currently apply to. Out-of-range slots are parked on the last
-    /// finger rather than dropped, so a driver reporting more contacts than the wire carries
-    /// can't silently write past the array.
-    slot: usize,
-    fingers: [Finger; 2],
-    /// `(min, max)` of `ABS_MT_POSITION_X` / `_Y`, for the 0..=65535 normalization.
-    x_range: (i32, i32),
-    y_range: (i32, i32),
-}
-
-#[derive(Clone, Copy, Default)]
-struct Finger {
-    active: bool,
-    /// The host currently believes this contact is down. Gates the lift: a node claimed with a
-    /// finger already on it reports coordinates without a `ABS_MT_TRACKING_ID`, which would
-    /// otherwise send a lift for a contact the host never saw start.
-    sent: bool,
-    x: i32,
-    y: i32,
-    /// Something in this report changed the contact — sent at the next `SYN_REPORT` and cleared.
-    dirty: bool,
-}
 
 impl Drop for Device {
     fn drop(&mut self) {
@@ -450,8 +389,7 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
         grab_warned_for: None,
         mouse: false,
         keyboard: false,
-        touchpad: None,
-        sensors: None,
+        pad: None,
     };
     let rel = event_bits(fd, EV_REL);
     let abs = event_bits(fd, EV_ABS);
@@ -472,12 +410,8 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
     dev.mouse = pointer && (grab_mouse || dev.keyboard);
     // Claimed in both cursor modes, unlike a mouse node: leaving it to the compositor is what
     // produces the stuck left button, which desktop mode wants gone just as much.
-    if is_pad_touchpad(absolute_pointer, bit(&key, BTN_TOUCH), || device_vendor(fd)) {
-        dev.touchpad = Some(Touchpad::new(fd));
-    } else if is_pad_motion(&abs, bit(&key, BTN_TOUCH) || bit(&key, BTN_SOUTH), || device_vendor(fd)) {
-        dev.sensors = Some(Sensors::new(fd));
-    }
-    if !dev.mouse && !dev.keyboard && dev.touchpad.is_none() && dev.sensors.is_none() {
+    dev.pad = Pad::probe(fd, &abs, &key, absolute_pointer);
+    if !dev.mouse && !dev.keyboard && dev.pad.is_none() {
         // Not ours, or a pointer-only node in desktop mode — left with the compositor so the
         // TV cursor is still the one you aim.
         return Probe::Skip;
@@ -485,10 +419,8 @@ fn open_hid(path: &Path, grab_mouse: bool) -> Probe {
     if dev.keyboard {
         set_repeat(fd);
     }
-    let kind = if dev.touchpad.is_some() {
-        "pad touchpad"
-    } else if dev.sensors.is_some() {
-        "pad motion"
+    let kind = if let Some(pad) = &dev.pad {
+        pad.kind()
     } else if dev.mouse && dev.keyboard {
         "mouse+keyboard"
     } else if dev.mouse {
@@ -507,101 +439,6 @@ fn set_repeat(fd: RawFd) {
     if unsafe { libc::ioctl(fd, eviocsrep(), rep.as_ptr()) } < 0 {
         tracing::debug!("EVIOCSREP: {}", std::io::Error::last_os_error());
     }
-}
-
-/// LG's virtual remotes advertise a full QWERTY keymap, so a "has `KEY_A`" filter would steal
-/// the Magic Remote / RCU from the compositor and leave the TV unnavigable. Names as they read
-/// in `/proc/bus/input/devices` on-device.
-/// A `PlayStation` pad's touchpad, which the kernel publishes as its own absolute/multitouch node
-/// alongside the pad itself — the source of the stuck left button [`mouse::is_touch_emulated`]
-/// describes, since the compositor drives the TV cursor from it. Claiming it takes it away from
-/// the compositor entirely and gives [`read_touch`] the contacts to forward as
-/// [`RichInput::Touchpad`], which is what makes a game's touchpad swipes work. The pad's own
-/// *click* doesn't come through here at all — that arrives on the pad node as `BTN_TOUCHPAD`
-/// through SDL's controller layer.
-///
-/// Matched on ids and capability bits, not the device name, which varies by driver and firmware:
-/// `BTN_TOUCH` on an absolute pointer (the pad's own node reports face buttons instead), from a
-/// Sony vendor id. `vendor` is lazy because it costs an ioctl the bit tests don't.
-fn is_pad_touchpad(absolute_pointer: bool, has_btn_touch: bool, vendor: impl FnOnce() -> u16) -> bool {
-    absolute_pointer && has_btn_touch && vendor() == VENDOR_SONY
-}
-
-/// A `PlayStation` pad's motion sensors, published as a third node beside the pad and its
-/// touchpad. SDL2 never reads it, so gyro aiming reaches the host only if this reader forwards it
-/// as [`RichInput::Motion`].
-///
-/// Matched on capability bits and vendor, like [`is_pad_touchpad`]: all six sensor axes and no
-/// buttons. Both other nodes carry those same axes — the pad node's are its sticks and triggers,
-/// the touchpad's are the contact — so the buttons (`BTN_SOUTH`, `BTN_TOUCH`) are what part them.
-/// Matching the pad node here would grab the gamepad away from SDL entirely.
-fn is_pad_motion(abs: &[u8; 128], has_buttons: bool, vendor: impl FnOnce() -> u16) -> bool {
-    (ABS_X..=ABS_RZ).all(|c| bit(abs, c)) && !has_buttons && vendor() == VENDOR_SONY
-}
-
-/// The units the wire carries: the raw `DualSense` report scale the host's *virtual* pad is
-/// calibrated for, since the host injects inputtino's fixed calibration blob. Same convention as
-/// the Linux and Apple clients.
-const WIRE_GYRO_LSB_PER_DEG_S: i32 = 20;
-const WIRE_ACCEL_LSB_PER_G: i32 = 10_000;
-
-/// `hid-playstation`'s own output scale, for a node that publishes no `resolution`.
-const DS_GYRO_RES_PER_DEG_S: i32 = 1024;
-const DS_ACC_RES_PER_G: i32 = 8192;
-
-/// Fixed-point fraction bits of [`Sensors::scale`]. Both real ratios (20/1024, 10000/8192) are
-/// exact at 16.
-const SCALE_SHIFT: u32 = 16;
-
-impl Sensors {
-    /// Builds the per-axis wire scale once, at open. The node's `resolution` is per device — the
-    /// driver derives it from *this* pad's factory calibration blob — so it is the only honest
-    /// answer to what a raw count here means. Reciprocal rather than a divisor: armv7 has no
-    /// 64-bit divide, and [`flush_sensors`] runs per read burst.
-    fn new(fd: RawFd) -> Self {
-        let scale = std::array::from_fn(|i| {
-            // Gyro axes first, then accelerometer — the order `read_sensors` fills.
-            let (code, wire, fallback) = if i < 3 {
-                (ABS_RX + i as u16, WIRE_GYRO_LSB_PER_DEG_S, DS_GYRO_RES_PER_DEG_S)
-            } else {
-                (ABS_X + (i - 3) as u16, WIRE_ACCEL_LSB_PER_G, DS_ACC_RES_PER_G)
-            };
-            let res = match abs_resolution(fd, code) {
-                r if r > 0 => r,
-                _ => fallback,
-            };
-            (i64::from(wire) << SCALE_SHIFT) / i64::from(res)
-        });
-        Self {
-            scale,
-            ..Default::default()
-        }
-    }
-}
-
-impl Touchpad {
-    /// Reads the node's axis ranges once, at open. A node whose `ABS_MT_POSITION_*` ranges are
-    /// unusable is still worth claiming (the compositor must not have it) — it just reports no
-    /// contacts, which [`normalize`] enforces.
-    fn new(fd: RawFd) -> Self {
-        Self {
-            slot: 0,
-            fingers: [Finger::default(); 2],
-            x_range: abs_range(fd, ABS_MT_POSITION_X),
-            y_range: abs_range(fd, ABS_MT_POSITION_Y),
-        }
-    }
-}
-
-/// Device units → the wire's `0..=65535` across the pad. `None` when the driver gave no range to
-/// scale against, since a bogus coordinate is worse than no contact at all.
-fn normalize(x: i32, y: i32, x_range: (i32, i32), y_range: (i32, i32)) -> Option<(u16, u16)> {
-    let scale = |v: i32, (min, max): (i32, i32)| {
-        let span = i64::from(max) - i64::from(min);
-        (span > 0).then(|| ((i64::from(v.clamp(min, max)) - i64::from(min)) * 65535 / span) as u16)
-    };
-    // evdev's +y is already down, the direction the wire and the host's virtual pad expect.
-    Some((scale(x, x_range)?, scale(y, y_range)?))
 }
 
 /// `EVIOCGABS(code)` — `struct input_absinfo` as `value, minimum, maximum, fuzz, flat,
@@ -647,6 +484,9 @@ fn device_vendor(fd: RawFd) -> u16 {
     id[1]
 }
 
+/// LG's virtual remotes advertise a full QWERTY keymap, so a "has `KEY_A`" filter would steal
+/// the Magic Remote / RCU from the compositor and leave the TV unnavigable. Names as they read
+/// in `/proc/bus/input/devices` on-device.
 fn is_tv_builtin(name: &str) -> bool {
     name.starts_with("LGE") || name.starts_with("Bluetooth-audio") || matches!(name, "CHECK INPUT" | "IoT keypad")
 }
@@ -674,10 +514,10 @@ fn apply_grab(devices: &mut [Device], want: bool) {
     for dev in devices {
         // A pad touchpad is claimed whether the reader is active or not: ungrabbing it hands the
         // compositor back a node it turns into a cursor with a stuck left button, which is the
-        // whole reason it's claimed (see `is_pad_touchpad`).
+        // whole reason it's claimed (see `pad::is_pad_touchpad`).
         // Same for the motion node: it too advertises absolute axes the compositor would
         // otherwise turn into a cursor, and its samples are only useful forwarded.
-        let want = want || dev.touchpad.is_some() || dev.sensors.is_some();
+        let want = want || dev.pad.is_some();
         if dev.grabbed == want {
             continue;
         }
@@ -750,7 +590,7 @@ fn reader_loop(sink: &impl Fn(HidReport), shared: &Shared) {
                     if fds[i].revents & DEAD == 0 {
                         continue;
                     }
-                    release_touches(&mut devices[i], sink);
+                    release_pad(&mut devices[i], sink);
                     let gone = devices.remove(i);
                     tracing::info!("HID device gone: {}", gone.path.display());
                     seen.retain(|p| *p != gone.path);
@@ -784,7 +624,14 @@ fn reader_loop(sink: &impl Fn(HidReport), shared: &Shared) {
     }
     // Stopping with a finger on the pad must not leave the host holding it.
     for dev in &mut devices {
-        release_touches(dev, sink);
+        release_pad(dev, sink);
+    }
+}
+
+/// [`Pad::release`] on a node that has one.
+fn release_pad(dev: &mut Device, sink: &impl Fn(HidReport)) {
+    if let Some(pad) = dev.pad.as_mut() {
+        pad.release(sink);
     }
 }
 
@@ -820,12 +667,8 @@ fn read_device(dev: &mut Device, sink: &impl Fn(HidReport), keys: &KeyActivity) 
             return; // EAGAIN on an empty non-blocking node, or the node went away
         }
         let n = n as usize;
-        // A claimed touchpad shares none of the mouse/keyboard decode below — different axes,
-        // different wire plane — so it takes the whole burst on its own path.
-        if let Some(pad) = dev.touchpad.as_mut() {
-            read_touch(pad, &buf[..n], size, sink);
-        } else if let Some(sensors) = dev.sensors.as_mut() {
-            read_sensors(sensors, &buf[..n], size);
+        if let Some(pad) = dev.pad.as_mut() {
+            pad.read(&buf[..n], size, sink);
         } else {
             decode_hid(dev, &buf[..n], size, sink, keys);
         }
@@ -834,8 +677,8 @@ fn read_device(dev: &mut Device, sink: &impl Fn(HidReport), keys: &KeyActivity) 
         }
     }
     flush_motion(dev, sink);
-    if let Some(sensors) = dev.sensors.as_mut() {
-        flush_sensors(sensors, sink);
+    if let Some(pad) = dev.pad.as_mut() {
+        pad.flush(sink);
     }
 }
 
@@ -886,137 +729,6 @@ fn decode_hid(dev: &mut Device, buf: &[u8], size: usize, sink: &impl Fn(HidRepor
     }
 }
 
-/// Decodes one read burst off a claimed pad touchpad into [`RichInput::Touchpad`] contacts.
-///
-/// Contacts are sent at `SYN_REPORT`, not per axis event: a moving finger reports x and y as two
-/// events, and sending between them would put half the samples on a stale axis. Only contacts a
-/// report actually touched are sent, so a resting finger costs one burst of decode and no
-/// datagrams at all.
-fn read_touch(pad: &mut Touchpad, buf: &[u8], size: usize, sink: &impl Fn(HidReport)) {
-    for chunk in buf.chunks_exact(size) {
-        // SAFETY: as `read_device` — exact-size chunk of plain `repr(C)` integers, read unaligned.
-        let ev = unsafe { chunk.as_ptr().cast::<InputEventRaw>().read_unaligned() };
-        match (ev.kind, ev.code) {
-            // A slot the wire can't carry is parked on the last finger, where its coordinates are
-            // simply overwritten by a contact that does fit — the pad only ever reports two.
-            (EV_ABS, ABS_MT_SLOT) => pad.slot = (ev.value.max(0) as usize).min(pad.fingers.len() - 1),
-            (EV_ABS, ABS_MT_TRACKING_ID) => {
-                let finger = &mut pad.fingers[pad.slot];
-                finger.active = ev.value >= 0;
-                finger.dirty = true;
-            }
-            (EV_ABS, ABS_MT_POSITION_X | ABS_MT_POSITION_Y) => {
-                let finger = &mut pad.fingers[pad.slot];
-                if ev.code == ABS_MT_POSITION_X {
-                    finger.x = ev.value;
-                } else {
-                    finger.y = ev.value;
-                }
-                finger.dirty = true;
-            }
-            (EV_SYN, SYN_REPORT) => {
-                let (x_range, y_range) = (pad.x_range, pad.y_range);
-                for (i, finger) in pad.fingers.iter_mut().enumerate() {
-                    if !finger.dirty {
-                        continue;
-                    }
-                    finger.dirty = false;
-                    if !finger.active && !finger.sent {
-                        continue; // never announced — nothing to lift
-                    }
-                    let Some(contact) = contact(i, finger, x_range, y_range) else {
-                        continue;
-                    };
-                    finger.sent = finger.active;
-                    sink(HidReport::Rich(contact));
-                }
-            }
-            _ => {}
-        }
-    }
-}
-
-/// Lifts every contact the host still believes is down on this node. A touch is a level, not an
-/// edge: a pad unplugged (or a reader stopped) mid-gesture would otherwise leave the finger down
-/// on the host's virtual pad with nothing left to release it.
-fn release_touches(dev: &mut Device, sink: &impl Fn(HidReport)) {
-    let Some(pad) = dev.touchpad.as_mut() else {
-        return;
-    };
-    let (x_range, y_range) = (pad.x_range, pad.y_range);
-    for (i, finger) in pad.fingers.iter_mut().enumerate() {
-        if !std::mem::take(&mut finger.sent) {
-            continue;
-        }
-        finger.active = false;
-        finger.dirty = false;
-        if let Some(contact) = contact(i, finger, x_range, y_range) {
-            sink(HidReport::Rich(contact));
-        }
-    }
-}
-
-/// One contact for the wire, or `None` when the node gave no usable axis range ([`normalize`]).
-///
-/// A lift's coordinates are whatever the contact last had, which is what the host wants — the
-/// release still has to land where the finger was. `pad` is 0 throughout: this client drives a
-/// single pad.
-fn contact(finger_idx: usize, finger: &Finger, x_range: (i32, i32), y_range: (i32, i32)) -> Option<RichInput> {
-    let (x, y) = normalize(finger.x, finger.y, x_range, y_range)?;
-    Some(RichInput::Touchpad {
-        pad: 0,
-        finger: finger_idx as u8,
-        active: finger.active,
-        x,
-        y,
-    })
-}
-
-/// Decodes one read burst off a claimed motion node into the newest complete sample.
-fn read_sensors(sensors: &mut Sensors, buf: &[u8], size: usize) {
-    for chunk in buf.chunks_exact(size) {
-        // SAFETY: as `read_device` — exact-size chunk of plain `repr(C)` integers, read unaligned.
-        let ev = unsafe { chunk.as_ptr().cast::<InputEventRaw>().read_unaligned() };
-        match (ev.kind, ev.code) {
-            // Gyro first, then accelerometer: the wire's order, so no shuffling at send.
-            (EV_ABS, ABS_RX..=ABS_RZ) => sensors.axes[(ev.code - ABS_RX) as usize] = ev.value,
-            (EV_ABS, ABS_X..=ABS_Z) => sensors.axes[(ev.code - ABS_X) as usize + 3] = ev.value,
-            // Only a completed report is a sample: sending mid-report would mix axes from two.
-            (EV_SYN, SYN_REPORT) => sensors.dirty = true,
-            _ => {}
-        }
-    }
-}
-
-/// Sends the newest sample once per read burst, and only when it moved — a pad lying still
-/// reports forever, and re-sending its resting attitude at 500 Hz would cost a datagram per
-/// sample to tell the host nothing.
-///
-/// Rescaled to the wire's units before the `i16` clamp: this node reports `hid-playstation`'s
-/// *calibrated* readings (~1024 counts per deg/s) where the wire wants the host virtual pad's raw
-/// report scale (~20), so forwarding them verbatim rails every axis on the slightest movement.
-/// The divide also quantizes a resting pad's bias jitter to a clean zero, which the skip below
-/// then stops sending.
-fn flush_sensors(sensors: &mut Sensors, sink: &impl Fn(HidReport)) {
-    if !std::mem::take(&mut sensors.dirty) {
-        return;
-    }
-    let axes: [i16; 6] = std::array::from_fn(|i| {
-        ((i64::from(sensors.axes[i]) * sensors.scale[i]) >> SCALE_SHIFT)
-            .clamp(i64::from(i16::MIN), i64::from(i16::MAX)) as i16
-    });
-    if sensors.sent == Some(axes) {
-        return;
-    }
-    sensors.sent = Some(axes);
-    let [gx, gy, gz, ax, ay, az] = axes;
-    sink(HidReport::Rich(RichInput::Motion {
-        pad: 0,
-        gyro: [gx, gy, gz],
-        accel: [ax, ay, az],
-    }));
-}
-
 /// Sends the accumulated deltas as one `MouseMove`, undamped — damping is for the remote's
 /// coarse deltas and would make a real mouse sluggish.
 fn flush_motion(dev: &mut Device, sink: &impl Fn(HidReport)) {
@@ -1043,7 +755,7 @@ fn button_code(code: u16) -> Option<u32> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_pad_motion, is_pad_touchpad, is_tv_builtin, ABS_RZ, ABS_X};
+    use super::is_tv_builtin;
 
     #[test]
     fn tv_builtins_are_skipped_by_name() {
@@ -1054,32 +766,4 @@ mod tests {
         assert!(!is_tv_builtin("MX MCHNCL M Keyboard"));
     }
 
-    /// Sony's other nodes must not match: claiming the pad node would take the gamepad away from
-    /// SDL, and the motion-sensor node reports absolutely without ever being touched.
-    #[test]
-    fn pad_touchpad_matches_only_the_touch_node() {
-        let sony = || 0x054c;
-        // Touchpad: BTN_TOUCH on an absolute pointer.
-        assert!(is_pad_touchpad(true, true, sony));
-        // Pad node — absolute (sticks), face buttons instead of BTN_TOUCH.
-        assert!(!is_pad_touchpad(true, false, sony));
-        // Motion sensors — no touch, no pointer axes.
-        assert!(!is_pad_touchpad(false, false, sony));
-        // A touchscreen from anyone else stays the compositor's.
-        assert!(!is_pad_touchpad(true, true, || 0x046d));
-    }
-
-    #[test]
-    fn pad_motion_matches_only_the_sensor_node() {
-        let sony = || 0x054c;
-        let mut sensors = [0u8; 128];
-        for c in ABS_X..=ABS_RZ {
-            sensors[(c / 8) as usize] |= 1 << (c % 8);
-        }
-        assert!(is_pad_motion(&sensors, false, sony));
-        // The touchpad node (BTN_TOUCH) and the pad node (BTN_SOUTH, sticks and triggers) cover
-        // the same six axes — the buttons are the only thing that parts them from the sensors.
-        assert!(!is_pad_motion(&sensors, true, sony));
-        assert!(!is_pad_motion(&sensors, false, || 0x046d));
-    }
 }

--- a/src/platform/webos/evdev/pad.rs
+++ b/src/platform/webos/evdev/pad.rs
@@ -12,7 +12,9 @@ use std::os::unix::io::RawFd;
 
 use punktfunk_core::quic::RichInput;
 
-use super::{abs_range, abs_resolution, bit, device_vendor, HidReport, InputEventRaw, ABS_X, EV_ABS, EV_SYN, SYN_REPORT};
+use super::{
+    abs_range, abs_resolution, bit, device_vendor, HidReport, InputEventRaw, ABS_X, EV_ABS, EV_SYN, SYN_REPORT,
+};
 
 /// A claimed pad node, decoded. Never both at once — they are separate nodes — which is why this
 /// is one enum on [`super::Device`] rather than two `Option`s that must not overlap.
@@ -151,7 +153,7 @@ struct Finger {
 }
 
 /// A `PlayStation` pad's touchpad, which the kernel publishes as its own absolute/multitouch node
-/// alongside the pad itself — the source of the stuck left button [`mouse::is_touch_emulated`]
+/// alongside the pad itself — the source of the stuck left button [`super::mouse::is_touch_emulated`]
 /// describes, since the compositor drives the TV cursor from it. Claiming it takes it away from
 /// the compositor entirely and gives [`read_touch`] the contacts to forward as
 /// [`RichInput::Touchpad`], which is what makes a game's touchpad swipes work. The pad's own
@@ -338,7 +340,11 @@ fn flush_sensors(sensors: &mut Sensors, sink: &impl Fn(HidReport)) {
         return;
     }
     let axes: [i16; 6] = std::array::from_fn(|i| {
-        ((i64::from(sensors.axes[i]) * sensors.scale[i]) >> SCALE_SHIFT)
+        // Truncating divide, not an arithmetic shift: a shift floors, so a resting pad's
+        // negative bias jitter would quantize to -1 where the positive half quantizes to 0 and
+        // the skip below would never catch it. The divisor is a power of two, so this is still
+        // shifts, not a 64-bit divide call.
+        ((i64::from(sensors.axes[i]) * sensors.scale[i]) / (1 << SCALE_SHIFT))
             .clamp(i64::from(i16::MIN), i64::from(i16::MAX)) as i16
     });
     if sensors.sent == Some(axes) {
@@ -352,7 +358,6 @@ fn flush_sensors(sensors: &mut Sensors, sink: &impl Fn(HidReport)) {
         accel: [ax, ay, az],
     }));
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/platform/webos/evdev/pad.rs
+++ b/src/platform/webos/evdev/pad.rs
@@ -1,0 +1,389 @@
+//! `PlayStation` pad nodes: the touchpad and the motion sensors.
+//!
+//! The kernel's `hid-playstation` publishes a `DualSense` as three evdev nodes — the pad itself,
+//! its touchpad and its motion sensors. SDL2 reads only the first, so the other two reach the
+//! host's virtual pad only if this reader claims them: [`RichInput::Touchpad`] contacts for a
+//! game's swipes, [`RichInput::Motion`] samples for gyro aiming. Claiming is not optional either
+//! way — both advertise absolute axes the compositor would otherwise turn into a second cursor,
+//! the touchpad with a stuck left button (see [`is_pad_touchpad`]).
+//!
+//! Everything here is pad-shaped; the generic mouse/keyboard reader is [`super`].
+use std::os::unix::io::RawFd;
+
+use punktfunk_core::quic::RichInput;
+
+use super::{abs_range, abs_resolution, bit, device_vendor, HidReport, InputEventRaw, ABS_X, EV_ABS, EV_SYN, SYN_REPORT};
+
+/// A claimed pad node, decoded. Never both at once — they are separate nodes — which is why this
+/// is one enum on [`super::Device`] rather than two `Option`s that must not overlap.
+pub(super) enum Pad {
+    Touchpad(Touchpad),
+    Motion(Sensors),
+}
+
+impl Pad {
+    /// Claims `fd` if it is one of the two pad nodes, from its capability bits alone. `None`
+    /// leaves the node to the generic probe in [`super::open_hid`].
+    pub(super) fn probe(fd: RawFd, abs: &[u8; 128], key: &[u8; 128], absolute_pointer: bool) -> Option<Self> {
+        let vendor = || device_vendor(fd);
+        if is_pad_touchpad(absolute_pointer, bit(key, BTN_TOUCH), vendor) {
+            Some(Self::Touchpad(Touchpad::new(fd)))
+        } else if is_pad_motion(abs, bit(key, BTN_TOUCH) || bit(key, BTN_SOUTH), vendor) {
+            Some(Self::Motion(Sensors::new(fd)))
+        } else {
+            None
+        }
+    }
+
+    /// Decodes one read burst. A pad node shares none of the mouse/keyboard decode — different
+    /// axes, different wire plane — so it takes the whole burst on its own path.
+    pub(super) fn read(&mut self, buf: &[u8], size: usize, sink: &impl Fn(HidReport)) {
+        match self {
+            Self::Touchpad(pad) => read_touch(pad, buf, size, sink),
+            Self::Motion(sensors) => read_sensors(sensors, buf, size),
+        }
+    }
+
+    /// Sends what the burst accumulated. Touch contacts already went out per `SYN_REPORT` (a
+    /// gesture is a stream of positions, not one level), so only motion has anything pending.
+    pub(super) fn flush(&mut self, sink: &impl Fn(HidReport)) {
+        if let Self::Motion(sensors) = self {
+            flush_sensors(sensors, sink);
+        }
+    }
+
+    /// Lifts every contact the host still believes is down. A touch is a level, not an edge: a
+    /// pad unplugged (or a reader stopped) mid-gesture would otherwise leave the finger down on
+    /// the host's virtual pad with nothing left to release it. Motion needs no equivalent — a
+    /// dropped sample is an attitude the host keeps, not a stuck input.
+    pub(super) fn release(&mut self, sink: &impl Fn(HidReport)) {
+        let Self::Touchpad(pad) = self else {
+            return;
+        };
+        let (x_range, y_range) = (pad.x_range, pad.y_range);
+        for (i, finger) in pad.fingers.iter_mut().enumerate() {
+            if !std::mem::take(&mut finger.sent) {
+                continue;
+            }
+            finger.active = false;
+            finger.dirty = false;
+            if let Some(contact) = contact(i, finger, x_range, y_range) {
+                sink(HidReport::Rich(contact));
+            }
+        }
+    }
+
+    /// How the node is named in the open log.
+    pub(super) fn kind(&self) -> &'static str {
+        match self {
+            Self::Touchpad(_) => "pad touchpad",
+            Self::Motion(_) => "pad motion",
+        }
+    }
+}
+
+/// The motion node's six axes, contiguous and in the `DualSense` report's own order: `ABS_X`..`_Z`
+/// accelerometer, `ABS_RX`..`_RZ` gyro (pitch/yaw/roll).
+const ABS_Z: u16 = 0x02;
+const ABS_RX: u16 = 0x03;
+const ABS_RZ: u16 = 0x05;
+/// Multitouch protocol B: which contact the following `ABS_MT_*` values belong to.
+const ABS_MT_SLOT: u16 = 0x2f;
+const ABS_MT_POSITION_X: u16 = 0x35;
+const ABS_MT_POSITION_Y: u16 = 0x36;
+/// `-1` lifts the slot's contact; anything else is a new or continuing one.
+const ABS_MT_TRACKING_ID: u16 = 0x39;
+
+/// Finger-on-surface, which only touch-class nodes carry — the pad's own node reports
+/// `BTN_SOUTH`/`BTN_EAST` and never this. See [`is_pad_touchpad`].
+const BTN_TOUCH: u16 = 0x14a;
+
+/// The pad's own south face button — what parts the gamepad node from the motion node, which
+/// advertises the same six absolute axes but no buttons at all. See [`is_pad_motion`].
+const BTN_SOUTH: u16 = 0x130;
+
+/// Sony's USB/BT vendor id. `hid-playstation` binds only Sony pads, and it's the split-node
+/// layout that creates the touchpad node this identifies.
+const VENDOR_SONY: u16 = 0x054c;
+
+/// Motion decode state. Sensor readings are levels, not deltas, so a read burst collapses to its
+/// newest sample and an unchanged sample is worth no datagram at all — a resting pad reports at
+/// its full rate forever.
+#[derive(Default)]
+pub(super) struct Sensors {
+    /// Pitch/yaw/roll then accelerometer, in the node's own units, as the wire orders them.
+    axes: [i32; 6],
+    /// A `SYN_REPORT` completed a sample since the last send.
+    dirty: bool,
+    /// Last sample actually sent, for the unchanged-sample skip.
+    sent: Option<[i16; 6]>,
+    /// Per-axis node units → wire units, `SCALE_SHIFT` fixed point — see [`Sensors::new`].
+    scale: [i64; 6],
+}
+
+/// Multitouch decode state for a claimed pad touchpad, plus the axis ranges its coordinates are
+/// normalized against.
+///
+/// Protocol B (`ABS_MT_SLOT` + `ABS_MT_TRACKING_ID`), which is what `hid-playstation` reports and
+/// all the wire has room for: two contacts, matching the `finger` field's `0`/`1`.
+pub(super) struct Touchpad {
+    /// The slot `ABS_MT_*` values currently apply to. Out-of-range slots are parked on the last
+    /// finger rather than dropped, so a driver reporting more contacts than the wire carries
+    /// can't silently write past the array.
+    slot: usize,
+    fingers: [Finger; 2],
+    /// `(min, max)` of `ABS_MT_POSITION_X` / `_Y`, for the 0..=65535 normalization.
+    x_range: (i32, i32),
+    y_range: (i32, i32),
+}
+
+#[derive(Clone, Copy, Default)]
+struct Finger {
+    active: bool,
+    /// The host currently believes this contact is down. Gates the lift: a node claimed with a
+    /// finger already on it reports coordinates without a `ABS_MT_TRACKING_ID`, which would
+    /// otherwise send a lift for a contact the host never saw start.
+    sent: bool,
+    x: i32,
+    y: i32,
+    /// Something in this report changed the contact — sent at the next `SYN_REPORT` and cleared.
+    dirty: bool,
+}
+
+/// A `PlayStation` pad's touchpad, which the kernel publishes as its own absolute/multitouch node
+/// alongside the pad itself — the source of the stuck left button [`mouse::is_touch_emulated`]
+/// describes, since the compositor drives the TV cursor from it. Claiming it takes it away from
+/// the compositor entirely and gives [`read_touch`] the contacts to forward as
+/// [`RichInput::Touchpad`], which is what makes a game's touchpad swipes work. The pad's own
+/// *click* doesn't come through here at all — that arrives on the pad node as `BTN_TOUCHPAD`
+/// through SDL's controller layer.
+///
+/// Matched on ids and capability bits, not the device name, which varies by driver and firmware:
+/// `BTN_TOUCH` on an absolute pointer (the pad's own node reports face buttons instead), from a
+/// Sony vendor id. `vendor` is lazy because it costs an ioctl the bit tests don't.
+fn is_pad_touchpad(absolute_pointer: bool, has_btn_touch: bool, vendor: impl FnOnce() -> u16) -> bool {
+    absolute_pointer && has_btn_touch && vendor() == VENDOR_SONY
+}
+
+/// A `PlayStation` pad's motion sensors, published as a third node beside the pad and its
+/// touchpad. SDL2 never reads it, so gyro aiming reaches the host only if this reader forwards it
+/// as [`RichInput::Motion`].
+///
+/// Matched on capability bits and vendor, like [`is_pad_touchpad`]: all six sensor axes and no
+/// buttons. Both other nodes carry those same axes — the pad node's are its sticks and triggers,
+/// the touchpad's are the contact — so the buttons (`BTN_SOUTH`, `BTN_TOUCH`) are what part them.
+/// Matching the pad node here would grab the gamepad away from SDL entirely.
+fn is_pad_motion(abs: &[u8; 128], has_buttons: bool, vendor: impl FnOnce() -> u16) -> bool {
+    (ABS_X..=ABS_RZ).all(|c| bit(abs, c)) && !has_buttons && vendor() == VENDOR_SONY
+}
+
+/// The units the wire carries: the raw `DualSense` report scale the host's *virtual* pad is
+/// calibrated for, since the host injects inputtino's fixed calibration blob. Same convention as
+/// the Linux and Apple clients.
+const WIRE_GYRO_LSB_PER_DEG_S: i32 = 20;
+const WIRE_ACCEL_LSB_PER_G: i32 = 10_000;
+
+/// `hid-playstation`'s own output scale, for a node that publishes no `resolution`.
+const DS_GYRO_RES_PER_DEG_S: i32 = 1024;
+const DS_ACC_RES_PER_G: i32 = 8192;
+
+/// Fixed-point fraction bits of [`Sensors::scale`]. Both real ratios (20/1024, 10000/8192) are
+/// exact at 16.
+const SCALE_SHIFT: u32 = 16;
+
+impl Sensors {
+    /// Builds the per-axis wire scale once, at open. The node's `resolution` is per device — the
+    /// driver derives it from *this* pad's factory calibration blob — so it is the only honest
+    /// answer to what a raw count here means. Reciprocal rather than a divisor: armv7 has no
+    /// 64-bit divide, and [`flush_sensors`] runs per read burst.
+    fn new(fd: RawFd) -> Self {
+        let scale = std::array::from_fn(|i| {
+            // Gyro axes first, then accelerometer — the order `read_sensors` fills.
+            let (code, wire, fallback) = if i < 3 {
+                (ABS_RX + i as u16, WIRE_GYRO_LSB_PER_DEG_S, DS_GYRO_RES_PER_DEG_S)
+            } else {
+                (ABS_X + (i - 3) as u16, WIRE_ACCEL_LSB_PER_G, DS_ACC_RES_PER_G)
+            };
+            let res = match abs_resolution(fd, code) {
+                r if r > 0 => r,
+                _ => fallback,
+            };
+            (i64::from(wire) << SCALE_SHIFT) / i64::from(res)
+        });
+        Self {
+            scale,
+            ..Default::default()
+        }
+    }
+}
+
+impl Touchpad {
+    /// Reads the node's axis ranges once, at open. A node whose `ABS_MT_POSITION_*` ranges are
+    /// unusable is still worth claiming (the compositor must not have it) — it just reports no
+    /// contacts, which [`normalize`] enforces.
+    fn new(fd: RawFd) -> Self {
+        Self {
+            slot: 0,
+            fingers: [Finger::default(); 2],
+            x_range: abs_range(fd, ABS_MT_POSITION_X),
+            y_range: abs_range(fd, ABS_MT_POSITION_Y),
+        }
+    }
+}
+
+/// Device units → the wire's `0..=65535` across the pad. `None` when the driver gave no range to
+/// scale against, since a bogus coordinate is worse than no contact at all.
+fn normalize(x: i32, y: i32, x_range: (i32, i32), y_range: (i32, i32)) -> Option<(u16, u16)> {
+    let scale = |v: i32, (min, max): (i32, i32)| {
+        let span = i64::from(max) - i64::from(min);
+        (span > 0).then(|| ((i64::from(v.clamp(min, max)) - i64::from(min)) * 65535 / span) as u16)
+    };
+    // evdev's +y is already down, the direction the wire and the host's virtual pad expect.
+    Some((scale(x, x_range)?, scale(y, y_range)?))
+}
+
+/// Decodes one read burst off a claimed pad touchpad into [`RichInput::Touchpad`] contacts.
+///
+/// Contacts are sent at `SYN_REPORT`, not per axis event: a moving finger reports x and y as two
+/// events, and sending between them would put half the samples on a stale axis. Only contacts a
+/// report actually touched are sent, so a resting finger costs one burst of decode and no
+/// datagrams at all.
+fn read_touch(pad: &mut Touchpad, buf: &[u8], size: usize, sink: &impl Fn(HidReport)) {
+    for chunk in buf.chunks_exact(size) {
+        // SAFETY: as `read_device` — exact-size chunk of plain `repr(C)` integers, read unaligned.
+        let ev = unsafe { chunk.as_ptr().cast::<InputEventRaw>().read_unaligned() };
+        match (ev.kind, ev.code) {
+            // A slot the wire can't carry is parked on the last finger, where its coordinates are
+            // simply overwritten by a contact that does fit — the pad only ever reports two.
+            (EV_ABS, ABS_MT_SLOT) => pad.slot = (ev.value.max(0) as usize).min(pad.fingers.len() - 1),
+            (EV_ABS, ABS_MT_TRACKING_ID) => {
+                let finger = &mut pad.fingers[pad.slot];
+                finger.active = ev.value >= 0;
+                finger.dirty = true;
+            }
+            (EV_ABS, ABS_MT_POSITION_X | ABS_MT_POSITION_Y) => {
+                let finger = &mut pad.fingers[pad.slot];
+                if ev.code == ABS_MT_POSITION_X {
+                    finger.x = ev.value;
+                } else {
+                    finger.y = ev.value;
+                }
+                finger.dirty = true;
+            }
+            (EV_SYN, SYN_REPORT) => {
+                let (x_range, y_range) = (pad.x_range, pad.y_range);
+                for (i, finger) in pad.fingers.iter_mut().enumerate() {
+                    if !finger.dirty {
+                        continue;
+                    }
+                    finger.dirty = false;
+                    if !finger.active && !finger.sent {
+                        continue; // never announced — nothing to lift
+                    }
+                    let Some(contact) = contact(i, finger, x_range, y_range) else {
+                        continue;
+                    };
+                    finger.sent = finger.active;
+                    sink(HidReport::Rich(contact));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// One contact for the wire, or `None` when the node gave no usable axis range ([`normalize`]).
+///
+/// A lift's coordinates are whatever the contact last had, which is what the host wants — the
+/// release still has to land where the finger was. `pad` is 0 throughout: this client drives a
+/// single pad.
+fn contact(finger_idx: usize, finger: &Finger, x_range: (i32, i32), y_range: (i32, i32)) -> Option<RichInput> {
+    let (x, y) = normalize(finger.x, finger.y, x_range, y_range)?;
+    Some(RichInput::Touchpad {
+        pad: 0,
+        finger: finger_idx as u8,
+        active: finger.active,
+        x,
+        y,
+    })
+}
+
+/// Decodes one read burst off a claimed motion node into the newest complete sample.
+fn read_sensors(sensors: &mut Sensors, buf: &[u8], size: usize) {
+    for chunk in buf.chunks_exact(size) {
+        // SAFETY: as `read_device` — exact-size chunk of plain `repr(C)` integers, read unaligned.
+        let ev = unsafe { chunk.as_ptr().cast::<InputEventRaw>().read_unaligned() };
+        match (ev.kind, ev.code) {
+            // Gyro first, then accelerometer: the wire's order, so no shuffling at send.
+            (EV_ABS, ABS_RX..=ABS_RZ) => sensors.axes[(ev.code - ABS_RX) as usize] = ev.value,
+            (EV_ABS, ABS_X..=ABS_Z) => sensors.axes[(ev.code - ABS_X) as usize + 3] = ev.value,
+            // Only a completed report is a sample: sending mid-report would mix axes from two.
+            (EV_SYN, SYN_REPORT) => sensors.dirty = true,
+            _ => {}
+        }
+    }
+}
+
+/// Sends the newest sample once per read burst, and only when it moved — a pad lying still
+/// reports forever, and re-sending its resting attitude at 500 Hz would cost a datagram per
+/// sample to tell the host nothing.
+///
+/// Rescaled to the wire's units before the `i16` clamp: this node reports `hid-playstation`'s
+/// *calibrated* readings (~1024 counts per deg/s) where the wire wants the host virtual pad's raw
+/// report scale (~20), so forwarding them verbatim rails every axis on the slightest movement.
+/// The divide also quantizes a resting pad's bias jitter to a clean zero, which the skip below
+/// then stops sending.
+fn flush_sensors(sensors: &mut Sensors, sink: &impl Fn(HidReport)) {
+    if !std::mem::take(&mut sensors.dirty) {
+        return;
+    }
+    let axes: [i16; 6] = std::array::from_fn(|i| {
+        ((i64::from(sensors.axes[i]) * sensors.scale[i]) >> SCALE_SHIFT)
+            .clamp(i64::from(i16::MIN), i64::from(i16::MAX)) as i16
+    });
+    if sensors.sent == Some(axes) {
+        return;
+    }
+    sensors.sent = Some(axes);
+    let [gx, gy, gz, ax, ay, az] = axes;
+    sink(HidReport::Rich(RichInput::Motion {
+        pad: 0,
+        gyro: [gx, gy, gz],
+        accel: [ax, ay, az],
+    }));
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::{is_pad_motion, is_pad_touchpad, ABS_RZ, ABS_X};
+
+    /// Sony's other nodes must not match: claiming the pad node would take the gamepad away from
+    /// SDL, and the motion-sensor node reports absolutely without ever being touched.
+    #[test]
+    fn pad_touchpad_matches_only_the_touch_node() {
+        let sony = || 0x054c;
+        // Touchpad: BTN_TOUCH on an absolute pointer.
+        assert!(is_pad_touchpad(true, true, sony));
+        // Pad node — absolute (sticks), face buttons instead of BTN_TOUCH.
+        assert!(!is_pad_touchpad(true, false, sony));
+        // Motion sensors — no touch, no pointer axes.
+        assert!(!is_pad_touchpad(false, false, sony));
+        // A touchscreen from anyone else stays the compositor's.
+        assert!(!is_pad_touchpad(true, true, || 0x046d));
+    }
+
+    #[test]
+    fn pad_motion_matches_only_the_sensor_node() {
+        let sony = || 0x054c;
+        let mut sensors = [0u8; 128];
+        for c in ABS_X..=ABS_RZ {
+            sensors[(c / 8) as usize] |= 1 << (c % 8);
+        }
+        assert!(is_pad_motion(&sensors, false, sony));
+        // The touchpad node (BTN_TOUCH) and the pad node (BTN_SOUTH, sticks and triggers) cover
+        // the same six axes — the buttons are the only thing that parts them from the sensors.
+        assert!(!is_pad_motion(&sensors, true, sony));
+        assert!(!is_pad_motion(&sensors, false, || 0x046d));
+    }
+}


### PR DESCRIPTION
## Summary
- Rescale DualSense motion (gyro/accel) to the wire protocol's units using each axis's EVIOCGABS resolution, folded into a per-axis fixed-point (Q16) multiplier applied at packet-build time — no divide, since armv7 has no 64-bit divide and this runs at up to 500 Hz. Previously the raw hid-playstation calibrated values (~1024/deg/s, ~8192/g) were forwarded as-is against the host's DualSense report scale (20/deg/s, 10000/g), ~51x too large, clamping gyro to the i16 limit on the slightest movement.
- Fixed-point rescale truncates rather than shifts, so a resting pad's negative bias jitter quantizes to zero like the positive half (a shift floored it to -1), keeping the unchanged-sample skip effective and datagrams quiet at rest.
- Split `evdev.rs` into a generic reader (ioctl wrappers, poll loop, grab handling, mouse/keyboard decode) and a new `pad` submodule holding all PlayStation-specific decode (touchpad, motion, node matching, constants, unit tests) behind a `Pad` enum. Replaces two `Option`s documented as "never both set" with one `Option<Pad>`, and collapses the probe/kind call sites accordingly. Also reunites a touchpad-predicate doc comment that had drifted onto the wrong function.
- Consolidates the duplicated `/proc/bus/input/devices` DualSense-block parse into one helper, switches CRC32 to take an iterator instead of copying into a per-report `Vec`, and moves the feedback report sequence number from a process-global atomic to a local (only the sender thread touches it).
- `packaging/description.html`: adds a DualSense feature bullet (adaptive triggers, lightbar, player LEDs, touchpad, gyro, rumble) and an older-webOS caveat to the store listing.

This is a unit-conversion fix, not a filter — the reference punktfunk Linux client applies no smoothing or drift correction to this pad, it just converts into the host's expected report scale, so this branch does the same rather than adding calibration logic.

Reusing `pf-client-core` was evaluated and rejected: its Linux target pulls SDL3+hidapi, pipewire, ffmpeg-next and Vulkan, none of which cross-build for armv7 webOS, and it's SDL3-based while this app is SDL2 — constants were ported, the crate was not imported. The wire scale constants likely belong upstream next to the shared protocol type; deferred since punktfunk-core is a pinned git dependency here.

## Test plan
- [ ] `task docker:lint` / `docker:check` (clippy -D warnings, rustfmt clean on cross target — done pre-push)
- [ ] Deploy to a real TV and confirm DualSense gyro aim now tracks ~1:1 instead of clamping
- [ ] Confirm touchpad swipe still works on-device after the evdev module split (not yet verified on hardware)