### PR TITLE
Confirm before resetting per-game settings

### DIFF
--- a/src/app/nav.rs
+++ b/src/app/nav.rs
@@ -31,10 +31,11 @@ pub(crate) enum ScreenKey {
     Collections,
     RenameCollection,
     RemoveCollection,
+    ResetGameSettings,
 }
 
 impl ScreenKey {
-    pub const COUNT: usize = Self::RemoveCollection as usize + 1;
+    pub const COUNT: usize = Self::ResetGameSettings as usize + 1;
 
     pub const fn of(screen: Screen) -> Self {
         match screen {
@@ -56,6 +57,7 @@ impl ScreenKey {
             Screen::Collections => Self::Collections,
             Screen::RenameCollection => Self::RenameCollection,
             Screen::RemoveCollection => Self::RemoveCollection,
+            Screen::ResetGameSettings => Self::ResetGameSettings,
         }
     }
 }
@@ -77,6 +79,7 @@ pub(crate) const fn over_scroll_list(screen: Screen) -> bool {
             | Screen::SendLogs
             | Screen::RenameCollection
             | Screen::RemoveCollection
+            | Screen::ResetGameSettings
     )
 }
 

--- a/src/app/pointer.rs
+++ b/src/app/pointer.rs
@@ -206,7 +206,12 @@ impl App {
             // so the pointer can pick action-vs-Cancel, not just confirm whatever the D-pad
             // last focused. `confirm_subtitle` is `None` for the variants with no buttons up
             // (a Wake with no MAC, a test still running), which reads as nothing to hover.
-            Screen::ForgetHost | Screen::SendLogs | Screen::Wake | Screen::SpeedTest | Screen::RemoveCollection => {
+            Screen::ForgetHost
+            | Screen::SendLogs
+            | Screen::Wake
+            | Screen::SpeedTest
+            | Screen::RemoveCollection
+            | Screen::ResetGameSettings => {
                 let Some(subtitle) = self.confirm_subtitle() else {
                     return false;
                 };
@@ -551,7 +556,12 @@ impl App {
             }
             // Nothing positional to hit: the confirm dialogs confirm whichever button
             // already has focus.
-            Screen::Wake | Screen::ForgetHost | Screen::SpeedTest | Screen::SendLogs | Screen::RemoveCollection => {}
+            Screen::Wake
+            | Screen::ForgetHost
+            | Screen::SpeedTest
+            | Screen::SendLogs
+            | Screen::RemoveCollection
+            | Screen::ResetGameSettings => {}
             // Nothing clickable but the close button (handled above).
             Screen::AddHost | Screen::EditHost | Screen::RenameCollection | Screen::About => return None,
         }

--- a/src/app/press.rs
+++ b/src/app/press.rs
@@ -45,6 +45,7 @@ impl App {
             Screen::Collections => self.handle_collections_event(ev, screen_w, screen_h),
             Screen::RenameCollection => self.handle_name_collection_event(ev, screen_w, screen_h),
             Screen::RemoveCollection => self.handle_remove_collection_event(ev),
+            Screen::ResetGameSettings => self.handle_reset_game_settings_event(ev),
         }
         None
     }
@@ -93,7 +94,12 @@ impl App {
             Screen::Home => matches!(self.home_focus, HomeFocus::Sidebar(_) | HomeFocus::SidebarMenu(_)),
             // The button only; the PIN digits above it are a field.
             Screen::Pairing => matches!(self.screens.pairing_focus, PairingFocus::RequestAccess),
-            Screen::Wake | Screen::ForgetHost | Screen::SpeedTest | Screen::SendLogs | Screen::RemoveCollection => true,
+            Screen::Wake
+            | Screen::ForgetHost
+            | Screen::SpeedTest
+            | Screen::SendLogs
+            | Screen::RemoveCollection
+            | Screen::ResetGameSettings => true,
             // Rows, not buttons.
             Screen::Settings(_)
             | Screen::AddHost

--- a/src/app/render/geometry.rs
+++ b/src/app/render/geometry.rs
@@ -216,7 +216,8 @@ impl App {
             | Screen::CursorSettings(_)
             | Screen::SendLogs
             | Screen::RenameCollection
-            | Screen::RemoveCollection => 1,
+            | Screen::RemoveCollection
+            | Screen::ResetGameSettings => 1,
         }
     }
 
@@ -372,7 +373,12 @@ impl App {
             }
             // Every two-button confirm dialog: one subtitle drives the card, so one
             // button-row geometry serves all four.
-            Screen::Wake | Screen::ForgetHost | Screen::SendLogs | Screen::SpeedTest | Screen::RemoveCollection => self
+            Screen::Wake
+            | Screen::ForgetHost
+            | Screen::SendLogs
+            | Screen::SpeedTest
+            | Screen::RemoveCollection
+            | Screen::ResetGameSettings => self
                 .confirm_subtitle()
                 .zip(self.confirm_focused())
                 .map(|(subtitle, i)| Self::confirm_focus_button_rect(screen_w, screen_h, fonts, &subtitle, i)),
@@ -510,6 +516,10 @@ impl App {
             }),
             Screen::RemoveCollection => f(&view::confirm::Modal {
                 title: view::collections::REMOVE_TITLE,
+                confirm: confirm.as_ref()?,
+            }),
+            Screen::ResetGameSettings => f(&view::confirm::Modal {
+                title: view::resetgame::TITLE,
                 confirm: confirm.as_ref()?,
             }),
         })

