### PR TITLE
Fix permanent audio mute after NDL loss hold, cap ABR at slider max

### DIFF
--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -208,6 +208,18 @@ the jump. `latch_pts_offset` takes only the first value after each `clear_pts_of
 resume, pacing off→on edge), and only off a frame NDL **accepted** — `play_audio` has no
 `ensure_loaded` guard of its own, so the latch doubles as the audio thread's start gate.
 
+⚠ **But flooring every packet on that ceiling is itself a mute.** A hold resume re-anchors the
+video plane onto the *current player clock*; when that maps the resumed audio BELOW the ceiling —
+the video plane was running ahead, or the clock plane bursted its `PRIME_LEAD` of silence during
+the gap — `fetch_max` pins every packet to one stamp, audio stops advancing, and nothing lifts it
+off again for the rest of the session. Field case (CX, 2026-08-20, offload on): the startup ABR
+probe at 300 Mbps saturated the airlink, one freeze-until-reanchor hold followed, and audio was
+gone from that point while video recovered normally. The fix is a per-latch `audio_skew_ms`: the
+first real packet after a re-latch shifts the whole stream to one packet above the ceiling and
+advances by its own cadence from there, leaving the floor as a defensive no-op. The drop path
+(`play_audio` with no latched offset) also **logs the gap on the packet that ends it** — silent, it
+cost a session its audio with nothing in the log to find.
+
 ⚠ The audio-enabled load returns success even on a TV that then plays nothing, so **no runtime
 probe can distinguish the two**. If a model regresses, the `NDL load state:`
 (`LOADCOMPLETED`/`PLAYING`) log says whether the pipeline ever started, and turning Experimental →
@@ -221,7 +233,9 @@ Don't read a slow *start* as this bug — a host compositor coming up has its ow
 
 This is `CAPACITY_PROBE_KBPS` in `punktfunk-core`'s `client/pump/data.rs` — a **hardcoded const with no cap knob** — directly at odds with this client capping its own speed test for the same "unbounded firehose starves the app" reason (below).
 
-**Fixed by capping the burst**: `main.rs` sets `PUNKTFUNK_ABR_PROBE_KBPS=300000` before anything spawns a thread (`setenv` isn't thread-safe, and core reads it while building its data-plane pump). Same order as the speed test's own cap, still above the airlink ceiling below — measures the link without knocking it over. Knob is core-side; **core v0.22.3 is the first release carrying it**, which is why the pin moved off v0.21.0. An older core ignores the variable.
+**Fixed by capping the burst**: `main.rs`'s `set_abr_env` sets `PUNKTFUNK_ABR_PROBE_KBPS` before anything spawns a thread (`setenv` isn't thread-safe, and core reads it while building its data-plane pump). Same order as the speed test's own cap, still above the airlink ceiling below — measures the link without knocking it over. Knob is core-side; **core v0.22.3 is the first release carrying it**, which is why the pin moved off v0.21.0. An older core ignores the variable.
+
+**300 was still too high on the CX** (2026-08-20): the probe saturated the airlink and opened a freeze-until-reanchor hold seconds into the session — the "Connection issues — recovering" toast — which on the offload path then cost the session its audio (see *NDL's audio plane*). Both knobs are now derived from `core::model::BITRATE_MAX_KBPS` — the settings slider's own ceiling, 200 Mbps, so there is one number to change: `PUNKTFUNK_ABR_MAX_MBPS` clamps the climb ceiling however it is learned (`abr::ceiling_cap_from_env`; the probe MEASURES that ceiling and `set_ceiling` is monotonic, so an over-read is otherwise permanent for the session), and the probe burst matches it — bursting above a ceiling the session can never use only buys loss. Descending below 200 stays core's job; its congestion signals walk the rate to their own 5 Mbps floor and **there is no client-side API to lower a ceiling mid-session**.
 
 That bump also brought a `connect` signature change — a `name: Option<String>` (label the host's pending-approval list shows) between `launch` and `pin`. All four call sites pass `None`, preserving fingerprint-derived label; sending a real TV name is a separate user-visible change.
 

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -4,6 +4,7 @@
 //! *widgets*, not this app's menus.
 use crate::core::caps::video_caps;
 use crate::core::event::MenuEvent;
+use crate::core::model::{BITRATE_AUTOMATIC, BITRATE_MAX_KBPS, BITRATE_MIN_KBPS, BITRATE_STEP_KBPS};
 use crate::services::store::{
     CodecPref, GamepadType, LogLevelOverride, OverrideField, Settings, SettingsOverride, VideoBackend,
 };
@@ -35,18 +36,8 @@ pub const RESOLUTIONS: [(u32, u32, &str, &str); 3] = [
 /// Sent to host as exact wire refresh rate.
 pub const REFRESH_RATES: [u32; 3] = [30, 60, 120];
 
-/// Slider range: 10-200 Mbps, 5 Mbps steps.
-pub const BITRATE_MIN_KBPS: u32 = 10_000;
-pub const BITRATE_MAX_KBPS: u32 = 200_000;
-pub const BITRATE_STEP_KBPS: u32 = 5_000;
-/// Sentinel one notch below `BITRATE_MIN_KBPS` on the slider: `punktfunk_core::client::NativeClient`
-/// arms its own client-side AIMD bitrate controller (`punktfunk_core::abr`) precisely when it's
-/// asked to connect with `bitrate_kbps == 0` — it reacts to unrecoverable frames, heavy loss,
-/// one-way-delay rise, and (via `session.rs`'s `report_decode_us` call) decode latency, backing off
-/// or climbing every ~750ms. A fixed Mbps number, however carefully picked, never adapts to a link
-/// that degrades mid-session — this does.
-pub const BITRATE_AUTOMATIC: u32 = 0;
-/// Above this, the Bitrate row shows a dull-orange caution caption (not a hard cap).
+/// Above this, the Bitrate row shows a dull-orange caution caption (not a hard cap). Presentation
+/// only, unlike the range itself (`core::model::BITRATE_MIN_KBPS`/`BITRATE_MAX_KBPS`).
 pub const BITRATE_WARN_KBPS: u32 = 150_000;
 
 /// Row indices for settings modal.

--- a/src/app/state/speedtest.rs
+++ b/src/app/state/speedtest.rs
@@ -9,9 +9,9 @@
 //! link speed. Bounds useful for bitrate picking on this TV.
 //!
 //! Rendering lives in `app::view::speedtest`.
-use crate::app::menu;
 use crate::app::App;
 use crate::core::event::MenuEvent;
+use crate::core::model;
 use crate::core::screen::Screen;
 use std::time::Instant;
 
@@ -199,5 +199,5 @@ pub(crate) fn recommended_kbps(outcome: &ProbeOutcome) -> Option<u32> {
     let raw = outcome.throughput_kbps / RECOMMEND_DENOMINATOR * RECOMMEND_NUMERATOR;
     // Whole Mbps, clamped to slider bounds (BITRATE_STEP_KBPS steps).
     let whole_mbps = (raw / 1000).max(1) * 1000;
-    Some(whole_mbps.clamp(menu::BITRATE_MIN_KBPS, menu::BITRATE_MAX_KBPS))
+    Some(whole_mbps.clamp(model::BITRATE_MIN_KBPS, model::BITRATE_MAX_KBPS))
 }

--- a/src/app/view/settings.rs
+++ b/src/app/view/settings.rs
@@ -2,6 +2,7 @@
 //! Logic lives in `app::state::settings`.
 use crate::app::menu;
 use crate::app::menu::SettingsScope;
+use crate::core::model;
 use crate::core::VERSION;
 use crate::services::store::{GamepadType, Settings, VideoBackend};
 use crate::ui;
@@ -92,11 +93,11 @@ pub(crate) fn rows(
     dualsense_limited: bool,
     webos_major: Option<u32>,
 ) -> Vec<FocusRow> {
-    let bitrate_frac = if settings.bitrate_kbps == menu::BITRATE_AUTOMATIC {
+    let bitrate_frac = if settings.bitrate_kbps == model::BITRATE_AUTOMATIC {
         0.0
     } else {
-        (settings.bitrate_kbps.saturating_sub(menu::BITRATE_MIN_KBPS)) as f32
-            / (menu::BITRATE_MAX_KBPS - menu::BITRATE_MIN_KBPS) as f32
+        (settings.bitrate_kbps.saturating_sub(model::BITRATE_MIN_KBPS)) as f32
+            / (model::BITRATE_MAX_KBPS - model::BITRATE_MIN_KBPS) as f32
     };
     let row_for = |logical: usize| match logical {
         menu::ROW_RESOLUTION => FocusRow::dropdown(
@@ -112,7 +113,7 @@ pub(crate) fn rows(
         menu::ROW_BITRATE => FocusRow::slider(
             crate::app::view::icons::ICON_SIGNAL,
             "Bitrate",
-            if settings.bitrate_kbps == menu::BITRATE_AUTOMATIC {
+            if settings.bitrate_kbps == model::BITRATE_AUTOMATIC {
                 "Automatic".to_string()
             } else {
                 format!("{} Mbps", settings.bitrate_kbps / 1000)

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -401,6 +401,23 @@ pub enum LogLevelOverride {
     Error,
 }
 
+/// Slider range, in 5 Mbps steps.
+pub const BITRATE_MIN_KBPS: u32 = 10_000;
+/// The one bitrate ceiling this client has. It bounds the manual slider AND, through `main`,
+/// `punktfunk_core::abr`'s automatic climb (`PUNKTFUNK_ABR_MAX_MBPS`) and the startup
+/// link-capacity probe's burst target (`PUNKTFUNK_ABR_PROBE_KBPS`) — an Automatic session that
+/// could climb past what the slider allows would just be a second, hidden setting.
+pub const BITRATE_MAX_KBPS: u32 = 200_000;
+/// Slider granularity — also the lattice of valid fixed-bitrate values.
+pub const BITRATE_STEP_KBPS: u32 = 5_000;
+/// Sentinel one notch below `BITRATE_MIN_KBPS` on the slider: `punktfunk_core::client::NativeClient`
+/// arms its own client-side AIMD bitrate controller (`punktfunk_core::abr`) precisely when it's
+/// asked to connect with `bitrate_kbps == 0` — it reacts to unrecoverable frames, heavy loss,
+/// one-way-delay rise, and (via `session.rs`'s `report_decode_us` call) decode latency, backing off
+/// or climbing every ~750ms. A fixed Mbps number, however carefully picked, never adapts to a link
+/// that degrades mid-session — this does.
+pub const BITRATE_AUTOMATIC: u32 = 0;
+
 /// Stream settings: resolution/framerate/bitrate/HDR/codec, plus the input and diagnostics
 /// toggles the Settings screens expose.
 ///
@@ -413,9 +430,8 @@ pub struct Settings {
     pub height: u32,
     /// Refresh rate (30/60/120) — sent to the host as the exact wire `Mode.refresh_hz`.
     pub refresh_hz: u32,
-    /// `0` (Automatic — `punktfunk_core`'s own client-side AIMD bitrate controller, see
-    /// `menu::BITRATE_AUTOMATIC`) or 10_000-150_000 (10-150 Mbps) fixed, adjusted via the settings
-    /// slider — see `menu::BITRATE_MIN_KBPS`/`BITRATE_MAX_KBPS`.
+    /// [`BITRATE_AUTOMATIC`] (`punktfunk_core`'s own client-side AIMD bitrate controller) or a
+    /// fixed [`BITRATE_MIN_KBPS`]..=[`BITRATE_MAX_KBPS`], adjusted via the settings slider.
     pub bitrate_kbps: u32,
     pub hdr_enabled: bool,
     /// Preferred session codec — see [`CodecPref`].
@@ -492,7 +508,7 @@ impl Default for Settings {
             // Automatic: a fixed number, however carefully picked (aurora-tv's own
             // moonlight-tv wiki calls ~35-40 Mbps the practical sweet spot for this decode
             // path), never adapts to a link that degrades mid-session the way punktfunk's
-            // own client-side AIMD controller does — see `menu::BITRATE_AUTOMATIC`.
+            // own client-side AIMD controller does — see [`BITRATE_AUTOMATIC`].
             bitrate_kbps: 0,
             hdr_enabled: true,
             stats_overlay: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ mod services;
 mod session;
 mod ui;
 
+use crate::core::model::BITRATE_MAX_KBPS;
+
 #[cfg(target_os = "linux")]
 mod runtime;
 
@@ -31,20 +33,21 @@ mod runtime {
     }
 }
 
-/// Ceiling for `punktfunk-core`'s startup link-capacity probe, in kbps.
+/// [`BITRATE_MAX_KBPS`] in the Mbps unit `PUNKTFUNK_ABR_MAX_MBPS` is spelled in.
+const ABR_MAX_MBPS: u32 = BITRATE_MAX_KBPS / 1_000;
+
+/// Publishes the two automatic-bitrate knobs `punktfunk_core` reads from the environment, both
+/// derived from [`BITRATE_MAX_KBPS`] — the client has one bitrate ceiling, and the settings slider
+/// is where it is edited.
 ///
-/// Core bursts at 2 Gbps by default, deliberately far above any plausible link so the burst
-/// measures the link rather than itself. On a TV's Wi-Fi that backfires: measured on the G5,
-/// three back-to-back connects split two ways — the two whose probe finished in ~1-2 s had
-/// video within 2-4 s, the one that hit core's 6 s timeout showed **no video for 14 seconds**
-/// (a black screen the user reads as a failed connect), and even a "successful" probe on that
-/// link had the host dropping 20k packets.
-///
-/// 300 Mbps matches what this client already burst-tests its own speed probe at
-/// (`session::probe::run_speed_probe`, capped for the same reason: an unbounded firehose starves a
-/// 2-3 core TV), and still sits well above the ~245 Mbps airlink ceiling this hardware can
-/// reach — so it measures the link without knocking it over.
-const ABR_PROBE_KBPS: &str = "300000";
+/// `PUNKTFUNK_ABR_MAX_MBPS` clamps core's climb ceiling however it is learned;
+/// `PUNKTFUNK_ABR_PROBE_KBPS` shrinks the startup burst that measures it, whose 2 Gbps default
+/// knocks a TV's Wi-Fi over. See `docs/NOTES.md` § "ABR startup probe" for the measurements
+/// behind both, and why descent below the ceiling stays core's job.
+fn set_abr_env() {
+    std::env::set_var("PUNKTFUNK_ABR_PROBE_KBPS", BITRATE_MAX_KBPS.to_string());
+    std::env::set_var("PUNKTFUNK_ABR_MAX_MBPS", ABR_MAX_MBPS.to_string());
+}
 
 fn main() -> anyhow::Result<()> {
     // Load-bearing, not belt-and-braces: `ureq` is built without a backend feature
@@ -55,10 +58,9 @@ fn main() -> anyhow::Result<()> {
     // mTLS library agent is unaffected either way; it names its provider via
     // `builder_with_provider`. Must land before any thread that might issue a request.
     punktfunk_core::tls::install_default_provider();
-    // Set before anything spawns a thread: `set_var` is not thread-safe, and core reads this
-    // while building its data-plane pump during `connect`. An older core simply ignores it.
-    // Deliberately no `PUNKTFUNK_ABR_MAX_MBPS` alongside it — the probe measures this link's
-    // ceiling, and a compiled-in cap would override that measurement with a guess.
-    std::env::set_var("PUNKTFUNK_ABR_PROBE_KBPS", ABR_PROBE_KBPS);
+    // Set before anything spawns a thread: `set_var` is not thread-safe, and core reads these
+    // while building its data-plane pump and bitrate controller during `connect`. An older core
+    // simply ignores them.
+    set_abr_env();
     runtime::run()
 }

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -5,7 +5,7 @@
 //! Never calls `NDL_DirectVideoSetArea` — stutters above 1080p, and v2 sizes its own
 //! punch-through plane (v1 can't; see [`super::v1`]).
 use std::ffi::{c_int, c_longlong, c_uint, c_void};
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, Ordering};
 use std::sync::{Mutex, MutexGuard, PoisonError};
 use std::time::{Duration, Instant};
 
@@ -43,6 +43,12 @@ const PRIME_LEAD: i64 = 8;
 /// Gap between prime bursts. Polled through, not slept through — the callback lands mid-gap,
 /// and this is launch-path time, i.e. black screen.
 const PRIME_RETRY: Duration = Duration::from_millis(20);
+
+/// Re-latch skew past which lip sync is audibly off and the jump that caused it is worth a line.
+const SKEW_WARN_MS: i64 = 200;
+
+/// Real packets dropped for want of a latched timeline between warnings — 200 × 5 ms = 1 s.
+const NO_OFFSET_WARN_PACKETS: u32 = 200;
 
 /// How long the clock plane waits for the real stream before feeding the plane itself.
 ///
@@ -112,6 +118,13 @@ pub struct NdlVideo {
     /// timestamp going backwards. Never reset — the ceiling has to survive a re-latch, which is
     /// exactly the case that would otherwise rewind it.
     last_audio_pts_ms: AtomicI64,
+    /// Constant added to every mapped real-audio stamp, re-derived on each latch
+    /// ([`Self::derive_audio_skew`]) so a resumed run lands above [`Self::last_audio_pts_ms`]
+    /// rather than flooring onto it — see [`Self::play_audio`].
+    audio_skew_ms: AtomicI64,
+    /// Real packets dropped since the current offset gap opened; both the periodic warning and
+    /// the one on the packet that ends the gap read it.
+    dropped_no_offset: AtomicU32,
     /// Player-clock ms at the last REAL packet fed by [`Self::play_audio`].
     /// [`Self::run_clock_plane`] reads it to stay off the plane while the real stream carries it.
     ///
@@ -215,6 +228,8 @@ impl NdlVideo {
             has_audio_plane: with_audio,
             pts_offset_ns: AtomicI64::new(NO_PTS_OFFSET),
             last_audio_pts_ms: AtomicI64::new(primed_pts_ms),
+            audio_skew_ms: AtomicI64::new(0),
+            dropped_no_offset: AtomicU32::new(0),
             last_real_feed_ms: AtomicI64::new(0),
             load_confirmed: AtomicBool::new(confirmed),
             pending_hdr: Mutex::new(None),
@@ -300,20 +315,54 @@ impl NdlVideo {
     /// size of the jump. NDL takes that as a rewind and stops playing audio for the rest of the
     /// session (observed on CX: audio worked in a session with no flush, gone in one with).
     /// `clear_pts_offset` at the sink's anchor resets is what re-derives it.
-    pub(crate) fn latch_pts_offset(&self, offset_ns: i64) {
+    ///
+    /// `base_ns` is the same frame's mapped stamp, i.e. where the resumed audio will land: this
+    /// edge is also where [`Self::derive_audio_skew`] runs, so the audio thread's steady state
+    /// stays a single relaxed load.
+    pub(crate) fn latch_pts_offset(&self, offset_ns: i64, base_ns: u64) {
         // The steady state is "already latched", and this runs per fed frame — keep the exclusive
         // access off the video thread's hot path once the offset is set.
         if self.pts_offset_ns.load(Ordering::Relaxed) != NO_PTS_OFFSET {
             return;
         }
-        let _ = self
+        if self
             .pts_offset_ns
-            .compare_exchange(NO_PTS_OFFSET, offset_ns, Ordering::Relaxed, Ordering::Relaxed);
+            .compare_exchange(NO_PTS_OFFSET, offset_ns, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            self.derive_audio_skew((base_ns / 1_000_000) as i64);
+        }
+    }
+
+    /// Place the run that starts at `base_ms` one packet above the audio ceiling, so the resumed
+    /// stream advances instead of flooring onto it — see [`Self::play_audio`].
+    ///
+    /// Under `lock_ffi` because the clock plane raises that ceiling from its own thread; the CAS
+    /// above makes this the once-per-latch path, not the per-frame one, so the video thread pays
+    /// for the guard only on a re-anchor.
+    fn derive_audio_skew(&self, base_ms: i64) {
+        let skew = {
+            let _ffi = lock_ffi();
+            // Never negative: a run already above the ceiling needs no help, and pulling it DOWN
+            // to meet one is the rewind NDL mutes on.
+            let skew = (self.last_audio_pts_ms.load(Ordering::Relaxed) + PRIME_PACKET_MS - base_ms).max(0);
+            self.audio_skew_ms.store(skew, Ordering::Relaxed);
+            skew
+        };
+        // The cost of the skew is lip sync: audio rides `skew` ms behind the picture until the next
+        // re-latch, because NDL has no way to pull its ceiling back down. A filler burst costs
+        // `PRIME_LEAD` packets of it and nobody notices; a video plane that jumped seconds ahead
+        // costs seconds, which is worth seeing in the log rather than only hearing. Logged outside
+        // the guard — the video feed shares it.
+        if skew > SKEW_WARN_MS {
+            tracing::warn!("NDL audio re-latched {skew}ms behind the picture (video plane jumped)");
+        }
     }
 
     /// Drop the latched offset — the two timelines just decoupled (the sink reset its anchor
     /// after a freeze-until-reanchor hold).
-    /// [`play_audio`](Self::play_audio) holds packets until the video plane latches a fresh one.
+    /// [`play_audio`](Self::play_audio) holds packets until the video plane latches a fresh one,
+    /// which is also where the skew that carries them is re-derived.
     pub(crate) fn clear_pts_offset(&self) {
         self.pts_offset_ns.store(NO_PTS_OFFSET, Ordering::Relaxed);
     }
@@ -329,22 +378,49 @@ impl NdlVideo {
     ///
     /// Returns `Ok(())` having fed nothing while no offset is latched: audio before the first
     /// video frame has no timeline to join yet, and dropping those few packets beats feeding them
-    /// at a stamp that jumps once the real offset lands.
+    /// at a stamp that jumps once the real offset lands. A gap is logged while it lasts and again
+    /// on the packet that ends it — the silent version of this cost a session its audio with
+    /// nothing in the log to find.
     ///
-    /// The stamp is also floored at the previous one — NDL reads a timestamp going backwards (an
-    /// out-of-order packet, or a re-latch after a hold) as a rewind and mutes the rest of the
-    /// session rather than resyncing.
+    /// **The stamp is skewed, not floored, across a re-latch.** NDL reads a timestamp going
+    /// backwards as a rewind and mutes the rest of the session, so the ceiling below is mandatory
+    /// — but flooring EVERY packet onto it is what killed audio in the field: the sink's re-anchor
+    /// maps the resumed stream onto the current player clock, and when that lands below the
+    /// ceiling (the video plane was running ahead — a receive-backlog flush jumping to live — or
+    /// the clock plane bursted its [`PRIME_LEAD`] of silence during the gap) every packet floors
+    /// to the same stamp, audio stops advancing, and nothing ever lifts it back off.
+    /// [`Self::derive_audio_skew`] moves the whole run above the ceiling instead; the floor stays
+    /// as the guard for what it cannot see — an out-of-order packet, or a burst landing between
+    /// the latch and the run's first packet — and is also what publishes the ceiling itself.
     pub fn play_audio(&self, packet: &[u8], host_pts_ns: u64) -> Result<()> {
-        let offset_ns = self.pts_offset_ns.load(Ordering::Relaxed);
-        if offset_ns == NO_PTS_OFFSET {
+        if self.pts_offset_ns.load(Ordering::Relaxed) == NO_PTS_OFFSET {
+            let dropped = self.dropped_no_offset.fetch_add(1, Ordering::Relaxed) + 1;
+            // Reported on the way through, not only on the packet that ends the gap: a gap that
+            // never ends is exactly the failure worth seeing, and that path logs nothing at all.
+            if dropped % NO_OFFSET_WARN_PACKETS == 0 {
+                tracing::warn!(
+                    "NDL audio dropped for {}ms — no latched timeline (the video plane has fed no \
+                     accepted frame since the last hold); the clock plane is pacing the picture",
+                    i64::from(dropped) * PRIME_PACKET_MS,
+                );
+            }
             return Ok(());
         }
-        let raw_ms = (host_pts_ns as i64).saturating_add(offset_ns).max(0) / 1_000_000;
-        // Floor under the guard, never before it: flooring first lets a packet measured against an
-        // older ceiling block here while `burst_silence` feeds higher, then hand NDL the stale
-        // stamp — a rewind, which mutes the session for good.
+        // Map, skew and floor under the guard, never before it: `lock_ffi` is the audio plane's
+        // only feed path, so this is what serialises against `burst_silence` — outside it a packet
+        // can read a ceiling the filler has already moved past and hand NDL a stale stamp, i.e. the
+        // rewind this whole path exists to avoid. The offset is re-read here for the same reason:
+        // the check above is only a fast path, and a clear/re-latch landing between the two would
+        // pair the OLD offset with the NEW skew — a stamp the size of the video plane's jump above
+        // the ceiling, onto which every later packet then floors.
         let ret = {
             let _ffi = lock_ffi();
+            let offset_ns = self.pts_offset_ns.load(Ordering::Relaxed);
+            if offset_ns == NO_PTS_OFFSET {
+                return Ok(());
+            }
+            let raw_ms = ((host_pts_ns as i64).saturating_add(offset_ns).max(0) / 1_000_000)
+                .saturating_add(self.audio_skew_ms.load(Ordering::Relaxed));
             let pts_ms = self.last_audio_pts_ms.fetch_max(raw_ms, Ordering::Relaxed).max(raw_ms);
             // SAFETY: NDL reads `size` bytes synchronously and does not retain the pointer.
             unsafe {
@@ -361,6 +437,15 @@ impl NdlVideo {
         // Player clock, not the packet's domain: the reader asks "how long since a packet ARRIVED".
         self.last_real_feed_ms
             .store((self.elapsed_ns() / 1_000_000) as i64, Ordering::Relaxed);
+        let dropped = self.dropped_no_offset.swap(0, Ordering::Relaxed);
+        if dropped > 0 {
+            tracing::info!(
+                "NDL audio resumed after {dropped} packet(s) ({}ms) with no latched timeline, \
+                 skew now {}ms",
+                i64::from(dropped) * PRIME_PACKET_MS,
+                self.audio_skew_ms.load(Ordering::Relaxed),
+            );
+        }
         Ok(())
     }
 

--- a/src/session/probe.rs
+++ b/src/session/probe.rs
@@ -95,7 +95,7 @@ pub fn request_access(host: &str, port: u16, identity: (String, String), timeout
 /// own result message.
 ///
 /// The target is chosen against what the answer can actually be *used* for: the bitrate
-/// slider caps at `menu::BITRATE_MAX_KBPS` (200 Mbps) and the recommendation is 70 % of
+/// slider caps at `core::model::BITRATE_MAX_KBPS` (200 Mbps) and the recommendation is 70 % of
 /// measured, so anything above ~285 Mbps already produces an identical clamped
 /// recommendation. 320 Mbps stays above that — it can still detect any ceiling that
 /// would change the advice — while keeping the overshoot bounded. Measured on a G5

--- a/src/session/sink.rs
+++ b/src/session/sink.rs
@@ -196,7 +196,7 @@ impl VideoPlayer {
     /// `run_clock_plane` stamps in the player clock directly.
     fn latch_pts_offset(&self, frame_pts_ns: u64, base_ns: u64) {
         if let Some(ndl) = self.audio_plane_ndl() {
-            ndl.latch_pts_offset(base_ns as i64 - frame_pts_ns as i64);
+            ndl.latch_pts_offset(base_ns as i64 - frame_pts_ns as i64, base_ns);
         }
     }
 


### PR DESCRIPTION
## Summary
- Loss-hold re-anchor could drop video's PTS base below NDL's latched audio ceiling; `fetch_max` then floored every later packet on that stamp and audio never resumed. Add a per-latch `audio_skew_ms` (derived in `derive_audio_skew`) so resumed audio rides above the ceiling instead of being swallowed by it.
- Re-read `pts_offset_ns` under `lock_ffi` in `play_audio` so a concurrent re-latch can't pair an old offset with the new skew and produce a stamp far above the ceiling.
- Cap the ABR probe burst and ceiling at `BITRATE_MAX_KBPS` (200 Mbps) instead of a fixed 300 Mbps, which was saturating the airlink and triggering the loss hold that exposed the mute. Moved `BITRATE_MIN/MAX/STEP/AUTOMATIC_KBPS` from `app::menu` to `core::model` so `main.rs` can read them.
- Recorded both invariants in `docs/NOTES.md`.

## Test plan
- [x] `task -s docker:lint` clean
- [ ] Force a loss hold on the TV with offload on and confirm audio returns (look for `NDL audio resumed after N packet(s) ... skew now Xms`)
- [ ] Confirm ABR probe/ceiling behavior at 200 Mbps cap on device