### PR TITLE
Gate audio-plane PTS latch on wall clock, not frame count

### DIFF
--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -268,7 +268,7 @@ What still matters:
   from the app at all. `session::sink::video_e2e_ns` still publishes that estimate for core.
 - ⚠ **Use `frame.pts_ns`, never the paced value**, wherever a host-clock comparison is made. Both
   are in scope at the submit site with near-identical names; the paced one has been mapped into
-  NDL's player clock by `HostPtsAnchor`.
+  NDL's player clock by `session::timeline::Pacing`.
 - The estimator's unit tests ship in-tree but **cannot run off-device**: `cargo test` links the
   whole binary and `-lNDL_directmedia` exists only in the cross sysroot.
 
@@ -335,52 +335,58 @@ must be read under that guard, or a packet measured against an older ceiling blo
 then hands NDL the stale stamp.
 
 ⚠ **The audio plane stamps off the PLAYER clock, not the host's (2026-08-28).** It used to map the
-host capture PTS through a shared `SessionClock` the video plane published, with a per-latch
+host capture PTS through the shared `SessionClock` the video plane published, with a per-latch
 `audio_skew_ms` lifting each resumed run above the ceiling. That **ratchets**: a
 freeze-until-reanchor stalls the mapped timeline while packets keep arriving, the resumed run lands
 below the ceiling it already reached, and the only monotonic repair is to add lead — which nothing
-in the session can ever pay back. Measured on a CX: five re-anchors inside four seconds walked the
-plane from 78 ms to 124 ms of lead, and the lip sync it buys is never recovered without a reload.
+in the session can ever pay back. Field case (CX, 2026-08-28, offload on): five re-anchors inside
+four seconds walked the plane from 78 ms to 124 ms of lead and the audio was gone for the rest of
+the session.
 
-So audio is stamped `player_clock + PLANE_LEAD_MS` and the host PTS is ignored (`AudioSink::feed`
-takes it and drops it). A wall clock cannot ratchet: it advances at the same rate whatever the host
-PTS does across a freeze, so a resumed run lands where an uninterrupted one would have, and
-`last_audio_pts_ms` is left with nothing to do but absorb reordering. The clock plane targets the
-same figure, so the two feeders share the ceiling without either driving it. `load_confirmed` is
-the plane's start gate, a job the video plane's latch used to do. `mariotaku/ss4s` made the same
-move in `ef0c0ae`, deleting a gap-filling thread it had added in `734e643`.
+So audio is now stamped `player_clock + PLANE_LEAD_MS` and the host PTS is ignored
+(`AudioSink::feed` takes it and drops it). A wall clock cannot ratchet: it advances at the same rate
+whatever the host PTS does across a freeze, so a resumed run lands where an uninterrupted one would
+have, and `last_audio_pts_ms` is left with nothing to do but absorb reordering. The clock plane
+targets the same figure, so the two feeders share the ceiling without either driving it.
+`load_confirmed` is the plane's start gate, which is what the video plane's latch used to double as.
 
-⚠ **The ratchet was real and was NOT the mute** — see the flush below, which is. Measured after
-this change, under a saturated airlink: 32 re-anchors, `plane_lead` pinned at 37-40 ms, `depth`
-flat, stamps provably monotonic, and audio still died. **Nothing the client hands NDL explains that
+⚠ **The ratchet was real and was NOT the mute.** Measured after the change, under a deliberately
+saturated airlink (276 Mb/s of competing download against a 188 Mb/s stream): 32 re-anchors,
+`plane_lead` pinned at 37-40 ms the whole way, `depth` flat at 40 ms, stamps provably monotonic and
+evenly spaced — and the audio still died permanently. **Nothing the client hands NDL explains this
 failure.** Do not spend another round on stamp arithmetic.
 
-Removed with the mapping: `SessionClock` (audio was its only reader), `AudioPlane::attach_clock`,
-`audio_skew_ms`, `skew_epoch`, and the audio-latch gate in `session::timeline`
-(`ready_for_audio` / `note_audio_latched` on both `CadencePacer` and `HostPtsAnchor`).
+⚠ **The loss hold no longer flushes, and THIS is what was muting the plane (2026-08-28,
+confirmed on device).** It was the last structural difference from `ss4s`, which never flushes
+mid-stream — its only recovery is unload+load, and it does not lose its Opus plane. Every flush
+stops the pipeline: each one used to be followed by `NDL load state: PLAYING (0x1a)`, a transition
+NDL only makes from not-playing. Confirmation (CX, 276 Mb/s of competing download against a
+188 Mb/s stream): 16 re-anchors, holds up to 2 s, **not one `PLAYING` transition in the whole log**,
+`plane_lead` 38-40 ms flat, and audio intact — where the identical storm against the flushing build
+killed it permanently. `NDL_DirectVideoFlushRenderBuffer` is safe to call and reports success; what
+it costs you is the audio plane, silently, for the rest of the session. The decode-error
+path still flushes, where the pipeline has actually errored and discarding its queue is the
+documented response; loss is a network event and NDL's queue holds good frames the hold is about to
+present anyway. This reopens a call the 2026-08-27 handover had marked a dead end — that verdict
+rested on records scoped to *before* `LOADCOMPLETED`, and on `Pacing::reset` needing
+`last_base_ns = 0`, which was only true *because* of the flush. `last_base_ns` now survives the
+reset: without a flush the pipeline still holds everything fed before it, and a run restarting from
+0 would walk the video stamp backwards.
 
-⚠ **The loss hold must NOT flush, and this is what was muting the Opus plane after a network
-hiccup (2026-08-28, confirmed on device).** `NDL_DirectVideoFlushRenderBuffer` stops the pipeline:
-each flush used to be followed by `NDL load state: PLAYING (0x1a)`, a transition NDL only makes
-from not-playing, and the restart kills the audio plane for the rest of the session. It returns
-success and leaves `depth` and `plane_lead` looking healthy right through the mute, so there is no
-error to find — only a reload recovers. `ss4s` never flushes mid-stream (its only recovery is
-unload+load) and does not have this bug; moonlight-tv#493 is the same failure unfixed, Opus route
-only, PCM immune.
+Removed with the host-PTS mapping: `SessionClock` (its only reader was audio),
+`AudioPlane::attach_clock`, `audio_skew_ms`, `skew_epoch`, the floored-packet run detector, and
+`CadencePacer::ready_for_audio` / `note_audio_latched` with the convergence gate behind them.
 
