### PR TITLE
Declare mid-stream gamepad kind on hotplug arrival

### DIFF
--- a/src/platform/webos/gamepad.rs
+++ b/src/platform/webos/gamepad.rs
@@ -73,6 +73,27 @@ fn type_for_name(name: &str) -> Option<crate::services::store::GamepadType> {
     }
 }
 
+/// Declares pad `pad`'s kind to the host mid-session, for a controller plugged in AFTER the
+/// handshake: the session default was settled from whatever was attached at connect time, so a
+/// `DualSense` connected mid-stream would otherwise drive the host's default Xbox pad — wrong
+/// glyphs and no adaptive triggers. `None` for `Auto` (nothing to declare; the host's own choice
+/// is what `Auto` means). Hosts without `HOST_CAP_GAMEPAD_STATE` ignore the tag.
+pub fn arrival_event(kind: crate::services::store::GamepadType, pad: u8) -> Option<InputEvent> {
+    let pref = kind.to_core();
+    if pref == punktfunk_core::config::GamepadPref::Auto {
+        return None;
+    }
+    Some(InputEvent {
+        kind: InputKind::GamepadArrival,
+        _pad: [0; 3],
+        code: u32::from(pref.to_u8()),
+        // No pad-audio caps: this client renders neither haptics nor pad speaker.
+        x: 0,
+        y: 0,
+        flags: punktfunk_core::input::encode_gamepad_arrival(pad, 0),
+    })
+}
+
 /// SDL2's `Axis` enum → punktfunk's `AXIS_*` wire id.
 fn axis_id(axis: Axis) -> u32 {
     match axis {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -25,6 +25,10 @@ use crate::ui::render::DrawCmd;
 struct ConnectOutcome {
     handle: std::thread::JoinHandle<Result<session::Connected>>,
     settings: store::Settings,
+    /// Whether the user's pick was `Automatic` — `settings.gamepad_type` has already been
+    /// resolved against the attached pad, so this is the only thing left that says a pad
+    /// hotplugged mid-stream should re-decide the kind rather than keep the session default.
+    gamepad_auto: bool,
     /// When the wait for a decoded frame runs out — one deadline for the whole launch, set by
     /// the loading screen (`app::hero`) and honoured again by the reveal in `stream`, so a host
     /// that connects and then decodes nothing costs [`crate::app::hero::FIRST_FRAME_WAIT`] once

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -14,6 +14,28 @@ fn reveal_deadline(started: Option<Instant>) -> Instant {
     started.unwrap_or_else(|| Instant::now() + crate::app::hero::FIRST_FRAME_WAIT)
 }
 
+/// How many copies of a mid-stream `GamepadArrival` to send — see its one caller.
+const ARRIVAL_SENDS: usize = 3;
+
+/// `DualSense` HID feedback (adaptive triggers, lightbar), opened only for a pad kind that emits
+/// it — anything else never sends these events. Not found (USB pad, no `luna-send-pub`) isn't an
+/// error: logged once, the feature just stays off.
+fn open_ds_feedback(kind: store::GamepadType) -> Option<crate::platform::webos::dualsense::Feedback> {
+    if !kind.is_dualsense() {
+        return None;
+    }
+    match crate::platform::webos::dualsense::find_address() {
+        Some(addr) => crate::platform::webos::dualsense::Feedback::new(addr),
+        None => {
+            tracing::info!(
+                "no Bluetooth DualSense found in /proc/bus/input/devices — \
+                 adaptive triggers off for this session"
+            );
+            None
+        }
+    }
+}
+
 pub(super) fn run_inner() -> Result<()> {
     // Stops webOS's launcher intercepting Back/Guide as its own shortcut (see `gamepad.rs`'s
     // BTN_GUIDE mapping). Must be set before window creation — these hints only latch there.
@@ -105,6 +127,7 @@ pub(super) fn run_inner() -> Result<()> {
         let Some(ConnectOutcome {
             handle: connect_thread,
             settings,
+            gamepad_auto,
             first_frame_deadline,
         }) = run_ui_flow(
             &mut canvas,
@@ -219,20 +242,10 @@ pub(super) fn run_inner() -> Result<()> {
         // DualSense HID feedback (adaptive triggers, lightbar), started only for an actual
         // DualSense — anything else never emits these events. Not found (USB pad, no
         // `luna-send-pub`) isn't an error: logged once, feature just stays off.
-        let mut ds_feedback = if settings.gamepad_type.is_dualsense() {
-            match crate::platform::webos::dualsense::find_address() {
-                Some(addr) => crate::platform::webos::dualsense::Feedback::new(addr),
-                None => {
-                    tracing::info!(
-                        "no Bluetooth DualSense found in /proc/bus/input/devices — \
-                             adaptive triggers off for this session"
-                    );
-                    None
-                }
-            }
-        } else {
-            None
-        };
+        let mut ds_feedback = open_ds_feedback(settings.gamepad_type);
+        // The pad kind the host currently builds for pad 0: the handshake default until a
+        // controller plugged in mid-stream declares another one.
+        let mut declared_pad = settings.gamepad_type;
 
         let mut scroll_acc = mouse::ScrollAccumulator::default();
         // Every button the client synthesizes rather than forwards: the remote's OK gestures and
@@ -365,13 +378,40 @@ pub(super) fn run_inner() -> Result<()> {
                         connected.disconnect_quit();
                         break 'running StreamOutcome::Quit;
                     }
-                    Event::ControllerDeviceAdded { which, .. } if controller.is_none() => {
-                        match game_controller.open(which) {
-                            Ok(c) => {
-                                tracing::info!("controller connected: {}", c.name());
-                                controller = Some(c);
+                    Event::ControllerDeviceAdded { which, .. } => {
+                        if controller.is_none() {
+                            match game_controller.open(which) {
+                                Ok(c) => {
+                                    tracing::info!("controller connected: {}", c.name());
+                                    controller = Some(c);
+                                }
+                                Err(e) => tracing::warn!("controller open failed: {e}"),
                             }
-                            Err(e) => tracing::warn!("controller open failed: {e}"),
+                        }
+                        // Outside the open, as in the menu loop: only the first pad becomes
+                        // `controller`, but a later one is still what `detect_type` names.
+                        // Under `Automatic` the handshake settled the pad kind from whatever was
+                        // attached at connect time — usually nothing — so a pad arriving now has
+                        // to declare itself or the host keeps driving its default Xbox pad. An
+                        // explicit pick needs none of this: the session default already is it.
+                        let kind = if gamepad_auto {
+                            gamepad::detect_type(&game_controller).unwrap_or_default()
+                        } else {
+                            declared_pad
+                        };
+                        if kind != declared_pad {
+                            if let Some(ev) = gamepad::arrival_event(kind, 0) {
+                                tracing::info!("pad 0 is {kind:?} (hotplug) — declaring it to the host");
+                                // Sent by hand rather than by the core's own arrival path, so it
+                                // carries no retransmit of its own; input rides unreliable
+                                // datagrams. Re-declaring is idempotent host-side.
+                                for _ in 0..ARRIVAL_SENDS {
+                                    connected.send_input(&ev);
+                                }
+                                declared_pad = kind;
+                                // Adaptive triggers/lightbar follow the kind the host now builds.
+                                ds_feedback = kind.is_dualsense().then(|| open_ds_feedback(kind)).flatten();
+                            }
                         }
                     }
                     Event::ControllerDeviceRemoved { .. } => {

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -121,7 +121,11 @@ pub(super) fn run_ui_flow(
     // Set once the reachability check passes — `spawn_connect` is already
     // running by then, so this just carries its handle out of the loop for
     // `run_inner` to join once the launch animation finishes.
-    let mut connect_handle: Option<(std::thread::JoinHandle<Result<session::Connected>>, store::Settings)> = None;
+    let mut connect_handle: Option<(
+        std::thread::JoinHandle<Result<session::Connected>>,
+        store::Settings,
+        bool,
+    )> = None;
     // Yellow button log overlay works here too (see streaming loop).
     let mut yellow_held = false;
     let mut home_held = false;
@@ -218,9 +222,10 @@ pub(super) fn run_ui_flow(
                 // point where the game being launched is known and the settings copy that
                 // rides the whole session is made. Clamped to caps like any global value.
                 let mut settings = launch_settings(&app, &target);
+                let gamepad_auto = settings.gamepad_type == store::GamepadType::Auto;
                 settings = resolve_gamepad_type(settings, game_controller);
                 let handle = spawn_connect(identity.clone(), target, settings)?;
-                connect_handle = Some((handle, settings));
+                connect_handle = Some((handle, settings, gamepad_auto));
             }
         }
         // Without a hero the screen is handed to the streaming loop at the end of the
@@ -232,7 +237,7 @@ pub(super) fn run_ui_flow(
             // `is_finished` is monotonic, so this needs no latch of its own.
             let connect = match connect_handle.as_ref() {
                 _ if CONNECT_FAILED.load(Ordering::Relaxed) => Connect::Failed,
-                Some((h, _)) if !h.is_finished() => Connect::Pending,
+                Some((h, _, _)) if !h.is_finished() => Connect::Pending,
                 _ => Connect::Done,
             };
             let presenting = crate::platform::webos::ndl::presenting();
@@ -522,9 +527,10 @@ pub(super) fn run_ui_flow(
     if text_input_active {
         text_input.stop();
     }
-    Ok(connect_handle.map(|(handle, settings)| ConnectOutcome {
+    Ok(connect_handle.map(|(handle, settings, gamepad_auto)| ConnectOutcome {
         handle,
         settings,
+        gamepad_auto,
         first_frame_deadline: app.render.hero.first_frame_deadline(),
     }))
 }


### PR DESCRIPTION
## Summary
- Controller: Automatic with no pad at connect resolves to wire Auto, letting the host pick (Xbox); a pad plugged in mid-stream then wrongly rode that session-default kind instead of its own
- ControllerDeviceAdded now re-detects kind on hotplug and, if it differs from what was declared, sends punktfunk-core's InputKind::GamepadArrival (pad 0) so the host rebuilds that pad's virtual device; DualSense HID feedback setup (adaptive triggers, lightbar) moved into open_ds_feedback so it can be re-armed or dropped when kind changes
- ConnectOutcome gains a gamepad_auto flag since settings.gamepad_type is resolved against connect-time pad state and can no longer tell an explicit pick from Automatic

## Test plan
- [ ] task docker:lint / fmt (already clean)
- [ ] Deploy to TV, start stream without a pad attached, plug in a DualSense mid-session, verify correct glyphs and adaptive triggers
- [ ] Verify switching from Xbox to DualSense (and back) mid-stream re-arms/drops HID feedback correctly