### PR TITLE
Keyboard Backspace erases text instead of closing modals

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -46,13 +46,6 @@ pub(crate) const LAUNCH_GROWTH: f32 = 3.5;
 const PIN_BADGE_MARGIN: i32 = 10;
 pub(crate) const CARD_POP: Duration = Duration::from_millis(300);
 pub(crate) const CARD_POP_SHRINK: f32 = 0.14;
-/// Modal open. Short: the card is the response to a keypress, and delay there reads as
-/// a slow TV, not as an animation.
-pub(crate) const MODAL_FADE: Duration = Duration::from_millis(75);
-/// Modal close. Slower than the open — nothing is waiting on it, and outlasting the
-/// incoming card is what makes a modal-to-modal step read as one replacing the other.
-pub(crate) const MODAL_FADE_OUT: Duration = Duration::from_millis(150);
-pub(crate) const DROPDOWN_FADE: Duration = MODAL_FADE;
 /// Transparent margin the modal tile leaves around the card so its drop shadow
 /// (`Painter::card_shadow`: blur `SHADOW_BLUR`=14, offset dy 5) fits inside the tile.
 /// The tile is sized to the card's bounding box plus this pad rather than the whole
@@ -383,12 +376,12 @@ impl App {
             Some((
                 dd.row,
                 dd.focused,
-                self.settings_ui.dropdown_fade.open_alpha(DROPDOWN_FADE),
+                self.settings_ui.dropdown_fade.open_alpha(),
             ))
         } else {
             self.settings_ui
                 .dropdown_fade
-                .closing_frame(DROPDOWN_FADE)
+                .closing_frame()
                 .map(|(alpha, (row, focused))| (row, focused, alpha))
         }
     }
@@ -588,6 +581,24 @@ impl App {
         }
         true
     }
+    /// Erases one character from whichever screen is currently editing text, reporting
+    /// whether it consumed the key. The counterpart to [`Self::back`]: one definition of
+    /// "what an erase means here", so the loop that sees the Backspace doesn't have to
+    /// know which screens edit what. `false` leaves the key to its normal `Back` meaning,
+    /// which is what makes an erase on an already-empty field still close the modal.
+    pub fn erase_text_entry(&mut self) -> bool {
+        match self.nav.screen {
+            Screen::AddHost | Screen::EditHost => {
+                !self.screens.add_host.text().is_empty() && {
+                    self.screens.add_host.backspace();
+                    true
+                }
+            }
+            Screen::Pairing => self.erase_pin_digit(),
+            _ => false,
+        }
+    }
+
     /// Applies a `Back` to whichever screen is current — the single shared
     /// definition of "what Back means here" for every caller that needs it
     /// pre-emptively rather than through the normal per-screen `MenuEvent`
@@ -617,12 +628,6 @@ impl App {
         self.handle_menu_event(MenuEvent::Back, screen_w, screen_h, fonts)
     }
 
-    /// How long the modal close in flight runs — one answer, so the tick, the snapshot and
-    /// the compose path never disagree about when the fade is over.
-    pub(crate) fn modal_close_dur(&self) -> Duration {
-        self.render.modal.fade.close_dur(MODAL_FADE, MODAL_FADE_OUT)
-    }
-
     /// Advances every live animation one tick — the eased scroll, the focus pop,
     /// the modal fade — and reports whether anything is still moving (the main
     /// loop keeps rendering while true). Expired animations report one final
@@ -643,11 +648,10 @@ impl App {
             }
             animating = true;
         }