--- a/src/app/render/key.rs
+++ b/src/app/render/key.rs
@@ -45,6 +45,8 @@ pub enum ModalFocusKey<'a> {
     SendLogsButton(usize),
     /// Which `Screen::RemoveCollection` button is focused (0 = Remove, 1 = Cancel).
     RemoveCollectionButton(usize),
+    /// Which `Screen::ResetGameSettings` button is focused (0 = Reset, 1 = Cancel).
+    ResetGameSettingsButton(usize),
     /// (focused row, the row's name, whether it is the one already holding the card, which
     /// trailing button is focused, whether the row is being dragged) — what the focused row
     /// draws, and nothing else: the list behind it is its own tiles.
@@ -130,6 +132,10 @@ pub enum ModalShellKey<'a> {
     RemoveCollection {
         name: &'a str,
         games: usize,
+    },
+    /// The game it asks about — its title is the whole subtitle.
+    ResetGameSettings {
+        game: &'a str,
     },
     /// The shell is title, rule and the card being moved — the rows are their own tiles, so
     /// nothing about the collections themselves belongs here except how many there are (the

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -264,6 +264,11 @@ impl App {
             Screen::RemoveCollection => self
                 .removed_collection()
                 .map(|(name, games)| ModalShellKey::RemoveCollection { name, games }),
+            Screen::ResetGameSettings => self
+                .settings_ui
+                .game_settings
+                .as_ref()
+                .map(|gs| ModalShellKey::ResetGameSettings { game: &gs.title }),
             // `EditHost` joins `AddHost` in having no shell key: its typed-digit
             // display has no separate focus tile to protect, so it just redraws on
             // any `content_dirty` tick.
@@ -360,6 +365,9 @@ impl App {
             Screen::SendLogs => Some(ModalFocusKey::SendLogsButton(self.nav.cursor(ScreenKey::SendLogs))),
             Screen::RemoveCollection => Some(ModalFocusKey::RemoveCollectionButton(
                 self.nav.cursor(ScreenKey::RemoveCollection),
+            )),
+            Screen::ResetGameSettings => Some(ModalFocusKey::ResetGameSettingsButton(
+                self.nav.cursor(ScreenKey::ResetGameSettings),
             )),
             // None has a single focused widget: the address form is one always-active
             // field, and About is a scrolling document.
@@ -496,7 +504,8 @@ impl App {
                     | Screen::ForgetHost
                     | Screen::SendLogs
                     | Screen::SpeedTest
-                    | Screen::RemoveCollection => match (self.confirm_of(), self.confirm_focused()) {
+                    | Screen::RemoveCollection
+                    | Screen::ResetGameSettings => match (self.confirm_of(), self.confirm_focused()) {
                         (Some(confirm), Some(i)) => {
                             let rect = Self::confirm_focus_button_rect(screen_w, screen_h, fonts, &confirm.subtitle, i);
                             Some(ui::rasterize(

--- a/src/app/screens/confirm.rs
+++ b/src/app/screens/confirm.rs
@@ -108,6 +108,13 @@ impl App {
                     view::collections::remove_subtitle(name, games),
                 )
             }
+            Screen::ResetGameSettings => Confirm::new(
+                Some(view::icons::ICON_DELETE),
+                "Reset",
+                palette().error,
+                "Cancel",
+                view::resetgame::subtitle(&self.settings_ui.game_settings.as_ref()?.title),
+            ),
             Screen::SendLogs => Confirm::new(
                 Some(view::icons::ICON_SEND),
                 "Send",

--- a/src/app/screens/list.rs
+++ b/src/app/screens/list.rs
@@ -60,7 +60,8 @@ impl App {
             // text form with no rows at all.
             | Screen::Collections
             | Screen::RenameCollection
-            | Screen::RemoveCollection => 0,
+            | Screen::RemoveCollection
+            | Screen::ResetGameSettings => 0,
         }
     }
 
@@ -129,7 +130,8 @@ impl App {
             | Screen::SendLogs
             | Screen::Collections
             | Screen::RenameCollection
-            | Screen::RemoveCollection => Vec::new(),
+            | Screen::RemoveCollection
+            | Screen::ResetGameSettings => Vec::new(),
         }
     }
 

--- a/src/app/screens/mod.rs
+++ b/src/app/screens/mod.rs
@@ -19,7 +19,12 @@ use crate::core::screen::Screen;
 /// absorbed by a `_ =>` arm into the wrong geometry.
 pub(crate) const fn is_confirm(screen: Screen) -> bool {
     match screen {
-        Screen::Wake | Screen::ForgetHost | Screen::SendLogs | Screen::SpeedTest | Screen::RemoveCollection => true,
+        Screen::Wake
+        | Screen::ForgetHost
+        | Screen::SendLogs
+        | Screen::SpeedTest
+        | Screen::RemoveCollection
+        | Screen::ResetGameSettings => true,
         Screen::Home
         | Screen::Pairing
         | Screen::Settings(_)
@@ -58,7 +63,8 @@ pub(crate) const fn is_scroll_list(screen: Screen) -> bool {
         | Screen::CursorSettings(_)
         | Screen::SendLogs
         | Screen::RenameCollection
-        | Screen::RemoveCollection => false,
+        | Screen::RemoveCollection
+        | Screen::ResetGameSettings => false,
     }
 }
 
@@ -87,6 +93,7 @@ pub(crate) const fn is_list_modal(screen: Screen) -> bool {
         // Collections is a scrolling list too, and its name dialog is a text form.
         | Screen::Collections
         | Screen::RenameCollection
-        | Screen::RemoveCollection => false,
+        | Screen::RemoveCollection
+        | Screen::ResetGameSettings => false,
     }
 }

--- a/src/app/state/gamesettings.rs
+++ b/src/app/state/gamesettings.rs
@@ -5,6 +5,7 @@
 use crate::app::menu;
 use crate::app::nav::ScreenKey;
 use crate::app::App;
+use crate::core::event::MenuEvent;
 use crate::core::screen::Screen;
 use crate::services::store::{Settings, SettingsOverride};
 
@@ -107,6 +108,39 @@ impl App {
 }
 
 impl App {
+    /// Raises the Reset confirmation over the per-game list, focused on Cancel — the same
+    /// dialog Forget host and Remove collection use (see `app::screens::confirm`), so the
+    /// destructive button is never the one a stray Confirm lands on.
+    pub(crate) fn open_reset_game_settings(&mut self) {
+        if self.settings_ui.game_settings.is_none() {
+            return;
+        }
+        self.nav.enter(Screen::ResetGameSettings, 1);
+    }
+
+    /// Handles one menu event on [`Screen::ResetGameSettings`].
+    pub(crate) fn handle_reset_game_settings_event(&mut self, ev: MenuEvent) {
+        if self.confirm_nav_event(ev) {
+            return;
+        }
+        match ev {
+            MenuEvent::Confirm => {
+                if self.nav.cursor(ScreenKey::ResetGameSettings) == 0 {
+                    self.reset_settings();
+                }
+                self.back_to_game_settings();
+            }
+            MenuEvent::Back | MenuEvent::Secondary => self.back_to_game_settings(),
+            MenuEvent::Up | MenuEvent::Down | MenuEvent::Left | MenuEvent::Right => {}
+        }
+    }
+
+    /// Back to the list the dialog was raised over, cursor untouched — the Reset row is still
+    /// where it was, shown or not.
+    fn back_to_game_settings(&mut self) {
+        self.nav.resume(Screen::Settings(menu::SettingsScope::Game));
+    }
+
     /// Whether `pin_id` carries any settings override on the selected host — what puts the
     /// amber dot in front of its card title, before anything is held.
     pub(crate) fn game_has_overrides(&self, pin_id: &str) -> bool {

--- a/src/app/state/settings.rs
+++ b/src/app/state/settings.rs
@@ -111,7 +111,7 @@ impl App {
                 // Puts the whole screen back: defaults on the global one, "inherit
                 // everything" on the per-game one. Both keep the row list and the focus
                 // where they are — nothing is shown or hidden by this (see `row_shown`).
-                Some(menu::SettingsRow::Reset) => self.reset_settings(),
+                Some(menu::SettingsRow::Reset) => self.open_reset_game_settings(),
                 // A locked row (see `menu::row_lock`) never opens its dropdown — there is
                 // nothing to pick, which is exactly what the greyed row already says.
                 Some(
@@ -162,7 +162,7 @@ impl App {
     ///
     /// Per-game only: the row appears on `SettingsScope::Game` alone (see
     /// `menu::settings_visible_logical_rows`), so a global screen can never reach here.
-    fn reset_settings(&mut self) {
+    pub(crate) fn reset_settings(&mut self) {
         let inherited = self.settings_ui.settings.presentable();
         if let Some(gs) = self.editing_game_mut() {
             gs.over = crate::services::store::SettingsOverride::default();

--- a/src/app/view/mod.rs
+++ b/src/app/view/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod home;
 pub(crate) mod hostmenu;
 pub(crate) mod icons;
 pub(crate) mod pairing;
+pub(crate) mod resetgame;
 pub(crate) mod scrolllist;
 pub(crate) mod sendlogs;
 pub(crate) mod settings;

--- a/src/app/view/resetgame.rs
+++ b/src/app/view/resetgame.rs
@@ -1,0 +1,9 @@
+//! "Reset this game's settings?" confirmation. Logic lives in `app::state::gamesettings`.
+//!
+//! The dialog itself is `app::view::confirm` — this is only its copy.
+
+pub const TITLE: &str = "Reset game settings?";
+
+pub fn subtitle(game_name: &str) -> String {
+    format!("{game_name} will go back to using the global settings. Its overrides are discarded.")
+}

--- a/src/core/screen.rs
+++ b/src/core/screen.rs
@@ -44,6 +44,9 @@ pub enum Screen {
     RenameCollection,
     /// "Remove collection?" — its games return to Library (see `app/state/collections.rs`).
     RemoveCollection,
+    /// "Reset game settings?" — the per-game Reset row's confirmation, raised over
+    /// `Settings(Game)` (see `app/state/gamesettings.rs`).
+    ResetGameSettings,
 }
 
 /// Pairing modal's focused input: PIN row or "Request access" button.


### PR DESCRIPTION
## Summary
- Reset row on per-game settings now raises a confirmation instead of wiping overrides on one press
- New `Screen::ResetGameSettings` reuses the existing confirm-dialog family (Forget host, Remove collection); no new dialog rendering code
- `app/view/resetgame.rs` holds title/subtitle copy; opens focused on Cancel
- `reset_settings` unchanged in behaviour, now called from the dialog

## Test plan
- [x] `task -s docker:check`
- [x] `task -s docker:lint`