### PR TITLE
Fix collections row alignment and Add/Move wording

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -759,6 +759,13 @@ impl App {
         self.selected_known_host()?.collection_of(pin_id)
     }
 
+    /// Whether a collection holds `pin_id` — what the card menu's Remove row, its Add/Move
+    /// wording and the collections modal's heading all turn on. Library *is* "in no
+    /// collection", so a card there is not held.
+    pub(crate) fn card_is_held(&self, pin_id: &str) -> bool {
+        self.collection_of_card(pin_id).is_some()
+    }
+
     pub(crate) fn known_host_mut(&mut self, host: &str, port: u16) -> Option<&mut KnownHost> {
         self.hosts.known.iter_mut().find(|h| h.host == host && h.port == port)
     }

--- a/src/app/render/geometry.rs
+++ b/src/app/render/geometry.rs
@@ -460,6 +460,7 @@ impl App {
             }),
             Screen::Collections => f(&view::collections::Modal {
                 rows: self.collections_row_count(),
+                title: view::collections::heading(self.collections_target_held()),
                 card: Some(self.collections_heading()),
             }),
             Screen::Pairing => f(&view::pairing::Modal {

--- a/src/app/render/key.rs
+++ b/src/app/render/key.rs
@@ -135,6 +135,8 @@ pub enum ModalShellKey<'a> {
     /// nothing about the collections themselves belongs here except how many there are (the
     /// card's height follows the row count).
     Collections {
+        /// Picks the heading — see `App::collections_target_held`.
+        held: bool,
         card: &'a str,
         rows: usize,
     },

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -208,6 +208,7 @@ impl App {
                 game: self.editing_game().map(|gs| gs.title.as_str()),
             }),
             Screen::Collections => Some(ModalShellKey::Collections {
+                held: self.collections_target_held(),
                 card: self.collections_heading(),
                 rows: self.collections_row_count(),
             }),

--- a/src/app/screens/rowbuttons.rs
+++ b/src/app/screens/rowbuttons.rs
@@ -90,11 +90,14 @@ impl App {
     /// exactly as a click that misses the ⋯ always has.
     pub(crate) fn row_button_at(&self, row: usize, row_rect: Rect, x: i32, y: i32) -> Option<RowButton> {
         let (leading, trailing) = self.row_buttons(row);
+        // The collections list always marks one row, so `align_values` keeps the dot's gutter
+        // clear on every row of it and its buttons sit that much further left.
+        let marked = matches!(self.nav.screen, Screen::Collections);
         if leading && leading_button_rect(row_rect).contains_point((x, y)) {
             return Some(RowButton::Leading);
         }
         (0..trailing.len())
-            .find(|&i| trailing_button_rect(row_rect, trailing.len(), i).contains_point((x, y)))
+            .find(|&i| trailing_button_rect(row_rect, trailing.len(), i, marked).contains_point((x, y)))
             .map(RowButton::Trailing)
     }
 }

--- a/src/app/state/collections.rs
+++ b/src/app/state/collections.rs
@@ -86,6 +86,16 @@ impl App {
         }
     }
 
