### PR TITLE
Hold submenu selection band until rise animation lands

### DIFF
--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -727,9 +727,13 @@ impl App {
                 let rows_top = window_top + title_h as i32;
                 // The selection sits under the row text, not over it: the band is an opaque
                 // surface fill, so a label drawn beneath it would be covered outright.
-                // It rides `rows_top` too, staying on its row for the whole rise.
+                // Held back until the rise lands: the band's shadow margin and its focus pop are
+                // added after `card_menu_band` clipped to the panel, so on a half-revealed row
+                // they hang the lit pill below the card's bottom edge. It still takes `rows_top`
+                // so the geometry stays one path with the labels.
                 if let Some((band, tile)) = self
                     .card_menu_band(r, panel_h, rows_top)
+                    .filter(|_| wipe >= 1.0)
                     .zip(tiles.get(tile::CARD_MENU_BAND))
                 {
                     // The rows block hangs off the *top* of the revealed window, so a row that


### PR DESCRIPTION
## Summary
- The held-card submenu's selection band is now held back until the panel's rise animation reaches full height (wipe >= 1.0)
- Fixes a bug where the focused row's selection pill was visible below the card's bottom edge during the rise, outside the cover art

## Cause
`card_menu_band` clips the band to the panel height (the card's bottom edge), but the compose path adds the tile's shadow margin (`ROW_TILE_PAD`) and the focus pop on top of that clipped rect. On a row the rise has only half revealed, those two push the lit pill past the card.

## Test plan
- [x] `task docker:lint` clean
- [ ] Visual check on the TV: long-press a card, confirm no pill flash below the card during the rise