### PR TITLE
Pace video release on the host's cadence, by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.28.0#7df321f459a6708f61e12683c99ce12efa0d25bc"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.31.3#5e30805490a835242aacd9d71556e93ef3ae7e06"
 
 [[package]]
 name = "fiat-crypto"
@@ -1272,8 +1272,8 @@ dependencies = [
 
 [[package]]
 name = "punktfunk-core"
-version = "0.28.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.28.0#7df321f459a6708f61e12683c99ce12efa0d25bc"
+version = "0.31.3"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.31.3#5e30805490a835242aacd9d71556e93ef3ae7e06"
 dependencies = [
  "aes-gcm",
  "cbindgen",
@@ -1282,6 +1282,7 @@ dependencies = [
  "hmac 0.13.0",
  "if-addrs",
  "libc",
+ "log",
  "opus",
  "quinn",
  "rand 0.9.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ tracing-appender = "0.2"
 # moved), and puts `#![deny(unsafe_code)]` over the crate that parses every byte off the network.
 # The one source-visible break is `note_frame_index`, which now returns a gap WIDTH — see
 # `session::video_pump`.
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.28.0", features = ["quic"] }
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.31.3", features = ["quic"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # mDNS LAN discovery; direct dep (not via pf-client-core — see session.rs docs).

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -156,7 +156,7 @@ MANIFEST (crate version — SPDX license — source)
   powerfmt 0.2.0 — MIT OR Apache-2.0 — https://github.com/jhpratt/powerfmt
   ppv-lite86 0.2.21 — MIT OR Apache-2.0 — https://github.com/cryptocorrosion/cryptocorrosion
   proc-macro2 1.0.107 — MIT OR Apache-2.0 — https://github.com/dtolnay/proc-macro2
-  punktfunk-core 0.28.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
+  punktfunk-core 0.31.3 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
   pxfm 0.1.30 — BSD-3-Clause OR Apache-2.0 — https://github.com/awxkee/pxfm
   quick-error 2.0.1 — MIT/Apache-2.0 — http://github.com/tailhook/quick-error
   quinn 0.11.11 — MIT OR Apache-2.0 — https://github.com/quinn-rs/quinn
@@ -261,7 +261,7 @@ MANIFEST (crate version — SPDX license — source)
 Crates whose package did not embed a license file (SPDX + source only)
 ----------------------------------------------------------------------------
   asn1-rs-impl 0.2.0 — MIT/Apache-2.0 — https://github.com/rusticata/asn1-rs.git
-  punktfunk-core 0.28.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
+  punktfunk-core 0.31.3 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
   sdl2-sys 0.38.0 — MIT AND Zlib — https://github.com/rust-sdl2/rust-sdl2
 
 ============================================================================

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -429,13 +429,78 @@ measure-only, so there is no prior art for correcting the lip sync, only for hol
   are named on the overlay (`Opus SW` / `Opus HW`) and in the `audio path:` log line precisely so a
   report says which one produced the numbers.
 
+**3. Smooth playback: stamps from the cadence loop, not the anchor (`Settings::smooth_playback`,
+Experimental, OFF by default — 2026-08-23, no on-device numbers yet).**
+
+The anchor above is a constant plus a one-off trim, and that shape has two holes. It carries **no
+rate term**: two free-running crystals produce a ramp, so the session's real lead walks away over
+minutes (either into latency, or into stamps behind the player clock, where NDL gives up pacing) and
+nothing pulls it back — trimming stops 3 s in. And its whole jitter margin is `TRIM_KEEP_NS` = 4 ms,
+picked for latency and *below the arrival spread of an ordinary link*, so by construction the
+latest-arriving frames of every measurement window are stamped in the past. The host's capture is
+damage-driven (PipeWire) on top of that, so its cadence is genuinely uneven before the network adds
+anything. That combination is the "stutters here, looks fine on the host's own monitor" report.
+
+`session::timeline::CadencePacer` wraps **`punktfunk_core::phase::CadenceClock`** (core v0.30+, the
+same loop the desktop/Android/Apple presenters pace on, so all clients compute the same statistic):
+a type-2 loop over `ready − pts` whose cushion is `2 × measured MAD`, floored at 0.5 ms and
+**capped at one frame interval** — that ceiling is core's invariant, not a knob: past a whole frame
+the honest fix is a buffer the user asked for, not a loop quietly holding frames. `snapping()`
+tuning, because NDL presents on the panel's grid and the snap-up already carries ~half a refresh.
+
+⚠ **It smooths the offset, never the timestamps.** Core tests that (`preserves_source_cadence`), and
+it is what makes the feature honest: a game genuinely rendering at 45 fps still looks exactly as
+irregular as it is. Only the transport's contribution is removed.
+
+What it does NOT fix, and no client-side work can: a stream rate that is not the panel rate or an
+exact divisor of it. 60 on 120 is fine; 50 on 60 is arithmetic.
+
+Wiring notes worth knowing before editing:
+
+- **Both mappings fold on every frame; one is used.** With the setting off, the loop's health is the
+  only evidence that turning it on would help — `cadence:` on the video heartbeat (`jitter`,
+  `cushion`, `late_stamp`, `late_due`, `reanchors`) and the overlay's `Cadence` line. `late_stamp`
+  counts frames whose ACTUAL stamp was already behind the player clock, so it is comparable across
+  the setting: that is the judder, counted.
+- **One picture folds ONCE.** Slice-progressive delivery repeats an AU's host PTS across its
+  pieces at increasing arrival times, so mapping per piece teaches the loop the AU's *tail* arrival
+  and inflates the measured jitter by the AU's own transmission time. `VideoStage::au_base_ns` holds
+  the stamp while the AU is open — which is also what makes every piece of one AU carry the same
+  timestamp, as NDL (start-code boundaries, no AU flag) needs.
+- **The stamp sequence is clamped monotonic per run** (`last_base_ns`), because the cushion can
+  shrink between frames and NDL reads a rewind as a permanent session mute. Cleared on reset, like
+  the anchor's own — NDL has been flushed by then.
+- **The audio latch gate differs per mapping** and cannot be shared: the anchor's waits for trimming
+  to *stop* (`TRIM_SETTLE_NS`), and this loop never stops moving, so it waits
+  `PACER_AUDIO_LATCH_FRAMES` (30) instead.
+- ⚠ **Open interaction with audio offload.** `SessionClock` latches ONE constant and audio rides it
+  for the run. Under the anchor that is exact (video's own mapping is a constant too); under the
+  cadence loop the video offset keeps moving, so the offload route's lip sync drifts by whatever the
+  loop tracks — crystal skew, tens of ppm. Bounded and slow, uncorrected, and not measured on device
+  yet. A forward-only re-latch is the shape a fix would take (`derive_audio_skew` already handles a
+  new epoch), but a backward correction is impossible on that plane by construction.
+- Not tried yet, in rough order of expected value: **phase-locked capture** (core has the whole
+  protocol — `NativeClient::report_phase` + `CLIENT_CAP_PHASE_LOCK`; the host aligns its capture tick
+  to the client's panel grid, which *reduces* latency instead of buffering against it, but needs a
+  real vblank anchor and NDL is submit-only, so the anchor would have to come off the graphics plane
+  with an unknown constant offset to the video plane's latch); an **adaptive `PLANE_LEAD_MS`** on the
+  offload route (the deleted SDL `JitterPolicy` did 25→90 ms under underruns); and **not freezing on
+  a one-frame gap** when LTR/RFI recovery is available, since `HOLD_GIVE_UP` is 2 s of frozen picture
+  per loss event and each hold re-anchors the timeline.
+
 ## ABR startup probe: 2 Gbps, upstream-hardcoded
 
 **"Automatic" bitrate fires a 2 Gbps burst ~2 s into every session, and on Wi-Fi that can cost the session its video entirely** — not a slow start but a flow that never establishes. Measured on G5: a "successful" probe still reported `send_dropped=20211`, i.e. link hammered far past what it can carry (~245 Mbps airlink ceiling), and probes that get nothing back sit on core's 6 s timeout. Capped at 300 Mbps the same link reports `send_dropped=0-167` and stream starts are reliable.
 
 Don't read a slow *start* as this bug — a host compositor coming up has its own startup time, and video legitimately arrives late on first connect of a session. Signal that matters: packet drops on the probe and video that never arrives at all.
 
-This is `CAPACITY_PROBE_KBPS` in `punktfunk-core`'s `client/pump/data.rs` — a **hardcoded const with no cap knob** — directly at odds with this client capping its own speed test for the same "unbounded firehose starves the app" reason (below).
+**Fixed upstream in core v0.31.3**: the probe target is now `stream_cap_kbps × 2` (still capped at
+2 Gbps) rather than a flat 2 Gbps, and a keyframe is requested at probe end when no frame completed
+across the burst. `PUNKTFUNK_ABR_PROBE_KBPS` and its `> 0` filter are unchanged, so this client's own
+pin below still wins and still reads the same. The history is kept because the pin is why it reads
+that way.
+
+This was `CAPACITY_PROBE_KBPS` in `punktfunk-core`'s `client/pump/data.rs` — a **hardcoded const with no cap knob** — directly at odds with this client capping its own speed test for the same "unbounded firehose starves the app" reason (below).
 
 **Fixed by capping the burst**: `main.rs`'s `set_abr_env` sets `PUNKTFUNK_ABR_PROBE_KBPS` before anything spawns a thread (`setenv` isn't thread-safe, and core reads it while building its data-plane pump). Same order as the speed test's own cap, still above the airlink ceiling below — measures the link without knocking it over. Knob is core-side; **core v0.22.3 is the first release carrying it**, which is why the pin moved off v0.21.0. An older core ignores the variable.
 

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -429,8 +429,9 @@ measure-only, so there is no prior art for correcting the lip sync, only for hol
   are named on the overlay (`Opus SW` / `Opus HW`) and in the `audio path:` log line precisely so a
   report says which one produced the numbers.
 
-**3. Smooth playback: stamps from the cadence loop, not the anchor (`Settings::smooth_playback`,
-Experimental, OFF by default — 2026-08-23, no on-device numbers yet).**
+**3. Cadence pacing: stamps from the cadence loop, not the anchor (the DEFAULT since 2026-08-23;
+`Settings::direct_playback` on the Experimental screen is the way back to the anchor. No on-device
+numbers yet).**
 
 The anchor above is a constant plus a one-off trim, and that shape has two holes. It carries **no
 rate term**: two free-running crystals produce a ramp, so the session's real lead walks away over
@@ -455,13 +456,20 @@ irregular as it is. Only the transport's contribution is removed.
 What it does NOT fix, and no client-side work can: a stream rate that is not the panel rate or an
 exact divisor of it. 60 on 120 is fine; 50 on 60 is arithmetic.
 
+Why the anchor stays in the tree at all: it is the mapping every session on this client ran until
+now, so it is the known-behaviour comparison for any regression report, and it is the honest answer
+for anyone who would rather have the judder than the cushion. `session::timeline::Pacing` is the one
+object that owns the choice — nothing above it branches on which mapping is live.
+
 Wiring notes worth knowing before editing:
 
-- **Both mappings fold on every frame; one is used.** With the setting off, the loop's health is the
-  only evidence that turning it on would help — `cadence:` on the video heartbeat (`jitter`,
-  `cushion`, `late_stamp`, `late_due`, `reanchors`) and the overlay's `Cadence` line. `late_stamp`
-  counts frames whose ACTUAL stamp was already behind the player clock, so it is comparable across
-  the setting: that is the judder, counted.
+- **Only the live mapping folds.** Both are stateful over the whole run, so shadowing the idle one
+  costs a mapping nobody reads plus a second set of numbers describing a session nobody is watching.
+  What makes the two comparable is `late_stamps` — frames whose ACTUAL stamp was already behind the
+  player clock, i.e. the judder, counted — which `Pacing` computes from the stamp in use and so
+  publishes on both paths. Reported as `pacing:` on the video heartbeat and `Pace` on the overlay.
+  The anchor measures no jitter, so its overlay line prints its name where the figure would go
+  rather than a zero.
 - **One picture folds ONCE.** Slice-progressive delivery repeats an AU's host PTS across its
   pieces at increasing arrival times, so mapping per piece teaches the loop the AU's *tail* arrival
   and inflates the measured jitter by the AU's own transmission time. `VideoStage::au_base_ns` holds
@@ -469,15 +477,17 @@ Wiring notes worth knowing before editing:
   timestamp, as NDL (start-code boundaries, no AU flag) needs.
 - **The stamp sequence is clamped monotonic per run** (`last_base_ns`), because the cushion can
   shrink between frames and NDL reads a rewind as a permanent session mute. Cleared on reset, like
-  the anchor's own — NDL has been flushed by then.
+  the anchor's own — NDL has been flushed by then. `the_pacer_never_walks_a_stamp_backwards_within_a_run`
+  is the gate; it is the one invariant here whose violation costs a session its audio outright.
 - **The audio latch gate differs per mapping** and cannot be shared: the anchor's waits for trimming
   to *stop* (`TRIM_SETTLE_NS`), and this loop never stops moving, so it waits
   `PACER_AUDIO_LATCH_FRAMES` (30) instead.
-- ⚠ **Open interaction with audio offload.** `SessionClock` latches ONE constant and audio rides it
-  for the run. Under the anchor that is exact (video's own mapping is a constant too); under the
-  cadence loop the video offset keeps moving, so the offload route's lip sync drifts by whatever the
-  loop tracks — crystal skew, tens of ppm. Bounded and slow, uncorrected, and not measured on device
-  yet. A forward-only re-latch is the shape a fix would take (`derive_audio_skew` already handles a
+- ⚠ **Open interaction with audio offload**, and it is now on the DEFAULT path. `SessionClock`
+  latches ONE constant and audio rides it for the run. Under the anchor that is exact (video's own
+  mapping is a constant too); under the cadence loop the video offset keeps moving, so the offload
+  route's lip sync drifts by whatever the loop tracks — crystal skew, tens of ppm. Bounded and slow,
+  uncorrected, not measured on device yet, and it only bites the opt-in offload route: the software
+  route's stamps never ride this mapping. A forward-only re-latch is the shape a fix would take (`derive_audio_skew` already handles a
   new epoch), but a backward correction is impossible on that plane by construction.
 - Not tried yet, in rough order of expected value: **phase-locked capture** (core has the whole
   protocol — `NativeClient::report_phase` + `CLIENT_CAP_PHASE_LOCK`; the host aligns its capture tick

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -475,6 +475,24 @@ Wiring notes worth knowing before editing:
   and inflates the measured jitter by the AU's own transmission time. `VideoStage::au_base_ns` holds
   the stamp while the AU is open — which is also what makes every piece of one AU carry the same
   timestamp, as NDL (start-code boundaries, no AU flag) needs.
+- ⚠ **The cushion's ceiling is the STREAM mode's interval, not `frame_interval_ns`.** Those are two
+  different quantities that happen to agree on most panels: the reconciled one exists to convert a
+  render-queue depth into time, so it follows the panel's drain cadence, while the cushion bounds how
+  long a frame may be HELD, so it must follow the cadence the host produces. Core states this with a
+  test of its own (`the_cadence_interval_comes_from_the_stream_mode_not_the_panel`) — a 120 fps
+  stream on a 60 Hz panel would otherwise license twice the hold the source can justify. The anchor's
+  trim ramp takes the same quantity, for the same reason: it pays debt off per frame, and frames come
+  from the source.
+- **Folded at arrival, which is where core wants it** ("called at SUBMIT rather than at take, so the
+  estimate sees the arrival process the transport actually produced"). `snapping()` tuning
+  permanently: `SourcePacer::follow` re-tunes to `free_running()` only where VRR is MEASURED live,
+  which needs on-glass stamps this platform does not have. `note_off_cadence` is wired by no client,
+  including this one — nothing on the wire marks a frame off-cadence.
+- **Re-anchor triggers**: the freeze-until-reanchor hold, via `reset_timeline`. Upstream also
+  re-anchors on a display change and on a mid-stream mode switch; this client never calls
+  `request_mode`, and a host-driven switch arrives with the loss that opens a hold anyway — but the
+  interval above is snapshotted at pipeline build, so if mid-session mode changes ever become a real
+  path here, that snapshot is the thing to fix.
 - **The stamp sequence is clamped monotonic per run** (`last_base_ns`), because the cushion can
   shrink between frames and NDL reads a rewind as a permanent session mute. Cleared on reset, like
   the anchor's own — NDL has been flushed by then. `the_pacer_never_walks_a_stamp_backwards_within_a_run`

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -154,14 +154,14 @@ pub enum ExpRow {
     /// this screen. Experimental because two of its three picks are hardware paths that no
     /// runtime probe can verify; locked to the software route where there is no NDL plane.
     AudioProcessing,
-    /// Play frames out on the host's cadence — `Settings::smooth_playback`. Experimental: trades
-    /// latency for smoothness, and by how much depends on the (measured, not chosen) link cushion.
-    SmoothPlayback,
+    /// Stamp from the fixed anchor instead of the cadence loop — `Settings::direct_playback`.
+    /// Experimental: trades smoothness back for latency, and what that costs depends on the link.
+    DirectPlayback,
 }
 
 /// Order is display order. `AudioProcessing` stays at index 1 so its dropdown's `(Screen, row)`
 /// tile key does not move.
-pub const EXP_ROWS: [ExpRow; 3] = [ExpRow::GameMode, ExpRow::AudioProcessing, ExpRow::SmoothPlayback];
+pub const EXP_ROWS: [ExpRow; 3] = [ExpRow::GameMode, ExpRow::AudioProcessing, ExpRow::DirectPlayback];
 
 /// Display position of [`ExpRow::AudioProcessing`] — the row a dropdown can hang off, which is
 /// what `DropdownState::row` names.
@@ -243,7 +243,7 @@ pub(crate) fn exp_row_lock(row: ExpRow, rooted: Option<bool>) -> Option<ExpRowLo
         (ExpRow::GameMode, None) => Some(ExpRowLock::RootUnknown),
         (ExpRow::GameMode, Some(false)) => Some(ExpRowLock::NotRooted),
         (ExpRow::AudioProcessing, _) if audio_routes().len() < 2 => Some(ExpRowLock::SoftwareOnly),
-        (ExpRow::GameMode, Some(true)) | (ExpRow::AudioProcessing, _) | (ExpRow::SmoothPlayback, _) => None,
+        (ExpRow::GameMode, Some(true)) | (ExpRow::AudioProcessing, _) | (ExpRow::DirectPlayback, _) => None,
     }
 }
 

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -154,9 +154,14 @@ pub enum ExpRow {
     /// this screen. Experimental because two of its three picks are hardware paths that no
     /// runtime probe can verify; locked to the software route where there is no NDL plane.
     AudioProcessing,
+    /// Play frames out on the host's cadence — `Settings::smooth_playback`. Experimental: trades
+    /// latency for smoothness, and by how much depends on the (measured, not chosen) link cushion.
+    SmoothPlayback,
 }
 
-pub const EXP_ROWS: [ExpRow; 2] = [ExpRow::GameMode, ExpRow::AudioProcessing];
+/// Order is display order. `AudioProcessing` stays at index 1 so its dropdown's `(Screen, row)`
+/// tile key does not move.
+pub const EXP_ROWS: [ExpRow; 3] = [ExpRow::GameMode, ExpRow::AudioProcessing, ExpRow::SmoothPlayback];
 
 /// Display position of [`ExpRow::AudioProcessing`] — the row a dropdown can hang off, which is
 /// what `DropdownState::row` names.
@@ -238,7 +243,7 @@ pub(crate) fn exp_row_lock(row: ExpRow, rooted: Option<bool>) -> Option<ExpRowLo
         (ExpRow::GameMode, None) => Some(ExpRowLock::RootUnknown),
         (ExpRow::GameMode, Some(false)) => Some(ExpRowLock::NotRooted),
         (ExpRow::AudioProcessing, _) if audio_routes().len() < 2 => Some(ExpRowLock::SoftwareOnly),
-        (ExpRow::GameMode, Some(true)) | (ExpRow::AudioProcessing, _) => None,
+        (ExpRow::GameMode, Some(true)) | (ExpRow::AudioProcessing, _) | (ExpRow::SmoothPlayback, _) => None,
     }
 }
 

--- a/src/app/render/key.rs
+++ b/src/app/render/key.rs
@@ -37,7 +37,7 @@ pub enum ModalFocusKey<'a> {
     /// (focused row, log level, stats-overlay on, show-logs on) — any change invalidates the tile.
     DiagnosticsRow(usize, LogLevelOverride, bool, bool),
     /// (focused row, Game mode on, the audio route, the root-probe verdict).
-    ExperimentalRow(usize, bool, AudioRoutePref, Option<bool>),
+    ExperimentalRow(usize, bool, bool, AudioRoutePref, Option<bool>),
     /// (focused row, cursor-capture on, cursor-gestures on, which rows are overridden) — any
     /// change invalidates the tile.
     CursorSettingsRow(usize, bool, bool, SettingsOverride),
@@ -113,6 +113,7 @@ pub enum ModalShellKey<'a> {
     },
     Experimental {
         game_mode: bool,
+        smooth_playback: bool,
         /// Named on the Audio processing row.
         audio_route: AudioRoutePref,
         /// The root-probe verdict — it locks the Game mode row and rewrites its caption.

--- a/src/app/render/key.rs
+++ b/src/app/render/key.rs
@@ -113,7 +113,7 @@ pub enum ModalShellKey<'a> {
     },
     Experimental {
         game_mode: bool,
-        smooth_playback: bool,
+        direct_playback: bool,
         /// Named on the Audio processing row.
         audio_route: AudioRoutePref,
         /// The root-probe verdict — it locks the Game mode row and rewrites its caption.

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -250,6 +250,7 @@ impl App {
             }),
             Screen::Experimental => Some(ModalShellKey::Experimental {
                 game_mode: self.settings_ui.settings.game_mode,
+                smooth_playback: self.settings_ui.settings.smooth_playback,
                 audio_route: self.settings_ui.settings.audio_route,
                 rooted: self.hosts.rooted,
             }),
@@ -345,6 +346,7 @@ impl App {
             Screen::Experimental => Some(ModalFocusKey::ExperimentalRow(
                 self.nav.cursor(ScreenKey::Experimental),
                 self.settings_ui.settings.game_mode,
+                self.settings_ui.settings.smooth_playback,
                 self.settings_ui.settings.audio_route,
                 self.hosts.rooted,
             )),

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -250,7 +250,7 @@ impl App {
             }),
             Screen::Experimental => Some(ModalShellKey::Experimental {
                 game_mode: self.settings_ui.settings.game_mode,
-                smooth_playback: self.settings_ui.settings.smooth_playback,
+                direct_playback: self.settings_ui.settings.direct_playback,
                 audio_route: self.settings_ui.settings.audio_route,
                 rooted: self.hosts.rooted,
             }),
@@ -346,7 +346,7 @@ impl App {
             Screen::Experimental => Some(ModalFocusKey::ExperimentalRow(
                 self.nav.cursor(ScreenKey::Experimental),
                 self.settings_ui.settings.game_mode,
-                self.settings_ui.settings.smooth_playback,
+                self.settings_ui.settings.direct_playback,
                 self.settings_ui.settings.audio_route,
                 self.hosts.rooted,
             )),

--- a/src/app/state/experimental.rs
+++ b/src/app/state/experimental.rs
@@ -82,7 +82,7 @@ impl App {
     }
 
     /// Opens the Experimental screen (Settings → `menu::SettingsRow::Experimental`). Holds unstable,
-    /// off-by-default toggles (hardware Opus decode, Game mode on rooted sets, smooth playback).
+    /// off-by-default toggles (hardware Opus decode, Game mode on rooted sets, direct playback).
     pub(crate) fn open_experimental(&mut self) {
         // Owed, not started — see `start_root_probe`.
         self.jobs.root_probe_owed = self.hosts.rooted.is_none() && self.jobs.rooted.is_none();
@@ -145,9 +145,9 @@ impl App {
                     menu::apply_audio_route(&mut self.settings_ui.settings, next);
                 }
             }
-            (Some(menu::ExpRow::SmoothPlayback), MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
-                let from = self.settings_ui.settings.smooth_playback;
-                self.settings_ui.settings.smooth_playback = !from;
+            (Some(menu::ExpRow::DirectPlayback), MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
+                let from = self.settings_ui.settings.direct_playback;
+                self.settings_ui.settings.direct_playback = !from;
                 self.arm_switch_anim(from);
             }
             (_, MenuEvent::Back) => {

--- a/src/app/state/experimental.rs
+++ b/src/app/state/experimental.rs
@@ -82,7 +82,7 @@ impl App {
     }
 
     /// Opens the Experimental screen (Settings → `menu::SettingsRow::Experimental`). Holds unstable,
-    /// off-by-default toggles (hardware Opus decode, Game mode on rooted sets).
+    /// off-by-default toggles (hardware Opus decode, Game mode on rooted sets, smooth playback).
     pub(crate) fn open_experimental(&mut self) {
         // Owed, not started — see `start_root_probe`.
         self.jobs.root_probe_owed = self.hosts.rooted.is_none() && self.jobs.rooted.is_none();
@@ -144,6 +144,11 @@ impl App {
                     let next = menu::cycle_index(current, len, ev == MenuEvent::Right);
                     menu::apply_audio_route(&mut self.settings_ui.settings, next);
                 }
+            }
+            (Some(menu::ExpRow::SmoothPlayback), MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
+                let from = self.settings_ui.settings.smooth_playback;
+                self.settings_ui.settings.smooth_playback = !from;
+                self.arm_switch_anim(from);
             }
             (_, MenuEvent::Back) => {
                 self.persist();

--- a/src/app/view/experimental.rs
+++ b/src/app/view/experimental.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 pub const TITLE: &str = "Experimental";
 pub const SUBTITLE: &str = "Unstable, off by default.";
 
-/// Game mode, audio processing, then smooth playback. Order must match `menu::EXP_ROWS`. `rooted` is the
+/// Game mode, audio processing, then direct playback. Order must match `menu::EXP_ROWS`. `rooted` is the
 /// root-probe verdict, `None` while it is still running.
 pub fn rows(settings: &Settings, rooted: Option<bool>) -> Vec<FocusRow> {
     // Driving the TV's Game picture/sound modes needs the Homebrew Channel's root helper — the
@@ -30,18 +30,18 @@ pub fn rows(settings: &Settings, rooted: Option<bool>) -> Vec<FocusRow> {
         menu::audio_route_label(settings.audio_route),
     )
     .with_subtext_opt(audio_route_hint(settings.audio_route));
-    // The lock's caption replaces the row's own: a row the user can't change has nothing more
-    // useful to say than why.
-    // The cushion is measured, not chosen, so the caption names the ceiling rather than a
-    // figure this screen cannot know — see `session::timeline::CadencePacer`.
-    let smooth = FocusRow::toggle(
+    // What it gives back is one frame at most (the cushion's own ceiling); what it costs is the
+    // judder, so the caption leads with that — see `session::timeline::Pacing`.
+    let direct = FocusRow::toggle(
         crate::app::view::icons::ICON_MEMORY,
-        "Smooth playback",
-        settings.smooth_playback,
+        "Direct playback",
+        settings.direct_playback,
     )
     .with_subtext(ui::widgets::RowSubtext::caution(
-        "Steadier picture, up to one frame more latency",
+        "Up to one frame less latency, may stutter",
     ));
+    // The lock's caption replaces the row's own: a row the user can't change has nothing more
+    // useful to say than why.
     let apply = |row: FocusRow, exp: ExpRow| match menu::exp_row_lock(exp, rooted) {
         Some(lock) => row.locked(true).with_subtext(lock_caption(lock)),
         None => row,
@@ -49,7 +49,7 @@ pub fn rows(settings: &Settings, rooted: Option<bool>) -> Vec<FocusRow> {
     vec![
         apply(game_mode, ExpRow::GameMode),
         apply(audio, ExpRow::AudioProcessing),
-        apply(smooth, ExpRow::SmoothPlayback),
+        apply(direct, ExpRow::DirectPlayback),
     ]
 }
 

--- a/src/app/view/experimental.rs
+++ b/src/app/view/experimental.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 pub const TITLE: &str = "Experimental";
 pub const SUBTITLE: &str = "Unstable, off by default.";
 
-/// Game mode, then audio processing. Order must match `menu::EXP_ROWS`. `rooted` is the
+/// Game mode, audio processing, then smooth playback. Order must match `menu::EXP_ROWS`. `rooted` is the
 /// root-probe verdict, `None` while it is still running.
 pub fn rows(settings: &Settings, rooted: Option<bool>) -> Vec<FocusRow> {
     // Driving the TV's Game picture/sound modes needs the Homebrew Channel's root helper — the
@@ -32,6 +32,16 @@ pub fn rows(settings: &Settings, rooted: Option<bool>) -> Vec<FocusRow> {
     .with_subtext_opt(audio_route_hint(settings.audio_route));
     // The lock's caption replaces the row's own: a row the user can't change has nothing more
     // useful to say than why.
+    // The cushion is measured, not chosen, so the caption names the ceiling rather than a
+    // figure this screen cannot know — see `session::timeline::CadencePacer`.
+    let smooth = FocusRow::toggle(
+        crate::app::view::icons::ICON_MEMORY,
+        "Smooth playback",
+        settings.smooth_playback,
+    )
+    .with_subtext(ui::widgets::RowSubtext::caution(
+        "Steadier picture, up to one frame more latency",
+    ));
     let apply = |row: FocusRow, exp: ExpRow| match menu::exp_row_lock(exp, rooted) {
         Some(lock) => row.locked(true).with_subtext(lock_caption(lock)),
         None => row,
@@ -39,6 +49,7 @@ pub fn rows(settings: &Settings, rooted: Option<bool>) -> Vec<FocusRow> {
     vec![
         apply(game_mode, ExpRow::GameMode),
         apply(audio, ExpRow::AudioProcessing),
+        apply(smooth, ExpRow::SmoothPlayback),
     ]
 }
 

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -771,6 +771,12 @@ pub struct Settings {
     /// since NDL only paces the picture against a fed plane. The routes differ in what RIDES it:
     /// `run_clock_plane`'s silent metronome, or the host's Opus.
     pub audio_route: AudioRoutePref,
+    /// Play frames out on the host's cadence instead of the instant they arrive — see
+    /// `session::timeline::CadencePacer`. Off by default, and the ONE gate on every
+    /// latency-adding measure in the video path: on, each frame is held by a cushion sized to the
+    /// link's measured jitter and capped at one frame interval (16.6 ms at 60 Hz), which is what
+    /// buys a cadence that doesn't beat against the panel. Takes effect on the next stream.
+    pub smooth_playback: bool,
     /// Resolve the Magic Remote's OK button into left click / right click / drag by how long
     /// it's held (see `platform::webos::mouse::RemoteButtons`). Off by default — with it
     /// off, OK stays the plain immediate left click it has always been, since a remote with
@@ -804,6 +810,7 @@ impl Default for Settings {
             cursor_capture: true,
             game_mode: false,
             audio_route: AudioRoutePref::default(),
+            smooth_playback: false,
             cursor_gestures: false,
             theme: ThemeChoice::default(),
         }

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -771,12 +771,14 @@ pub struct Settings {
     /// since NDL only paces the picture against a fed plane. The routes differ in what RIDES it:
     /// `run_clock_plane`'s silent metronome, or the host's Opus.
     pub audio_route: AudioRoutePref,
-    /// Play frames out on the host's cadence instead of the instant they arrive — see
-    /// `session::timeline::CadencePacer`. Off by default, and the ONE gate on every
-    /// latency-adding measure in the video path: on, each frame is held by a cushion sized to the
-    /// link's measured jitter and capped at one frame interval (16.6 ms at 60 Hz), which is what
-    /// buys a cadence that doesn't beat against the panel. Takes effect on the next stream.
-    pub smooth_playback: bool,
+    /// Stamp frames from the fixed anchor instead of playing them out on the host's cadence —
+    /// see `session::timeline::Pacing`. Off by default: the cadence loop holds each frame by a
+    /// cushion sized to the link's *measured* jitter (at most one frame interval, and its 0.5 ms
+    /// floor on a link with nothing wrong), which is what buys a cadence that doesn't beat against
+    /// the panel. On gives that cushion back and takes the judder with it — the ONE gate on every
+    /// latency-adding measure in the video path, which is why it lives on the Experimental screen
+    /// rather than beside Resolution. Takes effect on the next stream.
+    pub direct_playback: bool,
     /// Resolve the Magic Remote's OK button into left click / right click / drag by how long
     /// it's held (see `platform::webos::mouse::RemoteButtons`). Off by default — with it
     /// off, OK stays the plain immediate left click it has always been, since a remote with
@@ -810,7 +812,7 @@ impl Default for Settings {
             cursor_capture: true,
             game_mode: false,
             audio_route: AudioRoutePref::default(),
-            smooth_playback: false,
+            direct_playback: false,
             cursor_gestures: false,
             theme: ThemeChoice::default(),
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -38,6 +38,14 @@ pub fn reject_message(reason: RejectReason) -> String {
         RejectReason::SetupFailed => {
             "The host accepted the connection but couldn't start the stream — see host's logs.".into()
         }
+        RejectReason::AccessExpired => {
+            "Your access to this host has expired — ask the host's owner to grant it again.".into()
+        }
+        RejectReason::LaunchNotPermitted => {
+            "This device isn't permitted to launch games on the host — connect without picking a game, \
+             or ask the host's owner to allow launching."
+                .into()
+        }
     }
 }
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -105,6 +105,7 @@ fn spawn_connect(
                 gamepad_type: settings.gamepad_type,
                 cursor_capture: settings.cursor_capture,
                 audio_route: settings.audio_route,
+                smooth_playback: settings.smooth_playback,
             })
             // Flagged before the handle is joined, so the loading screen can stop waiting
             // for a stream that is not coming — the error itself still travels by `Result`.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -105,7 +105,7 @@ fn spawn_connect(
                 gamepad_type: settings.gamepad_type,
                 cursor_capture: settings.cursor_capture,
                 audio_route: settings.audio_route,
-                smooth_playback: settings.smooth_playback,
+                direct_playback: settings.direct_playback,
             })
             // Flagged before the handle is joined, so the loading screen can stop waiting
             // for a stream that is not coming — the error itself still travels by `Result`.

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -811,6 +811,14 @@ pub(super) fn run_inner() -> Result<()> {
                             connected.audio_buffer_ms()
                         ));
                     }
+                    // See `StreamStats::cadence_jitter_us` for what these mean and why both settings show them.
+                    lines.push(format!(
+                        "Cadence {} · jitter {:.1} ms · cush {:.1} ms · late {}",
+                        if connected.smooth_playback { "smooth" } else { "direct" },
+                        connected.stats().cadence_jitter_us.load(Ordering::Relaxed) as f32 / 1000.0,
+                        connected.stats().cadence_cushion_us.load(Ordering::Relaxed) as f32 / 1000.0,
+                        connected.stats().cadence_late.load(Ordering::Relaxed),
+                    ));
                     if let Some(line) = cpu_mem_line {
                         lines.push(line);
                     }

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -811,14 +811,18 @@ pub(super) fn run_inner() -> Result<()> {
                             connected.audio_buffer_ms()
                         ));
                     }
-                    // See `StreamStats::cadence_jitter_us` for what these mean and why both settings show them.
-                    lines.push(format!(
-                        "Cadence {} · jitter {:.1} ms · cush {:.1} ms · late {}",
-                        if connected.smooth_playback { "smooth" } else { "direct" },
-                        connected.stats().cadence_jitter_us.load(Ordering::Relaxed) as f32 / 1000.0,
-                        connected.stats().cadence_cushion_us.load(Ordering::Relaxed) as f32 / 1000.0,
-                        connected.stats().cadence_late.load(Ordering::Relaxed),
-                    ));
+                    // `late` is the judder, counted: frames NDL was handed too late to pace them.
+                    // `jitter` is what the cadence loop sizes its cushion from, and the anchor
+                    // measures none, so the direct mapping prints its name instead of a zero.
+                    let late = connected.stats().pacing_late.load(Ordering::Relaxed);
+                    lines.push(if connected.direct_playback {
+                        format!("Pace direct · late {late}")
+                    } else {
+                        format!(
+                            "Pace jitter {:.1} ms · late {late}",
+                            connected.stats().pacing_jitter_us.load(Ordering::Relaxed) as f32 / 1000.0,
+                        )
+                    });
                     if let Some(line) = cpu_mem_line {
                         lines.push(line);
                     }

--- a/src/session/connect.rs
+++ b/src/session/connect.rs
@@ -29,9 +29,9 @@ pub struct Connected {
     /// Where this session's audio actually ended up — the preference, resolved against what the
     /// load produced.
     pub audio_route: crate::services::store::AudioRoutePref,
-    /// Whether this session stamps frames from the cadence loop (`Settings::smooth_playback`).
-    /// Overlay only — the stage was handed the same flag through `SinkConfig`.
-    pub smooth_playback: bool,
+    /// Whether this session stamps from the fixed anchor (`Settings::direct_playback`). Overlay
+    /// only — the stage was handed the same flag through `SinkConfig`.
+    pub direct_playback: bool,
     /// Whether HDR mastering metadata is being applied this session (negotiated codec is
     /// HEVC *and* the host signalled HDR). Drives which Game picture mode the runtime asks
     /// the TV for — `game` vs `hdrGame` (see `platform::webos::game_mode`).
@@ -87,8 +87,8 @@ pub struct ConnectParams {
     pub gamepad_type: GamepadType,
     pub cursor_capture: bool,
     pub audio_route: crate::services::store::AudioRoutePref,
-    /// `Settings::smooth_playback` — see `session::stage::SinkConfig`.
-    pub smooth_playback: bool,
+    /// `Settings::direct_playback` — see `session::stage::SinkConfig`.
+    pub direct_playback: bool,
 }
 
 /// One `quic::CODEC_*` bit, or 0 where the preference names no single codec.
@@ -280,7 +280,7 @@ pub fn connect(params: &ConnectParams) -> Result<Connected> {
         stats,
         pipeline,
         audio_route: route,
-        smooth_playback: params.smooth_playback,
+        direct_playback: params.direct_playback,
         hdr: is_hdr,
     })
 }

--- a/src/session/connect.rs
+++ b/src/session/connect.rs
@@ -29,6 +29,9 @@ pub struct Connected {
     /// Where this session's audio actually ended up — the preference, resolved against what the
     /// load produced.
     pub audio_route: crate::services::store::AudioRoutePref,
+    /// Whether this session stamps frames from the cadence loop (`Settings::smooth_playback`).
+    /// Overlay only — the stage was handed the same flag through `SinkConfig`.
+    pub smooth_playback: bool,
     /// Whether HDR mastering metadata is being applied this session (negotiated codec is
     /// HEVC *and* the host signalled HDR). Drives which Game picture mode the runtime asks
     /// the TV for — `game` vs `hdrGame` (see `platform::webos::game_mode`).
@@ -84,6 +87,8 @@ pub struct ConnectParams {
     pub gamepad_type: GamepadType,
     pub cursor_capture: bool,
     pub audio_route: crate::services::store::AudioRoutePref,
+    /// `Settings::smooth_playback` — see `session::stage::SinkConfig`.
+    pub smooth_playback: bool,
 }
 
 /// One `quic::CODEC_*` bit, or 0 where the preference names no single codec.
@@ -275,6 +280,7 @@ pub fn connect(params: &ConnectParams) -> Result<Connected> {
         stats,
         pipeline,
         audio_route: route,
+        smooth_playback: params.smooth_playback,
         hdr: is_hdr,
     })
 }

--- a/src/session/pipeline.rs
+++ b/src/session/pipeline.rs
@@ -60,7 +60,7 @@ impl MediaPipeline {
             player.name(),
             client.audio_channels,
         );
-        let video_thread = spawn_video_thread(client, player, stop, stats, is_hdr, params.smooth_playback)?;
+        let video_thread = spawn_video_thread(client, player, stop, stats, is_hdr, params.direct_playback)?;
         // Failing here after the video thread is already up would otherwise detach it.
         let (audio_thread, clock_thread) = match spawn_plane_threads(client, plane, stop, route) {
             Ok(handles) => handles,
@@ -224,14 +224,14 @@ fn spawn_video_thread(
     stop: &Arc<AtomicBool>,
     stats: &Arc<StreamStats>,
     is_hdr: bool,
-    smooth_playback: bool,
+    direct_playback: bool,
 ) -> Result<std::thread::JoinHandle<()>> {
     let cfg = SinkConfig {
         stream_hz: client.mode().refresh_hz,
         report_decode_latency: client.wants_decode_latency(),
         clock_offset: client.clock_offset_shared(),
         video_e2e: client.video_e2e_shared(),
-        smooth_playback,
+        direct_playback,
     };
     let (client, stop, stats) = (client.clone(), stop.clone(), stats.clone());
     std::thread::Builder::new()

--- a/src/session/pipeline.rs
+++ b/src/session/pipeline.rs
@@ -60,7 +60,7 @@ impl MediaPipeline {
             player.name(),
             client.audio_channels,
         );
-        let video_thread = spawn_video_thread(client, player, stop, stats, is_hdr)?;
+        let video_thread = spawn_video_thread(client, player, stop, stats, is_hdr, params.smooth_playback)?;
         // Failing here after the video thread is already up would otherwise detach it.
         let (audio_thread, clock_thread) = match spawn_plane_threads(client, plane, stop, route) {
             Ok(handles) => handles,
@@ -224,12 +224,14 @@ fn spawn_video_thread(
     stop: &Arc<AtomicBool>,
     stats: &Arc<StreamStats>,
     is_hdr: bool,
+    smooth_playback: bool,
 ) -> Result<std::thread::JoinHandle<()>> {
     let cfg = SinkConfig {
         stream_hz: client.mode().refresh_hz,
         report_decode_latency: client.wants_decode_latency(),
         clock_offset: client.clock_offset_shared(),
         video_e2e: client.video_e2e_shared(),
+        smooth_playback,
     };
     let (client, stop, stats) = (client.clone(), stop.clone(), stats.clone());
     std::thread::Builder::new()

--- a/src/session/pump.rs
+++ b/src/session/pump.rs
@@ -150,13 +150,12 @@ impl VideoPump {
         self.stats
             .render_backlog
             .store(backlog.unwrap_or(-1), Ordering::Relaxed);
-        let (jitter_ns, cushion_ns, late_due, reanchors, late_stamps) = self.stage.cadence_health();
-        let to_us = |ns: i64| u32::try_from(ns.max(0) / 1_000).unwrap_or(u32::MAX);
-        self.stats.cadence_jitter_us.store(to_us(jitter_ns), Ordering::Relaxed);
-        self.stats
-            .cadence_cushion_us
-            .store(to_us(cushion_ns), Ordering::Relaxed);
-        self.stats.cadence_late.store(late_stamps, Ordering::Relaxed);
+        let pacing = self.stage.pacing_health();
+        self.stats.pacing_jitter_us.store(
+            u32::try_from(pacing.jitter_ns.max(0) / 1_000).unwrap_or(u32::MAX),
+            Ordering::Relaxed,
+        );
+        self.stats.pacing_late.store(pacing.late_stamps, Ordering::Relaxed);
         let plane_lead = self.stage.audio_plane_lead_ms();
         if let Some(ms) = plane_lead {
             self.stats
@@ -170,14 +169,19 @@ impl VideoPump {
         // DEBUG, so it costs a telemetry listener or `TELEMETRY_LEVEL=debug` to see — the
         // on-device file sink is INFO-only (`logger::resolved_level`).
         if self.video_log.due() {
-            // See `StreamStats::cadence_jitter_us` for what these mean and why both settings log them.
+            // `late_stamp` is the judder, counted: frames NDL was handed too late to pace. The
+            // rest describes whichever mapping produced it (see `session::timeline::PacingHealth`).
             tracing::debug!(
-                "cadence: jitter={:.1}ms cushion={:.1}ms late_stamp={late_stamps} late_due={late_due} reanchors={reanchors}",
-                jitter_ns as f64 / 1e6,
-                cushion_ns as f64 / 1e6,
+                "pacing: {} late_stamp={} jitter={:.1}ms cushion={:.1}ms reanchors={} trim={:.1}ms",
+                self.stage.pacing_label(),
+                pacing.late_stamps,
+                pacing.jitter_ns as f64 / 1e6,
+                pacing.cushion_ns as f64 / 1e6,
+                pacing.reanchors,
+                pacing.trimmed_ns as f64 / 1e6,
             );
             tracing::debug!(
-                "video: {} frames, parts={}, holding={}, dropped={}, backlog={}, pts_trim={}ms, plane_lead={}",
+                "video: {} frames, parts={}, holding={}, dropped={}, backlog={}, plane_lead={}",
                 self.frames(),
                 // Against `frames`: 0 means slice-progressive delivery never fired on this mode
                 // (core emits early parts only for an AU spanning more than one FEC block), so the
@@ -186,7 +190,6 @@ impl VideoPump {
                 self.stage.holding(),
                 self.client.frames_dropped(),
                 backlog.map_or_else(|| "n/a".to_string(), |b| b.to_string()),
-                self.stage.pts_trimmed_ms(),
                 // The audio plane's depth is a video figure: NDL paces the picture on it, and a
                 // lead sagging towards zero is what a stutter report should be read against.
                 plane_lead.map_or_else(|| "n/a".to_string(), |ms| format!("{ms}ms")),

--- a/src/session/pump.rs
+++ b/src/session/pump.rs
@@ -150,6 +150,13 @@ impl VideoPump {
         self.stats
             .render_backlog
             .store(backlog.unwrap_or(-1), Ordering::Relaxed);
+        let (jitter_ns, cushion_ns, late_due, reanchors, late_stamps) = self.stage.cadence_health();
+        let to_us = |ns: i64| u32::try_from(ns.max(0) / 1_000).unwrap_or(u32::MAX);
+        self.stats.cadence_jitter_us.store(to_us(jitter_ns), Ordering::Relaxed);
+        self.stats
+            .cadence_cushion_us
+            .store(to_us(cushion_ns), Ordering::Relaxed);
+        self.stats.cadence_late.store(late_stamps, Ordering::Relaxed);
         let plane_lead = self.stage.audio_plane_lead_ms();
         if let Some(ms) = plane_lead {
             self.stats
@@ -163,6 +170,12 @@ impl VideoPump {
         // DEBUG, so it costs a telemetry listener or `TELEMETRY_LEVEL=debug` to see — the
         // on-device file sink is INFO-only (`logger::resolved_level`).
         if self.video_log.due() {
+            // See `StreamStats::cadence_jitter_us` for what these mean and why both settings log them.
+            tracing::debug!(
+                "cadence: jitter={:.1}ms cushion={:.1}ms late_stamp={late_stamps} late_due={late_due} reanchors={reanchors}",
+                jitter_ns as f64 / 1e6,
+                cushion_ns as f64 / 1e6,
+            );
             tracing::debug!(
                 "video: {} frames, parts={}, holding={}, dropped={}, backlog={}, pts_trim={}ms, plane_lead={}",
                 self.frames(),

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 use punktfunk_core::quic;
 
 use crate::core::media::{AudioPlane, NotReady, SessionClock, VideoSink, VideoSinkCaps};
-use crate::session::timeline::{ms, reconciled_frame_interval_ns, CadencePacer, HostPtsAnchor};
+use crate::session::timeline::{ms, reconciled_frame_interval_ns, Pacing, PacingHealth};
 use crate::session::StreamStats;
 
 mod metrics;
@@ -87,12 +87,12 @@ pub struct SinkConfig {
     /// Where [`video_e2e_ns`] is published for the audio plane
     /// (`NativeClient::video_e2e_shared`). `0` = nothing on the glass yet.
     pub video_e2e: Arc<AtomicU64>,
-    /// Stamp frames from the cadence loop instead of the fixed anchor
-    /// (`Settings::smooth_playback`, Experimental). **The one gate on every latency-adding
-    /// measure on this path**: off is the shipped behaviour to the nanosecond, and on pays a
-    /// jitter-sized cushion of up to one frame interval for a cadence that does not beat against
-    /// the panel — see [`CadencePacer`].
-    pub smooth_playback: bool,
+    /// Stamp frames from the fixed anchor rather than the cadence loop
+    /// (`Settings::direct_playback`, Experimental). **The one gate on every latency-adding measure
+    /// on this path**, from the other side: the default pays a jitter-sized cushion of at most one
+    /// frame interval for a cadence that does not beat against the panel, and this gives that back
+    /// at the price of the judder — see `session::timeline::Pacing`.
+    pub direct_playback: bool,
 }
 
 /// Minimum spacing between [`SinkResult::NeedKeyframe`] results: the request travels on its own
@@ -123,21 +123,17 @@ pub struct VideoStage {
     /// that conversion ([`video_e2e_ns`] and [`VideoStage::decode_us`]), so one depth cannot mean two
     /// different latencies.
     frame_interval_ns: u64,
-    /// NDL host-PTS→player-clock mapping.
-    host_anchor: HostPtsAnchor,
-    /// The stamp the access unit currently being fed was given, while it is still open. Every
-    /// piece of one AU must carry the SAME timestamp (NDL finds AU boundaries by start code and
-    /// has no boundary flag of its own), and — the reason this is a field rather than a
-    /// recomputation — a picture must be folded into the mappings below exactly ONCE: on a
-    /// slice-progressive session the pieces of one AU repeat its host PTS at increasing arrival
-    /// times, so re-mapping per piece teaches both mappings the AU's TAIL arrival and inflates the
-    /// measured jitter with the AU's own transmission time. `None` on the whole-AU path and
-    /// between AUs.
+    /// NDL host-PTS→player-clock mapping — the cadence loop, or the anchor under
+    /// `Settings::direct_playback`. One object, so nothing in this file branches on which.
+    pacing: Pacing,
+    /// The stamp the access unit currently being fed was given, while it is still open. Every piece
+    /// of one AU must carry the SAME timestamp (NDL finds AU boundaries by start code and has no
+    /// boundary flag of its own), and — the reason this is a field rather than a recomputation — a
+    /// picture must be mapped exactly ONCE: slice-progressive delivery repeats an AU's host PTS
+    /// across its pieces at increasing arrival times, so re-mapping per piece teaches the mapping
+    /// the AU's TAIL arrival and inflates the measured jitter by the AU's own transmission time.
+    /// `None` on the whole-AU path and between AUs.
     au_base_ns: Option<u64>,
-    /// The cadence loop. Folds every frame whether or not its stamps are used — with the setting
-    /// off its health line is the evidence for turning it on — and owns the stamp when
-    /// [`SinkConfig::smooth_playback`] is set.
-    pacer: CadencePacer,
     /// Last polled depth, `None` if that query failed — which must not read as an empty queue.
     backlog_cached: Option<u64>,
     /// Recent poll depths, newest last — their minimum is the cushion the decode figure excludes
@@ -182,8 +178,7 @@ impl VideoStage {
             audio_plane,
             stats,
             frame_interval_ns,
-            host_anchor: HostPtsAnchor::new(frame_interval_ns),
-            pacer: CadencePacer::new(frame_interval_ns),
+            pacing: Pacing::new(frame_interval_ns, cfg.direct_playback),
             au_base_ns: None,
             cfg,
             backlog_cached: None,
@@ -216,8 +211,7 @@ impl VideoStage {
     /// plane's copy of it. The two move in lockstep or the planes end up on timelines that
     /// disagree.
     fn reset_timeline(&mut self) {
-        self.host_anchor.reset();
-        self.pacer.reset();
+        self.pacing.reset();
         self.au_base_ns = None;
         self.clock.clear();
     }
@@ -243,13 +237,7 @@ impl VideoStage {
         match self.sink.clock() {
             Some(clock) => {
                 let now = clock.now_ns();
-                // Both mappings are folded on every frame regardless of which is used (cheap, and
-                // each stateful over the whole run, so a lazily-fed one would be stale on demand).
-                let paced = self.pacer.map(frame_pts_ns, now);
-                let anchored = self.host_anchor.map(frame_pts_ns, now);
-                let base = if self.cfg.smooth_playback { paced } else { anchored };
-                self.pacer.note_stamp(base, now);
-                base
+                self.pacing.map(frame_pts_ns, now)
             }
             None => frame_pts_ns,
         }
@@ -324,27 +312,15 @@ impl VideoStage {
         }
     }
 
-    /// Whether the mapping in use has settled enough for the audio plane to latch it. The two
-    /// mappings settle on different evidence — the anchor waits for its trim to stop, the cadence
-    /// loop for enough frames to have been folded — so the gate follows whichever is stamping.
-    fn timeline_ready_for_audio(&self) -> bool {
-        if self.cfg.smooth_playback {
-            self.pacer.ready_for_audio()
-        } else {
-            self.host_anchor.ready_for_audio()
-        }
+    /// What the live mapping has to say for itself — see [`PacingHealth`]. The whole point of
+    /// publishing it on both mappings is that `late_stamps` makes them comparable.
+    pub fn pacing_health(&self) -> PacingHealth {
+        self.pacing.health()
     }
 
-    /// The cadence loop's health for the video heartbeat — see [`CadencePacer::health`]. Reported
-    /// on both settings, since the whole point of measuring with it off is to decide.
-    pub fn cadence_health(&self) -> (i64, i64, u64, u64, u64) {
-        self.pacer.health()
-    }
-
-    /// Standing PTS lead this run has trimmed off NDL's stamps, in ms — the decoder-hold latency
-    /// the session started with, and the only place it is observable (see [`HostPtsAnchor`]).
-    pub fn pts_trimmed_ms(&self) -> u64 {
-        self.host_anchor.trimmed_ns() / 1_000_000
+    /// Which mapping is stamping this session (`paced` / `direct`).
+    pub fn pacing_label(&self) -> &'static str {
+        self.pacing.label()
     }
 
     /// Audio-plane queue depth in ms, or `None` on a session with no plane — see
@@ -469,7 +445,7 @@ impl VideoStage {
                 // Held back until the anchor's trim has settled: audio stamps ride this offset and
                 // can only move forward, so latching onto a mapping still being pulled earlier
                 // costs lip sync (see `HostPtsAnchor::ready_for_audio`).
-                if self.timeline_ready_for_audio() {
+                if self.pacing.ready_for_audio() {
                     self.clock.latch(base_ns as i64 - pts_ns as i64);
                 }
                 let decode_us = self

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -178,7 +178,14 @@ impl VideoStage {
             audio_plane,
             stats,
             frame_interval_ns,
-            pacing: Pacing::new(frame_interval_ns, cfg.direct_playback),
+            // The SOURCE's nominal interval, NOT `frame_interval_ns`: that one is reconciled
+            // onto the panel because it converts a render-queue depth into time, and this one
+            // is the cushion's ceiling, so it has to describe the cadence the HOST produces.
+            // Core says so with a test of its own
+            // (`the_cadence_interval_comes_from_the_stream_mode_not_the_panel`): a 120 fps
+            // stream on a 60 Hz panel would otherwise license twice the hold the source's own
+            // cadence can justify.
+            pacing: Pacing::new(1_000_000_000 / u64::from(stream_hz), cfg.direct_playback),
             au_base_ns: None,
             cfg,
             backlog_cached: None,

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 use punktfunk_core::quic;
 
 use crate::core::media::{AudioPlane, NotReady, SessionClock, VideoSink, VideoSinkCaps};
-use crate::session::timeline::{ms, reconciled_frame_interval_ns, HostPtsAnchor};
+use crate::session::timeline::{ms, reconciled_frame_interval_ns, CadencePacer, HostPtsAnchor};
 use crate::session::StreamStats;
 
 mod metrics;
@@ -87,6 +87,12 @@ pub struct SinkConfig {
     /// Where [`video_e2e_ns`] is published for the audio plane
     /// (`NativeClient::video_e2e_shared`). `0` = nothing on the glass yet.
     pub video_e2e: Arc<AtomicU64>,
+    /// Stamp frames from the cadence loop instead of the fixed anchor
+    /// (`Settings::smooth_playback`, Experimental). **The one gate on every latency-adding
+    /// measure on this path**: off is the shipped behaviour to the nanosecond, and on pays a
+    /// jitter-sized cushion of up to one frame interval for a cadence that does not beat against
+    /// the panel — see [`CadencePacer`].
+    pub smooth_playback: bool,
 }
 
 /// Minimum spacing between [`SinkResult::NeedKeyframe`] results: the request travels on its own
@@ -119,6 +125,19 @@ pub struct VideoStage {
     frame_interval_ns: u64,
     /// NDL host-PTS→player-clock mapping.
     host_anchor: HostPtsAnchor,
+    /// The stamp the access unit currently being fed was given, while it is still open. Every
+    /// piece of one AU must carry the SAME timestamp (NDL finds AU boundaries by start code and
+    /// has no boundary flag of its own), and — the reason this is a field rather than a
+    /// recomputation — a picture must be folded into the mappings below exactly ONCE: on a
+    /// slice-progressive session the pieces of one AU repeat its host PTS at increasing arrival
+    /// times, so re-mapping per piece teaches both mappings the AU's TAIL arrival and inflates the
+    /// measured jitter with the AU's own transmission time. `None` on the whole-AU path and
+    /// between AUs.
+    au_base_ns: Option<u64>,
+    /// The cadence loop. Folds every frame whether or not its stamps are used — with the setting
+    /// off its health line is the evidence for turning it on — and owns the stamp when
+    /// [`SinkConfig::smooth_playback`] is set.
+    pacer: CadencePacer,
     /// Last polled depth, `None` if that query failed — which must not read as an empty queue.
     backlog_cached: Option<u64>,
     /// Recent poll depths, newest last — their minimum is the cushion the decode figure excludes
@@ -164,6 +183,8 @@ impl VideoStage {
             stats,
             frame_interval_ns,
             host_anchor: HostPtsAnchor::new(frame_interval_ns),
+            pacer: CadencePacer::new(frame_interval_ns),
+            au_base_ns: None,
             cfg,
             backlog_cached: None,
             backlog_recent: std::collections::VecDeque::with_capacity(CUSHION_MIN_POLLS),
@@ -196,6 +217,8 @@ impl VideoStage {
     /// disagree.
     fn reset_timeline(&mut self) {
         self.host_anchor.reset();
+        self.pacer.reset();
+        self.au_base_ns = None;
         self.clock.clear();
     }
 
@@ -205,11 +228,28 @@ impl VideoStage {
     /// so the host's capture PTS is mapped onto it ([`HostPtsAnchor`]) — which is also what keeps
     /// video and any audio plane in ONE timeline. A sink without one presents in feed order and
     /// the stamp is discarded at the feed, so the host PTS passes through untouched.
+    /// This AU's stamp: computed on the piece that opens it and repeated for the rest — see
+    /// [`Self::au_base_ns`]. `partial` is whether this piece leaves the AU open.
+    fn au_stamp_ns(&mut self, frame_pts_ns: u64, partial: bool) -> u64 {
+        let base = match self.au_base_ns {
+            Some(open) => open,
+            None => self.pts_base_ns(frame_pts_ns),
+        };
+        self.au_base_ns = partial.then_some(base);
+        base
+    }
+
     fn pts_base_ns(&mut self, frame_pts_ns: u64) -> u64 {
         match self.sink.clock() {
             Some(clock) => {
                 let now = clock.now_ns();
-                self.host_anchor.map(frame_pts_ns, now)
+                // Both mappings are folded on every frame regardless of which is used (cheap, and
+                // each stateful over the whole run, so a lazily-fed one would be stale on demand).
+                let paced = self.pacer.map(frame_pts_ns, now);
+                let anchored = self.host_anchor.map(frame_pts_ns, now);
+                let base = if self.cfg.smooth_playback { paced } else { anchored };
+                self.pacer.note_stamp(base, now);
+                base
             }
             None => frame_pts_ns,
         }
@@ -284,6 +324,23 @@ impl VideoStage {
         }
     }
 
+    /// Whether the mapping in use has settled enough for the audio plane to latch it. The two
+    /// mappings settle on different evidence — the anchor waits for its trim to stop, the cadence
+    /// loop for enough frames to have been folded — so the gate follows whichever is stamping.
+    fn timeline_ready_for_audio(&self) -> bool {
+        if self.cfg.smooth_playback {
+            self.pacer.ready_for_audio()
+        } else {
+            self.host_anchor.ready_for_audio()
+        }
+    }
+
+    /// The cadence loop's health for the video heartbeat — see [`CadencePacer::health`]. Reported
+    /// on both settings, since the whole point of measuring with it off is to decide.
+    pub fn cadence_health(&self) -> (i64, i64, u64, u64, u64) {
+        self.pacer.health()
+    }
+
     /// Standing PTS lead this run has trimmed off NDL's stamps, in ms — the decoder-hold latency
     /// the session started with, and the only place it is observable (see [`HostPtsAnchor`]).
     pub fn pts_trimmed_ms(&self) -> u64 {
@@ -327,8 +384,10 @@ impl VideoStage {
         // the pieces so far leave this AU decodable.
         let PartStep::Feed { partial, lost_parts } = self.parts.step(frame, self.caps.partial_au) else {
             // Same reason as the `drop_open` below: the AU this was accumulating submission time
-            // for is abandoned, so its cost must not be charged to whatever AU comes next.
+            // for is abandoned, so its cost must not be charged to whatever AU comes next. Its
+            // stamp goes with it — the next AU is a new picture and maps itself.
             self.au_feed_us = 0;
+            self.au_base_ns = None;
             return SinkResult::Held;
         };
         // Only a completed AU is a frame — a session feeding pieces would otherwise count one
@@ -352,8 +411,9 @@ impl VideoStage {
         if !matches!(result, SinkResult::Presented { .. }) {
             self.parts.drop_open();
             // The AU this was accumulating for will never complete, so it must not be added to
-            // whatever AU comes next.
+            // whatever AU comes next — nor may its stamp be repeated onto one.
             self.au_feed_us = 0;
+            self.au_base_ns = None;
         }
         result
     }
@@ -364,7 +424,7 @@ impl VideoStage {
             HoldGate::Feed { request_keyframe } => request_keyframe,
         };
 
-        let base_ns = self.pts_base_ns(pts_ns);
+        let base_ns = self.au_stamp_ns(pts_ns, flags.partial);
         // The submit instant, on CLOCK_REALTIME — the same basis the host stamps `pts_ns` with and
         // the skew handshake compares, so the two are directly subtractable. Taken BEFORE the feed
         // call: `play` blocks for its submission time, and the frame enters NDL's pipeline behind
@@ -409,7 +469,7 @@ impl VideoStage {
                 // Held back until the anchor's trim has settled: audio stamps ride this offset and
                 // can only move forward, so latching onto a mapping still being pulled earlier
                 // costs lip sync (see `HostPtsAnchor::ready_for_audio`).
-                if self.host_anchor.ready_for_audio() {
+                if self.timeline_ready_for_audio() {
                     self.clock.latch(base_ns as i64 - pts_ns as i64);
                 }
                 let decode_us = self

--- a/src/session/stats.rs
+++ b/src/session/stats.rs
@@ -16,6 +16,15 @@ pub struct StreamStats {
     pub feed_us: AtomicU32,
     /// NDL render-buffer backlog or -1 if unavailable.
     pub render_backlog: AtomicI32,
+    /// The cadence loop's measured jitter (mean absolute deviation of `ready − pts`) and the
+    /// cushion it would hold to cover it, in µs — published on the heartbeat's cadence whether or
+    /// not smooth playback is on, since with it OFF these are the numbers that say whether turning
+    /// it on is worth the latency (see `session::timeline::CadencePacer`).
+    pub cadence_jitter_us: AtomicU32,
+    pub cadence_cushion_us: AtomicU32,
+    /// Frames whose stamp was already behind the player clock when fed — presented at feed cadence
+    /// rather than paced, which is the judder. Cumulative for the session.
+    pub cadence_late: AtomicU64,
     /// Audio-plane queue depth in ms (`NdlVideo::audio_plane_lead_ms`). A video figure as much as
     /// an audio one — NDL paces the picture on this — and can legitimately be negative, so there
     /// is no sentinel: the overlay prints it only on a route that has a plane.

--- a/src/session/stats.rs
+++ b/src/session/stats.rs
@@ -16,15 +16,12 @@ pub struct StreamStats {
     pub feed_us: AtomicU32,
     /// NDL render-buffer backlog or -1 if unavailable.
     pub render_backlog: AtomicI32,
-    /// The cadence loop's measured jitter (mean absolute deviation of `ready − pts`) and the
-    /// cushion it would hold to cover it, in µs — published on the heartbeat's cadence whether or
-    /// not smooth playback is on, since with it OFF these are the numbers that say whether turning
-    /// it on is worth the latency (see `session::timeline::CadencePacer`).
-    pub cadence_jitter_us: AtomicU32,
-    pub cadence_cushion_us: AtomicU32,
-    /// Frames whose stamp was already behind the player clock when fed — presented at feed cadence
-    /// rather than paced, which is the judder. Cumulative for the session.
-    pub cadence_late: AtomicU64,
+    /// The live mapping's measured jitter (mean absolute deviation of `ready − pts`), in µs, and
+    /// the frames it stamped too late to pace — see `session::timeline::PacingHealth`. Published on
+    /// the heartbeat's cadence under both mappings, so a stutter report can be read against them
+    /// whichever one produced it.
+    pub pacing_jitter_us: AtomicU32,
+    pub pacing_late: AtomicU64,
     /// Audio-plane queue depth in ms (`NdlVideo::audio_plane_lead_ms`). A video figure as much as
     /// an audio one — NDL paces the picture on this — and can legitimately be negative, so there
     /// is no sentinel: the overlay prints it only on a route that has a plane.

--- a/src/session/timeline.rs
+++ b/src/session/timeline.rs
@@ -65,8 +65,9 @@ const PACER_AUDIO_LATCH_FRAMES: u64 = 30;
 /// to the anchor.
 pub struct CadencePacer {
     clock: punktfunk_core::phase::CadenceClock,
-    /// Nominal source interval, and the cushion's ceiling (see `CadenceClock::cushion_ns`).
-    frame_interval_ns: i64,
+    /// The source's nominal interval, and the cushion's ceiling (see `CadenceClock::cushion_ns`)
+    /// — see [`Self::new`] for why it is not the panel's.
+    source_interval_ns: i64,
     /// Last stamp handed out this run. NDL reads a stamp going backwards as a rewind and answers
     /// by muting the session for good, and the cushion CAN shrink between frames, so the sequence
     /// is clamped monotonic — exactly as [`HostPtsAnchor::map`] does, and reset with the run for
@@ -78,13 +79,16 @@ pub struct CadencePacer {
 }
 
 impl CadencePacer {
-    pub fn new(frame_interval_ns: u64) -> Self {
+    /// `source_interval_ns` is the negotiated STREAM mode's frame interval — the cadence the host
+    /// produces — and never the panel's. It is the cushion's ceiling, so a panel period would let a
+    /// stream running faster than the panel be held for longer than its own cadence justifies.
+    pub fn new(source_interval_ns: u64) -> Self {
         Self {
             // `snapping`, not `free_running`: NDL presents on the panel's own grid, so the snap-up
             // to the next latch already carries roughly half a refresh of implicit slack and the
             // cushion does not have to cover the distribution alone.
             clock: punktfunk_core::phase::CadenceClock::new(punktfunk_core::phase::CadenceTuning::snapping()),
-            frame_interval_ns: i64::try_from(frame_interval_ns).unwrap_or(i64::MAX),
+            source_interval_ns: i64::try_from(source_interval_ns).unwrap_or(i64::MAX),
             last_base_ns: 0,
             frames_this_run: 0,
         }
@@ -97,7 +101,7 @@ impl CadencePacer {
     pub fn map(&mut self, host_pts_ns: u64, player_clock_ns: u64) -> u64 {
         self.frames_this_run += 1;
         let ready = i64::try_from(player_clock_ns).unwrap_or(i64::MAX);
-        let due = self.clock.due_ns(host_pts_ns, ready, self.frame_interval_ns);
+        let due = self.clock.due_ns(host_pts_ns, ready, self.source_interval_ns);
         // A due time in the past is a late frame and core's contract is "present at the next
         // opportunity" — which is what handing NDL a stamp at or behind its clock already means.
         let base = u64::try_from(due).unwrap_or(0).max(self.last_base_ns);
@@ -172,12 +176,15 @@ enum Mode {
 }
 
 impl Pacing {
-    pub fn new(frame_interval_ns: u64, direct: bool) -> Self {
+    /// `source_interval_ns` is the stream mode's own interval — see [`CadencePacer::new`]. The
+    /// anchor's ramp is sized against the same quantity: it pays trim debt off per FRAME, and a
+    /// frame is what the source, not the panel, delivers.
+    pub fn new(source_interval_ns: u64, direct: bool) -> Self {
         Self {
             mode: if direct {
-                Mode::Anchor(HostPtsAnchor::new(frame_interval_ns))
+                Mode::Anchor(HostPtsAnchor::new(source_interval_ns))
             } else {
-                Mode::Cadence(CadencePacer::new(frame_interval_ns))
+                Mode::Cadence(CadencePacer::new(source_interval_ns))
             },
             late_stamps: 0,
         }

--- a/src/session/timeline.rs
+++ b/src/session/timeline.rs
@@ -30,6 +30,115 @@ pub fn reconciled_frame_interval_ns(stream_hz: u32) -> u64 {
     1_000_000_000 / u64::from(hz.max(1))
 }
 
+/// Frames the cadence loop folds before the audio plane may latch its mapping
+/// ([`CadencePacer::ready_for_audio`]). Half a second at 60 Hz — long enough for the offset
+/// estimate to leave its cold-start sample behind, short enough that offloaded audio is not
+/// audibly missing at session start. The trim path's own gate is [`TRIM_SETTLE_NS`], which is a
+/// different quantity and cannot be shared: that one waits for trimming to STOP, and this loop
+/// never stops moving.
+const PACER_AUDIO_LATCH_FRAMES: u64 = 30;
+
+/// Plays frames out on the host's own cadence instead of on their arrival instant, by stamping
+/// them from [`punktfunk_core::phase::CadenceClock`] rather than from a fixed anchor.
+///
+/// **Why this is a different shape from [`HostPtsAnchor`], not a tweak to it.** The anchor is a
+/// constant taken from frame 0 plus a one-off trim: it has no rate term (two free-running crystals
+/// produce a ramp, so the session's real lead walks away over minutes with nothing to pull it
+/// back), and its jitter margin is whatever [`TRIM_KEEP_NS`] happens to be — 4 ms, chosen for
+/// latency, and below the arrival spread of an ordinary link. Every frame arriving later than that
+/// margin is stamped in the player clock's past, which NDL answers by presenting it at feed
+/// cadence: the judder. `CadenceClock` is a type-2 loop over the same quantity (`ready − pts`) and
+/// sizes its cushion from the measured mean absolute deviation, capped at one frame interval.
+///
+/// **It smooths the OFFSET, never the timestamps** — that is core's invariant, tested there by
+/// `preserves_source_cadence`, and it is the property that makes this honest: a game genuinely
+/// rendering at an irregular rate still looks exactly as irregular as it is. What is removed is
+/// the transport's contribution, not the source's.
+///
+/// The cost is the cushion, so this is opt-in: `Settings::smooth_playback`, gating every
+/// latency-adding measure on this path (see `SinkConfig::smooth_playback`). The loop still runs
+/// when the setting is off — its health line is what says whether turning it on is worth it — but
+/// its output is discarded and the anchor above keeps stamping.
+pub struct CadencePacer {
+    clock: punktfunk_core::phase::CadenceClock,
+    /// Nominal source interval, and the cushion's ceiling (see `CadenceClock::cushion_ns`).
+    frame_interval_ns: i64,
+    /// Last stamp handed out this run. NDL reads a stamp going backwards as a rewind and answers
+    /// by muting the session for good, and the cushion CAN shrink between frames, so the sequence
+    /// is clamped monotonic — exactly as [`HostPtsAnchor::map`] does, and reset with the run for
+    /// the same reason (a flush restarts the timeline).
+    last_base_ns: u64,
+    /// Frames folded since the last [`Self::reset`], for [`Self::ready_for_audio`]. Not read off
+    /// `CadenceHealth::frames`, which counts the whole session.
+    frames_this_run: u64,
+    /// Frames whose stamp was already behind the player clock when it was fed — the direct
+    /// "the cushion is too small" signal, counted for whichever mapping is actually in use rather
+    /// than for the loop, so it is comparable across the setting.
+    late_stamps: u64,
+}
+
+impl CadencePacer {
+    pub fn new(frame_interval_ns: u64) -> Self {
+        Self {
+            // `snapping`, not `free_running`: NDL presents on the panel's own grid, so the snap-up
+            // to the next latch already carries roughly half a refresh of implicit slack and the
+            // cushion does not have to cover the distribution alone.
+            clock: punktfunk_core::phase::CadenceClock::new(punktfunk_core::phase::CadenceTuning::snapping()),
+            frame_interval_ns: i64::try_from(frame_interval_ns).unwrap_or(i64::MAX),
+            last_base_ns: 0,
+            frames_this_run: 0,
+            late_stamps: 0,
+        }
+    }
+
+    /// Fold one frame and return its stamp in the player's clock domain. `player_clock_ns` is when
+    /// the frame became presentable, i.e. now — the loop is domain-agnostic, so the constant
+    /// between the host's capture clock and NDL's player clock is simply absorbed by the offset
+    /// estimate and there is no conversion anywhere in this path.
+    pub fn map(&mut self, host_pts_ns: u64, player_clock_ns: u64) -> u64 {
+        self.frames_this_run += 1;
+        let ready = i64::try_from(player_clock_ns).unwrap_or(i64::MAX);
+        let due = self.clock.due_ns(host_pts_ns, ready, self.frame_interval_ns);
+        // A due time in the past is a late frame and core's contract is "present at the next
+        // opportunity" — which is what handing NDL a stamp at or behind its clock already means.
+        let base = u64::try_from(due).unwrap_or(0).max(self.last_base_ns);
+        self.last_base_ns = base;
+        base
+    }
+
+    /// Count one fed frame whose stamp had already passed. Called with the stamp actually used, so
+    /// the figure describes the session the user is watching and not the shadow loop.
+    pub fn note_stamp(&mut self, base_ns: u64, player_clock_ns: u64) {
+        if base_ns <= player_clock_ns {
+            self.late_stamps += 1;
+        }
+    }
+
+    /// Drop the run: the timeline jumped (a freeze-until-reanchor hold), so the offset estimate no
+    /// longer describes anything. The loop keeps its jitter estimate on purpose — that describes
+    /// the link, not the stream, and a cushion collapsing to its floor after every recovery would
+    /// spend the next few hundred frames presenting late.
+    pub fn reset(&mut self) {
+        self.clock.reset();
+        self.frames_this_run = 0;
+        // Cleared with the run, like the anchor's own: NDL has been flushed, so the stamps that
+        // came before it are no longer a floor this run has to clear.
+        self.last_base_ns = 0;
+    }
+
+    /// Whether the audio plane may latch this mapping — see [`PACER_AUDIO_LATCH_FRAMES`].
+    pub fn ready_for_audio(&self) -> bool {
+        self.frames_this_run >= PACER_AUDIO_LATCH_FRAMES
+    }
+
+    /// `(jitter_ns, cushion_ns, late_due, reanchors, late_stamps)` for the video heartbeat: the
+    /// loop's own health plus the one figure it cannot know (see [`Self::note_stamp`]).
+    pub fn health(&self) -> (i64, i64, u64, u64, u64) {
+        let h = self.clock.health();
+        (h.jitter_ns, h.cushion_ns, h.late, h.reanchors, self.late_stamps)
+    }
+}
+
 /// Window the lead minimum is taken over (see [`HostPtsAnchor::observe_lead`]). Short enough
 /// that several windows fit inside [`TRIM_SETTLE_NS`], long enough (30 frames at 60 Hz) that a
 /// single early arrival can't be mistaken for the standing floor.
@@ -330,6 +439,32 @@ mod tests {
             let base = a.map(stuck, stuck + 5_000_000 + repeat);
             assert!(base >= last, "repeat {repeat}: {base} < {last}");
             last = base;
+        }
+    }
+
+    /// The cadence loop's cushion moves with the measured jitter, and a repeated host PTS gains
+    /// nothing to cover a shrinking one — either way the stamp would step BACKWARDS, which NDL
+    /// reads as a rewind and answers by muting the session for the rest of the run. Proven
+    /// non-vacuous by planting the defect (dropping the `.max(last_base_ns)` in
+    /// `CadencePacer::map`), which fails this.
+    #[test]
+    fn the_pacer_never_walks_a_stamp_backwards_within_a_run() {
+        let interval = 16_666_666u64;
+        let mut p = CadencePacer::new(interval);
+        let mut last = 0;
+        // A jittery opening (which builds a cushion), then a dead-calm tail (which shrinks it),
+        // with a repeated stamp thrown in where the shrink is fastest.
+        for i in 0..600u64 {
+            let host_pts = i * interval;
+            let jitter = if i < 200 { (i % 7) * 2_000_000 } else { 0 };
+            let base = p.map(host_pts, host_pts + 10_000_000 + jitter);
+            assert!(base >= last, "frame {i}: {base} < {last}");
+            last = base;
+            if i == 200 {
+                let repeat = p.map(host_pts, host_pts + 10_000_000);
+                assert!(repeat >= last, "repeat: {repeat} < {last}");
+                last = repeat;
+            }
         }
     }
 

--- a/src/session/timeline.rs
+++ b/src/session/timeline.rs
@@ -1,5 +1,9 @@
-//! Timeline plumbing for the video pump: the panel-reconciled frame interval and the
-//! host-PTS → player-clock anchor NDL needs (it has no PTS clock of its own).
+//! Timeline plumbing for the video pump: the panel-reconciled frame interval, and the
+//! host-PTS → player-clock mapping NDL needs (it has no PTS clock of its own).
+//!
+//! Two mappings, picked by [`Pacing`]: the cadence loop ([`CadencePacer`], the default) and the
+//! fixed anchor ([`HostPtsAnchor`], the Experimental escape hatch). Exactly one is live per
+//! session — see [`Pacing`] for why they are not both folded.
 
 use crate::platform::webos::sdl_webos;
 
@@ -55,10 +59,10 @@ const PACER_AUDIO_LATCH_FRAMES: u64 = 30;
 /// rendering at an irregular rate still looks exactly as irregular as it is. What is removed is
 /// the transport's contribution, not the source's.
 ///
-/// The cost is the cushion, so this is opt-in: `Settings::smooth_playback`, gating every
-/// latency-adding measure on this path (see `SinkConfig::smooth_playback`). The loop still runs
-/// when the setting is off — its health line is what says whether turning it on is worth it — but
-/// its output is discarded and the anchor above keeps stamping.
+/// **The default**, because the cushion it pays is measured rather than chosen: on a link with
+/// nothing wrong it collapses to its 0.5 ms floor and costs essentially nothing, and it only grows
+/// where there is real jitter to cover. `Settings::direct_playback` (Experimental) is the way back
+/// to the anchor.
 pub struct CadencePacer {
     clock: punktfunk_core::phase::CadenceClock,
     /// Nominal source interval, and the cushion's ceiling (see `CadenceClock::cushion_ns`).
@@ -71,10 +75,6 @@ pub struct CadencePacer {
     /// Frames folded since the last [`Self::reset`], for [`Self::ready_for_audio`]. Not read off
     /// `CadenceHealth::frames`, which counts the whole session.
     frames_this_run: u64,
-    /// Frames whose stamp was already behind the player clock when it was fed — the direct
-    /// "the cushion is too small" signal, counted for whichever mapping is actually in use rather
-    /// than for the loop, so it is comparable across the setting.
-    late_stamps: u64,
 }
 
 impl CadencePacer {
@@ -87,7 +87,6 @@ impl CadencePacer {
             frame_interval_ns: i64::try_from(frame_interval_ns).unwrap_or(i64::MAX),
             last_base_ns: 0,
             frames_this_run: 0,
-            late_stamps: 0,
         }
     }
 
@@ -104,14 +103,6 @@ impl CadencePacer {
         let base = u64::try_from(due).unwrap_or(0).max(self.last_base_ns);
         self.last_base_ns = base;
         base
-    }
-
-    /// Count one fed frame whose stamp had already passed. Called with the stamp actually used, so
-    /// the figure describes the session the user is watching and not the shadow loop.
-    pub fn note_stamp(&mut self, base_ns: u64, player_clock_ns: u64) {
-        if base_ns <= player_clock_ns {
-            self.late_stamps += 1;
-        }
     }
 
     /// Drop the run: the timeline jumped (a freeze-until-reanchor hold), so the offset estimate no
@@ -131,11 +122,124 @@ impl CadencePacer {
         self.frames_this_run >= PACER_AUDIO_LATCH_FRAMES
     }
 
-    /// `(jitter_ns, cushion_ns, late_due, reanchors, late_stamps)` for the video heartbeat: the
-    /// loop's own health plus the one figure it cannot know (see [`Self::note_stamp`]).
-    pub fn health(&self) -> (i64, i64, u64, u64, u64) {
-        let h = self.clock.health();
-        (h.jitter_ns, h.cushion_ns, h.late, h.reanchors, self.late_stamps)
+    fn health(&self) -> punktfunk_core::phase::CadenceHealth {
+        self.clock.health()
+    }
+}
+
+/// What the live mapping has to say for itself, on the video heartbeat and the stats overlay.
+/// One shape for both mappings, so a report reads the same whichever is in use — a field a mapping
+/// has no notion of is simply `0`.
+#[derive(Clone, Copy, Default)]
+pub struct PacingHealth {
+    /// Measured jitter (mean absolute deviation of `ready − pts`), and what the cadence loop holds
+    /// to cover it. Both `0` under the anchor, which measures neither.
+    pub jitter_ns: i64,
+    pub cushion_ns: i64,
+    /// Frames whose stamp was already behind the player clock when fed: presented at feed cadence
+    /// rather than paced, which is the judder. **The one figure both mappings publish**, so it is
+    /// what a before/after comparison rests on.
+    pub late_stamps: u64,
+    /// Times the mapping gave up tracking and re-anchored.
+    pub reanchors: u64,
+    /// Standing lead the anchor has trimmed off this run, in ns. `0` under the cadence loop, which
+    /// has no trim — its offset estimate is the whole mechanism.
+    pub trimmed_ns: u64,
+}
+
+/// The host-PTS → player-clock mapping this session stamps with.
+///
+/// **Only the live one is folded.** Both are stateful over the whole run, so running the idle one
+/// in the shadows would cost a mapping that is never read and a second set of numbers describing a
+/// session nobody is watching. What makes the two comparable is [`PacingHealth::late_stamps`],
+/// computed from the stamp actually used and so present on both paths.
+pub struct Pacing {
+    mode: Mode,
+    /// Frames fed with a stamp already behind the player clock — see [`PacingHealth::late_stamps`].
+    /// Held here rather than in either mapping precisely because it must mean the same thing on
+    /// both.
+    late_stamps: u64,
+}
+
+enum Mode {
+    /// The default — see [`CadencePacer`].
+    Cadence(CadencePacer),
+    /// `Settings::direct_playback`: the fixed anchor plus its one-off trim, the mapping this client
+    /// shipped before the cadence loop. Kept as the escape hatch for a set where the loop
+    /// misbehaves, and as the lowest-latency answer for anyone who would rather have the judder
+    /// than the cushion.
+    Anchor(HostPtsAnchor),
+}
+
+impl Pacing {
+    pub fn new(frame_interval_ns: u64, direct: bool) -> Self {
+        Self {
+            mode: if direct {
+                Mode::Anchor(HostPtsAnchor::new(frame_interval_ns))
+            } else {
+                Mode::Cadence(CadencePacer::new(frame_interval_ns))
+            },
+            late_stamps: 0,
+        }
+    }
+
+    /// This frame's stamp in the player's clock domain, and the late-stamp bookkeeping with it.
+    pub fn map(&mut self, host_pts_ns: u64, player_clock_ns: u64) -> u64 {
+        let base = match &mut self.mode {
+            Mode::Cadence(p) => p.map(host_pts_ns, player_clock_ns),
+            Mode::Anchor(a) => a.map(host_pts_ns, player_clock_ns),
+        };
+        if base <= player_clock_ns {
+            self.late_stamps += 1;
+        }
+        base
+    }
+
+    /// Drop the run: the timeline jumped and nothing derived from it holds.
+    pub fn reset(&mut self) {
+        match &mut self.mode {
+            Mode::Cadence(p) => p.reset(),
+            Mode::Anchor(a) => a.reset(),
+        }
+    }
+
+    /// Whether the audio plane may latch this mapping. The two settle on different evidence and
+    /// cannot share a gate: the anchor waits for trimming to STOP, and the cadence loop never stops
+    /// moving, so it waits for enough frames instead.
+    pub fn ready_for_audio(&self) -> bool {
+        match &self.mode {
+            Mode::Cadence(p) => p.ready_for_audio(),
+            Mode::Anchor(a) => a.ready_for_audio(),
+        }
+    }
+
+    pub fn health(&self) -> PacingHealth {
+        let late_stamps = self.late_stamps;
+        match &self.mode {
+            Mode::Cadence(p) => {
+                let h = p.health();
+                PacingHealth {
+                    jitter_ns: h.jitter_ns,
+                    cushion_ns: h.cushion_ns,
+                    late_stamps,
+                    reanchors: h.reanchors,
+                    trimmed_ns: 0,
+                }
+            }
+            Mode::Anchor(a) => PacingHealth {
+                late_stamps,
+                trimmed_ns: a.trimmed_ns(),
+                ..PacingHealth::default()
+            },
+        }
+    }
+
+    /// Which mapping is live, for the log line and the overlay.
+    pub fn label(&self) -> &'static str {
+        match &self.mode {
+            Mode::Cadence(_) => "paced",
+            Mode::Anchor(_) => "direct",
+        }
     }
 }
 


### PR DESCRIPTION
## What

Bumps `punktfunk-core` v0.28.0 -> v0.31.3 and uses its `CadenceClock` to pace
video release to the host's frame cadence, instead of stamping frames on the
instant they arrive. This is now the **default**; the previous mapping stays as
an Experimental opt-out ("Direct playback").

## Why

Reported symptom: distracting stutter during gameplay, not visible on the
monitor attached to the host.

The `HostPtsAnchor` mapping this client shipped has two holes: no rate term
(frame 0's arrival latency held as a constant plus a one-off trim that stops
after 3s, so two free-running crystals drift the session's real lead over
minutes with nothing pulling it back), and a jitter margin (`TRIM_KEEP_NS` =
4ms) below an ordinary link's arrival spread, which by construction leaves the
latest-arriving frames of each window stamped in the past. The host's capture is
also damage-driven (PipeWire), so its cadence is genuinely uneven before the
network adds anything. Frames miss refresh slots, get held an extra refresh, the
next lands early — the classic double-hitch. There was no client-side buffer,
reordering, or release scheduler, and nothing measuring cadence, before this.

## Design

- `CadencePacer` (`src/session/timeline.rs`) wraps core's `CadenceClock` — the
  same playout loop the desktop/Android/Apple presenters use — instead of a
  bespoke pacing loop, so every client computes the same statistic and shares
  the same tested invariant (it smooths the *offset*, never the timestamps: an
  irregularly-rendering game still looks exactly as irregular). Stamps become
  `pts + tracked_offset + cushion`; cushion is 2x the mean absolute deviation
  of `(ready - pts)`, capped at one frame interval and floored at 0.5ms. Tuned
  with `snapping()` since NDL already presents on the panel's refresh grid,
  which carries ~half a refresh of implicit slack.
- **Default, not opt-in.** The cushion is measured rather than chosen: on a link
  with nothing wrong it sits at its floor and costs essentially nothing, and it
  only grows where there is real jitter to cover. `Settings::direct_playback`
  (Experimental, off by default) is the way back to the anchor — the
  known-behaviour comparison for any regression report, and the honest answer
  for anyone who would rather have the judder than the cushion. It remains the
  one gate on every latency-adding measure in the video path.
- The cushion's ceiling is the **stream mode's** interval, not the panel-reconciled one the stage
  uses for queue-depth conversion. Two quantities that agree on most panels but not in principle:
  the reconciled one follows the panel's drain cadence, and the cushion bounds how long a frame may
  be *held*, so it must follow the cadence the host produces — core states this with a test of its
  own. The anchor's trim ramp takes the same quantity, for the same reason.
- `session::timeline::Pacing` owns which mapping is live, so nothing above it
  branches on it. **Only the live mapping folds**: both are stateful over the
  whole run, so shadowing the idle one bought a mapping nobody reads plus a
  second set of numbers describing a session nobody is watching.
- What makes the two comparable is `late_stamps` — frames whose actual stamp was
  already behind the player clock, i.e. the judder, counted — which `Pacing`
  computes from the stamp in use and so publishes on both paths. Reported as
  `pacing:` on the video heartbeat and one short `Pace` line on the stats
  overlay (`Pace jitter 1.2 ms · late 5`, or `Pace direct · late 5` where no
  jitter is measured).
- `VideoStage::au_base_ns` holds one stamp per AU, since slice-progressive
  delivery (on for every NDL v2 session) repeats an AU's PTS across pieces at
  increasing arrival times — mapping per piece would teach the loop each AU's
  tail arrival and inflate measured jitter by the AU's own transmission time.
  NDL finds AU boundaries by start code and has no boundary flag, so this is
  also what keeps every piece of one AU on the same timestamp.
- Stamps are clamped monotonic per run: the cushion can shrink between frames,
  and NDL reads a timestamp going backwards as a rewind, muting audio for the
  rest of the session. Cleared on reset, matching the existing anchor.
- The two mappings cannot share an audio-latch gate: the anchor's waits for
  trimming to stop; the cadence loop never stops moving, so it waits a fixed 30
  folded frames instead.
- `errors.rs`: `RejectReason` gained `AccessExpired`/`LaunchNotPermitted` in
  0.31.3 (the one compile break from the bump); matched using upstream's own
  wording from `pf-client-core`'s `trust.rs` so messages agree with every other
  punktfunk client.

Audited against core's own presenter, and matching it: frames are folded at **arrival** (core: "at
SUBMIT rather than at take, so the estimate sees the arrival process the transport actually
produced"); `snapping()` tuning is permanent, since `follow()`'s `free_running()` re-tune applies
only where VRR is *measured* live and that needs on-glass stamps NDL cannot give; and
`note_off_cadence` is wired by no client, this one included — nothing on the wire marks a frame
off-cadence.

## Known gaps / follow-ups (documented in `docs/NOTES.md`)

- With audio offload on (itself opt-in Experimental), `SessionClock` latches one
  constant for the run, so lip sync drifts at crystal rate under the cadence
  loop — tens of ppm, bounded, uncorrected, and now on the default path. Only
  the offload route is affected; the software route's stamps never ride this
  mapping. A forward-only re-latch is the shape a fix would take.
- Phase-locked capture (core has the protocol — `report_phase` /
  `CLIENT_CAP_PHASE_LOCK`) was deliberately deferred: it would reduce latency
  rather than buffer against the problem, but it needs a real vblank anchor and
  NDL is submit-only.
- Re-anchor triggers: the freeze-until-reanchor hold. Upstream also re-anchors on a display change
  and on a mid-stream mode switch; this client never calls `request_mode`, and a host-driven switch
  arrives with the loss that opens a hold anyway — but the interval is snapshotted at pipeline build,
  so that snapshot is the thing to fix if mid-session mode changes become a real path here.
- Also deferred: an adaptive `PLANE_LEAD_MS` on the audio-offload route, and not
  entering the 2s freeze-until-reanchor hold for a one-frame gap when LTR/RFI
  recovery is available.
- No wire/ABI/protocol change from the core bump. Two behaviour changes in
  0.31.3 worth reviewer attention: host Linux capture now stamps PTS from
  compositor metadata rather than PipeWire callback delivery time (that jitter
  was previously reproduced faithfully on the panel), and the ABR startup probe
  is now sized from the session instead of bursting a flat 2 Gbps.
- One unit test added (the monotonic-stamp invariant only — the one whose
  violation permanently mutes a session). This crate's tests cannot run
  off-device; `cargo test` links against NDL, which exists only in the cross
  sysroot.

## Test plan

- [x] `task docker:lint` (clippy, `-D warnings`) clean
- [x] `task docker:build` clean
- [x] `task docker:package` clean
- [ ] Not yet run on a TV. Next step: a real gaming session on the default, then
      the same content with Direct playback on, comparing `late` and `jitter`
      off the overlay's `Pace` line or the `pacing:` heartbeat. `late` climbing
      on direct and settling on the default is the result this is aiming at.
