### PR TITLE
Expire the Home status line after 15 seconds

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -55,6 +55,10 @@ pub(crate) const SCROLL_INDICATOR_HOLD: Duration = Duration::from_millis(700);
 pub(crate) const SCROLL_INDICATOR_FADE: Duration = Duration::from_millis(350);
 pub(crate) const SCROLL_INDICATOR_LIFETIME: Duration =
     Duration::from_millis(SCROLL_INDICATOR_HOLD.as_millis() as u64 + SCROLL_INDICATOR_FADE.as_millis() as u64);
+/// How long a Home status line stays up before it clears itself. Every line here is
+/// ambient (a load result, a wake report, a launch error) and none of them stay true
+/// forever, so the grid gets its bottom edge back instead of keeping stale text.
+pub(crate) const HOME_STATUS_LIFETIME: Duration = Duration::from_secs(15);
 /// Wider than track for rounded caps not to clip.
 const SCROLL_INDICATOR_TILE_W: u32 = 10;
 
@@ -120,6 +124,9 @@ pub struct App {
     /// success, which wiped the error a second after the user landed back on the grid. Anything
     /// the user's own actions produce replaces it as usual.
     pub(crate) home_status_sticky: bool,
+    /// When the current status line went up, so `tick_animations` can expire it after
+    /// `HOME_STATUS_LIFETIME`. Stamped by `set_home_status`, which every writer goes through.
+    home_status_shown_at: Option<Instant>,
     pub(crate) launch_ready: Option<ConnectTarget>,
     pub(crate) launch_anim: Option<Instant>,
     pub(crate) launch_anim_idx: Option<usize>,
@@ -184,7 +191,8 @@ impl App {
     /// The Home status line. `sticky` marks a line that must survive the library reload a
     /// fresh menu entry starts — that reload clears the status on success, which otherwise
     /// wiped a launch error a second after the user landed back on the grid.
-    pub fn set_home_status(&mut self, status: Option<String>, sticky: bool) {
+    pub(crate) fn set_home_status(&mut self, status: Option<String>, sticky: bool) {
+        self.home_status_shown_at = status.is_some().then(Instant::now);
         self.home_status = status;
         self.home_status_sticky = sticky;
     }
@@ -231,6 +239,7 @@ impl App {
             home_focus: HomeFocus::Sidebar(0),
             home_status: None,
             home_status_sticky: false,
+            home_status_shown_at: None,
             launch_ready: None,
             launch_anim: None,
             launch_anim_idx: None,
@@ -546,7 +555,7 @@ impl App {
         // have run for minutes with no modal up, the bar's job is to report that the
         // host came back, not just that a fetch started.
         if let Some(name) = name {
-            self.home_status = Some(format!("{name} is back online — loading its library…"));
+            self.set_home_status(Some(format!("{name} is back online — loading its library…")), false);
         }
     }
 
@@ -676,6 +685,15 @@ impl App {
             if t.elapsed() >= ui::animation::FOCUS_POP {
                 self.render.modal.switch_anim = None;
             }
+            animating = true;
+        }
+        // The lifetime outranks `home_status_sticky`: sticky defends a line against the
+        // library reload's clear, not against the clock.
+        // Only the expiring frame reports `animating` — the idle branch's `wait_for_event`
+        // still times out at `TICK_BUDGET`, so this runs on schedule without holding the
+        // SoC at 60Hz for the whole 15s.
+        if self.home_status_shown_at.is_some_and(|t| t.elapsed() >= HOME_STATUS_LIFETIME) {
+            self.set_home_status(None, false);
             animating = true;
         }
         if let Some(t) = self.render.scroll.shown_at {

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -457,8 +457,7 @@ impl App {
         self.clear_grid_pins();
         self.library.art.clear();
         self.jobs.cancel_library();
-        self.home_status = None;
-        self.home_status_sticky = false;
+        self.set_home_status(None, false);
         self.home_focus = HomeFocus::Sidebar(0);
         self.render.grid.focus_last = 0;
         self.render.grid.dirty = true;
@@ -474,11 +473,10 @@ impl App {
             .iter()
             .find(|h| h.host == host && h.port == port)
             .map_or_else(|| host.clone(), |h| h.name.clone());
-        self.home_status = Some(format!("Loading library from {name}…"));
         // Picking a host is the user's own action, so its progress replaces whatever the last
         // launch left on screen. The reload `App::new` starts is not this — it runs before
         // `home_status_sticky` is ever set.
-        self.home_status_sticky = false;
+        self.set_home_status(Some(format!("Loading library from {name}…")), false);
         self.library.games = Vec::new();
         self.clear_grid_pins();
         self.library.games_loaded = false;
@@ -557,12 +555,12 @@ impl App {
                     self.home_focus = HomeFocus::Grid(0);
                 }
                 if !self.home_status_sticky {
-                    self.home_status = None;
+                    self.set_home_status(None, false);
                 }
                 // Held until now rather than shown at startup: the hint points at the cards,
                 // so it waits for a library to exist. Spent on sight, whatever happens next.
                 if std::mem::take(&mut self.intro_hint_owed) {
-                    self.home_status = Some(crate::app::state::cardmenu::INTRO_HINT.to_string());
+                    self.set_home_status(Some(crate::app::state::cardmenu::INTRO_HINT.to_string()), false);
                 }
                 self.prune_stale_game_prefs();
                 self.reorder_games_by_pin();
@@ -598,7 +596,7 @@ impl App {
             // The host answered — just not with a usable library — so Desktop is a
             // legitimate fallback here, unlike the `Unreachable` branch above.
             self.library.games_loaded = true;
-            self.home_status = Some(reason);
+            self.set_home_status(Some(reason), false);
         }
     }
     /// Confirms grid card, arming the launch straight away so the connect thread starts on the
@@ -652,8 +650,7 @@ impl App {
         // The zoom and the fade to black say the launch started; a status line under them
         // only competes with that. Cleared so the last launch's failure doesn't sit under
         // this one either.
-        self.home_status = None;
-        self.home_status_sticky = false;
+        self.set_home_status(None, false);
         self.launch_anim_idx = Some(idx);
         self.launch_ready = Some(ConnectTarget {
             host,

--- a/src/app/state/sendlogs.rs
+++ b/src/app/state/sendlogs.rs
@@ -61,12 +61,12 @@ impl App {
     /// "sending…" status; the outcome replaces it via `drain_send_logs`.
     fn start_log_upload(&mut self) {
         let Some(path) = crate::logger::latest_log_file(&crate::services::store::app_dir()) else {
-            self.home_status = Some("No logs to send yet.".into());
+            self.set_home_status(Some("No logs to send yet.".into()), false);
             return;
         };
         let (tx, rx) = std::sync::mpsc::channel();
         self.jobs.send_logs = Some(rx);
-        self.home_status = Some("Sending logs to the developer…".into());
+        self.set_home_status(Some("Sending logs to the developer…".into()), false);
         tracing::info!("send logs: uploading {}", path.display());
         std::thread::spawn(move || {
             let _ = tx.send(upload_logs(&path));
@@ -82,11 +82,11 @@ impl App {
                 match msg {
                     SendLogsMsg::Ok(s) => {
                         tracing::info!("send logs: {s}");
-                        self.home_status = Some(s);
+                        self.set_home_status(Some(s), false);
                     }
                     SendLogsMsg::Err(s) => {
                         tracing::warn!("send logs failed: {s}");
-                        self.home_status = Some(s);
+                        self.set_home_status(Some(s), false);
                     }
                 }
                 self.jobs.send_logs = None;

--- a/src/app/state/wake.rs
+++ b/src/app/state/wake.rs
@@ -37,7 +37,7 @@ impl App {
             // No modal is up in this branch, so the Home bar is the only place the
             // wait is visible at all — without this it would sit on `select_host`'s
             // stale "Loading library…" until the host came back (or didn't).
-            self.home_status = Some(Self::wake_home_status(&wake));
+            self.set_home_status(Some(Self::wake_home_status(&wake)), false);
         } else {
             self.nav.screen = Screen::Wake;
         }
@@ -123,7 +123,7 @@ impl App {
             self.nav.screen = Screen::Wake;
         }
         if let Some(status) = new_status {
-            self.home_status = Some(status);
+            self.set_home_status(Some(status), false);
         }
         changed
     }
@@ -173,14 +173,15 @@ impl App {
     /// Unsent wakes drop entirely, leaving error text behind.
     fn dismiss_wake(&mut self) {
         self.nav.screen = Screen::Home;
-        match self.screens.wake.as_mut() {
+        let status = match self.screens.wake.as_mut() {
             Some(wake) if wake.sent => {
                 // WHY: set silent=false so tick_wake won't re-pop the prompt after user dismisses.
                 wake.silent = false;
-                self.home_status = Some(Self::wake_home_status(wake));
+                Some(Self::wake_home_status(wake))
             }
-            _ => self.home_status = self.screens.wake.take().map(|w| w.reason),
-        }
+            _ => self.screens.wake.take().map(|w| w.reason),
+        };
+        self.set_home_status(status, false);
     }
 
     /// Home status bar line for background wake (auto-send or dismissed modal).


### PR DESCRIPTION
## Summary
- Home grid's bottom status line now clears itself 15s after it appears, instead of sitting there indefinitely
- All direct writes to `home_status` route through `set_home_status`, which stamps `home_status_shown_at` and owns the sticky flag; `tick_animations` expires it past `HOME_STATUS_LIFETIME`
- The 15s clock outranks `home_status_sticky` — sticky only defends a line against the library reload's clear, not the clock

## Test plan
- [x] `task docker:lint`