-        let close_dur = self.modal_close_dur();
-        if self.render.modal.fade.tick_split(MODAL_FADE, close_dur) {
+        if self.render.modal.fade.tick() {
             animating = true;
         }
-        if self.settings_ui.dropdown_fade.tick(DROPDOWN_FADE) {
+        if self.settings_ui.dropdown_fade.tick() {
             animating = true;
         }
         // The hero loading screen keeps panning for as long as the launch is on screen,

--- a/src/app/modal.rs
+++ b/src/app/modal.rs
@@ -78,7 +78,7 @@ impl Default for ModalState {
             // composite of an unbuilt modal is a pixel, not a division by zero.
             tile_region: Rect::new(0, 0, 1, 1),
             prev: None,
-            fade: ui::fade::ModalFade::new(),
+            fade: ui::fade::ModalFade::modal(),
             focus_anim: None,
             switch_anim: None,
         }

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -7,21 +7,12 @@ use crate::app::render::tile;
 use crate::app::render::SnapshotBody;
 use crate::app::{
     hero, render_input, view, App, HomeFocus, Screen, CARD_GROWTH, CARD_POP, CARD_POP_SHRINK, LAUNCH_GROWTH,
-    MODAL_FADE, MODAL_TILE_PAD, PIN_BADGE_MARGIN, SCROLL_INDICATOR_FADE, SCROLL_INDICATOR_HOLD,
+    MODAL_TILE_PAD, PIN_BADGE_MARGIN, SCROLL_INDICATOR_FADE, SCROLL_INDICATOR_HOLD,
     SCROLL_INDICATOR_TILE_W, STATUS_BG_PAD,
 };
 use crate::ui;
 use crate::ui::cache::TileStore;
 use crate::ui::render::{DrawCmd, Rect};
-
-/// How far a modal card slides down as it fades out (and up as it fades in), in px.
-const MODAL_RISE: f32 = 26.0;
-
-/// How far a modal layer is still offset at fade progress `p` — the rise both the entering
-/// card and the closing snapshot ride, and which its frost pane has to ride with it.
-fn modal_rise(p: f32) -> i32 {
-    ((1.0 - p) * MODAL_RISE) as i32
-}
 
 /// How tall each step of an edge fade's alpha ramp is. Every step is one `TexCropped` with its
 /// own alpha, and SDL cannot batch across an alpha-mod change, so this divides `SCROLL_FADE_H`
@@ -69,14 +60,14 @@ impl App {
         let m = if matches!(screen, Screen::Home) {
             0.0
         } else {
-            self.render.modal.fade.open_alpha(MODAL_FADE)
+            self.render.modal.fade.open_alpha()
         };
         // `m` is what a cross-fade's leaving card is drawn as the inverse of (see `ModalFade`).
         let closing = self
             .render
             .modal
             .prev
-            .zip(self.render.modal.fade.closing_frame_against(self.modal_close_dur(), m))
+            .zip(self.render.modal.fade.closing_frame_against(m))
             .map(|(prev, (alpha, _))| (alpha, prev));
         // The backdrop belongs to "a modal is up", not to either card: re-fading it
         // mid-step would brighten the whole screen and read as a blink. It only fades when
@@ -102,11 +93,11 @@ impl App {
         // had. The invariant to keep: nothing that tints the whole screen may be pushed
         // before a frost pane.
         if !matches!(screen, Screen::Home) {
-            let region = self.render.modal.tile_region.offset(0, modal_rise(m));
+            let region = self.render.modal.tile_region.offset(0, ui::animation::modal_rise(m));
             self.push_frost(cmds, region, (255.0 * m) as u8);
         }
         if let Some((alpha, prev)) = closing {
-            self.push_frost(cmds, prev.region.offset(0, modal_rise(alpha)), (255.0 * alpha) as u8);
+            self.push_frost(cmds, prev.region.offset(0, ui::animation::modal_rise(alpha)), (255.0 * alpha) as u8);
         }
         if scrim > 0.0 {
             cmds.push(DrawCmd::Fill {
@@ -120,7 +111,7 @@ impl App {
         // Last, so it fades away *over* what it uncovers: the entering card is often the
         // larger (a submenu returning to Settings) and would otherwise hide it entirely.
         if let Some((alpha, prev)) = closing {
-            let dy = modal_rise(alpha);
+            let dy = ui::animation::modal_rise(alpha);
             let a = (255.0 * alpha) as u8;
             cmds.push(DrawCmd::Tex {
                 tile: tile::MODAL_PREV,
@@ -189,7 +180,7 @@ impl App {
     ) {
         // Paired as one argument to stay inside clippy's `too_many_arguments` limit.
         let (screen_w, screen_h) = (size.w, size.h);
-        let dy = modal_rise(m);
+        let dy = ui::animation::modal_rise(m);
         // The tile now covers only the card region (see `prepare_modal`), so it
         // composites there rather than full-screen. Opening plays the same motion
         // `compose_modal`'s closing snapshot uses below, in reverse — fade + rise, no

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -15,7 +15,7 @@ use crate::app::render::key::{ModalFocusKey, ModalShellKey, ScrollContentKey};
 use crate::app::render::tile;
 use crate::app::render::SnapshotBody;
 use crate::app::{
-    menu, view, App, HomeFocus, PairingFocus, Screen, ABOUT_WINDOW_BUDGET, ABOUT_WINDOW_MARGIN, DROPDOWN_FADE,
+    menu, view, App, HomeFocus, PairingFocus, Screen, ABOUT_WINDOW_BUDGET, ABOUT_WINDOW_MARGIN,
     SCROLL_INDICATOR_TILE_W,
 };
 use crate::ui;
@@ -136,7 +136,7 @@ impl App {
         let (screen_w, screen_h) = (size.w, size.h);
         // Presence only — this decides whether a snapshot is still wanted, not what it
         // is drawn at, so it needs neither the entering alpha nor the exact duration.
-        let closing = self.render.modal.fade.closing_frame(self.modal_close_dur());
+        let closing = self.render.modal.fade.closing_frame();
         if closing.is_none() {
             // Fade over (or cancelled by reopening the same screen) — drop the copies
             // rather than keep two card-sized textures alive for nothing.
@@ -578,7 +578,7 @@ impl App {
             })? {
                 updated.push(tile::DROPDOWN_FOCUS);
             }
-        } else if !self.settings_ui.dropdown_fade.is_closing(DROPDOWN_FADE) {
+        } else if !self.settings_ui.dropdown_fade.is_closing() {
             // Keep the tiles cached while a close-fade is in flight — `draw_list`
             // still composites them at falling alpha.
             tiles.remove(tile::DROPDOWN_OVERLAY);

--- a/src/app/settingsui.rs
+++ b/src/app/settingsui.rs
@@ -33,7 +33,7 @@ impl SettingsUi {
             settings,
             game_settings: None,
             dropdown: None,
-            dropdown_fade: ui::fade::ModalFade::new(),
+            dropdown_fade: ui::fade::ModalFade::modal(),
             slider_drag: false,
         }
     }

--- a/src/app/state/experimental.rs
+++ b/src/app/state/experimental.rs
@@ -57,7 +57,7 @@ impl App {
         // next visit rather than paying for it behind a screen that no longer asks.
         if !self.jobs.root_probe_owed
             || !matches!(self.nav.screen, Screen::Experimental)
-            || self.render.modal.fade.is_animating(crate::app::MODAL_FADE)
+            || self.render.modal.fade.is_animating()
         {
             return;
         }

--- a/src/app/state/pairing.rs
+++ b/src/app/state/pairing.rs
@@ -184,6 +184,24 @@ impl App {
         }
     }
 
+    /// Undoes the last typed digit: `enter_pin_digit` writes then advances, so erasing
+    /// means stepping back onto the digit just written and clearing it. The row is a
+    /// fixed four-box odometer, so "clear" is 0 rather than an empty box. `false` when
+    /// there is nothing left to undo — an all-zero PIN, or a ceremony already in flight
+    /// (whose only meaningful key is the Back that cancels it).
+    pub(crate) fn erase_pin_digit(&mut self) -> bool {
+        if self.screens.pairing_busy || self.screens.pin_digits == [0; 4] {
+            return false;
+        }
+        self.screens.pairing_focus = PairingFocus::Pin;
+        if self.screens.pin_digits[self.screens.pin_digit_index] == 0 && self.screens.pin_digit_index > 0 {
+            self.screens.pin_digit_index -= 1;
+            self.render.modal.focus_anim = Some(Instant::now());
+        }
+        self.screens.pin_digits[self.screens.pin_digit_index] = 0;
+        true
+    }
+
     /// Start PIN pairing on background thread (30s timeout).
     pub(crate) fn try_pair(&mut self) {
         let entry = &self.hosts.entries[self.screens.pairing_entry];

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -325,14 +325,14 @@ pub enum VideoBackend {
 ///
 /// The default is the glass look, which is `ui::theme::PRESETS`' first entry: a fresh
 /// install has no `theme` key at all and draws frosted until someone picks otherwise. A
-/// document that names `"default"` keeps the flat look — the change is to what *absence*
-/// means, not to anyone's stored pick.
+/// document that names the flat look keeps it — the change is to what *absence* means, not
+/// to anyone's stored pick.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ThemeChoice {
-    Default,
+    Funk,
     #[default]
-    DefaultGlass,
+    FunkGlass,
 }
 
 /// Anything but a name this build knows deserializes to [`ThemeChoice::default`].
@@ -345,7 +345,8 @@ impl<'de> Deserialize<'de> for ThemeChoice {
         // Through `Value` so any JSON shape at all lands here rather than failing to parse.
         let v = serde_json::Value::deserialize(d)?;
         Ok(match v.as_str() {
-            Some("default") => Self::Default,
+            // `"default"` is what older documents call the flat look.
+            Some("funk" | "default") => Self::Funk,
             _ => Self::default(),
         })
     }

--- a/src/runtime/input.rs
+++ b/src/runtime/input.rs
@@ -109,7 +109,7 @@ pub(super) struct ConfirmDialog {
     subtitle: &'static str,
     buttons: [crate::ui::widgets::ConfirmButton<'static>; 2],
     focus: Option<usize>,
-    pub(super) fade: crate::ui::fade::ModalFade<usize>,
+    fade: crate::ui::fade::ModalFade<usize>,
     /// Re-render only on open; focused button is its own tile.
     shell_dirty: bool,
     focus_dirty: bool,
@@ -134,7 +134,7 @@ impl ConfirmDialog {
             subtitle,
             buttons,
             focus: None,
-            fade: crate::ui::fade::ModalFade::new(),
+            fade: crate::ui::fade::ModalFade::modal(),
             shell_dirty: false,
             focus_dirty: false,
             focus_anim: None,
@@ -178,11 +178,16 @@ impl ConfirmDialog {
     }
 
     /// Returns `(focus, alpha, is_closing)` to draw, or `None` if nothing to show.
-    pub(super) fn frame(&self, dur: Duration) -> Option<(usize, f32, bool)> {
-        if let Some((alpha, focus)) = self.fade.closing_frame(dur) {
+    pub(super) fn frame(&self) -> Option<(usize, f32, bool)> {
+        if let Some((alpha, focus)) = self.fade.closing_frame() {
             return Some((focus, alpha, true));
         }
-        self.focus.map(|focus| (focus, self.fade.open_alpha(dur), false))
+        self.focus.map(|focus| (focus, self.fade.open_alpha(), false))
+    }
+
+    /// Advances the fade; `true` while either direction is still in flight.
+    pub(super) fn tick(&mut self) -> bool {
+        self.fade.tick()
     }
 
     /// Feeds one SDL event to the open dialog. Fresh presses only, so an
@@ -278,7 +283,7 @@ impl ConfirmDialog {
         blurrable: bool,
         cmds: &mut Vec<DrawCmd>,
     ) -> Result<()> {
-        let Some((focus, m, _closing)) = self.frame(MODAL_FADE) else {
+        let Some((focus, m, _closing)) = self.frame() else {
             return Ok(());
         };
         let (w, h) = (screen.w, screen.h);
@@ -319,8 +324,8 @@ impl ConfirmDialog {
             compositor.upload(texture_creator, tile::DISCONNECT_FOCUS_BUTTON, &tile, false)?;
         }
         // Same open/close motion as the `App`'s `Screen` modals (see `compose_modal`):
-        // slide in/out ~26px while fading, same curve in both directions, no scale.
-        let dy = ((1.0 - m) * 26.0) as i32;
+        // the shared rise, same curve in both directions, no scale.
+        let dy = crate::ui::animation::modal_rise(m);
         let pad = crate::ui::tiles::ROW_TILE_PAD;
         let base = crate::ui::render::Rect::new(
             btn_rect.x() - pad,
@@ -700,6 +705,16 @@ pub(super) fn handle_ui_event(
                     Screen::AddHost | Screen::EditHost => app.enter_add_host_digit(digit),
                     _ => unreachable!(),
                 }
+                return EventAction::Next;
+            }
+            // Backspace is a *text* key here, not navigation: `menu_event_for_key` maps it to
+            // Back (a remote whose Back arrives as Backspace still has to work), which would
+            // close the modal on every attempt to correct a typo — from a USB keyboard and
+            // from webOS's on-screen keyboard alike, since the OSK's erase key is delivered
+            // as a synthetic Backspace rather than as `TextInput`. Consumed only when the
+            // screen had something to erase, so on such a remote Backspace still leaves an
+            // empty field the way Back does.
+            if k == sdl2::keyboard::Keycode::Backspace && app.erase_text_entry() {
                 return EventAction::Next;
             }
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -8,7 +8,7 @@ use sdl2::controller::GameController;
 
 use crate::app::hero::Connect;
 use crate::app::render::tile;
-use crate::app::{App, HomeFocus, Screen, MODAL_FADE};
+use crate::app::{App, HomeFocus, Screen};
 use crate::core::event::MenuEvent;
 use crate::platform::webos::compositor::Compositor;
 use crate::platform::webos::cursor;

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -273,11 +273,11 @@ pub(super) fn run_inner() -> Result<()> {
         // crashed an earlier attempt, see docs/NOTES.md). Green button flips it live, session-only.
         let mut stats_enabled = settings.stats_overlay;
         // Fades in/out on the same curve as the toast below — see `ModalFade::visibility_alpha`.
-        let mut stats_fade = crate::ui::fade::ModalFade::<()>::new();
+        let mut stats_fade = crate::ui::fade::ModalFade::<()>::overlay();
         if stats_enabled {
             stats_fade.open();
         }
-        let mut log_fade = crate::ui::fade::ModalFade::<()>::new();
+        let mut log_fade = crate::ui::fade::ModalFade::<()>::overlay();
         // Seeded from live key state, not `false`: these are rising-edge polls, and the launch
         // itself is a keypress. A key still down when the stream loop starts (webOS's EXIT
         // gesture in particular — a synthetic press whose key-up may never arrive) would read as
@@ -648,7 +648,7 @@ pub(super) fn run_inner() -> Result<()> {
             }
             // Wider than `is_open()`: a dismissed dialog still draws (fading out) a few more
             // ticks, used below to skip the stats overlay for exactly those ticks.
-            let dialog_frame = disconnect.frame(MODAL_FADE);
+            let dialog_frame = disconnect.frame();
             if dialog_frame.is_some() {
                 // Own clear/present pass over the punch-through video, unlike the menu's
                 // shared command list.
@@ -667,7 +667,7 @@ pub(super) fn run_inner() -> Result<()> {
                 canvas.clear();
                 compositor.present(&mut canvas, &cmds)?;
                 canvas.present();
-            } else if disconnect.fade.tick(MODAL_FADE) {
+            } else if disconnect.tick() {
                 // Close-fade just finished. Confirmed Disconnect: break now, nothing to wipe
                 // since the pre-stream UI takes the canvas next.
                 if let Some(outcome) = pending_outcome.take() {
@@ -695,9 +695,9 @@ pub(super) fn run_inner() -> Result<()> {
             let notif_active = notif_frame.is_some();
             // Fade in/out on the toast's curve instead of cutting instantly; `visibility_alpha`
             // keeps returning `Some` through the close fade after the toggle itself flips off.
-            let stats_alpha = stats_fade.visibility_alpha(crate::ui::fade::OVERLAY_FADE, stats_enabled);
+            let stats_alpha = stats_fade.visibility_alpha(stats_enabled);
             let log_overlay_on = log_overlay_state() != LogOverlayState::Off;
-            let log_alpha = log_fade.visibility_alpha(crate::ui::fade::OVERLAY_FADE, log_overlay_on);
+            let log_alpha = log_fade.visibility_alpha(log_overlay_on);
             let overlay_active = stats_alpha.is_some() || log_alpha.is_some() || notif_active;
             if overlay_was_active && !overlay_active {
                 // Nothing else clears this canvas — the faded-out tile would stick otherwise.
@@ -710,8 +710,8 @@ pub(super) fn run_inner() -> Result<()> {
             overlay_was_active = overlay_active;
             // A fade in flight needs frequent frames; steady-state stats/log are fine at ~2Hz.
             let fading = notif_active
-                || stats_fade.is_animating(crate::ui::fade::OVERLAY_FADE)
-                || log_fade.is_animating(crate::ui::fade::OVERLAY_FADE);
+                || stats_fade.is_animating()
+                || log_fade.is_animating();
             let redraw_interval = if fading {
                 Duration::from_millis(33)
             } else {

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -362,7 +362,7 @@ pub(super) fn run_ui_flow(
         // The quit dialog runs its own open/close fade and focus-pop, so keep ticking
         // while it (or its close-fade) is on screen, and force one redraw on the frame it
         // finally clears so it doesn't linger over the menu.
-        let quit_dialog_active = quit_dialog.frame(MODAL_FADE).is_some();
+        let quit_dialog_active = quit_dialog.frame().is_some();
         if quit_dialog_was_active && !quit_dialog_active {
             dirty = true;
         }

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -104,6 +104,17 @@ pub fn focus_tile_rect(base: Rect, focus_anim: Option<Instant>, press: Press) ->
     press.rect(zoom_rect(base, anim_frac(focus_anim, FOCUS_POP), FOCUS_GROWTH))
 }
 
+/// How far a modal card slides down as it fades out (and up as it fades in), in px.
+const MODAL_RISE: f32 = 26.0;
+
+/// How far a modal layer is still offset at fade progress `p` — the rise the entering card,
+/// the closing snapshot and the card's own frost pane all ride. Shared so the `App`'s
+/// `Screen` modals and the runtime-side confirm dialogs (which have no `App`) travel the
+/// same distance on the same curve.
+pub fn modal_rise(p: f32) -> i32 {
+    ((1.0 - p) * MODAL_RISE) as i32
+}
+
 /// Cubic ease-out function.
 pub fn ease(f: f32) -> f32 {
     1.0 - (1.0 - f).powi(3)

--- a/src/ui/fade.rs
+++ b/src/ui/fade.rs
@@ -12,6 +12,15 @@ use std::time::{Duration, Instant};
 /// the same.
 pub const OVERLAY_FADE: Duration = Duration::from_millis(400);
 
+/// Modal open. Short: the card is the response to a keypress, and delay there reads as
+/// a slow TV, not as an animation.
+pub const MODAL_FADE: Duration = Duration::from_millis(75);
+
+/// Modal close, when nothing is opening behind it. Slower than the open — nothing is
+/// waiting on it, and outlasting the incoming card is what makes a modal-to-modal step
+/// read as one replacing the other.
+pub const MODAL_FADE_OUT: Duration = Duration::from_millis(150);
+
 /// `T` is whatever the caller needs preserved while closing (e.g. which screen was
 /// open) so the fade-out can keep rendering it after the live state has already moved
 /// on — use `()` if there's only ever one thing this could be.
@@ -20,20 +29,33 @@ pub struct ModalFade<T = ()> {
     closing: Option<(Instant, T)>,
     /// Whether the close in flight has something opening behind it — see [`Self::close_cross`].
     cross: bool,
-}
-
-impl<T: Copy + PartialEq> Default for ModalFade<T> {
-    fn default() -> Self {
-        Self::new()
-    }
+    /// The two clocks, fixed when the fade is constructed rather than passed per call: a
+    /// caller that reads one alpha on the open duration and ticks on another retires a fade
+    /// half way through it, which is precisely how the quit dialog drifted out of step with
+    /// every other modal. Here that pair cannot be mismatched.
+    open_dur: Duration,
+    solo_close_dur: Duration,
 }
 
 impl<T: Copy + PartialEq> ModalFade<T> {
-    pub fn new() -> Self {
+    /// A modal layer: [`MODAL_FADE`] in, [`MODAL_FADE_OUT`] out (an open behind it shortens
+    /// the close back to the open's clock, see [`Self::close_cross`]).
+    pub fn modal() -> Self {
+        Self::new(MODAL_FADE, MODAL_FADE_OUT)
+    }
+
+    /// A transient in-stream overlay: [`OVERLAY_FADE`] both ways.
+    pub fn overlay() -> Self {
+        Self::new(OVERLAY_FADE, OVERLAY_FADE)
+    }
+
+    fn new(open_dur: Duration, solo_close_dur: Duration) -> Self {
         Self {
             open_since: None,
             closing: None,
             cross: false,
+            open_dur,
+            solo_close_dur,
         }
     }
 
@@ -66,12 +88,12 @@ impl<T: Copy + PartialEq> ModalFade<T> {
     }
 
     /// How long the close in flight runs: a cross-fade matches the open exactly, a lone close
-    /// takes `solo`'s slower dissolve — there is nothing arriving to hide it.
-    pub fn close_dur(&self, open: Duration, solo: Duration) -> Duration {
+    /// takes the slower dissolve — there is nothing arriving to hide it.
+    fn close_dur(&self) -> Duration {
         if self.cross {
-            open
+            self.open_dur
         } else {
-            solo
+            self.solo_close_dur
         }
     }
 
@@ -97,7 +119,8 @@ impl<T: Copy + PartialEq> ModalFade<T> {
     }
 
     /// Returns `(alpha, payload)` while a close is in flight; `None` otherwise.
-    pub fn closing_frame(&self, dur: Duration) -> Option<(f32, T)> {
+    pub fn closing_frame(&self) -> Option<(f32, T)> {
+        let dur = self.close_dur();
         let (t, payload) = self.closing.filter(|(t, _)| t.elapsed() < dur)?;
         Some((1.0 - anim_frac(Some(t), dur), payload))
     }
@@ -105,52 +128,49 @@ impl<T: Copy + PartialEq> ModalFade<T> {
     /// [`Self::closing_frame`] for the one caller that draws a cross-fade: `open` is the alpha
     /// of whatever is opening this frame, and a cross-fade's closing overlay is its inverse
     /// rather than its own ease, so the pair sums to one at every instant.
-    pub fn closing_frame_against(&self, dur: Duration, open: f32) -> Option<(f32, T)> {
-        match self.closing_frame(dur)? {
+    pub fn closing_frame_against(&self, open: f32) -> Option<(f32, T)> {
+        match self.closing_frame()? {
             (_, payload) if self.cross => Some((1.0 - open, payload)),
             frame => Some(frame),
         }
     }
 
     /// Whether a close is in flight, for callers that need its presence but not its alpha.
-    pub fn is_closing(&self, dur: Duration) -> bool {
+    pub fn is_closing(&self) -> bool {
+        let dur = self.close_dur();
         self.closing.is_some_and(|(t, _)| t.elapsed() < dur)
     }
 
     /// Open-fade alpha: eases 0.0 -> 1.0, `1.0` once finished or if never opened.
     /// Ease-*in*, so it is `closing_frame`'s curve played backwards.
-    pub fn open_alpha(&self, dur: Duration) -> f32 {
-        anim_frac_in(self.open_since, dur)
+    pub fn open_alpha(&self) -> f32 {
+        anim_frac_in(self.open_since, self.open_dur)
     }
 
     /// Alpha for a simple show/hide overlay driven by `shown`: `Some` through the close
     /// fade even after `shown` has already flipped to `false` (so the last frame doesn't
     /// cut instantly), and `None` once fully faded and hidden.
-    pub fn visibility_alpha(&self, dur: Duration, shown: bool) -> Option<f32> {
-        if let Some((alpha, _)) = self.closing_frame(dur) {
+    pub fn visibility_alpha(&self, shown: bool) -> Option<f32> {
+        if let Some((alpha, _)) = self.closing_frame() {
             return Some(alpha);
         }
-        shown.then(|| self.open_alpha(dur))
+        shown.then(|| self.open_alpha())
     }
 
     /// Whether an open or close fade is still mid-flight (i.e. hasn't yet reached its
     /// steady state). Pure and non-mutating, unlike `tick` — safe to call just to pick a
     /// redraw cadence.
-    pub fn is_animating(&self, dur: Duration) -> bool {
-        self.open_since.is_some_and(|t| t.elapsed() < dur) || self.closing.is_some_and(|(t, _)| t.elapsed() < dur)
+    pub fn is_animating(&self) -> bool {
+        self.open_since.is_some_and(|t| t.elapsed() < self.open_dur) || self.is_closing()
     }
 
-    /// Advances the clock; returns whether either fade is still in flight.
-    pub fn tick(&mut self, dur: Duration) -> bool {
-        self.tick_split(dur, dur)
-    }
-
-    /// [`tick`](Self::tick) for a caller whose two directions run at different speeds —
-    /// each clock clears on its own duration, or the shorter keeps asking for dead redraws.
-    pub fn tick_split(&mut self, open_dur: Duration, close_dur: Duration) -> bool {
+    /// Advances the clock; returns whether either fade is still in flight. Each direction
+    /// clears on its own duration, or the shorter keeps asking for dead redraws.
+    pub fn tick(&mut self) -> bool {
+        let close_dur = self.close_dur();
         let mut animating = false;
         if let Some(t) = self.open_since {
-            if t.elapsed() >= open_dur {
+            if t.elapsed() >= self.open_dur {
                 self.open_since = None;
             }
             animating = true;

--- a/src/ui/theme/presets.rs
+++ b/src/ui/theme/presets.rs
@@ -39,8 +39,8 @@ const ICONS: Icons = Icons {
 
 /// Flat opaque panels. Costs no GPU memory and no render-target binds at all.
 pub const DEFAULT: Theme = Theme {
-    name: "Default",
-    choice: ThemeChoice::Default,
+    name: "Funk",
+    choice: ThemeChoice::Funk,
     palette: PALETTE,
     icons: ICONS,
     glass: None,
@@ -52,8 +52,8 @@ pub const DEFAULT: Theme = Theme {
 /// is not something a spec answers — the compositor probes, logs `frosted modals: <bool>` and
 /// falls back to flat fills on its own, so this is safe to offer everywhere.
 pub const GLASS: Theme = Theme {
-    name: "Default Glass",
-    choice: ThemeChoice::DefaultGlass,
+    name: "Funk Glass",
+    choice: ThemeChoice::FunkGlass,
     palette: PALETTE,
     icons: ICONS,
     glass: Some(Glass {


### PR DESCRIPTION
## Summary
- Keyboard/OSK Backspace was mapped to Back, so correcting a typo in Add Host or a
  pairing PIN digit closed the modal instead of erasing a character. `App::erase_text_entry`
  routes Backspace to the current screen's own erase (add-host text field, odometer-style
  PIN digit back-step) and only falls through to Back when there's nothing left to erase.
- Covers both a USB keyboard and webOS's on-screen keyboard, whose erase key also arrives
  as a synthetic Backspace rather than as TextInput.
- Consolidated modal fade durations along the way: each `ModalFade` now owns its own
  open/close pair (`modal()` vs `overlay()`) instead of every call site passing durations
  in, which is how the quit dialog previously drifted out of step between its tick and its
  read. Extracted the shared rise offset into `ui::animation::modal_rise` so runtime-side
  confirm dialogs and `App`'s `Screen` modals travel the same curve.

## Test plan
- [x] `task docker:lint` clean
- [ ] On-device: type into Add Host / pairing PIN with a USB keyboard, confirm Backspace
      erases instead of closing the modal
- [ ] On-device: same via webOS on-screen keyboard
- [ ] Confirm Backspace still closes the modal when the field is already empty
- [ ] Modal/dropdown/confirm-dialog fades still look right (open, close, cross-fade between
      modals, in-stream stats/log overlay fade)