-Confirmation (CX, 276 Mb/s of competing download against a 188 Mb/s stream): 16 re-anchors, holds
-up to 2 s, **not one `PLAYING` transition in the whole log**, and audio intact — where the identical
-storm against the flushing build killed it permanently. The decode-error path still flushes, where
-the pipeline has actually errored; loss is a network event and NDL's queue holds good frames the
-hold is about to present anyway.
+This is where `mariotaku/ss4s` ended up too, from the other direction: `734e643` added a thread
+feeding empty Opus frames through gaps ("if a huge gap appeared between frames, audio output will be
+distorted"), then `ef0c0ae` deleted the whole mechanism and moved both planes onto
+`CLOCK_MONOTONIC - mediaLoadedTime`. moonlight-tv#493 ("Stream loses audio after network hiccup") is
+the unfixed version of this failure — same symptom, Opus route only, PCM never reproduces it, only a
+full restart recovers.
 
-This required `CadencePacer::reset` to STOP zeroing `last_base_ns`. That clearing was only correct
-*because* of the flush — without one the pipeline still holds everything fed before the hold, and a
-run restarting from 0 walks the video stamp backwards, which is the rewind NDL mutes on.
-
-⚠ This reopens a call an earlier handover had marked a dead end. That verdict rested on in-tree
-records scoped to *before* `LOADCOMPLETED`, and on `Pacing::reset` needing `last_base_ns = 0` —
-which was itself a consequence of the flush, not an independent constraint.
+Removed with it: `SessionClock` (its only reader was audio), `AudioPlane::attach_clock`,
+`audio_skew_ms`, `skew_epoch`, the floored-packet run detector, and `CadencePacer::ready_for_audio`
+/ `note_audio_latched` with the convergence gate behind them.
 
 ⚠ The audio-enabled load returns success even on a TV that then plays nothing, so **no runtime
 probe can distinguish the two**. If a model regresses, the `NDL load state:`
@@ -394,7 +400,9 @@ The video feed itself is already copy-free — core reassembles one contiguous `
 Annex-B rewrite, no client-side queue. So these are about *when* bytes are released, not how they
 move. (A third lever, PCM on NDL's audio plane, was built and then removed — see § "Audio".)
 
-**1. The PTS anchor's standing lead (`session::timeline`, on by default).** `HostPtsAnchor` maps
+**1. The PTS anchor's standing lead (`session::timeline`, REMOVED 2026-08-27 — see lever 3, which
+replaced it; kept here because the failure it describes is what the cadence loop has to keep
+solving).** The anchor mapped
 `base = player0 + (host_pts - host0)`, which bakes frame 0's own delivery latency into every later
 frame: one that arrives faster than frame 0 did gets a stamp in NDL's future and
 `pauseAtDecodeTime` holds it there for the difference. Frame 0 is the first keyframe, behind the
@@ -406,10 +414,12 @@ interval per frame (the stamps must never go backwards) and only inside the firs
 anchor. `pts lead: trimming Xms` at INFO, plus `pts_trim=` on the video heartbeat, is how much
 standing hold the session started with — a number not otherwise observable from the app.
 
-⚠ **The audio plane no longer latches this mapping at all (2026-08-28)** — it stamps off the player
-clock, so there is nothing for the trim to be unsafe against and the gate that used to hold audio
-through the settle window (at the cost of real silence after every recovery) is gone. See § "NDL's
-audio plane".
+⚠ **The audio plane no longer latches this mapping at all (2026-08-28).** It used to: audio stamps
+rode the offset the video plane published, so the plane could not latch a mapping that was still
+moving, and a convergence gate (`CadencePacer::ready_for_audio`) held it while the estimate settled
+— dropping real packets, 5 ms of audible silence each, through that window. Audio is now on the
+player clock and has no mapping to wait for, so the gate and its silence are gone. See § "NDL's
+audio plane" for why.
 
 **2. Slice-progressive feed (on, every NDL v2 session).** Without it the decoder
 sees byte 0 of a frame only once that frame's LAST datagram lands; at 200 Mbps a keyframe is many
@@ -436,16 +446,12 @@ wire they stamp at ≈ the player clock — a packet arrives *after* the frame i
 the PTS trim above pulled the shared offset another ~36 ms earlier. Depth ≈ 0, renderer at the edge
 of underrun, picture stutters on network jitter: the exact symptom the clock plane was introduced to
 cure, back again the moment real audio displaced the metronome. (Found on the since-deleted PCM
-route, but the mechanism is the plane's, so it applies to offload identically.) It was intermittent
-only because
-`derive_audio_skew` picked up whatever ceiling the metronome happened to reach during its 300 ms
-grace, which is a race.
+route, but the mechanism is the plane's, so it applies to offload identically.)
 
-Fixed by `PLANE_LEAD_MS` (= the same 40 ms), added to every real stamp in `play_audio` and
-discounted in `derive_audio_skew` so the two don't stack. **Not** by interleaving silence in front
-of real audio — that raises `last_audio_pts_ms` and the real packets then floor onto it, which is a
-permanent session mute rather than a stutter. NDL takes no depth argument, so a stamp in the future
-is the only way to ask it for one. This is the same job the deleted SDL `JitterPolicy` did with its
+Fixed by `PLANE_LEAD_MS` (= the same 40 ms), added to every real stamp in `play_audio`. The clock
+plane targets the same figure, so silence and real audio meet at the same lead and neither pushes
+the other's ceiling. NDL takes no depth argument, so a stamp in the future is the only way to ask it
+for one. This is the same job the deleted SDL `JitterPolicy` did with its
 25 ms ring (adaptive to 90 under underruns); the route removed that ring and put nothing in its
 place. Cost is lip sync, `PLANE_LEAD_MS` behind the picture, roughly cancelling the trim's ~36 ms —
 walk it down on device against `lead` on the overlay's audio line and `plane_lead=` on the video
@@ -457,11 +463,11 @@ measure-only, so there is no prior art for correcting the lip sync, only for hol
   are named on the overlay (`Opus SW` / `Opus HW`) and in the `audio path:` log line precisely so a
   report says which one produced the numbers.
 
-**3. Cadence pacing: stamps from the cadence loop, not the anchor (the DEFAULT since 2026-08-23;
-`Settings::direct_playback` on the Experimental screen is the way back to the anchor. No on-device
-numbers yet).**
+**3. Cadence pacing: stamps from the cadence loop (the DEFAULT since 2026-08-23, and since
+2026-08-27 the ONLY mapping — the `Settings::direct_playback` escape hatch is gone. On a CX at
+1440p120 the anchor stamped ~17% of frames late against the loop's ~7%).**
 
-The anchor above is a constant plus a one-off trim, and that shape has two holes. It carries **no
+The anchor above was a constant plus a one-off trim, and that shape has two holes. It carries **no
 rate term**: two free-running crystals produce a ramp, so the session's real lead walks away over
 minutes (either into latency, or into stamps behind the player clock, where NDL gives up pacing) and
 nothing pulls it back — trimming stops 3 s in. And its whole jitter margin is `TRIM_KEEP_NS` = 4 ms,
@@ -525,16 +531,10 @@ Wiring notes worth knowing before editing:
   shrink between frames and NDL reads a rewind as a permanent session mute. Cleared on reset, like
   the anchor's own — NDL has been flushed by then. `the_pacer_never_walks_a_stamp_backwards_within_a_run`
   is the gate; it is the one invariant here whose violation costs a session its audio outright.
-- **The audio latch gate differs per mapping** and cannot be shared: the anchor's waits for trimming
-  to *stop* (`TRIM_SETTLE_NS`), and this loop never stops moving, so it waits
-  `PACER_AUDIO_LATCH_FRAMES` (30) instead.
-- ⚠ **Open interaction with audio offload**, and it is now on the DEFAULT path. `SessionClock`
-  latches ONE constant and audio rides it for the run. Under the anchor that is exact (video's own
-  mapping is a constant too); under the cadence loop the video offset keeps moving, so the offload
-  route's lip sync drifts by whatever the loop tracks — crystal skew, tens of ppm. Bounded and slow,
-  uncorrected, not measured on device yet, and it only bites the opt-in offload route: the software
-  route's stamps never ride this mapping. A forward-only re-latch is the shape a fix would take (`derive_audio_skew` already handles a
-  new epoch), but a backward correction is impossible on that plane by construction.
+- **The audio latch gate is gone** (2026-08-28): audio no longer rides this mapping at all, so the
+  loop has no audio-facing constraint left. The lip-sync drift this used to carry — the offload
+  route riding one latched constant while the video offset kept moving — went with it: both planes
+  now advance on the player clock at the same rate.
 - Not tried yet, in rough order of expected value: **phase-locked capture** (core has the whole
   protocol — `NativeClient::report_phase` + `CLIENT_CAP_PHASE_LOCK`; the host aligns its capture tick
   to the client's panel grid, which *reduces* latency instead of buffering against it, but needs a

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -351,6 +351,29 @@ advances by its own cadence from there, leaving the floor as a defensive no-op. 
 (`play_audio` with no latched offset) also **logs the gap on the packet that ends it** — silent, it
 cost a session its audio with nothing in the log to find.
 
+⚠ **The loss hold must NOT flush, and this is what was muting the Opus plane after a network
+hiccup (2026-08-28, confirmed on device).** `NDL_DirectVideoFlushRenderBuffer` stops the pipeline:
+each flush used to be followed by `NDL load state: PLAYING (0x1a)`, a transition NDL only makes
+from not-playing, and the restart kills the audio plane for the rest of the session. It returns
+success and leaves `depth` and `plane_lead` looking healthy right through the mute, so there is no
+error to find — only a reload recovers. `ss4s` never flushes mid-stream (its only recovery is
+unload+load) and does not have this bug; moonlight-tv#493 is the same failure unfixed, Opus route
+only, PCM immune.
+
+Confirmation (CX, 276 Mb/s of competing download against a 188 Mb/s stream): 16 re-anchors, holds
+up to 2 s, **not one `PLAYING` transition in the whole log**, and audio intact — where the identical
+storm against the flushing build killed it permanently. The decode-error path still flushes, where
+the pipeline has actually errored; loss is a network event and NDL's queue holds good frames the
+hold is about to present anyway.
+
+This required `CadencePacer::reset` to STOP zeroing `last_base_ns`. That clearing was only correct
+*because* of the flush — without one the pipeline still holds everything fed before the hold, and a
+run restarting from 0 walks the video stamp backwards, which is the rewind NDL mutes on.
+
+⚠ This reopens a call an earlier handover had marked a dead end. That verdict rested on in-tree
+records scoped to *before* `LOADCOMPLETED`, and on `Pacing::reset` needing `last_base_ns = 0` —
+which was itself a consequence of the flush, not an independent constraint.
+
 ⚠ The audio-enabled load returns success even on a TV that then plays nothing, so **no runtime
 probe can distinguish the two**. If a model regresses, the `NDL load state:`
 (`LOADCOMPLETED`/`PLAYING`) log says whether the pipeline ever started, and turning Experimental →

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -332,24 +332,32 @@ no error to find on the audio side, so do not go looking for one.
 session**, and does not resync. `NdlVideo::play_audio` and `NdlVideo::burst_silence` are the only
 feed points, both serialised under `lock_ffi` and both flooring at `last_audio_pts_ms` — the floor
 must be read under that guard, or a packet measured against an older ceiling blocks on the lock and
-then hands NDL the stale stamp. For hardware decode the offset is additionally
-**latched, not recomputed per frame**: a receive-backlog flush jumps host PTS forward while the
-player clock does not, and a re-derived offset would drag the audio stamp backwards by the size of
-the jump. `latch_pts_offset` takes only the first value after each `clear_pts_offset` (hold
-resume, pacing off→on edge), and only off a frame NDL **accepted** — `play_audio` has no
-`ensure_loaded` guard of its own, so the latch doubles as the audio thread's start gate.
+then hands NDL the stale stamp.
 
-⚠ **But flooring every packet on that ceiling is itself a mute.** A hold resume re-anchors the
-video plane onto the *current player clock*; when that maps the resumed audio BELOW the ceiling —
-the video plane was running ahead, or the clock plane bursted its `PRIME_LEAD` of silence during
-the gap — `fetch_max` pins every packet to one stamp, audio stops advancing, and nothing lifts it
-off again for the rest of the session. Field case (CX, 2026-08-20, offload on): the startup ABR
-probe at 300 Mbps saturated the airlink, one freeze-until-reanchor hold followed, and audio was
-gone from that point while video recovered normally. The fix is a per-latch `audio_skew_ms`: the
-first real packet after a re-latch shifts the whole stream to one packet above the ceiling and
-advances by its own cadence from there, leaving the floor as a defensive no-op. The drop path
-(`play_audio` with no latched offset) also **logs the gap on the packet that ends it** — silent, it
-cost a session its audio with nothing in the log to find.
+⚠ **The audio plane stamps off the PLAYER clock, not the host's (2026-08-28).** It used to map the
+host capture PTS through a shared `SessionClock` the video plane published, with a per-latch
+`audio_skew_ms` lifting each resumed run above the ceiling. That **ratchets**: a
+freeze-until-reanchor stalls the mapped timeline while packets keep arriving, the resumed run lands
+below the ceiling it already reached, and the only monotonic repair is to add lead — which nothing
+in the session can ever pay back. Measured on a CX: five re-anchors inside four seconds walked the
+plane from 78 ms to 124 ms of lead, and the lip sync it buys is never recovered without a reload.
+
+So audio is stamped `player_clock + PLANE_LEAD_MS` and the host PTS is ignored (`AudioSink::feed`
+takes it and drops it). A wall clock cannot ratchet: it advances at the same rate whatever the host
+PTS does across a freeze, so a resumed run lands where an uninterrupted one would have, and
+`last_audio_pts_ms` is left with nothing to do but absorb reordering. The clock plane targets the
+same figure, so the two feeders share the ceiling without either driving it. `load_confirmed` is
+the plane's start gate, a job the video plane's latch used to do. `mariotaku/ss4s` made the same
+move in `ef0c0ae`, deleting a gap-filling thread it had added in `734e643`.
+
+⚠ **The ratchet was real and was NOT the mute** — see the flush below, which is. Measured after
+this change, under a saturated airlink: 32 re-anchors, `plane_lead` pinned at 37-40 ms, `depth`
+flat, stamps provably monotonic, and audio still died. **Nothing the client hands NDL explains that
+failure.** Do not spend another round on stamp arithmetic.
+
+Removed with the mapping: `SessionClock` (audio was its only reader), `AudioPlane::attach_clock`,
+`audio_skew_ms`, `skew_epoch`, and the audio-latch gate in `session::timeline`
+(`ready_for_audio` / `note_audio_latched` on both `CadencePacer` and `HostPtsAnchor`).
 
 ⚠ **The loss hold must NOT flush, and this is what was muting the Opus plane after a network
 hiccup (2026-08-28, confirmed on device).** `NDL_DirectVideoFlushRenderBuffer` stops the pipeline:
@@ -398,13 +406,10 @@ interval per frame (the stamps must never go backwards) and only inside the firs
 anchor. `pts lead: trimming Xms` at INFO, plus `pts_trim=` on the video heartbeat, is how much
 standing hold the session started with — a number not otherwise observable from the app.
 
-⚠ **The audio plane latches this mapping late, and that is what makes the trim safe.** Audio
-stamps ride the offset the video plane publishes and `play_audio` can only move a stamp FORWARD (a
-rewind mutes the session for good), so a trim taken after audio has latched would land as lip-sync
-error rather than latency saved. `HostPtsAnchor::ready_for_audio` therefore holds
-`latch_pts_offset` for `TRIM_SETTLE_NS` (600 ms) — one measurement window plus slack — and trimming
-stops at the same instant. The audio pump drops its packets through that window and logs the gap;
-`run_clock_plane` paces the picture meanwhile, which it was doing at session start anyway.
+⚠ **The audio plane no longer latches this mapping at all (2026-08-28)** — it stamps off the player
+clock, so there is nothing for the trim to be unsafe against and the gate that used to hold audio
+through the settle window (at the cost of real silence after every recovery) is gone. See § "NDL's
+audio plane".
 
 **2. Slice-progressive feed (on, every NDL v2 session).** Without it the decoder
 sees byte 0 of a frame only once that frame's LAST datagram lands; at 200 Mbps a keyframe is many

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -269,6 +269,14 @@ What still matters:
 - ⚠ **Use `frame.pts_ns`, never the paced value**, wherever a host-clock comparison is made. Both
   are in scope at the submit site with near-identical names; the paced one has been mapped into
   NDL's player clock by `session::timeline::Pacing`.
+- ⚠ **NDL can fail the whole load asynchronously, and then never recovers.** Seen on a CX: load
+  state `0x12` with `errorCode 600`, after which every `NDL_DirectVideoPlay` returns -1, the clock
+  plane's `NDL_DirectAudioPlay` fails too (so the thread that paces the picture exits for good) and
+  NDL reports `UNLOADCOMPLETED` on its own. There is no reload path in-session, and a re-anchor —
+  the response to lost frames — does nothing for a lost pipeline, so the client spun on failed feeds
+  with a frozen picture and no audio while the QUIC session stayed perfectly healthy. `ndl::fatal()`
+  latches that state, `VideoSink::is_dead` carries it up backend-blind, and the stream loop ends the
+  session and returns to the menu. What PROVOKES the 600 is still unknown.
 - The estimator's unit tests ship in-tree but **cannot run off-device**: `cargo test` links the
   whole binary and `-lNDL_directmedia` exists only in the cross sysroot.
 

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -147,9 +147,6 @@ pub enum ExpRow {
     /// this screen. Experimental because two of its three picks are hardware paths that no
     /// runtime probe can verify; locked to the software route where there is no NDL plane.
     AudioProcessing,
-    /// Stamp from the fixed anchor instead of the cadence loop — `Settings::direct_playback`.
-    /// Experimental: trades smoothness back for latency, and what that costs depends on the link.
-    DirectPlayback,
     /// Opens `Screen::HdrCalibration` — measures this panel's HDR volume so the client stops
     /// advertising one TV's numbers to every TV. Experimental because the measurement is by eye
     /// and the patterns run on the video plane outside a session.
@@ -158,12 +155,7 @@ pub enum ExpRow {
 
 /// Order is display order. `AudioProcessing` stays at index 1 so its dropdown's `(Screen, row)`
 /// tile key does not move.
-pub const EXP_ROWS: [ExpRow; 4] = [
-    ExpRow::GameMode,
-    ExpRow::AudioProcessing,
-    ExpRow::DirectPlayback,
-    ExpRow::HdrCalibration,
-];
+pub const EXP_ROWS: [ExpRow; 3] = [ExpRow::GameMode, ExpRow::AudioProcessing, ExpRow::HdrCalibration];
 
 /// Display position of [`ExpRow::AudioProcessing`] — the row a dropdown can hang off, which is
 /// what `DropdownState::row` names.
@@ -243,10 +235,7 @@ pub(crate) fn exp_row_lock(row: ExpRow, settings: &Settings, rooted: Option<bool
         (ExpRow::GameMode, Some(false)) => Some(ExpRowLock::NotRooted),
         (ExpRow::AudioProcessing, _) if audio_routes().len() < 2 => Some(ExpRowLock::SoftwareOnly),
         (ExpRow::HdrCalibration, _) if !settings.hdr_enabled || !video_caps().hdr => Some(ExpRowLock::HdrOff),
-        (ExpRow::GameMode, Some(true))
-        | (ExpRow::AudioProcessing, _)
-        | (ExpRow::DirectPlayback, _)
-        | (ExpRow::HdrCalibration, _) => None,
+        (ExpRow::GameMode, Some(true)) | (ExpRow::AudioProcessing, _) | (ExpRow::HdrCalibration, _) => None,
     }
 }
 

--- a/src/app/render/key.rs
+++ b/src/app/render/key.rs
@@ -44,7 +44,6 @@ pub enum ModalFocusKey<'a> {
         /// Which of the row's buttons is lit — the Calibrate row's Clear.
         button: Option<RowButton>,
         game_mode: bool,
-        direct_playback: bool,
         audio_route: AudioRoutePref,
         hdr_enabled: bool,
         hdr: Option<HdrDisplay>,
@@ -133,7 +132,6 @@ pub enum ModalShellKey<'a> {
     },
     Experimental {
         game_mode: bool,
-        direct_playback: bool,
         /// Named on the Audio processing row.
         audio_route: AudioRoutePref,
         /// HDR off locks the Calibrate row and rewrites its caption.

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -251,7 +251,6 @@ impl App {
             }),
             Screen::Experimental => Some(ModalShellKey::Experimental {
                 game_mode: self.settings_ui.settings.game_mode,
-                direct_playback: self.settings_ui.settings.direct_playback,
                 audio_route: self.settings_ui.settings.audio_route,
                 hdr_enabled: self.settings_ui.settings.hdr_enabled,
                 hdr: self.calibrated_hdr_display(),
@@ -361,7 +360,6 @@ impl App {
                 row: self.nav.cursor(ScreenKey::Experimental),
                 button: self.screens.row_button,
                 game_mode: self.settings_ui.settings.game_mode,
-                direct_playback: self.settings_ui.settings.direct_playback,
                 audio_route: self.settings_ui.settings.audio_route,
                 hdr_enabled: self.settings_ui.settings.hdr_enabled,
                 hdr: self.calibrated_hdr_display(),

--- a/src/app/state/experimental.rs
+++ b/src/app/state/experimental.rs
@@ -164,11 +164,6 @@ impl App {
                     menu::apply_audio_route(&mut self.settings_ui.settings, next);
                 }
             }
-            (Some(menu::ExpRow::DirectPlayback), MenuEvent::Left | MenuEvent::Right | MenuEvent::Confirm) => {
-                let from = self.settings_ui.settings.direct_playback;
-                self.settings_ui.settings.direct_playback = !from;
-                self.arm_switch_anim(from);
-            }
             (Some(menu::ExpRow::HdrCalibration), MenuEvent::Confirm)
                 if menu::exp_row_lock(
                     menu::ExpRow::HdrCalibration,

--- a/src/app/view/experimental.rs
+++ b/src/app/view/experimental.rs
@@ -31,16 +31,6 @@ pub fn rows(settings: &Settings, rooted: Option<bool>) -> Vec<FocusRow> {
         menu::audio_route_label(settings.audio_route),
     )
     .with_subtext_opt(audio_route_hint(settings.audio_route));
-    // What it gives back is one frame at most (the cushion's own ceiling); what it costs is the
-    // judder, so the caption leads with that — see `session::timeline::Pacing`.
-    let direct = FocusRow::toggle(
-        crate::app::view::icons::ICON_MEMORY,
-        "Direct playback",
-        settings.direct_playback,
-    )
-    .with_subtext(ui::widgets::RowSubtext::caution(
-        "Up to one frame less latency, may stutter",
-    ));
     // Named on the row once measured, because "is this TV calibrated, and to what" is the only
     // question anyone opens this row to answer.
     let calibrate = FocusRow::action(icons::ICON_SUN, "Calibrate HDR")
@@ -63,7 +53,6 @@ pub fn rows(settings: &Settings, rooted: Option<bool>) -> Vec<FocusRow> {
     vec![
         apply(game_mode, ExpRow::GameMode),
         apply(audio, ExpRow::AudioProcessing),
-        apply(direct, ExpRow::DirectPlayback),
         apply(calibrate, ExpRow::HdrCalibration),
     ]
 }

--- a/src/core/media.rs
+++ b/src/core/media.rs
@@ -99,6 +99,13 @@ pub trait VideoSink: Send {
     fn audio_plane(&self) -> Option<Arc<dyn AudioPlane>> {
         None
     }
+
+    /// Whether this decoder has failed in a way no re-anchor can undo, so the stage should stop
+    /// feeding it and the session should end rather than run on a picture that will never return.
+    /// `false` on a backend with no such notion, which is then simply never fatal.
+    fn is_dead(&self) -> bool {
+        false
+    }
 }
 
 /// What an audio sink takes. Declared by the sink; the stage above produces exactly this and

--- a/src/core/media.rs
+++ b/src/core/media.rs
@@ -9,7 +9,7 @@
 //! **The traits describe capability, not policy.** A sink says what it can take
 //! ([`VideoSinkCaps`]) and does it; anchoring, freeze-until-reanchor, backlog metering and
 //! concealment are the stages' business, above this seam and identical on every backend.
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -28,84 +28,6 @@ impl std::fmt::Display for NotReady {
 }
 
 impl std::error::Error for NotReady {}
-
-/// [`SessionClock::offset_ns`] before the video plane has published a mapping. Not 0 — a genuine
-/// offset of 0 ns is possible, and "unset" must be distinguishable from it.
-const NO_OFFSET: i64 = i64::MIN;
-
-/// The one mapping between the host's capture clock and the sink's own, shared by every plane in
-/// a session.
-///
-/// **Both planes must be stamped in one time base.** The decoder runs its own A/V synchronisation
-/// against the stamps it is fed, and regulating a video plane on host-capture cadence against an
-/// audio plane on arrival wall-clock is what froze the picture on webOS 10.3 (docs/NOTES.md §
-/// "NDL's audio plane"). Before this existed the mapping lived in the video sink's own atomics and
-/// was pushed into the audio plane frame by frame; one object both planes read is the same
-/// guarantee with one owner.
-///
-/// **Latched, not republished.** The mapping is stable only while the video stage's anchor is, so
-/// the first value after each [`Self::clear`] wins and later ones are ignored. Re-deriving it per
-/// frame lets any jump in the video timeline — a receive-backlog flush jumping to live drops
-/// frames, so host PTS leaps forward while the sink clock does not — drag the audio stamp
-/// *backwards* by the size of the jump, which NDL takes as a rewind and answers by muting the rest
-/// of the session.
-#[derive(Debug)]
-pub struct SessionClock {
-    offset_ns: AtomicI64,
-    /// Bumped on every latch, so a reader can tell "the same mapping" from "a fresh one" without
-    /// being called back on the video thread. A plane with per-latch work of its own (NDL derives
-    /// its stamp skew) does it on its own thread, the first time it sees a new epoch.
-    epoch: AtomicU64,
-}
-
-impl Default for SessionClock {
-    fn default() -> Self {
-        Self {
-            offset_ns: AtomicI64::new(NO_OFFSET),
-            epoch: AtomicU64::new(0),
-        }
-    }
-}
-
-impl SessionClock {
-    /// Publish `offset_ns` if nothing is latched. Called per fed frame; only the first after each
-    /// [`Self::clear`] takes.
-    pub fn latch(&self, offset_ns: i64) {
-        // The steady state is "already latched", and this runs per fed frame — keep the exclusive
-        // access off the video thread's hot path once the offset is set.
-        if self.offset_ns.load(Ordering::Relaxed) != NO_OFFSET {
-            return;
-        }
-        if self
-            .offset_ns
-            .compare_exchange(NO_OFFSET, offset_ns, Ordering::Relaxed, Ordering::Relaxed)
-            .is_ok()
-        {
-            self.epoch.fetch_add(1, Ordering::Release);
-        }
-    }
-
-    /// Decouple: the two timelines no longer agree (the video stage reset its anchor after a
-    /// freeze-until-reanchor hold). Readers hold until the next latch.
-    pub fn clear(&self) {
-        self.offset_ns.store(NO_OFFSET, Ordering::Relaxed);
-    }
-
-    /// Which mapping is current — see [`Self::epoch`]. Pair it with [`Self::map_host_ns`]: a
-    /// reader that sees a new epoch is on a fresh timeline.
-    pub fn epoch(&self) -> u64 {
-        self.epoch.load(Ordering::Acquire)
-    }
-
-    /// `host_pts_ns` in the sink's clock domain, or `None` while nothing is latched — audio ahead
-    /// of the first video frame has no timeline to join yet.
-    pub fn map_host_ns(&self, host_pts_ns: u64) -> Option<u64> {
-        match self.offset_ns.load(Ordering::Relaxed) {
-            NO_OFFSET => None,
-            offset => Some((host_pts_ns as i64).saturating_add(offset).max(0) as u64),
-        }
-    }
-}
 
 /// What a video backend can be asked to do. Every `false` here is a stage behaviour that must
 /// switch off, not a call that may fail — the alternative is per-backend `match`es scattered
@@ -217,8 +139,8 @@ pub trait AudioSink: Send + Sync {
     /// What this sink takes. The stage produces it; nothing converts on the way in.
     fn format(&self) -> AudioFormat;
 
-    /// Feed one packet, stamped in the host's capture clock. A sink that paces on a timeline maps
-    /// it through the session's [`SessionClock`]; one that just plays what it is given ignores it.
+    /// Feed one packet, stamped in the host's capture clock. A sink that paces on a timeline of
+    /// its own maps it; one that just plays what it is given ignores it.
     fn feed(&self, samples: Samples<'_>, host_pts_ns: u64) -> Result<()>;
 
     /// Queue depth in ms where the sink knows one, for the stats overlay.
@@ -233,10 +155,6 @@ pub trait AudioSink: Send + Sync {
 /// picture against a fed plane, so a plane starved of packets is a video stutter, not an audio
 /// fault (docs/NOTES.md § "NDL's audio plane").
 pub trait AudioPlane: AudioSink {
-    /// Hand the plane the session's shared timeline, once, before anything is fed. Every stamp it
-    /// hands the hardware is mapped through this — see [`SessionClock`].
-    fn attach_clock(&self, clock: Arc<SessionClock>);
-
     /// How far the plane's stamps run ahead of its clock, in ms — the depth NDL paces the
     /// PICTURE on, and so the figure a stutter report is read against. Sagging towards zero is
     /// the signature.

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -912,14 +912,6 @@ pub struct Settings {
     /// since NDL only paces the picture against a fed plane. The routes differ in what RIDES it:
     /// `run_clock_plane`'s silent metronome, or the host's Opus.
     pub audio_route: AudioRoutePref,
-    /// Stamp frames from the fixed anchor instead of playing them out on the host's cadence —
-    /// see `session::timeline::Pacing`. Off by default: the cadence loop holds each frame by a
-    /// cushion sized to the link's *measured* jitter (at most one frame interval, and its 0.5 ms
-    /// floor on a link with nothing wrong), which is what buys a cadence that doesn't beat against
-    /// the panel. On gives that cushion back and takes the judder with it — the ONE gate on every
-    /// latency-adding measure in the video path, which is why it lives on the Experimental screen
-    /// rather than beside Resolution. Takes effect on the next stream.
-    pub direct_playback: bool,
     /// Resolve the Magic Remote's OK button into left click / right click / drag by how long
     /// it's held (see `platform::webos::mouse::RemoteButtons`). Off by default — with it
     /// off, OK stays the plain immediate left click it has always been, since a remote with
@@ -956,7 +948,6 @@ impl Default for Settings {
             cursor_capture: true,
             game_mode: false,
             audio_route: AudioRoutePref::default(),
-            direct_playback: false,
             cursor_gestures: false,
             theme: ThemeChoice::default(),
         }

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -138,6 +138,11 @@ static PLAYING: EventSeq = EventSeq::new();
 /// and a host that delivers its first frame seconds late (new-flow stall, startup capacity
 /// probe) would otherwise show as seconds of black.
 static FRAME_FED: EventSeq = EventSeq::new();
+/// Set by any load state that is neither a transition we asked for nor one we can act on — in the
+/// field, `0x12` with `errorCode 600`, which NDL follows by failing every `play` until the pipeline
+/// unloads itself. Latched rather than pulsed: the load is gone, and there is no later callback
+/// that takes it back. Cleared only by [`arm_load`], which is to say by a NEW load.
+static FATAL: AtomicBool = AtomicBool::new(false);
 
 /// Records v2 load-state transitions so loads, feeds and the UI reveal can wait on them.
 extern "C" fn on_load_state(state: c_int, num: c_longlong, detail: *const c_char) {
@@ -162,7 +167,11 @@ extern "C" fn on_load_state(state: c_int, num: c_longlong, detail: *const c_char
             } else {
                 unsafe { CStr::from_ptr(detail) }.to_string_lossy().into_owned()
             };
-            tracing::warn!("NDL load state: unknown 0x{state:x} ({state}) num={num} {detail}");
+            // Fatal by construction: the states worth acting on are enumerated above, so anything
+            // else is NDL reporting that this load has failed asynchronously. Feeding it further
+            // produces nothing but a `play` error per frame — see [`fatal`].
+            FATAL.store(true, Ordering::Release);
+            tracing::warn!("NDL load state: fatal 0x{state:x} ({state}) num={num} {detail}");
             return;
         }
     };
@@ -175,6 +184,15 @@ fn arm_load() {
     LOAD_COMPLETED.arm();
     PLAYING.arm();
     FRAME_FED.arm();
+    FATAL.store(false, Ordering::Release);
+}
+
+/// Whether the current load has reported a fatal state — see [`FATAL`]. The session reads this to
+/// tell "NDL is gone" from "these frames failed", which are the same thing at the `play` call and
+/// want opposite responses: the second is a re-anchor, the first cannot be recovered from without
+/// a new load.
+pub fn fatal() -> bool {
+    FATAL.load(Ordering::Acquire)
 }
 
 /// `PLAYING` for the current load. Diagnostics only — see [`PLAYING`].

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -147,7 +147,7 @@ static FRAME_FED: EventSeq = EventSeq::new();
 /// every `play` until the pipeline unloads itself. Latched rather than pulsed: the load is gone,
 /// and there is no later callback that takes it back. Cleared only by [`arm_load`], which is to
 /// say by a NEW load.
-static FATAL: AtomicBool = AtomicBool::new(false);
+static FATAL: EventSeq = EventSeq::new();
 
 /// Records v2 load-state transitions so loads, feeds and the UI reveal can wait on them.
 extern "C" fn on_load_state(state: c_int, num: c_longlong, detail: *const c_char) {
@@ -173,9 +173,11 @@ extern "C" fn on_load_state(state: c_int, num: c_longlong, detail: *const c_char
                 unsafe { CStr::from_ptr(detail) }.to_string_lossy().into_owned()
             };
             if state == STATE_ERROR {
-                // Feeding on produces nothing but a `play` error per frame — see [`fatal`].
-                FATAL.store(true, Ordering::Release);
-                tracing::error!("NDL load state: fatal 0x{state:x} ({state}) num={num} {detail}");
+                // Feeding on produces nothing but a `play` error per frame — see [`fatal`]. Logged
+                // once per load; NDL repeats the state while the pipeline tears itself down.
+                if FATAL.bump_first() {
+                    tracing::error!("NDL load state: fatal 0x{state:x} ({state}) num={num} {detail}");
+                }
             } else {
                 // Unmapped, and not the state that has ever been seen to kill a load. Logged so a
                 // device trace can identify it, but NOT latched: ending a healthy session on a
@@ -194,7 +196,7 @@ fn arm_load() {
     LOAD_COMPLETED.arm();
     PLAYING.arm();
     FRAME_FED.arm();
-    FATAL.store(false, Ordering::Release);
+    FATAL.arm();
 }
 
 /// Whether the current load has reported a fatal state — see [`FATAL`]. The session reads this to
@@ -202,7 +204,7 @@ fn arm_load() {
 /// want opposite responses: the second is a re-anchor, the first cannot be recovered from without
 /// a new load.
 pub fn fatal() -> bool {
-    FATAL.load(Ordering::Acquire)
+    FATAL.fired()
 }
 
 /// `PLAYING` for the current load. Diagnostics only — see [`PLAYING`].

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -70,6 +70,11 @@ impl NdlCodec {
 const STATE_LOADCOMPLETED: c_int = 0x16;
 const STATE_UNLOADCOMPLETED: c_int = 0x17;
 const STATE_PLAYING: c_int = 0x1a;
+/// The one state measured to kill a load for good: seen on a CX as `0x12` with `errorCode 600`,
+/// after which every feed fails and NDL unloads itself (docs/NOTES.md § "A/V sync"). Only this
+/// one latches [`FATAL`] — the enum is sparse (0x18/0x19 are unmapped) and a benign notification
+/// treated as fatal would end a healthy session outright.
+const STATE_ERROR: c_int = 0x12;
 
 /// Bound, not a requirement: feeding an unloaded decoder is the first-frames-black cause,
 /// but a model that never delivers the callback must still stream.
@@ -138,10 +143,10 @@ static PLAYING: EventSeq = EventSeq::new();
 /// and a host that delivers its first frame seconds late (new-flow stall, startup capacity
 /// probe) would otherwise show as seconds of black.
 static FRAME_FED: EventSeq = EventSeq::new();
-/// Set by any load state that is neither a transition we asked for nor one we can act on — in the
-/// field, `0x12` with `errorCode 600`, which NDL follows by failing every `play` until the pipeline
-/// unloads itself. Latched rather than pulsed: the load is gone, and there is no later callback
-/// that takes it back. Cleared only by [`arm_load`], which is to say by a NEW load.
+/// Set by [`STATE_ERROR`] — in the field, `0x12` with `errorCode 600`, which NDL follows by failing
+/// every `play` until the pipeline unloads itself. Latched rather than pulsed: the load is gone,
+/// and there is no later callback that takes it back. Cleared only by [`arm_load`], which is to
+/// say by a NEW load.
 static FATAL: AtomicBool = AtomicBool::new(false);
 
 /// Records v2 load-state transitions so loads, feeds and the UI reveal can wait on them.
@@ -167,11 +172,16 @@ extern "C" fn on_load_state(state: c_int, num: c_longlong, detail: *const c_char
             } else {
                 unsafe { CStr::from_ptr(detail) }.to_string_lossy().into_owned()
             };
-            // Fatal by construction: the states worth acting on are enumerated above, so anything
-            // else is NDL reporting that this load has failed asynchronously. Feeding it further
-            // produces nothing but a `play` error per frame — see [`fatal`].
-            FATAL.store(true, Ordering::Release);
-            tracing::warn!("NDL load state: fatal 0x{state:x} ({state}) num={num} {detail}");
+            if state == STATE_ERROR {
+                // Feeding on produces nothing but a `play` error per frame — see [`fatal`].
+                FATAL.store(true, Ordering::Release);
+                tracing::error!("NDL load state: fatal 0x{state:x} ({state}) num={num} {detail}");
+            } else {
+                // Unmapped, and not the state that has ever been seen to kill a load. Logged so a
+                // device trace can identify it, but NOT latched: ending a healthy session on a
+                // notification we simply don't have a name for is the worse failure.
+                tracing::warn!("NDL load state: unmapped 0x{state:x} ({state}) num={num} {detail}");
+            }
             return;
         }
     };

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -369,8 +369,19 @@ impl NdlVideo {
         // BEFORE `load_instant`, so its ceiling already sits a whole prime ahead, and targeting the
         // raw clock would feed nothing until it caught up — dead exactly at session start. The
         // resulting constant offset from the video timeline costs a metronome nothing.
-        let mut base_ms = self.last_audio_pts_ms.load(Ordering::Relaxed);
-        let mut pts_ms = base_ms;
+        // On the offload route the real stream owns the ceiling, so a fill targets exactly what
+        // [`Self::play_audio`] targets and carries no base of its own: `burst_silence` floors on
+        // the ceiling the stream left, and adding the prime's base on top of that raised it by one
+        // `PLANE_LEAD_MS` per fill episode — recovered audio then floored onto the jump and pinned
+        // to a single stamp for the length of it, the ratchet this path exists to avoid.
+        //
+        // The metronome route is the only feed, so it continues the prime's stamps instead of
+        // restarting from the player clock: the prime runs BEFORE `load_instant`, so its ceiling
+        // already sits a whole prime ahead and targeting the raw clock would feed nothing until the
+        // clock caught up — dead exactly at session start. The constant offset costs a metronome
+        // nothing.
+        let base_ms = if yields_to_real { 0 } else { self.last_audio_pts_ms.load(Ordering::Relaxed) };
+        let mut pts_ms = self.last_audio_pts_ms.load(Ordering::Relaxed);
         let mut filling = false;
         while !stop.load(Ordering::Relaxed) {
             let now_ms = (self.elapsed_ns() / 1_000_000) as i64;
@@ -383,20 +394,13 @@ impl NdlVideo {
                 continue;
             }
             if yields_to_real && !filling {
-                // Target exactly what [`Self::play_audio`] targets, so the handoff back costs
-                // nothing: `burst_silence` floors at the ceiling the real stream left, so the fill
-                // resumes from it without stacking another lead ON TOP. Carrying the prime's base
-                // through here instead raised the ceiling by one `PLANE_LEAD_MS` per fill episode
-                // — and recovered audio then floored onto that jump, pinned to a single stamp for
-                // the length of it, which is the ratchet this path exists to avoid.
-                base_ms = 0;
                 tracing::warn!(
                     "NDL clock plane: no host audio for {REAL_FEED_GRACE_MS}ms — filling silence \
                      to keep the picture paced (host capture is likely dead)"
                 );
                 filling = true;
             }
-            match self.burst_silence(pts_ms, base_ms + now_ms + PRIME_LEAD * PRIME_PACKET_MS) {
+            match self.burst_silence(pts_ms, base_ms + now_ms + PLANE_LEAD_MS) {
                 Ok(fed_to) => pts_ms = fed_to,
                 Err(e) => {
                     // Dead for the session; the picture keeps running unpaced, as it did before

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -668,4 +668,8 @@ impl VideoSink for std::sync::Arc<NdlVideo> {
         self.has_audio_plane()
             .then(|| Self::clone(self) as std::sync::Arc<dyn AudioPlane>)
     }
+
+    fn is_dead(&self) -> bool {
+        super::fatal()
+    }
 }

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -5,7 +5,7 @@
 //! Never calls `NDL_DirectVideoSetArea` — stutters above 1080p, and v2 sizes its own
 //! punch-through plane (v1 can't; see [`super::v1`]).
 use std::ffi::c_uint;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::{Mutex, MutexGuard, PoisonError};
 use std::time::{Duration, Instant};
 
@@ -49,12 +49,13 @@ const PRIME_LEAD: i64 = 8;
 /// **This is not a sync tweak, it is what keeps the picture paced.** NDL regulates the video plane
 /// against its audio renderer, and the renderer's clock only advances smoothly while it has data
 /// queued ahead of it. Fed straight off the wire the real stream stamps at ≈ the player clock (a
-/// packet arrives *after* the frame it was captured with, and the PTS trim pulled the shared offset
-/// another ~36 ms earlier), so the renderer runs at the edge of underrun and the picture stutters
-/// on network jitter — the exact failure the clock plane was introduced to fix, back again the
-/// moment real audio displaced the metronome. Adding a constant here restores the depth without
-/// interleaving silence, which would raise the ceiling real packets then floor onto (see
-/// [`NdlVideo::play_audio`] — that is a permanent session mute, not a stutter).
+/// packet arrives *after* the frame it was captured with), so the renderer runs at the edge of
+/// underrun and the picture stutters on network jitter — the exact failure the clock plane was
+/// introduced to fix, back again the moment real audio displaced the metronome. Adding a constant
+/// here restores the depth without interleaving silence into the real stream.
+///
+/// The clock plane targets the same figure, which is what lets the two feeders share
+/// [`NdlVideo::last_audio_pts_ms`] without either driving it.
 ///
 /// **The SDL path does the same thing, in its own currency** — `platform::webos::audio` primes and
 /// holds a 25 ms ring ahead of the speaker for exactly this reason: a renderer needs data queued
@@ -70,12 +71,6 @@ const PLANE_LEAD_MS: i64 = PRIME_LEAD * PRIME_PACKET_MS;
 /// Gap between prime bursts. Polled through, not slept through — the callback lands mid-gap,
 /// and this is launch-path time, i.e. black screen.
 const PRIME_RETRY: Duration = Duration::from_millis(20);
-
-/// Re-latch skew past which lip sync is audibly off and the jump that caused it is worth a line.
-const SKEW_WARN_MS: i64 = 200;
-
-/// Real packets dropped for want of a latched timeline between warnings — 200 × 5 ms = 1 s.
-const NO_OFFSET_WARN_PACKETS: u32 = 200;
 
 /// How long the clock plane waits for the real stream before feeding the plane itself.
 ///
@@ -115,26 +110,14 @@ pub struct NdlVideo {
     /// Whether this load got an audio plane. False on a video-only load, i.e. one whose
     /// audio-enabled attempt was rejected — and with it goes the picture's pacing reference.
     audio: bool,
-    /// The session's shared host-PTS → player-clock mapping, attached by the video stage before
-    /// anything is fed (`core::media::SessionClock`). Both planes stamp through it, which is the
-    /// whole reason it is one object rather than two agreeing copies.
-    clock: std::sync::OnceLock<std::sync::Arc<crate::core::media::SessionClock>>,
-    /// Mapping epoch the audio thread has already derived its skew for — see
-    /// [`Self::derive_audio_skew`]. Re-derivation runs on the audio thread's own next packet
-    /// rather than on the video thread that latched, which keeps `lock_ffi` out of the picture's
-    /// way on every re-anchor.
-    skew_epoch: AtomicU64,
-    /// Highest audio stamp fed so far (ms), so [`Self::play_audio`] can never hand NDL a
-    /// timestamp going backwards. Never reset — the ceiling has to survive a re-latch, which is
-    /// exactly the case that would otherwise rewind it.
+    /// Highest audio stamp fed so far (ms), shared by [`Self::play_audio`] and the clock plane so
+    /// neither can hand NDL a timestamp going backwards — NDL reads a rewind as a seek and mutes
+    /// the rest of the session.
+    ///
+    /// It is a floor, never a driver: both feeders target the player clock plus
+    /// [`PLANE_LEAD_MS`], so the ceiling can only ever be at most one lead ahead of real time and
+    /// cannot ratchet away from it.
     last_audio_pts_ms: AtomicI64,
-    /// Constant added to every mapped real-audio stamp, re-derived on each latch
-    /// ([`Self::derive_audio_skew`]) so a resumed run lands above [`Self::last_audio_pts_ms`]
-    /// rather than flooring onto it — see [`Self::play_audio`].
-    audio_skew_ms: AtomicI64,
-    /// Real packets dropped since the current offset gap opened; both the periodic warning and
-    /// the one on the packet that ends the gap read it.
-    dropped_no_offset: AtomicU32,
     /// Player-clock ms at the last REAL packet fed by [`Self::play_audio`].
     /// [`Self::run_clock_plane`] reads it to stay off the plane while the real stream carries it.
     ///
@@ -230,11 +213,7 @@ impl NdlVideo {
             load_instant: Instant::now(),
             load_requested,
             audio,
-            clock: std::sync::OnceLock::new(),
-            skew_epoch: AtomicU64::new(0),
             last_audio_pts_ms: AtomicI64::new(primed_pts_ms),
-            audio_skew_ms: AtomicI64::new(0),
-            dropped_no_offset: AtomicU32::new(0),
             last_real_feed_ms: AtomicI64::new(0),
             load_confirmed: AtomicBool::new(confirmed),
             pending_hdr: Mutex::new(None),
@@ -253,10 +232,11 @@ impl NdlVideo {
     /// A burst at a time, because a packet fed before the plane exists may be dropped silently
     /// (`NDL_DirectAudioPlay` reports success either way).
     ///
-    /// The ceiling is handed to `last_audio_pts_ms`: real packets are stamped in the video plane's
-    /// domain, which also starts near 0, so without that floor the first would read as a rewind —
-    /// which mutes the session permanently (see [`Self::play_audio`]). Flooring costs a few early
-    /// packets their exact stamp; the alternative is no audio at all.
+    /// The highest stamp is handed to `last_audio_pts_ms`: the prime runs BEFORE `load_instant`,
+    /// so its stamps already sit a lead ahead of where the player clock starts, and without that
+    /// floor the first real packet would read as a rewind — which mutes the session permanently
+    /// (see [`Self::play_audio`]). It costs a few early packets their exact stamp, bounded by
+    /// [`PRIME_LEAD`], and the player clock overtakes it within one lead.
     fn prime_audio(fns: &'static ffi::V2) -> (i64, bool) {
         let silence = &OPUS_SILENCE[..];
         let start = Instant::now();
@@ -299,112 +279,52 @@ impl NdlVideo {
         self.audio
     }
 
-    /// Place the run that starts at `base_ms` one packet above the audio ceiling, so the resumed
-    /// stream advances instead of flooring onto it — see [`Self::play_audio`].
+    /// Feed one Opus packet to the audio plane, stamped on the PLAYER clock.
     ///
-    /// The run's own first stamp is `base_ms + PLANE_LEAD_MS`, not `base_ms`, so the lead is
-    /// discounted here — charging skew for a gap the lead already closes would stack the two and
-    /// push audio a second lead behind the picture on every re-latch.
+    /// **The host's capture PTS is deliberately ignored.** Deriving the audio stamp from it (via
+    /// the session clock, plus a skew re-derived on every re-anchor) ratchets: a video freeze
+    /// stalls the mapped timeline while packets keep arriving, the run resumes below the ceiling
+    /// it already reached, and the only monotonic repair is to add lead — which nothing in the
+    /// session can ever pay back. Measured on a CX: five re-anchors inside four seconds walked the
+    /// plane from 78 ms to 124 ms of lead and the session went silent for good, with healthy depth
+    /// and sane per-latch skew the whole way. `mariotaku/ss4s` removed the same apparatus in
+    /// `ef0c0ae` and stamps both planes off `CLOCK_MONOTONIC` since load; moonlight-tv#493 is the
+    /// unfixed version of this failure.
     ///
-    /// Under `lock_ffi` because the clock plane raises that ceiling from its own thread. Called
-    /// from the audio thread on the first packet of a new mapping epoch, so the video thread never
-    /// pays for this guard at all.
-    fn derive_audio_skew(&self, base_ms: i64) {
-        let skew = {
-            let _ffi = lock_ffi();
-            // Never negative: a run already above the ceiling needs no help, and pulling it DOWN
-            // to meet one is the rewind NDL mutes on.
-            let skew =
-                (self.last_audio_pts_ms.load(Ordering::Relaxed) + PRIME_PACKET_MS - (base_ms + PLANE_LEAD_MS)).max(0);
-            self.audio_skew_ms.store(skew, Ordering::Relaxed);
-            skew
-        };
-        // The cost of the skew is lip sync: audio rides `skew` ms behind the picture until the next
-        // re-latch, because NDL has no way to pull its ceiling back down. A filler burst costs
-        // `PRIME_LEAD` packets of it and nobody notices; a video plane that jumped seconds ahead
-        // costs seconds, which is worth seeing in the log rather than only hearing. Logged outside
-        // the guard — the video feed shares it.
-        if skew > SKEW_WARN_MS {
-            tracing::warn!("NDL audio re-latched {skew}ms behind the picture (video plane jumped)");
-        }
-    }
-
-    /// Feed one Opus packet to NDL's audio plane, for the TV's own decoder to render. Called only
-    /// on the offload route, where the real stream rides the plane. `host_pts_ns` is the packet's own host capture
-    /// timestamp, NOT arrival time.
+    /// A wall clock cannot ratchet. It advances at the same rate whatever the host PTS does across
+    /// a freeze, so a resumed run lands where an uninterrupted one would have, and the ceiling
+    /// below is left with nothing to do but absorb reordering.
     ///
-    /// Every stamp carries [`PLANE_LEAD_MS`] on top of the mapped host time, so NDL always holds
-    /// that much audio ahead of its renderer — read that constant before touching this arithmetic.
+    /// Every stamp carries [`PLANE_LEAD_MS`] on top of it, so NDL always holds that much audio
+    /// ahead of its renderer — read that constant before touching this arithmetic. The clock plane
+    /// targets the same figure, which is what lets the two feeders share the ceiling without
+    /// either pushing it.
     ///
-    /// **Both planes must be stamped in one time base** — NDL runs its own A/V synchronisation
-    /// against these values, and regulating a video plane on host-capture cadence against an audio
-    /// plane on arrival wall-clock is what froze the picture on webOS 10.3 (docs/NOTES.md § "NDL's
-    /// audio plane"). So the host PTS goes through the video plane's own offset
-    /// ([`latch_pts_offset`](Self::latch_pts_offset)).
-    ///
-    /// Returns `Ok(())` having fed nothing while no offset is latched: audio before the first
-    /// video frame has no timeline to join yet, and dropping those few packets beats feeding them
-    /// at a stamp that jumps once the real offset lands. A gap is logged while it lasts and again
-    /// on the packet that ends it — the silent version of this cost a session its audio with
-    /// nothing in the log to find.
-    ///
-    /// **The stamp is skewed, not floored, across a re-latch.** NDL reads a timestamp going
-    /// backwards as a rewind and mutes the rest of the session, so the ceiling below is mandatory
-    /// — but flooring EVERY packet onto it is what killed audio in the field: the sink's re-anchor
-    /// maps the resumed stream onto the current player clock, and when that lands below the
-    /// ceiling (the video plane was running ahead — a receive-backlog flush jumping to live — or
-    /// the clock plane bursted its [`PRIME_LEAD`] of silence during the gap) every packet floors
-    /// to the same stamp, audio stops advancing, and nothing ever lifts it back off.
-    /// [`Self::derive_audio_skew`] moves the whole run above the ceiling instead; the floor stays
-    /// as the guard for what it cannot see — an out-of-order packet, or a burst landing between
-    /// the latch and the run's first packet — and is also what publishes the ceiling itself.
-    pub fn play_audio(&self, packet: &[u8], host_pts_ns: u64) -> Result<()> {
-        // Fast path: no latched timeline means nothing to stamp against, and the packet is dropped.
-        let Some((clock, probe_ns)) = self.clock.get().and_then(|c| Some((c, c.map_host_ns(host_pts_ns)?))) else {
-            let dropped = self.dropped_no_offset.fetch_add(1, Ordering::Relaxed) + 1;
-            // Reported on the way through, not only on the packet that ends the gap: a gap that
-            // never ends is exactly the failure worth seeing, and that path logs nothing at all.
-            if dropped % NO_OFFSET_WARN_PACKETS == 0 {
-                tracing::warn!(
-                    "NDL audio dropped for {}ms — no latched timeline (the video plane has fed no \
-                     accepted frame since the last hold); the clock plane is pacing the picture",
-                    i64::from(dropped) * PRIME_PACKET_MS,
-                );
-            }
+    /// **Both planes are still in one time base** — NDL synchronises them against each other, and
+    /// the video plane's own stamps are the player clock too (`session::timeline::Pacing` maps the
+    /// host PTS onto it). What changed is that audio no longer rides the mapping's jumps.
+    pub fn play_audio(&self, packet: &[u8]) -> Result<()> {
+        // The plane's start gate. Feeding a pipeline NDL has not finished loading costs the
+        // session its audio outright, and unlike the video feed this path has no `ensure_loaded`
+        // of its own — the prime is what carries the plane through the load window.
+        if !self.load_confirmed.load(Ordering::Relaxed) {
             return Ok(());
-        };
-        // A mapping this thread hasn't stamped against yet needs its skew re-derived first — the
-        // run has to land ABOVE the ceiling the previous one (or the metronome) left behind.
-        // Outside `lock_ffi`, which `derive_audio_skew` takes for itself.
-        let epoch = clock.epoch();
-        if self.skew_epoch.swap(epoch, Ordering::Relaxed) != epoch {
-            self.derive_audio_skew((probe_ns / 1_000_000) as i64);
         }
+        let now_ms = (self.elapsed_ns() / 1_000_000) as i64;
+        let target_ms = now_ms + PLANE_LEAD_MS;
         {
             let _ffi = lock_ffi();
-            // Re-read under the guard: the check above is only a fast path, and a clear/re-latch
-            // landing between the two would pair a stale mapping with the new skew.
-            let Some(base_ns) = clock.map_host_ns(host_pts_ns) else {
-                return Ok(());
-            };
-            let raw_ms = ((base_ns / 1_000_000) as i64)
-                .saturating_add(self.audio_skew_ms.load(Ordering::Relaxed))
-                .saturating_add(PLANE_LEAD_MS);
-            let pts_ms = self.last_audio_pts_ms.fetch_max(raw_ms, Ordering::Relaxed).max(raw_ms);
+            // Floor only: `target_ms` is already ahead of anything the clock plane can have fed,
+            // so this bites solely on a packet arriving out of order or inside the same
+            // millisecond as its predecessor.
+            let pts_ms = self
+                .last_audio_pts_ms
+                .fetch_max(target_ms, Ordering::Relaxed)
+                .max(target_ms);
             self.fns.audio_play(packet, pts_ms)?;
         }
         // Player clock, not the packet's domain: the reader asks "how long since a packet ARRIVED".
-        self.last_real_feed_ms
-            .store((self.elapsed_ns() / 1_000_000) as i64, Ordering::Relaxed);
-        let dropped = self.dropped_no_offset.swap(0, Ordering::Relaxed);
-        if dropped > 0 {
-            tracing::info!(
-                "NDL audio resumed after {dropped} packet(s) ({}ms) with no latched timeline, \
-                 skew now {}ms",
-                i64::from(dropped) * PRIME_PACKET_MS,
-                self.audio_skew_ms.load(Ordering::Relaxed),
-            );
-        }
+        self.last_real_feed_ms.store(now_ms, Ordering::Relaxed);
         Ok(())
     }
 
@@ -496,7 +416,7 @@ impl NdlVideo {
     }
 
     /// Nanoseconds since `load()` (NDL PTS domain). The sink anchors the host PTS onto this
-    /// (`session::timeline::HostPtsAnchor`) — NDL has no PTS clock of its own.
+    /// (`session::timeline::Pacing`) — NDL has no PTS clock of its own.
     pub(crate) fn elapsed_ns(&self) -> u64 {
         self.load_instant.elapsed().as_nanos() as u64
     }
@@ -563,7 +483,7 @@ impl NdlVideo {
     }
 
     /// Feed one access unit at `pts_ns` (ns since `load()`), truncated to ms for NDL.
-    /// Pass the host-anchored base (`session::timeline::HostPtsAnchor`), not raw `elapsed_ns()`,
+    /// Pass the mapped base (`session::timeline::Pacing`), not raw `elapsed_ns()`,
     /// so video and offloaded audio share one timeline.
     pub fn play(&self, au: &[u8], pts_ns: u64) -> Result<()> {
         self.ensure_loaded()?;
@@ -678,12 +598,14 @@ impl AudioSink for NdlVideo {
         AudioFormat::Opus { channels: 2 }
     }
 
-    fn feed(&self, samples: Samples<'_>, host_pts_ns: u64) -> Result<()> {
+    /// `host_pts_ns` is ignored — the plane stamps off the player clock, which is the whole point
+    /// of [`NdlVideo::play_audio`].
+    fn feed(&self, samples: Samples<'_>, _host_pts_ns: u64) -> Result<()> {
         let Samples::Opus(packet) = samples else {
             // The plane decodes; decoded samples are the SDL device's shape and never reach here.
             bail!("NDL audio plane takes Opus packets only");
         };
-        self.play_audio(packet, host_pts_ns)
+        self.play_audio(packet)
     }
 
     fn depth_ms(&self) -> Option<i64> {
@@ -692,10 +614,6 @@ impl AudioSink for NdlVideo {
 }
 
 impl AudioPlane for NdlVideo {
-    fn attach_clock(&self, clock: std::sync::Arc<crate::core::media::SessionClock>) {
-        let _ = self.clock.set(clock);
-    }
-
     fn lead_ms(&self) -> i64 {
         self.audio_plane_lead_ms()
     }

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -383,10 +383,13 @@ impl NdlVideo {
                 continue;
             }
             if yields_to_real && !filling {
-                // Rebase onto where the real stream left the ceiling: the start-of-session base
-                // would re-add the prime's whole lead on top of it, and recovered audio then floors
-                // to that jumped ceiling — pinned to one stamp for the length of the jump.
-                base_ms = self.last_audio_pts_ms.load(Ordering::Relaxed) - now_ms;
+                // Target exactly what [`Self::play_audio`] targets, so the handoff back costs
+                // nothing: `burst_silence` floors at the ceiling the real stream left, so the fill
+                // resumes from it without stacking another lead ON TOP. Carrying the prime's base
+                // through here instead raised the ceiling by one `PLANE_LEAD_MS` per fill episode
+                // — and recovered audio then floored onto that jump, pinned to a single stamp for
+                // the length of it, which is the ratchet this path exists to avoid.
+                base_ms = 0;
                 tracing::warn!(
                     "NDL clock plane: no host audio for {REAL_FEED_GRACE_MS}ms — filling silence \
                      to keep the picture paced (host capture is likely dead)"

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -104,7 +104,6 @@ fn spawn_connect(
                 gamepad_type: settings.gamepad_type,
                 cursor_capture: settings.cursor_capture,
                 audio_route: settings.audio_route,
-                direct_playback: settings.direct_playback,
                 display_hdr: settings.hdr_display().hdr_meta(),
             })
             // Flagged before the handle is joined, so the loading screen can stop waiting

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -816,17 +816,12 @@ pub(super) fn run_inner() -> Result<()> {
                         ));
                     }
                     // `late` is the judder, counted: frames NDL was handed too late to pace them.
-                    // `jitter` is what the cadence loop sizes its cushion from, and the anchor
-                    // measures none, so the direct mapping prints its name instead of a zero.
+                    // `jitter` is what the cadence loop sizes its cushion from.
                     let late = connected.stats().pacing_late.load(Ordering::Relaxed);
-                    lines.push(if connected.direct_playback {
-                        format!("Pace direct · late {late}")
-                    } else {
-                        format!(
-                            "Pace jitter {:.1} ms · late {late}",
-                            connected.stats().pacing_jitter_us.load(Ordering::Relaxed) as f32 / 1000.0,
-                        )
-                    });
+                    lines.push(format!(
+                        "Pace jitter {:.1} ms · late {late}",
+                        connected.stats().pacing_jitter_us.load(Ordering::Relaxed) as f32 / 1000.0,
+                    ));
                     if let Some(line) = cpu_mem_line {
                         lines.push(line);
                     }

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -899,6 +899,14 @@ pub(super) fn run_inner() -> Result<()> {
                     canvas.present();
                 }
             }
+            // The decoder is gone for this load (`core::media::VideoSink::is_dead`, set by the
+            // pump). The transport is still healthy, so nothing below would ever end the session
+            // and the user would sit in front of a frozen picture — end it here instead.
+            if connected.stats().decoder_dead.load(Ordering::Relaxed) {
+                tracing::error!("decoder failed for good — returning to the menu");
+                menu_toast = Some("Video decoder failed — session ended".to_string());
+                break 'running StreamOutcome::ReturnToMenu;
+            }
             if connected.is_session_ended() {
                 tracing::info!("host ended the session");
                 // `is_session_ended` covers both a graceful host close and a network

--- a/src/session/connect.rs
+++ b/src/session/connect.rs
@@ -29,9 +29,6 @@ pub struct Connected {
     /// Where this session's audio actually ended up — the preference, resolved against what the
     /// load produced.
     pub audio_route: crate::services::store::AudioRoutePref,
-    /// Whether this session stamps from the fixed anchor (`Settings::direct_playback`). Overlay
-    /// only — the stage was handed the same flag through `SinkConfig`.
-    pub direct_playback: bool,
     /// Whether HDR mastering metadata is being applied this session (negotiated codec is
     /// HEVC *and* the host signalled HDR). Drives which Game picture mode the runtime asks
     /// the TV for — `game` vs `hdrGame` (see `platform::webos::game_mode`).
@@ -86,8 +83,6 @@ pub struct ConnectParams {
     pub gamepad_type: GamepadType,
     pub cursor_capture: bool,
     pub audio_route: crate::services::store::AudioRoutePref,
-    /// `Settings::direct_playback` — see `session::stage::SinkConfig`.
-    pub direct_playback: bool,
     /// The panel volume advertised to the host and used until host metadata arrives.
     pub display_hdr: quic::HdrMeta,
 }
@@ -282,7 +277,6 @@ pub fn connect(params: &ConnectParams) -> Result<Connected> {
         stats,
         pipeline,
         audio_route: route,
-        direct_playback: params.direct_playback,
         hdr: is_hdr,
     })
 }

--- a/src/session/pipeline.rs
+++ b/src/session/pipeline.rs
@@ -60,7 +60,7 @@ impl MediaPipeline {
             player.name(),
             client.audio_channels,
         );
-        let video_thread = spawn_video_thread(client, player, stop, stats, is_hdr, params.direct_playback)?;
+        let video_thread = spawn_video_thread(client, player, stop, stats, is_hdr)?;
         // Failing here after the video thread is already up would otherwise detach it.
         let (audio_thread, clock_thread) = match spawn_plane_threads(client, plane, stop, route) {
             Ok(handles) => handles,
@@ -199,14 +199,12 @@ fn spawn_video_thread(
     stop: &Arc<AtomicBool>,
     stats: &Arc<StreamStats>,
     is_hdr: bool,
-    direct_playback: bool,
 ) -> Result<std::thread::JoinHandle<()>> {
     let cfg = SinkConfig {
         stream_hz: client.mode().refresh_hz,
         report_decode_latency: client.wants_decode_latency(),
         clock_offset: client.clock_offset_shared(),
         video_e2e: client.video_e2e_shared(),
-        direct_playback,
     };
     let (client, stop, stats) = (client.clone(), stop.clone(), stats.clone());
     std::thread::Builder::new()

--- a/src/session/pump.rs
+++ b/src/session/pump.rs
@@ -138,6 +138,16 @@ impl VideoPump {
                     tracing::warn!("request_keyframe: {e:#}");
                 }
             }
+            // Nothing above this loop can revive the decoder — the load is gone and the plane
+            // threads have exited with it — so the session ends and the runtime returns to the
+            // menu, where the next launch builds a fresh pipeline.
+            SinkResult::Dead => {
+                // Once, not per frame: the stream loop needs a poll or two to notice, and the
+                // stage answers `Dead` to every delivery in the meantime.
+                if !self.stats.decoder_dead.swap(true, Ordering::Relaxed) {
+                    tracing::error!("decoder failed for good — ending the session");
+                }
+            }
         }
     }
 

--- a/src/session/pump.rs
+++ b/src/session/pump.rs
@@ -170,15 +170,13 @@ impl VideoPump {
         // on-device file sink is INFO-only (`logger::resolved_level`).
         if self.video_log.due() {
             // `late_stamp` is the judder, counted: frames NDL was handed too late to pace. The
-            // rest describes whichever mapping produced it (see `session::timeline::PacingHealth`).
+            // rest describes the loop that produced them (see `session::timeline::PacingHealth`).
             tracing::debug!(
-                "pacing: {} late_stamp={} jitter={:.1}ms cushion={:.1}ms reanchors={} trim={:.1}ms",
-                self.stage.pacing_label(),
+                "pacing: late_stamp={} jitter={:.1}ms cushion={:.1}ms reanchors={}",
                 pacing.late_stamps,
                 pacing.jitter_ns as f64 / 1e6,
                 pacing.cushion_ns as f64 / 1e6,
                 pacing.reanchors,
-                pacing.trimmed_ns as f64 / 1e6,
             );
             tracing::debug!(
                 "video: {} frames, parts={}, holding={}, dropped={}, backlog={}, plane_lead={}",

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -451,9 +451,12 @@ impl VideoStage {
                 // its audio outright.
                 // Held back until the anchor's trim has settled: audio stamps ride this offset and
                 // can only move forward, so latching onto a mapping still being pulled earlier
-                // costs lip sync (see `HostPtsAnchor::ready_for_audio`).
+                // costs lip sync (see `Pacing::ready_for_audio`). The mapping only converges once
+                // per session: telling the pacer it landed on an ACCEPTED frame is what lets a
+                // recovery run re-latch without another window of silence.
                 if self.pacing.ready_for_audio() {
                     self.clock.latch(base_ns as i64 - pts_ns as i64);
+                    self.pacing.note_audio_latched();
                 }
                 let decode_us = self
                     .cfg

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -73,6 +73,10 @@ pub enum SinkResult {
     Held,
     /// Skipped or failed, and the throttle allows asking the host for a keyframe now.
     NeedKeyframe,
+    /// The decoder is gone and no frame will present again on it — see
+    /// [`crate::core::media::VideoSink::is_dead`]. The pump ends the session on this rather than
+    /// re-anchoring, which is the response to lost FRAMES and does nothing for a lost PIPELINE.
+    Dead,
 }
 
 /// Everything the sink needs to know up front.
@@ -383,6 +387,9 @@ impl VideoStage {
     fn feed(&mut self, au: &[u8], pts_ns: u64, flags: FrameFlags) -> SinkResult {
         // Checked before the gate, not inside it: a dead decoder also fails every `flush` the hold
         // path takes, so the hold would spend `HOLD_GIVE_UP` re-deciding this per frame.
+        if self.sink.is_dead() {
+            return SinkResult::Dead;
+        }
         let request_keyframe = match self.gate(&flags) {
             HoldGate::Skip(result) => return result,
             HoldGate::Feed { request_keyframe } => request_keyframe,

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 
 use punktfunk_core::quic;
 
-use crate::core::media::{AudioPlane, NotReady, SessionClock, VideoSink, VideoSinkCaps};
+use crate::core::media::{AudioPlane, NotReady, VideoSink, VideoSinkCaps};
 use crate::session::timeline::{ms, reconciled_frame_interval_ns, Pacing, PacingHealth};
 use crate::session::StreamStats;
 
@@ -107,15 +107,12 @@ pub struct VideoStage {
     sink: Box<dyn VideoSink>,
     /// What this backend can be asked to do — read instead of matching on which backend it is.
     caps: VideoSinkCaps,
-    /// The audio plane this load produced, if any — kept for its depth reading; everything the
-    /// stage publishes to it goes through [`Self::clock`].
+    /// The audio plane this load produced, if any — kept for its depth reading. The stage
+    /// publishes nothing to it: the plane stamps off the player clock on its own.
     audio_plane: Option<std::sync::Arc<dyn AudioPlane>>,
     /// Slice-progressive reassembly state — a pass-through on a backend that doesn't take parts
     /// (see [`AuParts`]).
     parts: AuParts,
-    /// The one host-PTS → sink-clock mapping this session's planes share. The stage owns it
-    /// because the video plane is what derives it, frame by frame.
-    clock: Arc<SessionClock>,
     stats: Arc<StreamStats>,
     cfg: SinkConfig,
     /// The panel's actual drain cadence, reconciled against the stream rate. NDL drains at panel
@@ -166,13 +163,8 @@ impl VideoStage {
         let frame_interval_ns = reconciled_frame_interval_ns(stream_hz);
         let audio_plane = sink.audio_plane();
         let caps = sink.caps();
-        let clock = Arc::new(SessionClock::default());
-        if let Some(plane) = &audio_plane {
-            plane.attach_clock(clock.clone());
-        }
         Self {
             parts: AuParts::default(),
-            clock,
             caps,
             sink,
             audio_plane,
@@ -220,7 +212,6 @@ impl VideoStage {
     fn reset_timeline(&mut self) {
         self.pacing.reset();
         self.au_base_ns = None;
-        self.clock.clear();
     }
 
     /// This frame's stamp in the sink's own clock domain.
@@ -285,8 +276,8 @@ impl VideoStage {
         if self.last_backlog_poll.is_none_or(|t| t.elapsed() >= BACKLOG_POLL) {
             self.last_backlog_poll = Some(Instant::now());
             self.backlog_cached = self.sink.queue_depth().map(u64::from);
-            // A freeze flushes NDL, so a depth polled while held is an emptied buffer, not this
-            // mode's settled lead. Learning from it would clamp the cushion back to the floor for
+            // A freeze stops the pipeline, so a depth polled while held is not this mode's
+            // settled lead. Learning from it would clamp the cushion back to the floor for
             // [`CUSHION_MIN_POLLS`] after every loss event — and at 60Hz one unaccounted frame is
             // 16.6ms, straight back over the ABR's decode-rise threshold. The cached depth itself
             // still updates: A/V sync wants the truth, only the learned cushion is held steady.
@@ -445,19 +436,6 @@ impl VideoStage {
                 // Only a frame NDL actually accepted is on its way to the glass. A failed feed is
                 // followed by a flush and a hold, where the reference would be meaningless.
                 self.publish_video_e2e(submit_realtime_ns, pts_ns, backlog);
-                // Same reason, and it also doubles as the audio plane's start gate. `play_audio` has
-                // no `ensure_loaded` guard of its own, so latching off a REJECTED frame turns the
-                // audio thread loose on a pipeline NDL hasn't loaded yet — which costs the session
-                // its audio outright.
-                // Held back until the anchor's trim has settled: audio stamps ride this offset and
-                // can only move forward, so latching onto a mapping still being pulled earlier
-                // costs lip sync (see `Pacing::ready_for_audio`). The mapping only converges once
-                // per session: telling the pacer it landed on an ACCEPTED frame is what lets a
-                // recovery run re-latch without another window of silence.
-                if self.pacing.ready_for_audio() {
-                    self.clock.latch(base_ns as i64 - pts_ns as i64);
-                    self.pacing.note_audio_latched();
-                }
                 let decode_us = self
                     .cfg
                     .report_decode_latency

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -1,7 +1,7 @@
 //! The single place that talks to the video decoder.
 //!
 //! Everything between "an access unit arrived" and "NDL has been fed" lives here: host-PTS
-//! anchoring on the refresh-rate-reconciled frame interval, backpressure metering,
+//! mapping on the refresh-rate-reconciled frame interval, backpressure metering,
 //! freeze-until-reanchor, and keyframe-request throttling. The video pump keeps only the
 //! parts that are wire-shaped — pulling frames, and *how* a keyframe is asked for, which it
 //! answers to [`SinkResult::NeedKeyframe`] with `NativeClient::request_keyframe`.
@@ -87,12 +87,6 @@ pub struct SinkConfig {
     /// Where [`video_e2e_ns`] is published for the audio plane
     /// (`NativeClient::video_e2e_shared`). `0` = nothing on the glass yet.
     pub video_e2e: Arc<AtomicU64>,
-    /// Stamp frames from the fixed anchor rather than the cadence loop
-    /// (`Settings::direct_playback`, Experimental). **The one gate on every latency-adding measure
-    /// on this path**, from the other side: the default pays a jitter-sized cushion of at most one
-    /// frame interval for a cadence that does not beat against the panel, and this gives that back
-    /// at the price of the judder — see `session::timeline::Pacing`.
-    pub direct_playback: bool,
 }
 
 /// Minimum spacing between [`SinkResult::NeedKeyframe`] results: the request travels on its own
@@ -120,8 +114,7 @@ pub struct VideoStage {
     /// that conversion ([`video_e2e_ns`] and [`VideoStage::decode_us`]), so one depth cannot mean two
     /// different latencies.
     frame_interval_ns: u64,
-    /// NDL host-PTS→player-clock mapping — the cadence loop, or the anchor under
-    /// `Settings::direct_playback`. One object, so nothing in this file branches on which.
+    /// NDL host-PTS→player-clock mapping — see `session::timeline::Pacing`.
     pacing: Pacing,
     /// The stamp the access unit currently being fed was given, while it is still open. Every piece
     /// of one AU must carry the SAME timestamp (NDL finds AU boundaries by start code and has no
@@ -177,7 +170,7 @@ impl VideoStage {
             // (`the_cadence_interval_comes_from_the_stream_mode_not_the_panel`): a 120 fps
             // stream on a 60 Hz panel would otherwise license twice the hold the source's own
             // cadence can justify.
-            pacing: Pacing::new(1_000_000_000 / u64::from(stream_hz), cfg.direct_playback),
+            pacing: Pacing::new(1_000_000_000 / u64::from(stream_hz)),
             au_base_ns: None,
             cfg,
             backlog_cached: None,
@@ -217,7 +210,7 @@ impl VideoStage {
     /// This frame's stamp in the sink's own clock domain.
     ///
     /// A sink with a clock has no PTS clock of its own (NDL counts from its load),
-    /// so the host's capture PTS is mapped onto it ([`HostPtsAnchor`]) — which is also what keeps
+    /// so the host's capture PTS is mapped onto it (`session::timeline::Pacing`) — which is also what keeps
     /// video and any audio plane in ONE timeline. A sink without one presents in feed order and
     /// the stamp is discarded at the feed, so the host PTS passes through untouched.
     /// This AU's stamp: computed on the piece that opens it and repeated for the rest — see
@@ -316,11 +309,6 @@ impl VideoStage {
         self.pacing.health()
     }
 
-    /// Which mapping is stamping this session (`paced` / `direct`).
-    pub fn pacing_label(&self) -> &'static str {
-        self.pacing.label()
-    }
-
     /// Audio-plane queue depth in ms, or `None` on a session with no plane — see
     /// `NdlVideo::audio_plane_lead_ms`. Here because it is a *video* symptom: the plane's depth is
     /// what NDL paces the picture on, so it belongs next to the backlog in the video heartbeat.
@@ -393,6 +381,8 @@ impl VideoStage {
     }
 
     fn feed(&mut self, au: &[u8], pts_ns: u64, flags: FrameFlags) -> SinkResult {
+        // Checked before the gate, not inside it: a dead decoder also fails every `flush` the hold
+        // path takes, so the hold would spend `HOLD_GIVE_UP` re-deciding this per frame.
         let request_keyframe = match self.gate(&flags) {
             HoldGate::Skip(result) => return result,
             HoldGate::Feed { request_keyframe } => request_keyframe,
@@ -458,16 +448,17 @@ impl VideoStage {
         if flags.loss && !self.holding() {
             self.begin_hold();
             tracing::warn!("loss (frame {}) — freezing", flags.index);
-            // NO FLUSH on the loss hold. `NDL_DirectVideoFlushRenderBuffer` stops the pipeline —
-            // every flush here used to be followed by NDL reporting `PLAYING (0x1a)`, a transition
-            // it only makes from not-playing — and the restart kills the Opus audio plane for the
-            // rest of the session. It reports success and leaves `depth`/`plane_lead` healthy
-            // throughout, so nothing client-side sees it; only a reload recovers. `ss4s` never
-            // flushes mid-stream and does not have this bug (docs/NOTES.md § "NDL's audio plane").
+            // NO FLUSH on the loss hold — this is the last structural difference from `ss4s`, which
+            // never flushes mid-stream (its only recovery is unload+load) and does not lose its
+            // Opus plane. Every flush here stops the pipeline: each one is followed by NDL
+            // reporting `PLAYING (0x1a)`, a transition it only makes from not-playing. A CX
+            // survived 32 of them in one storm with perfectly monotonic audio stamps at a constant
+            // 40 ms lead and still went permanently silent, so what kills the plane is the restart,
+            // not anything the feed says (see docs/NOTES.md § "NDL's audio plane").
             //
-            // The decode-error path still flushes: there the pipeline has actually errored and
-            // discarding its queue is the documented response. Loss is a network event, and NDL's
-            // queue holds good frames the hold is about to present anyway.
+            // The decode-error path below still flushes: there the pipeline has actually errored
+            // and discarding its queue is the documented response. Loss is a network event — NDL's
+            // queue holds good frames that the hold is about to present anyway.
         }
         let Some(started) = self.hold_started else {
             return HoldGate::Feed {

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -480,9 +480,16 @@ impl VideoStage {
         if flags.loss && !self.holding() {
             self.begin_hold();
             tracing::warn!("loss (frame {}) — freezing", flags.index);
-            if self.caps.flush {
-                let _ = self.sink.flush();
-            }
+            // NO FLUSH on the loss hold. `NDL_DirectVideoFlushRenderBuffer` stops the pipeline —
+            // every flush here used to be followed by NDL reporting `PLAYING (0x1a)`, a transition
+            // it only makes from not-playing — and the restart kills the Opus audio plane for the
+            // rest of the session. It reports success and leaves `depth`/`plane_lead` healthy
+            // throughout, so nothing client-side sees it; only a reload recovers. `ss4s` never
+            // flushes mid-stream and does not have this bug (docs/NOTES.md § "NDL's audio plane").
+            //
+            // The decode-error path still flushes: there the pipeline has actually errored and
+            // discarding its queue is the documented response. Loss is a network event, and NDL's
+            // queue holds good frames the hold is about to present anyway.
         }
         let Some(started) = self.hold_started else {
             return HoldGate::Feed {

--- a/src/session/stats.rs
+++ b/src/session/stats.rs
@@ -26,6 +26,10 @@ pub struct StreamStats {
     /// an audio one — NDL paces the picture on this — and can legitimately be negative, so there
     /// is no sentinel: the overlay prints it only on a route that has a plane.
     pub audio_plane_lead_ms: AtomicI32,
+    /// The decoder failed in a way no re-anchor undoes (`core::media::VideoSink::is_dead`). Read by
+    /// the stream loop, which ends the session on it: the transport is still healthy, so nothing
+    /// else would ever end it, and the user would sit in front of a frozen picture with no audio.
+    pub decoder_dead: AtomicBool,
 }
 
 /// Short display name for a resolved wire codec id (the stats overlay's header).

--- a/src/session/timeline.rs
+++ b/src/session/timeline.rs
@@ -144,9 +144,8 @@ impl CadencePacer {
         let normal = self.frames_this_run >= PACER_AUDIO_LATCH_FRAMES && elapsed_ns >= PACER_AUDIO_LATCH_NS;
         // One genuine sample has anchored the estimate; the second delivery may be a repeat, whose
         // stamp is that same estimate plus the cushion — see [`PACER_AUDIO_DEADLINE_NS`].
-        let deadline = self.frames_this_run >= 1
-            && self.deliveries_this_run >= 2
-            && elapsed_ns >= PACER_AUDIO_DEADLINE_NS;
+        let deadline =
+            self.frames_this_run >= 1 && self.deliveries_this_run >= 2 && elapsed_ns >= PACER_AUDIO_DEADLINE_NS;
         self.converged_normally |= normal;
         self.convergence_ready |= normal || deadline;
         // A due time in the past is a late frame and core's contract is "present at the next
@@ -168,9 +167,11 @@ impl CadencePacer {
         self.converged_normally = false;
         self.convergence_ready = false;
         self.last_host_pts_ns = None;
-        // Cleared with the run, like the anchor's own: NDL has been flushed, so the stamps that
-        // came before it are no longer a floor this run has to clear.
-        self.last_base_ns = 0;
+        // `last_base_ns` deliberately SURVIVES the reset. It used to be cleared here because the
+        // loss hold flushed NDL, which made the previous run's stamps irrelevant — the hold no
+        // longer flushes (`VideoStage::gate`), so the pipeline still holds everything fed before
+        // it and a run restarting from 0 would walk the video stamp backwards. NDL answers a
+        // rewind by muting, which is the failure this whole path exists to avoid.
     }
 
     /// Whether an accepted completed AU may latch this mapping. A repeat may carry it: by the time

--- a/src/session/timeline.rs
+++ b/src/session/timeline.rs
@@ -34,23 +34,6 @@ pub fn reconciled_frame_interval_ns(stream_hz: u32) -> u64 {
     1_000_000_000 / u64::from(hz.max(1))
 }
 
-/// Evidence before the audio plane may latch the cadence mapping.
-///
-/// This used to be 30 frames, which made the wait inversely proportional to the delivered frame
-/// rate: 500 ms at 60 Hz became 3 seconds at 10 Hz. Wall clock is the honest quantity, so the gate
-/// is eight on-cadence samples AND half a second — a floor that costs a 240 Hz stream 500 ms where
-/// the frame count charged it 125, which is the right way round: a converged estimate is what the
-/// audio plane is waiting on, not a frame tally.
-///
-/// The deadline caps the silence at a fixed wall time once ONE genuine sample has anchored the
-/// estimate and a second delivery has arrived, whatever kind. A static desktop delivers one genuine
-/// stamp and then repeats indefinitely; gating on genuine samples alone leaves that session with no
-/// audio at all. The deadline is deliberately degraded operation: a small A/V offset is better than
-/// silence.
-const PACER_AUDIO_LATCH_FRAMES: u64 = 8;
-const PACER_AUDIO_LATCH_NS: u64 = 500_000_000;
-const PACER_AUDIO_DEADLINE_NS: u64 = 1_000_000_000;
-
 /// Plays frames out on the host's own cadence instead of on their arrival instant, by stamping
 /// them from [`punktfunk_core::phase::CadenceClock`] rather than from a fixed anchor.
 ///
@@ -82,22 +65,6 @@ pub struct CadencePacer {
     /// is clamped monotonic — exactly as [`HostPtsAnchor::map`] does, and reset with the run for
     /// the same reason (a flush restarts the timeline).
     last_base_ns: u64,
-    /// On-cadence frames folded since the last [`Self::reset`], for [`Self::ready_for_audio`]. Not
-    /// read off `CadenceHealth::frames`, which counts the whole session.
-    frames_this_run: u64,
-    /// Every delivery this run, repeats included — what the deadline path counts, so a repeat-only
-    /// stream still reaches it.
-    deliveries_this_run: u64,
-    /// Player-clock start of this run's convergence window.
-    run_started_ns: Option<u64>,
-    /// Once a run converged the NORMAL way, recovery runs may latch on their first accepted frame.
-    /// Never set from the deadline path: promoting a deliberately degraded latch would let every
-    /// later run in the session skip the wait on the strength of one that never converged.
-    settled_once: bool,
-    /// This run reached the full evidence bar, as opposed to the deadline.
-    converged_normally: bool,
-    /// This run has enough evidence to latch if the decoder accepts the frame.
-    convergence_ready: bool,
     /// Exact repeated source stamps are off-cadence, not estimator observations.
     last_host_pts_ns: Option<u64>,
 }
@@ -114,12 +81,6 @@ impl CadencePacer {
             clock: punktfunk_core::phase::CadenceClock::new(punktfunk_core::phase::CadenceTuning::snapping()),
             source_interval_ns: i64::try_from(source_interval_ns).unwrap_or(i64::MAX),
             last_base_ns: 0,
-            frames_this_run: 0,
-            deliveries_this_run: 0,
-            run_started_ns: None,
-            settled_once: false,
-            converged_normally: false,
-            convergence_ready: false,
             last_host_pts_ns: None,
         }
     }
@@ -129,25 +90,14 @@ impl CadencePacer {
     /// between the host's capture clock and NDL's player clock is simply absorbed by the offset
     /// estimate and there is no conversion anywhere in this path.
     pub fn map(&mut self, host_pts_ns: u64, player_clock_ns: u64) -> u64 {
-        let started_ns = *self.run_started_ns.get_or_insert(player_clock_ns);
         let ready = i64::try_from(player_clock_ns).unwrap_or(i64::MAX);
         let repeated = self.last_host_pts_ns == Some(host_pts_ns);
         let due = if repeated {
             self.clock.note_off_cadence(ready, self.source_interval_ns)
         } else {
-            self.frames_this_run += 1;
             self.clock.due_ns(host_pts_ns, ready, self.source_interval_ns)
         };
         self.last_host_pts_ns = Some(host_pts_ns);
-        self.deliveries_this_run += 1;
-        let elapsed_ns = player_clock_ns.saturating_sub(started_ns);
-        let normal = self.frames_this_run >= PACER_AUDIO_LATCH_FRAMES && elapsed_ns >= PACER_AUDIO_LATCH_NS;
-        // One genuine sample has anchored the estimate; the second delivery may be a repeat, whose
-        // stamp is that same estimate plus the cushion — see [`PACER_AUDIO_DEADLINE_NS`].
-        let deadline =
-            self.frames_this_run >= 1 && self.deliveries_this_run >= 2 && elapsed_ns >= PACER_AUDIO_DEADLINE_NS;
-        self.converged_normally |= normal;
-        self.convergence_ready |= normal || deadline;
         // A due time in the past is a late frame and core's contract is "present at the next
         // opportunity" — which is what handing NDL a stamp at or behind its clock already means.
         let base = u64::try_from(due).unwrap_or(0).max(self.last_base_ns);
@@ -161,31 +111,12 @@ impl CadencePacer {
     /// spend the next few hundred frames presenting late.
     pub fn reset(&mut self) {
         self.clock.reset();
-        self.frames_this_run = 0;
-        self.deliveries_this_run = 0;
-        self.run_started_ns = None;
-        self.converged_normally = false;
-        self.convergence_ready = false;
         self.last_host_pts_ns = None;
         // `last_base_ns` deliberately SURVIVES the reset. It used to be cleared here because the
         // loss hold flushed NDL, which made the previous run's stamps irrelevant — the hold no
         // longer flushes (`VideoStage::gate`), so the pipeline still holds everything fed before
         // it and a run restarting from 0 would walk the video stamp backwards. NDL answers a
         // rewind by muting, which is the failure this whole path exists to avoid.
-    }
-
-    /// Whether an accepted completed AU may latch this mapping. A repeat may carry it: by the time
-    /// either gate opens, at least one genuine sample has anchored the estimate, and a repeat is
-    /// stamped from that same estimate. Refusing them instead would mute a static desktop, which
-    /// delivers one genuine stamp and then repeats.
-    pub fn ready_for_audio(&self) -> bool {
-        self.settled_once || self.convergence_ready
-    }
-
-    /// Records that NDL accepted the frame carrying the mapping the audio plane latched — see
-    /// [`Self::settled_once`], which only a normally converged run sets.
-    pub fn note_audio_latched(&mut self) {
-        self.settled_once |= self.converged_normally;
     }
 
     fn health(&self) -> punktfunk_core::phase::CadenceHealth {
@@ -272,24 +203,6 @@ impl Pacing {
         }
     }
 
-    /// Whether the audio plane may latch this mapping. The two settle on different evidence and
-    /// cannot share a gate: the anchor waits for trimming to STOP, and the cadence loop never stops
-    /// moving, so it waits for a converged offset estimate instead (see
-    /// [`CadencePacer::ready_for_audio`]).
-    pub fn ready_for_audio(&self) -> bool {
-        match &self.mode {
-            Mode::Cadence(p) => p.ready_for_audio(),
-            Mode::Anchor(a) => a.ready_for_audio(),
-        }
-    }
-
-    /// Records the accepted frame on which the shared audio mapping latched.
-    pub fn note_audio_latched(&mut self) {
-        if let Mode::Cadence(p) = &mut self.mode {
-            p.note_audio_latched();
-        }
-    }
-
     pub fn health(&self) -> PacingHealth {
         let late_stamps = self.late_stamps;
         match &self.mode {
@@ -372,10 +285,6 @@ pub struct HostPtsAnchor {
     /// Whether [`Self::map`] is allowed to trim (see [`Self::new`]). Re-armed on every
     /// [`Self::reset`] — each run's anchor bakes in its own lead.
     trim: bool,
-    /// Whether any run of this session has finished trimming. Survives [`Self::reset`], and is
-    /// what lets a re-anchor latch audio immediately instead of muting it for another
-    /// [`TRIM_SETTLE_NS`] — see [`Self::ready_for_audio`].
-    settled_once: bool,
     /// Trim actually applied so far, ramped toward `trim_target_ns` (see [`TRIM_RAMP_DIVISOR`]).
     trim_ns: u64,
     /// Trim the windows have asked for. `trim_ns` catches up to it over the following frames.
@@ -385,9 +294,6 @@ pub struct HostPtsAnchor {
     /// Player clock at the start of the current measurement window, and the smallest lead seen
     /// inside it. `None` until the first mapped frame after an anchor.
     window: Option<(u64, u64)>,
-    /// Player clock at the most recent [`Self::map`], so [`Self::ready_for_audio`] can answer
-    /// without a clock read of its own.
-    last_player_ns: u64,
     /// Last base this run handed out. The ramp is sized against the frame interval, so a delivery
     /// whose host PTS did not advance by one (a repeated stamp, a variable-rate source) would
     /// otherwise subtract more trim than `raw` gained and emit a stamp BEHIND its predecessor —
@@ -396,8 +302,7 @@ pub struct HostPtsAnchor {
 }
 
 impl HostPtsAnchor {
-    /// The trim is always armed; what keeps it compatible with audio on NDL's plane is
-    /// [`TRIM_SETTLE_NS`] plus [`Self::ready_for_audio`], not a per-route switch.
+    /// The trim is always armed; audio no longer rides this mapping, so nothing gates on it.
     pub fn new(frame_interval_ns: u64) -> Self {
         Self {
             trim: true,
@@ -406,33 +311,9 @@ impl HostPtsAnchor {
         }
     }
 
-    /// Whether this mapping has stopped moving, i.e. whether NDL's audio plane may latch it.
-    ///
-    /// `false` for the first [`TRIM_SETTLE_NS`] of a run: audio latched inside that window would
-    /// be anchored to a timeline the trim is still pulling earlier, and it cannot follow. The audio
-    /// pump drops its packets until this turns true and says so in the log
-    /// (`NdlVideo::play_audio`), while the clock plane keeps the picture paced.
-    ///
-    /// **Only the session's FIRST run waits.** Once a run has settled, every later one is ready on
-    /// its first mapped frame — see [`Self::settled_once`]. Making each run wait afresh cost
-    /// [`TRIM_SETTLE_NS`] of *silence* after every freeze-until-reanchor recovery, and a loss event
-    /// is exactly when the user is least willing to lose the sound too. What the early latch pays
-    /// instead is the trim that run goes on to take, landing as lip-sync error rather than latency
-    /// saved — bounded by one window's standing lead, i.e. tens of ms against 600 of dropout.
-    pub fn ready_for_audio(&self) -> bool {
-        let Some((_, anchor_player_ns)) = self.anchor else {
-            return false;
-        };
-        if self.settled_once {
-            return true;
-        }
-        self.trim_ns == self.trim_target_ns && self.last_player_ns.saturating_sub(anchor_player_ns) >= TRIM_SETTLE_NS
-    }
-
     /// Drop the mapping — the timeline jumped and nothing derived from it holds. Trimming re-arms
     /// with it: the new anchor bakes in its own delivery latency (a recovery keyframe arriving late
     /// behind a loss burst is a bad one to inherit), so the lead has to be measured again.
-    /// [`Self::settled_once`] is what does NOT reset.
     pub fn reset(&mut self) {
         self.anchor = None;
         self.trim = true;
@@ -447,7 +328,6 @@ impl HostPtsAnchor {
     /// (a host PTS going backwards vs. the anchor would otherwise underflow), less whatever
     /// standing lead has been trimmed off the run.
     pub fn map(&mut self, host_pts_ns: u64, player_clock_ns: u64) -> u64 {
-        self.last_player_ns = player_clock_ns;
         let Some((host0, player0)) = self.anchor else {
             self.anchor = Some((host_pts_ns, player_clock_ns));
             self.window = Some((player_clock_ns, u64::MAX));
@@ -493,7 +373,6 @@ impl HostPtsAnchor {
         // being collected with it, so the steady state is one subtraction per frame.
         if player_clock_ns.saturating_sub(anchor_player_ns) >= TRIM_SETTLE_NS {
             self.trim = false;
-            self.settled_once = true;
             tracing::debug!("pts lead: settled with {:.1}ms trimmed", ms(self.trim_ns));
             return;
         }

--- a/src/session/timeline.rs
+++ b/src/session/timeline.rs
@@ -34,13 +34,22 @@ pub fn reconciled_frame_interval_ns(stream_hz: u32) -> u64 {
     1_000_000_000 / u64::from(hz.max(1))
 }
 
-/// Frames the cadence loop folds before the audio plane may latch its mapping
-/// ([`CadencePacer::ready_for_audio`]). Half a second at 60 Hz — long enough for the offset
-/// estimate to leave its cold-start sample behind, short enough that offloaded audio is not
-/// audibly missing at session start. The trim path's own gate is [`TRIM_SETTLE_NS`], which is a
-/// different quantity and cannot be shared: that one waits for trimming to STOP, and this loop
-/// never stops moving.
-const PACER_AUDIO_LATCH_FRAMES: u64 = 30;
+/// Evidence before the audio plane may latch the cadence mapping.
+///
+/// This used to be 30 frames, which made the wait inversely proportional to the delivered frame
+/// rate: 500 ms at 60 Hz became 3 seconds at 10 Hz. Wall clock is the honest quantity, so the gate
+/// is eight on-cadence samples AND half a second — a floor that costs a 240 Hz stream 500 ms where
+/// the frame count charged it 125, which is the right way round: a converged estimate is what the
+/// audio plane is waiting on, not a frame tally.
+///
+/// The deadline caps the silence at a fixed wall time once ONE genuine sample has anchored the
+/// estimate and a second delivery has arrived, whatever kind. A static desktop delivers one genuine
+/// stamp and then repeats indefinitely; gating on genuine samples alone leaves that session with no
+/// audio at all. The deadline is deliberately degraded operation: a small A/V offset is better than
+/// silence.
+const PACER_AUDIO_LATCH_FRAMES: u64 = 8;
+const PACER_AUDIO_LATCH_NS: u64 = 500_000_000;
+const PACER_AUDIO_DEADLINE_NS: u64 = 1_000_000_000;
 
 /// Plays frames out on the host's own cadence instead of on their arrival instant, by stamping
 /// them from [`punktfunk_core::phase::CadenceClock`] rather than from a fixed anchor.
@@ -73,9 +82,24 @@ pub struct CadencePacer {
     /// is clamped monotonic — exactly as [`HostPtsAnchor::map`] does, and reset with the run for
     /// the same reason (a flush restarts the timeline).
     last_base_ns: u64,
-    /// Frames folded since the last [`Self::reset`], for [`Self::ready_for_audio`]. Not read off
-    /// `CadenceHealth::frames`, which counts the whole session.
+    /// On-cadence frames folded since the last [`Self::reset`], for [`Self::ready_for_audio`]. Not
+    /// read off `CadenceHealth::frames`, which counts the whole session.
     frames_this_run: u64,
+    /// Every delivery this run, repeats included — what the deadline path counts, so a repeat-only
+    /// stream still reaches it.
+    deliveries_this_run: u64,
+    /// Player-clock start of this run's convergence window.
+    run_started_ns: Option<u64>,
+    /// Once a run converged the NORMAL way, recovery runs may latch on their first accepted frame.
+    /// Never set from the deadline path: promoting a deliberately degraded latch would let every
+    /// later run in the session skip the wait on the strength of one that never converged.
+    settled_once: bool,
+    /// This run reached the full evidence bar, as opposed to the deadline.
+    converged_normally: bool,
+    /// This run has enough evidence to latch if the decoder accepts the frame.
+    convergence_ready: bool,
+    /// Exact repeated source stamps are off-cadence, not estimator observations.
+    last_host_pts_ns: Option<u64>,
 }
 
 impl CadencePacer {
@@ -91,6 +115,12 @@ impl CadencePacer {
             source_interval_ns: i64::try_from(source_interval_ns).unwrap_or(i64::MAX),
             last_base_ns: 0,
             frames_this_run: 0,
+            deliveries_this_run: 0,
+            run_started_ns: None,
+            settled_once: false,
+            converged_normally: false,
+            convergence_ready: false,
+            last_host_pts_ns: None,
         }
     }
 
@@ -99,9 +129,26 @@ impl CadencePacer {
     /// between the host's capture clock and NDL's player clock is simply absorbed by the offset
     /// estimate and there is no conversion anywhere in this path.
     pub fn map(&mut self, host_pts_ns: u64, player_clock_ns: u64) -> u64 {
-        self.frames_this_run += 1;
+        let started_ns = *self.run_started_ns.get_or_insert(player_clock_ns);
         let ready = i64::try_from(player_clock_ns).unwrap_or(i64::MAX);
-        let due = self.clock.due_ns(host_pts_ns, ready, self.source_interval_ns);
+        let repeated = self.last_host_pts_ns == Some(host_pts_ns);
+        let due = if repeated {
+            self.clock.note_off_cadence(ready, self.source_interval_ns)
+        } else {
+            self.frames_this_run += 1;
+            self.clock.due_ns(host_pts_ns, ready, self.source_interval_ns)
+        };
+        self.last_host_pts_ns = Some(host_pts_ns);
+        self.deliveries_this_run += 1;
+        let elapsed_ns = player_clock_ns.saturating_sub(started_ns);
+        let normal = self.frames_this_run >= PACER_AUDIO_LATCH_FRAMES && elapsed_ns >= PACER_AUDIO_LATCH_NS;
+        // One genuine sample has anchored the estimate; the second delivery may be a repeat, whose
+        // stamp is that same estimate plus the cushion — see [`PACER_AUDIO_DEADLINE_NS`].
+        let deadline = self.frames_this_run >= 1
+            && self.deliveries_this_run >= 2
+            && elapsed_ns >= PACER_AUDIO_DEADLINE_NS;
+        self.converged_normally |= normal;
+        self.convergence_ready |= normal || deadline;
         // A due time in the past is a late frame and core's contract is "present at the next
         // opportunity" — which is what handing NDL a stamp at or behind its clock already means.
         let base = u64::try_from(due).unwrap_or(0).max(self.last_base_ns);
@@ -116,14 +163,28 @@ impl CadencePacer {
     pub fn reset(&mut self) {
         self.clock.reset();
         self.frames_this_run = 0;
+        self.deliveries_this_run = 0;
+        self.run_started_ns = None;
+        self.converged_normally = false;
+        self.convergence_ready = false;
+        self.last_host_pts_ns = None;
         // Cleared with the run, like the anchor's own: NDL has been flushed, so the stamps that
         // came before it are no longer a floor this run has to clear.
         self.last_base_ns = 0;
     }
 
-    /// Whether the audio plane may latch this mapping — see [`PACER_AUDIO_LATCH_FRAMES`].
+    /// Whether an accepted completed AU may latch this mapping. A repeat may carry it: by the time
+    /// either gate opens, at least one genuine sample has anchored the estimate, and a repeat is
+    /// stamped from that same estimate. Refusing them instead would mute a static desktop, which
+    /// delivers one genuine stamp and then repeats.
     pub fn ready_for_audio(&self) -> bool {
-        self.frames_this_run >= PACER_AUDIO_LATCH_FRAMES
+        self.settled_once || self.convergence_ready
+    }
+
+    /// Records that NDL accepted the frame carrying the mapping the audio plane latched — see
+    /// [`Self::settled_once`], which only a normally converged run sets.
+    pub fn note_audio_latched(&mut self) {
+        self.settled_once |= self.converged_normally;
     }
 
     fn health(&self) -> punktfunk_core::phase::CadenceHealth {
@@ -212,11 +273,19 @@ impl Pacing {
 
     /// Whether the audio plane may latch this mapping. The two settle on different evidence and
     /// cannot share a gate: the anchor waits for trimming to STOP, and the cadence loop never stops
-    /// moving, so it waits for enough frames instead.
+    /// moving, so it waits for a converged offset estimate instead (see
+    /// [`CadencePacer::ready_for_audio`]).
     pub fn ready_for_audio(&self) -> bool {
         match &self.mode {
             Mode::Cadence(p) => p.ready_for_audio(),
             Mode::Anchor(a) => a.ready_for_audio(),
+        }
+    }
+
+    /// Records the accepted frame on which the shared audio mapping latched.
+    pub fn note_audio_latched(&mut self) {
+        if let Mode::Cadence(p) = &mut self.mode {
+            p.note_audio_latched();
         }
     }
 

--- a/src/session/timeline.rs
+++ b/src/session/timeline.rs
@@ -1,9 +1,8 @@
 //! Timeline plumbing for the video pump: the panel-reconciled frame interval, and the
 //! host-PTS → player-clock mapping NDL needs (it has no PTS clock of its own).
 //!
-//! One mapping, [`CadencePacer`], wrapped by [`Pacing`]. The fixed anchor it replaced stamped
-//! from a constant taken at frame 0 and had no rate term at all; see [`CadencePacer`] for why
-//! that shape could not be repaired in place.
+//! One mapping, [`Pacing`]. The fixed anchor it replaced stamped from a constant taken at frame 0
+//! and had no rate term at all; see [`Pacing`] for why that shape could not be repaired in place.
 
 use crate::platform::webos::sdl_webos;
 
@@ -56,7 +55,7 @@ pub fn reconciled_frame_interval_ns(stream_hz: u32) -> u64 {
 /// grows where there is real jitter to cover. The anchor was kept selectable for a while as
 /// `Settings::direct_playback`; on real hardware it stamped ~17% of frames late at 120 Hz against
 /// the loop's ~7%, so it is gone.
-pub struct CadencePacer {
+pub struct Pacing {
     clock: punktfunk_core::phase::CadenceClock,
     /// The source's nominal interval, and the cushion's ceiling (see `CadenceClock::cushion_ns`)
     /// — see [`Self::new`] for why it is not the panel's.
@@ -67,9 +66,13 @@ pub struct CadencePacer {
     last_base_ns: u64,
     /// Exact repeated source stamps are off-cadence, not estimator observations.
     last_host_pts_ns: Option<u64>,
+    /// Frames fed with a stamp already behind the player clock — see [`PacingHealth::late_stamps`].
+    /// Counted around the loop rather than inside it: it is a property of the stamp handed to NDL,
+    /// not of the estimate that produced it.
+    late_stamps: u64,
 }
 
-impl CadencePacer {
+impl Pacing {
     /// `source_interval_ns` is the negotiated STREAM mode's frame interval — the cadence the host
     /// produces — and never the panel's. It is the cushion's ceiling, so a panel period would let a
     /// stream running faster than the panel be held for longer than its own cadence justifies.
@@ -82,6 +85,7 @@ impl CadencePacer {
             source_interval_ns: i64::try_from(source_interval_ns).unwrap_or(i64::MAX),
             last_base_ns: 0,
             last_host_pts_ns: None,
+            late_stamps: 0,
         }
     }
 
@@ -102,6 +106,9 @@ impl CadencePacer {
         // opportunity" — which is what handing NDL a stamp at or behind its clock already means.
         let base = u64::try_from(due).unwrap_or(0).max(self.last_base_ns);
         self.last_base_ns = base;
+        if base <= player_clock_ns {
+            self.late_stamps += 1;
+        }
         base
     }
 
@@ -119,8 +126,15 @@ impl CadencePacer {
         // rewind by muting, which is the failure this whole path exists to avoid.
     }
 
-    fn health(&self) -> punktfunk_core::phase::CadenceHealth {
-        self.clock.health()
+    /// What the mapping has to say for itself — see [`PacingHealth`].
+    pub fn health(&self) -> PacingHealth {
+        let h = self.clock.health();
+        PacingHealth {
+            jitter_ns: h.jitter_ns,
+            cushion_ns: h.cushion_ns,
+            late_stamps: self.late_stamps,
+            reanchors: h.reanchors,
+        }
     }
 }
 
@@ -136,50 +150,6 @@ pub struct PacingHealth {
     pub late_stamps: u64,
     /// Times the mapping gave up tracking and re-anchored.
     pub reanchors: u64,
-}
-
-/// The host-PTS → player-clock mapping this session stamps with: [`CadencePacer`], plus the one
-/// count that describes the stamps rather than the loop.
-pub struct Pacing {
-    pacer: CadencePacer,
-    /// Frames fed with a stamp already behind the player clock — see [`PacingHealth::late_stamps`].
-    /// Counted here rather than inside the loop: it is a property of the stamp handed to NDL, not
-    /// of the estimate that produced it.
-    late_stamps: u64,
-}
-
-impl Pacing {
-    /// `source_interval_ns` is the stream mode's own interval — see [`CadencePacer::new`].
-    pub fn new(source_interval_ns: u64) -> Self {
-        Self {
-            pacer: CadencePacer::new(source_interval_ns),
-            late_stamps: 0,
-        }
-    }
-
-    /// This frame's stamp in the player's clock domain, and the late-stamp bookkeeping with it.
-    pub fn map(&mut self, host_pts_ns: u64, player_clock_ns: u64) -> u64 {
-        let base = self.pacer.map(host_pts_ns, player_clock_ns);
-        if base <= player_clock_ns {
-            self.late_stamps += 1;
-        }
-        base
-    }
-
-    /// Drop the run: the timeline jumped and nothing derived from it holds.
-    pub fn reset(&mut self) {
-        self.pacer.reset();
-    }
-
-    pub fn health(&self) -> PacingHealth {
-        let h = self.pacer.health();
-        PacingHealth {
-            jitter_ns: h.jitter_ns,
-            cushion_ns: h.cushion_ns,
-            late_stamps: self.late_stamps,
-            reanchors: h.reanchors,
-        }
-    }
 }
 
 /// Nanoseconds as milliseconds, for log lines.

--- a/src/session/timeline.rs
+++ b/src/session/timeline.rs
@@ -1,9 +1,9 @@
 //! Timeline plumbing for the video pump: the panel-reconciled frame interval, and the
 //! host-PTS → player-clock mapping NDL needs (it has no PTS clock of its own).
 //!
-//! Two mappings, picked by [`Pacing`]: the cadence loop ([`CadencePacer`], the default) and the
-//! fixed anchor ([`HostPtsAnchor`], the Experimental escape hatch). Exactly one is live per
-//! session — see [`Pacing`] for why they are not both folded.
+//! One mapping, [`CadencePacer`], wrapped by [`Pacing`]. The fixed anchor it replaced stamped
+//! from a constant taken at frame 0 and had no rate term at all; see [`CadencePacer`] for why
+//! that shape could not be repaired in place.
 
 use crate::platform::webos::sdl_webos;
 
@@ -37,11 +37,11 @@ pub fn reconciled_frame_interval_ns(stream_hz: u32) -> u64 {
 /// Plays frames out on the host's own cadence instead of on their arrival instant, by stamping
 /// them from [`punktfunk_core::phase::CadenceClock`] rather than from a fixed anchor.
 ///
-/// **Why this is a different shape from [`HostPtsAnchor`], not a tweak to it.** The anchor is a
-/// constant taken from frame 0 plus a one-off trim: it has no rate term (two free-running crystals
-/// produce a ramp, so the session's real lead walks away over minutes with nothing to pull it
-/// back), and its jitter margin is whatever [`TRIM_KEEP_NS`] happens to be — 4 ms, chosen for
-/// latency, and below the arrival spread of an ordinary link. Every frame arriving later than that
+/// **Why this is a different shape from the fixed anchor it replaced, not a tweak to it.** That
+/// anchor was a constant taken from frame 0 plus a one-off trim: it had no rate term (two
+/// free-running crystals produce a ramp, so the session's real lead walks away over minutes with
+/// nothing to pull it back), and its jitter margin was the 4 ms of lead its trim deliberately left
+/// behind — chosen for latency, and below the arrival spread of an ordinary link. Every frame arriving later than that
 /// margin is stamped in the player clock's past, which NDL answers by presenting it at feed
 /// cadence: the judder. `CadenceClock` is a type-2 loop over the same quantity (`ready − pts`) and
 /// sizes its cushion from the measured mean absolute deviation, capped at one frame interval.
@@ -51,10 +51,11 @@ pub fn reconciled_frame_interval_ns(stream_hz: u32) -> u64 {
 /// rendering at an irregular rate still looks exactly as irregular as it is. What is removed is
 /// the transport's contribution, not the source's.
 ///
-/// **The default**, because the cushion it pays is measured rather than chosen: on a link with
-/// nothing wrong it collapses to its 0.5 ms floor and costs essentially nothing, and it only grows
-/// where there is real jitter to cover. `Settings::direct_playback` (Experimental) is the way back
-/// to the anchor.
+/// **The only mapping**, because the cushion it pays is measured rather than chosen: on a link
+/// with nothing wrong it collapses to its 0.5 ms floor and costs essentially nothing, and it only
+/// grows where there is real jitter to cover. The anchor was kept selectable for a while as
+/// `Settings::direct_playback`; on real hardware it stamped ~17% of frames late at 120 Hz against
+/// the loop's ~7%, so it is gone.
 pub struct CadencePacer {
     clock: punktfunk_core::phase::CadenceClock,
     /// The source's nominal interval, and the cushion's ceiling (see `CadenceClock::cushion_ns`)
@@ -62,8 +63,7 @@ pub struct CadencePacer {
     source_interval_ns: i64,
     /// Last stamp handed out this run. NDL reads a stamp going backwards as a rewind and answers
     /// by muting the session for good, and the cushion CAN shrink between frames, so the sequence
-    /// is clamped monotonic — exactly as [`HostPtsAnchor::map`] does, and reset with the run for
-    /// the same reason (a flush restarts the timeline).
+    /// is clamped monotonic, and reset with the run (a flush restarts the timeline).
     last_base_ns: u64,
     /// Exact repeated source stamps are off-cadence, not estimator observations.
     last_host_pts_ns: Option<u64>,
@@ -124,71 +124,42 @@ impl CadencePacer {
     }
 }
 
-/// What the live mapping has to say for itself, on the video heartbeat and the stats overlay.
-/// One shape for both mappings, so a report reads the same whichever is in use — a field a mapping
-/// has no notion of is simply `0`.
+/// What the mapping has to say for itself, on the video heartbeat and the stats overlay.
 #[derive(Clone, Copy, Default)]
 pub struct PacingHealth {
     /// Measured jitter (mean absolute deviation of `ready − pts`), and what the cadence loop holds
-    /// to cover it. Both `0` under the anchor, which measures neither.
+    /// to cover it.
     pub jitter_ns: i64,
     pub cushion_ns: i64,
     /// Frames whose stamp was already behind the player clock when fed: presented at feed cadence
-    /// rather than paced, which is the judder. **The one figure both mappings publish**, so it is
-    /// what a before/after comparison rests on.
+    /// rather than paced, which is the judder — the figure a before/after comparison rests on.
     pub late_stamps: u64,
     /// Times the mapping gave up tracking and re-anchored.
     pub reanchors: u64,
-    /// Standing lead the anchor has trimmed off this run, in ns. `0` under the cadence loop, which
-    /// has no trim — its offset estimate is the whole mechanism.
-    pub trimmed_ns: u64,
 }
 
-/// The host-PTS → player-clock mapping this session stamps with.
-///
-/// **Only the live one is folded.** Both are stateful over the whole run, so running the idle one
-/// in the shadows would cost a mapping that is never read and a second set of numbers describing a
-/// session nobody is watching. What makes the two comparable is [`PacingHealth::late_stamps`],
-/// computed from the stamp actually used and so present on both paths.
+/// The host-PTS → player-clock mapping this session stamps with: [`CadencePacer`], plus the one
+/// count that describes the stamps rather than the loop.
 pub struct Pacing {
-    mode: Mode,
+    pacer: CadencePacer,
     /// Frames fed with a stamp already behind the player clock — see [`PacingHealth::late_stamps`].
-    /// Held here rather than in either mapping precisely because it must mean the same thing on
-    /// both.
+    /// Counted here rather than inside the loop: it is a property of the stamp handed to NDL, not
+    /// of the estimate that produced it.
     late_stamps: u64,
 }
 
-enum Mode {
-    /// The default — see [`CadencePacer`].
-    Cadence(CadencePacer),
-    /// `Settings::direct_playback`: the fixed anchor plus its one-off trim, the mapping this client
-    /// shipped before the cadence loop. Kept as the escape hatch for a set where the loop
-    /// misbehaves, and as the lowest-latency answer for anyone who would rather have the judder
-    /// than the cushion.
-    Anchor(HostPtsAnchor),
-}
-
 impl Pacing {
-    /// `source_interval_ns` is the stream mode's own interval — see [`CadencePacer::new`]. The
-    /// anchor's ramp is sized against the same quantity: it pays trim debt off per FRAME, and a
-    /// frame is what the source, not the panel, delivers.
-    pub fn new(source_interval_ns: u64, direct: bool) -> Self {
+    /// `source_interval_ns` is the stream mode's own interval — see [`CadencePacer::new`].
+    pub fn new(source_interval_ns: u64) -> Self {
         Self {
-            mode: if direct {
-                Mode::Anchor(HostPtsAnchor::new(source_interval_ns))
-            } else {
-                Mode::Cadence(CadencePacer::new(source_interval_ns))
-            },
+            pacer: CadencePacer::new(source_interval_ns),
             late_stamps: 0,
         }
     }
 
     /// This frame's stamp in the player's clock domain, and the late-stamp bookkeeping with it.
     pub fn map(&mut self, host_pts_ns: u64, player_clock_ns: u64) -> u64 {
-        let base = match &mut self.mode {
-            Mode::Cadence(p) => p.map(host_pts_ns, player_clock_ns),
-            Mode::Anchor(a) => a.map(host_pts_ns, player_clock_ns),
-        };
+        let base = self.pacer.map(host_pts_ns, player_clock_ns);
         if base <= player_clock_ns {
             self.late_stamps += 1;
         }
@@ -197,204 +168,17 @@ impl Pacing {
 
     /// Drop the run: the timeline jumped and nothing derived from it holds.
     pub fn reset(&mut self) {
-        match &mut self.mode {
-            Mode::Cadence(p) => p.reset(),
-            Mode::Anchor(a) => a.reset(),
-        }
+        self.pacer.reset();
     }
 
     pub fn health(&self) -> PacingHealth {
-        let late_stamps = self.late_stamps;
-        match &self.mode {
-            Mode::Cadence(p) => {
-                let h = p.health();
-                PacingHealth {
-                    jitter_ns: h.jitter_ns,
-                    cushion_ns: h.cushion_ns,
-                    late_stamps,
-                    reanchors: h.reanchors,
-                    trimmed_ns: 0,
-                }
-            }
-            Mode::Anchor(a) => PacingHealth {
-                late_stamps,
-                trimmed_ns: a.trimmed_ns(),
-                ..PacingHealth::default()
-            },
+        let h = self.pacer.health();
+        PacingHealth {
+            jitter_ns: h.jitter_ns,
+            cushion_ns: h.cushion_ns,
+            late_stamps: self.late_stamps,
+            reanchors: h.reanchors,
         }
-    }
-
-    /// Which mapping is live, for the log line and the overlay.
-    pub fn label(&self) -> &'static str {
-        match &self.mode {
-            Mode::Cadence(_) => "paced",
-            Mode::Anchor(_) => "direct",
-        }
-    }
-}
-
-/// Window the lead minimum is taken over (see [`HostPtsAnchor::observe_lead`]). Short enough
-/// that several windows fit inside [`TRIM_SETTLE_NS`], long enough (30 frames at 60 Hz) that a
-/// single early arrival can't be mistaken for the standing floor.
-const TRIM_WINDOW_NS: u64 = 500_000_000;
-/// How long after an anchor trimming is allowed — and therefore how long the audio plane waits
-/// before it latches this mapping ([`HostPtsAnchor::ready_for_audio`]).
-///
-/// One [`TRIM_WINDOW_NS`] plus slack, not the several seconds the measurement alone would like.
-/// The reason is the audio plane: its stamps ride this mapping's offset and can only ever move
-/// FORWARD (a rewind mutes the session for good), so a trim taken after audio has latched lands as
-/// lip-sync error instead of latency saved. Trimming therefore has to be finished before audio
-/// joins — and audio joining ~600 ms into a session costs nothing, because `run_clock_plane` is
-/// pacing the picture through exactly that window anyway.
-const TRIM_SETTLE_NS: u64 = 600_000_000;
-/// Lead deliberately left in place. Trimming to exactly zero puts every frame's stamp at or
-/// behind the player clock, which is where NDL presents at feed cadence — the very thing the
-/// audio plane's pacing exists to avoid. One 240 Hz frame of slack keeps the stamps ahead
-/// without being a queue.
-const TRIM_KEEP_NS: u64 = 4_000_000;
-/// Smallest trim worth taking. Below this the correction is inside the jitter it was measured
-/// through, and each step costs a log line.
-const TRIM_MIN_STEP_NS: u64 = 4_000_000;
-/// Fraction of one frame interval the trim may pay off per frame. The stamps this mapping hands
-/// NDL must never go backwards, and `raw` only advances by one frame interval per frame — so a
-/// debt taken in one step would emit a stamp *behind* its predecessor. Paid off at a quarter of
-/// the interval instead: the frame spacing tightens by 25% until the debt clears (a 40 ms debt is
-/// ~10 frames of it) and the sequence stays strictly increasing throughout.
-const TRIM_RAMP_DIVISOR: u64 = 4;
-
-/// Maps the host's capture-clock PTS onto NDL's own player clock, anchored once at the
-/// first frame of a run: `base = player_anchor + (host_pts - host_anchor)`. Keeps the
-/// video and offloaded audio on one shared mapping (see
-/// [`crate::session::stage::VideoStage`]). Same anchoring as SS4S's
-/// `ndl_player.c::SS4S_NDL_webOS5_NextVideoPts`. Reset after a freeze-until-reanchor hold,
-/// where the timeline jumps.
-///
-/// **Plus a lead trim, which is where the latency is.** The anchor bakes frame 0's own delivery
-/// latency into the mapping: every later frame that arrives faster than frame 0 did gets a stamp
-/// in NDL's *future*, and `pauseAtDecodeTime` holds it there. Frame 0 is the session's first
-/// keyframe, arriving behind the connect handshake and (on Automatic) the ABR capacity probe —
-/// i.e. very likely the worst-latency frame of the whole run, and the lead it leaves is a
-/// standing cost for as long as the anchor lives. SS4S sidesteps this by stamping arrival time
-/// (`now - mediaLoadedTime`), which never holds a frame but also throws away the relative
-/// spacing NDL paces on. This keeps the spacing and removes the constant: the minimum lead over
-/// a window is, by definition, slack no frame in that window needed, so it is subtracted.
-#[derive(Default)]
-pub struct HostPtsAnchor {
-    /// `(host_pts_ns, player_clock_ns)` of the frame the current run anchored on.
-    anchor: Option<(u64, u64)>,
-    /// Whether [`Self::map`] is allowed to trim (see [`Self::new`]). Re-armed on every
-    /// [`Self::reset`] — each run's anchor bakes in its own lead.
-    trim: bool,
-    /// Trim actually applied so far, ramped toward `trim_target_ns` (see [`TRIM_RAMP_DIVISOR`]).
-    trim_ns: u64,
-    /// Trim the windows have asked for. `trim_ns` catches up to it over the following frames.
-    trim_target_ns: u64,
-    /// Per-frame ramp step: a quarter of the reconciled frame interval.
-    ramp_ns: u64,
-    /// Player clock at the start of the current measurement window, and the smallest lead seen
-    /// inside it. `None` until the first mapped frame after an anchor.
-    window: Option<(u64, u64)>,
-    /// Last base this run handed out. The ramp is sized against the frame interval, so a delivery
-    /// whose host PTS did not advance by one (a repeated stamp, a variable-rate source) would
-    /// otherwise subtract more trim than `raw` gained and emit a stamp BEHIND its predecessor —
-    /// which NDL reads as a rewind and answers by muting the session for good.
-    last_base_ns: u64,
-}
-
-impl HostPtsAnchor {
-    /// The trim is always armed; audio no longer rides this mapping, so nothing gates on it.
-    pub fn new(frame_interval_ns: u64) -> Self {
-        Self {
-            trim: true,
-            ramp_ns: (frame_interval_ns / TRIM_RAMP_DIVISOR).max(1),
-            ..Self::default()
-        }
-    }
-
-    /// Drop the mapping — the timeline jumped and nothing derived from it holds. Trimming re-arms
-    /// with it: the new anchor bakes in its own delivery latency (a recovery keyframe arriving late
-    /// behind a loss burst is a bad one to inherit), so the lead has to be measured again.
-    pub fn reset(&mut self) {
-        self.anchor = None;
-        self.trim = true;
-        self.trim_ns = 0;
-        self.trim_target_ns = 0;
-        self.window = None;
-        self.last_base_ns = 0;
-    }
-
-    /// Base reference for `host_pts_ns`. First call anchors on `player_clock_ns` and
-    /// returns it verbatim; later calls project the host PTS delta forward, floored at 0
-    /// (a host PTS going backwards vs. the anchor would otherwise underflow), less whatever
-    /// standing lead has been trimmed off the run.
-    pub fn map(&mut self, host_pts_ns: u64, player_clock_ns: u64) -> u64 {
-        let Some((host0, player0)) = self.anchor else {
-            self.anchor = Some((host_pts_ns, player_clock_ns));
-            self.window = Some((player_clock_ns, u64::MAX));
-            self.last_base_ns = player_clock_ns;
-            return player_clock_ns;
-        };
-        self.trim_ns = self.trim_target_ns.min(self.trim_ns + self.ramp_ns);
-        let delta = host_pts_ns as i64 - host0 as i64;
-        let raw = (player0 as i64 + delta).max(0) as u64;
-        let base = raw.saturating_sub(self.trim_ns).max(self.last_base_ns);
-        self.last_base_ns = base;
-        if self.trim {
-            self.observe_lead(base.saturating_sub(player_clock_ns), player_clock_ns, player0);
-        }
-        base
-    }
-
-    /// Folds one frame's lead into the current window and takes the trim when the window closes.
-    ///
-    /// The minimum is the whole point: it is the slack the *earliest-arriving* frame of the
-    /// window still had, so subtracting it cannot make any frame in that window late. Frames
-    /// that arrive later than the anchor's baked-in latency read a lead of 0 and pin the window
-    /// to no trim at all, which is the correct answer — that session has no standing lead to
-    /// give back.
-    fn observe_lead(&mut self, lead_ns: u64, player_clock_ns: u64, anchor_player_ns: u64) {
-        // A window measured while the ramp still owes trim would count the same slack twice —
-        // the debt is real but not yet subtracted, so it still reads as lead.
-        if self.trim_ns != self.trim_target_ns {
-            self.window = Some((player_clock_ns, u64::MAX));
-            return;
-        }
-        let Some((started, min_lead)) = self.window else {
-            self.window = Some((player_clock_ns, lead_ns));
-            return;
-        };
-        let min_lead = min_lead.min(lead_ns);
-        if player_clock_ns.saturating_sub(started) < TRIM_WINDOW_NS {
-            self.window = Some((started, min_lead));
-            return;
-        }
-        // Past the settle window the anchor's own lead has long since been measured; a lead
-        // appearing now belongs to the host timeline and is not ours to remove. Windows stop
-        // being collected with it, so the steady state is one subtraction per frame.
-        if player_clock_ns.saturating_sub(anchor_player_ns) >= TRIM_SETTLE_NS {
-            self.trim = false;
-            tracing::debug!("pts lead: settled with {:.1}ms trimmed", ms(self.trim_ns));
-            return;
-        }
-        self.window = Some((player_clock_ns, u64::MAX));
-        let step = min_lead.saturating_sub(TRIM_KEEP_NS);
-        if step < TRIM_MIN_STEP_NS {
-            return;
-        }
-        self.trim_target_ns += step;
-        // INFO, once or twice a session: this is the one line that says how much standing
-        // decoder-hold latency the session started with, which is not observable any other way.
-        tracing::info!(
-            "pts lead: trimming {:.1}ms (window min {:.1}ms, {:.1}ms total)",
-            ms(step),
-            ms(min_lead),
-            ms(self.trim_target_ns),
-        );
-    }
-
-    /// Standing lead removed from this run's mapping, for the session log.
-    pub fn trimmed_ns(&self) -> u64 {
-        self.trim_target_ns
     }
 }
 


### PR DESCRIPTION
Opus audio offloaded to NDL's audio plane went permanently silent mid-stream after any network
hiccup, and stayed silent for the rest of the session.

The cause is the loss hold's flush. `NDL_DirectVideoFlushRenderBuffer` does not just discard
queued frames, it stops the whole pipeline, and the restart takes the audio plane out for good.
The hold no longer flushes; the decode-error path still does. Confirmed on a CX under 276 Mb/s of
competing download against a 188 Mb/s stream: 16 re-anchors, holds up to 2s, zero pipeline
restarts, audio intact. The identical storm against the flushing build killed it.

Three things found alongside it:

**Audio stamps come off the player clock.** Mapping audio through the host's PTS ratcheted a
permanent lead of roughly 45ms per loss storm (measured 78ms to 124ms) that it could never pay
back. Audio now stamps at `player_clock + PLANE_LEAD_MS` and ignores host PTS, which lets
`SessionClock`, the skew and epoch plumbing and the audio-latch gate on both pacers go. Real drift
bug, but not the mute.

**The direct playback pacer is gone.** The old fixed-anchor mapping, kept selectable as a setting,
stamped about 17% of frames late at 120Hz against the cadence loop's 7%. Removed with its setting,
UI row and plumbing.

**A failed NDL load now ends the session.** NDL can fail a load asynchronously and never recover:
every feed returns -1, the audio plane dies, NDL unloads itself, and the QUIC session stays
perfectly healthy, so the client used to spin on failed feeds in front of a frozen picture
forever. There is no in-session reload path, so the stream loop returns to the menu with a toast.
Only the one load state measured to do this latches the flag. Other unmapped states log and
continue: no header for that enum exists in the tree or the cross sysroot, and ending a healthy
session on a notification we cannot name is the worse failure. The log line is the evidence needed
to map the rest.

Cleanup: `Pacing` had become a pass-through wrapper once the second mapping went, so it is one
struct now; the clock plane's silence fill hoists its base out of the loop and targets the same
figure the real feed does instead of stacking a lead per fill episode; the fatal flag reuses the
same per-load event primitive as the other NDL load events.

About 700 lines deleted against 300 added.

Not yet verified on device, worth a reviewer's attention:

- The picture across a loss hold. Audio was confirmed, the video half of the no-flush change has
  no device evidence.
- Lip sync by ear. Audio no longer carries the old PTS trim's compensation, so `PLANE_LEAD_MS` is
  the single knob.
- webOS 10.3. A PTS-domain mismatch is what froze the picture on a G5 once before.
