### PR TITLE
Rename theme presets to Funk/Funk Glass

### DIFF
--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -325,14 +325,14 @@ pub enum VideoBackend {
 ///
 /// The default is the glass look, which is `ui::theme::PRESETS`' first entry: a fresh
 /// install has no `theme` key at all and draws frosted until someone picks otherwise. A
-/// document that names `"default"` keeps the flat look — the change is to what *absence*
-/// means, not to anyone's stored pick.
+/// document that names the flat look keeps it — the change is to what *absence* means, not
+/// to anyone's stored pick.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ThemeChoice {
-    Default,
+    Funk,
     #[default]
-    DefaultGlass,
+    FunkGlass,
 }
 
 /// Anything but a name this build knows deserializes to [`ThemeChoice::default`].
@@ -345,7 +345,8 @@ impl<'de> Deserialize<'de> for ThemeChoice {
         // Through `Value` so any JSON shape at all lands here rather than failing to parse.
         let v = serde_json::Value::deserialize(d)?;
         Ok(match v.as_str() {
-            Some("default") => Self::Default,
+            // `"default"` is what older documents call the flat look.
+            Some("funk" | "default") => Self::Funk,
             _ => Self::default(),
         })
     }

--- a/src/ui/theme/presets.rs
+++ b/src/ui/theme/presets.rs
@@ -39,8 +39,8 @@ const ICONS: Icons = Icons {
 
 /// Flat opaque panels. Costs no GPU memory and no render-target binds at all.
 pub const DEFAULT: Theme = Theme {
-    name: "Default",
-    choice: ThemeChoice::Default,
+    name: "Funk",
+    choice: ThemeChoice::Funk,
     palette: PALETTE,
     icons: ICONS,
     glass: None,
@@ -52,8 +52,8 @@ pub const DEFAULT: Theme = Theme {
 /// is not something a spec answers — the compositor probes, logs `frosted modals: <bool>` and
 /// falls back to flat fills on its own, so this is safe to offer everywhere.
 pub const GLASS: Theme = Theme {
-    name: "Default Glass",
-    choice: ThemeChoice::DefaultGlass,
+    name: "Funk Glass",
+    choice: ThemeChoice::FunkGlass,
     palette: PALETTE,
     icons: ICONS,
     glass: Some(Glass {


### PR DESCRIPTION
## Summary
- "Default"/"Default Glass" presets renamed to "Funk"/"Funk Glass" for branding.
- `ThemeChoice::Default`/`DefaultGlass` renamed to `Funk`/`FunkGlass`; serialized names become `funk`/`funk_glass`.
- Hand-written `Deserialize` still maps legacy `"default"` to the flat look, so existing stored settings keep their pick.

## Test plan
- [x] `task docker:check`