+    /// Whether a collection already holds the card the modal is acting on — which is all the
+    /// heading needs (`view::collections::heading`), and what the shell tile keys on.
+    pub(crate) fn collections_target_held(&self) -> bool {
+        self.screens
+            .collections
+            .target
+            .as_deref()
+            .is_some_and(|target| self.card_is_held(target))
+    }
+
     /// Whether the focused row's leading button is held open on `screen` — the drag handle
     /// of a collection row being moved, and nothing on any other scrolling list.
     pub(crate) fn dragged_handle(&self, screen: Screen) -> bool {

--- a/src/app/view/cardmenu.rs
+++ b/src/app/view/cardmenu.rs
@@ -20,7 +20,7 @@ impl App {
     /// count is safe at that point.
     pub(crate) fn card_menu_row_kinds(&self, pin_id: &str) -> &'static [CardMenuRow] {
         // Nothing to remove a Library card from — Library *is* "in no collection".
-        if self.collection_of_card(pin_id).is_some() {
+        if self.card_is_held(pin_id) {
             &[CardMenuRow::MoveTo, CardMenuRow::Remove, CardMenuRow::Settings]
         } else {
             &[CardMenuRow::MoveTo, CardMenuRow::Settings]
@@ -30,10 +30,11 @@ impl App {
     /// [`card_menu_row_kinds`](Self::card_menu_row_kinds) with the icon and label each row
     /// draws.
     pub(crate) fn card_menu_rows(&self, pin_id: &str) -> Vec<(&'static str, &'static str)> {
+        let held = self.card_is_held(pin_id);
         self.card_menu_row_kinds(pin_id)
             .iter()
             .map(|kind| match kind {
-                CardMenuRow::MoveTo => (crate::ui::theme::icons().pin, "Add to\u{2026}"),
+                CardMenuRow::MoveTo => (crate::ui::theme::icons().pin, view::collections::menu_row_label(held)),
                 CardMenuRow::Remove => (view::icons::ICON_DELETE, "Remove"),
                 CardMenuRow::Settings => (view::icons::ICON_SETTINGS, "Settings"),
             })
@@ -42,7 +43,7 @@ impl App {
 
     /// How many rows the submenu on `pin_id`'s card has — what its geometry divides by.
     pub(crate) fn card_menu_row_count(&self, pin_id: &str) -> usize {
-        2 + usize::from(self.collection_of_card(pin_id).is_some())
+        2 + usize::from(self.card_is_held(pin_id))
     }
 
     /// The open submenu's rows band in screen space, and the card it hangs off — the

--- a/src/app/view/collections.rs
+++ b/src/app/view/collections.rs
@@ -14,7 +14,30 @@ use crate::ui::ModalMetrics;
 use crate::ui::ModalScreen;
 use anyhow::Result;
 
-pub(crate) const TITLE: &str = "Add to";
+const TITLE: &str = "Add to";
+const MOVE_TITLE: &str = "Move to";
+/// What the list is doing, by whether a collection already holds the card: one that sits in
+/// Library can only be gained by a collection, one that is held leaves its own behind. The
+/// card menu's row ([`menu_row_label`]) opens this modal, so both read it from here and the
+/// two can't drift apart.
+pub(crate) fn heading(held: bool) -> &'static str {
+    if held {
+        MOVE_TITLE
+    } else {
+        TITLE
+    }
+}
+
+/// [`heading`] as the card menu's row reads it — the same words, with the ellipsis that says
+/// it opens something.
+pub(crate) fn menu_row_label(held: bool) -> &'static str {
+    if held {
+        "Move to\u{2026}"
+    } else {
+        "Add to\u{2026}"
+    }
+}
+
 pub(crate) const ADD_ROW: &str = "Add collection";
 pub(crate) const REMOVE_TITLE: &str = "Remove collection?";
 /// Replaces the card's name in the heading while a row is being dragged: the list is doing
@@ -105,6 +128,9 @@ pub(crate) fn rows(host: &KnownHost, holding: Option<usize>) -> Vec<FocusRow> {
     if host.can_add_collection() {
         rows.push(FocusRow::action(icons::ICON_ADD, ADD_ROW.to_string()));
     }
+    // Library has no Remove and one row wears the mark dot, both of which would otherwise
+    // shift that row's count.
+    ui::widgets::align_values(&mut rows);
     rows
 }
 
@@ -117,14 +143,18 @@ pub(crate) fn row_count(host: &KnownHost) -> usize {
 fn count_label(count: Option<usize>) -> String {
     match count {
         Some(1) => "1 game".to_string(),
+        // "0 games" is noise next to the subtext that already says the row is hidden, and
+        // Library has no count at all.
+        Some(0) | None => String::new(),
         Some(n) => format!("{n} games"),
-        None => String::new(),
     }
 }
 
 /// The modal as a [`ModalScreen`] — the shell only; its rows are their own tiles.
 pub(crate) struct Modal<'a> {
     pub rows: usize,
+    /// From [`heading`].
+    pub title: &'static str,
     /// The card being moved, named after the heading so the list says what it acts on.
     pub card: Option<&'a str>,
 }
@@ -141,7 +171,7 @@ impl ModalScreen for Modal<'_> {
             c,
             self.rows,
             scrolllist::COLLECTIONS_WIDTH_FRAC,
-            TITLE,
+            self.title,
             self.card,
             hover_close,
         )

--- a/src/ui/widgets/rows.rs
+++ b/src/ui/widgets/rows.rs
@@ -48,6 +48,12 @@ pub struct FocusRow {
     /// action stays a single press. Per-row, so one row in a list can offer fewer than its
     /// neighbours (Library has no Remove). Empty (the default) draws nothing.
     pub trailing: &'static [&'static str],
+    /// Room to keep clear at the row's right end, in trailing buttons, when placing the
+    /// value label — over and above the buttons this row actually has. A list whose rows
+    /// carry different counts (Library has no Remove) would otherwise hang its values at
+    /// different x; [`align_values`] sets this so the column lines up. 0 (the default)
+    /// reserves exactly the row's own buttons.
+    pub value_reserve: usize,
     /// The row's own [`icon`](Self::icon) is a button too, in the slot it already draws in —
     /// reached with Left, where [`trailing`](Self::trailing) is reached with Right. For the
     /// action a row wants *before* its label rather than after it (a collection's drag
@@ -67,6 +73,10 @@ pub struct FocusRow {
     /// is the caller's business. `None` (the default) draws nothing and leaves the row's
     /// control the width the dot would have taken.
     pub mark: Option<Color>,
+    /// Keep the [`mark`](Self::mark) gutter clear even though this row wears no dot — what
+    /// [`align_values`] sets on a list where some *other* row does, so one marked row does
+    /// not pull its own value 32px left of its neighbours'.
+    pub mark_reserve: bool,
     /// A small secondary line drawn under the row's label *only while the row is focused*
     /// (e.g. the high-bitrate "may be unstable on Wi-Fi" caution on the Bitrate row).
     /// Unfocused, the label stays vertically centred and nothing is drawn; on focus the
@@ -127,11 +137,13 @@ impl FocusRow {
             danger: false,
             locked: false,
             trailing: &[],
+            value_reserve: 0,
             trailing_focused: None,
             leading_button: false,
             leading_focused: false,
             leading_active: false,
             mark: None,
+            mark_reserve: false,
             subtext: None,
         }
     }
@@ -269,9 +281,19 @@ pub struct RowGeom {
     pub mark: Rect,
 }
 
+/// The room a row keeps clear at its right end for the [`FocusRow::mark`] dot, 0 on a list
+/// where none is drawn. Every right-anchored piece — the control, the value label, the
+/// trailing buttons — starts inside it, so nothing lands under the dot.
+pub fn mark_gutter(marked: bool) -> i32 {
+    if marked {
+        2 * MARK_DOT_R + MARK_GAP
+    } else {
+        0
+    }
+}
+
 pub fn row_layout(row_rect: Rect, marked: bool) -> RowGeom {
-    let reserve = if marked { 2 * MARK_DOT_R + MARK_GAP } else { 0 };
-    let control_right = row_rect.right() - CONTROL_PAD - reserve;
+    let control_right = row_rect.right() - CONTROL_PAD - mark_gutter(marked);
     let track_w = 220u32.min(row_rect.width() / 3);
     let cy = row_rect.y() + row_rect.height() as i32 / 2;
     RowGeom {
@@ -309,18 +331,32 @@ pub fn trailing_width(count: usize) -> i32 {
     count as i32 * (SIDEBAR_MENU_BTN as i32 + TRAILING_GAP)
 }
 
+/// Puts every row's value label in one column: each reserves the widest row's
+/// trailing-button room, and the mark gutter if any row is marked
+/// ([`FocusRow::value_reserve`], [`FocusRow::mark_reserve`]). A right-aligned value otherwise
+/// stops wherever its own row's buttons and dot leave off, so one odd row out looks ragged.
+pub fn align_values(rows: &mut [FocusRow]) {
+    let widest = rows.iter().map(|r| r.trailing.len()).max().unwrap_or(0);
+    let any_marked = rows.iter().any(|r| r.mark.is_some());
+    for row in rows {
+        row.value_reserve = widest;
+        row.mark_reserve = any_marked;
+    }
+}
+
 /// Gap between two trailing buttons, and between the last one and the row's edge.
 const TRAILING_GAP: i32 = 10;
 
 /// Trailing button `i` of `count`, packed from the row's right edge in the order they are
-/// drawn. The one-button case is exactly a sidebar row's ⋯, which is what the host menu's
+/// drawn — inside the [`mark_gutter`], so the last button clears the dot rather than sitting
+/// under it. The one-button case is exactly a sidebar row's ⋯, which is what the host menu's
 /// Wake row draws — one geometry, so the pointer's per-icon hit test and the painter cannot
 /// disagree about where a button is.
-pub fn trailing_button_rect(row_rect: Rect, count: usize, i: usize) -> Rect {
+pub fn trailing_button_rect(row_rect: Rect, count: usize, i: usize, marked: bool) -> Rect {
     let from_right = count.saturating_sub(i + 1) as i32;
     let stride = SIDEBAR_MENU_BTN as i32 + TRAILING_GAP;
     Rect::new(
-        row_rect.right() - SIDEBAR_MENU_BTN as i32 - TRAILING_GAP - from_right * stride,
+        row_rect.right() - mark_gutter(marked) - SIDEBAR_MENU_BTN as i32 - TRAILING_GAP - from_right * stride,
         row_rect.y() + (row_rect.height() as i32 - SIDEBAR_MENU_BTN as i32) / 2,
         SIDEBAR_MENU_BTN,
         SIDEBAR_MENU_BTN,
@@ -490,11 +526,13 @@ pub struct FocusRowKey<'a> {
     danger: bool,
     locked: bool,
     trailing: &'a [&'static str],
+    value_reserve: usize,
     trailing_focused: Option<usize>,
     leading_button: bool,
     leading_focused: bool,
     leading_active: bool,
     mark: Option<Rgba8>,
+    mark_reserve: bool,
     subtext: Option<(&'a str, Rgba8)>,
 }
 
@@ -514,11 +552,13 @@ impl FocusRow {
             danger: self.danger,
             locked: self.locked,
             trailing: self.trailing,
+            value_reserve: self.value_reserve,
             trailing_focused: self.trailing_focused,
             leading_button: self.leading_button,
             leading_focused: self.leading_focused,
             leading_active: self.leading_active,
             mark: self.mark.map(color_bytes),
+            mark_reserve: self.mark_reserve,
             subtext: self.subtext.as_ref().map(|s| (s.text.as_str(), color_bytes(s.color))),
         }
     }
@@ -549,7 +589,8 @@ impl Canvas<'_, '_> {
         self.painter.selectable_fixed(row_rect, focused);
 
         // Past the row's control, on the right edge — the width `row_layout` took off it.
-        let geom = row_layout(row_rect, row.mark.is_some());
+        let marked = row.mark.is_some() || row.mark_reserve;
+        let geom = row_layout(row_rect, marked);
         if let Some(color) = row.mark {
             self.painter.fill_rounded_rect(geom.mark, MARK_DOT_R, color);
         }
@@ -627,7 +668,7 @@ impl Canvas<'_, '_> {
             // Action rows have no control; `value` is a muted hint only, never interactive.
             RowKind::Action => {
                 if !row.value.is_empty() {
-                    let menu_w = trailing_width(row.trailing.len());
+                    let menu_w = trailing_width(row.value_reserve.max(row.trailing.len()));
                     let value_w = self.fonts.raster.measure(value_font, &row.value).0;
                     self.text(
                         value_font,
@@ -641,7 +682,7 @@ impl Canvas<'_, '_> {
         }
         for (i, &icon) in row.trailing.iter().enumerate() {
             self.row_button(
-                trailing_button_rect(row_rect, row.trailing.len(), i),
+                trailing_button_rect(row_rect, row.trailing.len(), i, marked),
                 icon,
                 focused,
                 row.trailing_focused == Some(i),

--- a/src/ui/widgets/sidebar.rs
+++ b/src/ui/widgets/sidebar.rs
@@ -39,7 +39,7 @@ pub fn sidebar_icon_rect(drawn: Rect) -> Rect {
 /// A row's ⋯ button. The single-button case of a focus row's trailing buttons — one
 /// geometry, so the sidebar's ⋯ and a list row's cannot drift apart.
 pub fn sidebar_menu_button_rect(row_rect: Rect) -> Rect {
-    super::trailing_button_rect(row_rect, 1, 0)
+    super::trailing_button_rect(row_rect, 1, 0, false)
 }
 
 impl Painter {


### PR DESCRIPTION
Fixes #162.

Collections list values (row counts, mark dot, trailing buttons) misaligned. Two causes, both in right-anchored row layout: Library carries one trailing button where others carry two, and `row_layout` shrinks the right edge by 32px only on the row wearing the mark dot. Remove also collided with that dot. Separately, "Add to…" was the wrong verb for a card being moved out of its current collection.

Changes:

- `ui::widgets::rows`: `FocusRow` gains `value_reserve`/`mark_reserve` layout inputs (in `FocusRowKey`, so cache keys stay correct). New `align_values` sets every row to the widest trailing-button count and turns on the mark gutter list-wide if any row is marked. New `mark_gutter(marked)` is the single source of truth for the reserved width; `row_layout` and `trailing_button_rect` both use it. Buttons now pack inside the gutter instead of under the dot.
- `app::view::collections` / `app::state::collections`: rows call `align_values`. Empty collections drop the "0 games" value (the subtext already covers it). Heading and menu row label switch between "Add to" / "Move to" based on `collections_target_held()`.
- `app::view::cardmenu`: "Add to…" row reads "Move to…" under the same condition that shows Remove.
- `app::mod`: `App::card_is_held(pin_id)` replaces four hand-spelled `collection_of_card(..).is_some()` checks.
- `app::render::{key,prepare,geometry}`: `ModalShellKey::Collections` keys on `held` so the shell rebuilds when the heading changes.
- `app::screens::rowbuttons`: pointer hit test passes the same `marked` flag for `Screen::Collections` so clicks land on the drawn icons.

No config or migration changes. Collections is the only marked list, so the pointer hit test keys the gutter off `Screen::Collections`.

Verified with `task docker:lint` and `docker:fmt`. Not yet run on a TV.
