### PR TITLE
Update punktfunk core to v0.32.0 and align ABR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.31.3#5e30805490a835242aacd9d71556e93ef3ae7e06"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.32.0#ded8586123ab85a171bfa1a7ae441f8e5ba41c83"
 
 [[package]]
 name = "fiat-crypto"
@@ -1272,8 +1272,8 @@ dependencies = [
 
 [[package]]
 name = "punktfunk-core"
-version = "0.31.3"
-source = "git+https://git.unom.io/unom/punktfunk?tag=v0.31.3#5e30805490a835242aacd9d71556e93ef3ae7e06"
+version = "0.32.0"
+source = "git+https://git.unom.io/unom/punktfunk?tag=v0.32.0#ded8586123ab85a171bfa1a7ae441f8e5ba41c83"
 dependencies = [
  "aes-gcm",
  "cbindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
-# v0.22.3 is the first release carrying core's `PUNKTFUNK_ABR_PROBE_KBPS` cap, which `main.rs`
-# sets — before it, the startup probe bursts at a fixed 2 Gbps (see docs/NOTES.md).
+# v0.22.3 is the first release carrying core's `PUNKTFUNK_ABR_PROBE_KBPS` override, which
+# `main.rs` sets to the TV-safe target documented in docs/NOTES.md.
 # v0.24.0 brings the ABR sweep (eleven defects: the 20 Mbps pin, throughput measured in media
 # bytes not wire bytes, a decode ceiling that latched at the choke rate) and probe throughput
 # measured over the client's own receive interval — all client-side, so the bump is the fix.
@@ -56,7 +56,9 @@ tracing-appender = "0.2"
 # moved), and puts `#![deny(unsafe_code)]` over the crate that parses every byte off the network.
 # The one source-visible break is `note_frame_index`, which now returns a gap WIDTH — see
 # `session::video_pump`.
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.31.3", features = ["quic"] }
+# v0.32.0 makes bitrate values total wire budgets and adds recovery-point marks. The webOS pump
+# mirrors those semantics while keeping NDL queue depth out of the decoder-pressure signal.
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", tag = "v0.32.0", features = ["quic"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # mDNS LAN discovery; direct dep (not via pf-client-core — see session.rs docs).

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -156,7 +156,7 @@ MANIFEST (crate version — SPDX license — source)
   powerfmt 0.2.0 — MIT OR Apache-2.0 — https://github.com/jhpratt/powerfmt
   ppv-lite86 0.2.21 — MIT OR Apache-2.0 — https://github.com/cryptocorrosion/cryptocorrosion
   proc-macro2 1.0.107 — MIT OR Apache-2.0 — https://github.com/dtolnay/proc-macro2
-  punktfunk-core 0.31.3 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
+  punktfunk-core 0.32.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
   pxfm 0.1.30 — BSD-3-Clause OR Apache-2.0 — https://github.com/awxkee/pxfm
   quick-error 2.0.1 — MIT/Apache-2.0 — http://github.com/tailhook/quick-error
   quinn 0.11.11 — MIT OR Apache-2.0 — https://github.com/quinn-rs/quinn
@@ -261,7 +261,7 @@ MANIFEST (crate version — SPDX license — source)
 Crates whose package did not embed a license file (SPDX + source only)
 ----------------------------------------------------------------------------
   asn1-rs-impl 0.2.0 — MIT/Apache-2.0 — https://github.com/rusticata/asn1-rs.git
-  punktfunk-core 0.31.3 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
+  punktfunk-core 0.32.0 — MIT OR Apache-2.0 — https://git.unom.io/unom/punktfunk
   sdl2-sys 0.38.0 — MIT AND Zlib — https://github.com/rust-sdl2/rust-sdl2
 
 ============================================================================

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -548,9 +548,7 @@ Wiring notes worth knowing before editing:
   to the client's panel grid, which *reduces* latency instead of buffering against it, but needs a
   real vblank anchor and NDL is submit-only, so the anchor would have to come off the graphics plane
   with an unknown constant offset to the video plane's latch); an **adaptive `PLANE_LEAD_MS`** on the
-  offload route (the deleted SDL `JitterPolicy` did 25→90 ms under underruns); and **not freezing on
-  a one-frame gap** when LTR/RFI recovery is available, since `HOLD_GIVE_UP` is 2 s of frozen picture
-  per loss event and each hold re-anchors the timeline.
+  offload route (the deleted SDL `JitterPolicy` did 25→90 ms under underruns).
 
 ## ABR startup probe: 2 Gbps, upstream-hardcoded
 
@@ -568,7 +566,13 @@ This was `CAPACITY_PROBE_KBPS` in `punktfunk-core`'s `client/pump/data.rs` — a
 
 **Fixed by capping the burst**: `main.rs`'s `set_abr_env` sets `PUNKTFUNK_ABR_PROBE_KBPS` before anything spawns a thread (`setenv` isn't thread-safe, and core reads it while building its data-plane pump). Same order as the speed test's own cap, still above the airlink ceiling below — measures the link without knocking it over. Knob is core-side; **core v0.22.3 is the first release carrying it**, which is why the pin moved off v0.21.0. An older core ignores the variable.
 
-**300 was still too high on the CX** (2026-08-20): the probe saturated the airlink and opened a freeze-until-reanchor hold seconds into the session — the "Connection issues — recovering" toast — which on the offload path then cost the session its audio (see *NDL's audio plane*). Both knobs are now derived from `core::model::BITRATE_MAX_KBPS` — the settings slider's own ceiling, 200 Mbps, so there is one number to change: `PUNKTFUNK_ABR_MAX_MBPS` clamps the climb ceiling however it is learned (`abr::ceiling_cap_from_env`; the probe MEASURES that ceiling and `set_ceiling` is monotonic, so an over-read is otherwise permanent for the session), and the probe burst matches it — bursting above a ceiling the session can never use only buys loss. Descending below 200 stays core's job; its congestion signals walk the rate to their own 5 Mbps floor and **there is no client-side API to lower a ceiling mid-session**.
+The old 200 Mbps probe target could not prove the client's own 200 Mbps ceiling: core deliberately
+keeps only 70% of measured delivery, making 140 Mbps the theoretical maximum and much less on a
+short burst through the TV's receive path. The target is now 320 Mbps, matching the connection test's
+proven-safe cap. That is high enough to clear core's margin and far below the mode-derived ~1.8 Gbps
+4K120 target. `PUNKTFUNK_ABR_MAX_MBPS` still clamps the learned ceiling to the settings slider's
+200 Mbps maximum. Host/network signals own climbs and descent; NDL contributes only measured feed
+backpressure.
 
 That bump also brought a `connect` signature change — a `name: Option<String>` (label the host's pending-approval list shows) between `launch` and `pin`. All four call sites pass `None`, preserving fingerprint-derived label; sending a real TV name is a separate user-visible change.
 

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -673,7 +673,7 @@ pub enum LogLevelOverride {
 /// Slider range, in 5 Mbps steps.
 pub const BITRATE_MIN_KBPS: u32 = 10_000;
 /// The one bitrate ceiling this client has. It bounds the manual slider AND, through `main`,
-/// `punktfunk_core::abr`'s automatic climb (`PUNKTFUNK_ABR_MAX_MBPS`) and the startup
+/// `punktfunk_core::abr`'s automatic wire-budget climb (`PUNKTFUNK_ABR_MAX_MBPS`) and the startup
 /// link-capacity probe's burst target (`PUNKTFUNK_ABR_PROBE_KBPS`) — an Automatic session that
 /// could climb past what the slider allows would just be a second, hidden setting.
 pub const BITRATE_MAX_KBPS: u32 = 200_000;

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,17 +33,18 @@ mod runtime {
 
 /// [`BITRATE_MAX_KBPS`] in the Mbps unit `PUNKTFUNK_ABR_MAX_MBPS` is spelled in.
 const ABR_MAX_MBPS: u32 = BITRATE_MAX_KBPS / 1_000;
+/// Same proven-safe target as the client's connection test. Core keeps 70% of delivered probe
+/// throughput, so probing at the 200 Mbps policy ceiling can never prove that ceiling.
+const ABR_PROBE_KBPS: u32 = 320_000;
 
-/// Publishes the two automatic-bitrate knobs `punktfunk_core` reads from the environment, both
-/// derived from [`BITRATE_MAX_KBPS`] — the client has one bitrate ceiling, and the settings slider
-/// is where it is edited.
+/// Publishes the two automatic-bitrate knobs `punktfunk_core` reads from the environment.
 ///
 /// `PUNKTFUNK_ABR_MAX_MBPS` clamps core's climb ceiling however it is learned;
-/// `PUNKTFUNK_ABR_PROBE_KBPS` shrinks the startup burst that measures it, whose 2 Gbps default
-/// knocks a TV's Wi-Fi over. See `docs/NOTES.md` § "ABR startup probe" for the measurements
-/// behind both, and why descent below the ceiling stays core's job.
+/// `PUNKTFUNK_ABR_PROBE_KBPS` uses the connection test's proven-safe 320 Mbps target. This clears
+/// core's 70% safety margin while avoiding its mode-derived 1.8 Gbps 4K120 burst. See
+/// `docs/NOTES.md` § "ABR startup probe".
 fn set_abr_env() {
-    std::env::set_var("PUNKTFUNK_ABR_PROBE_KBPS", BITRATE_MAX_KBPS.to_string());
+    std::env::set_var("PUNKTFUNK_ABR_PROBE_KBPS", ABR_PROBE_KBPS.to_string());
     std::env::set_var("PUNKTFUNK_ABR_MAX_MBPS", ABR_MAX_MBPS.to_string());
 }
 

--- a/src/runtime/session_ext.rs
+++ b/src/runtime/session_ext.rs
@@ -126,8 +126,9 @@ impl Connected {
             hdr: client.color.is_hdr(),
             frames_dropped: Some(client.frames_dropped()),
             fec_recovered: Some(client.fec_recovered_shards()),
-            // The encoder's CURRENT target, not the session-start negotiation: on Automatic the
-            // ABR re-targets mid-session. `0` = a host too old to report.
+            // The CURRENT total wire budget, not the session-start negotiation: on Automatic the
+            // ABR re-targets mid-session. Core v0.32 changed this from encoder rate to wire budget;
+            // `0` means a host too old to report.
             target_kbps: match client.current_bitrate_kbps() {
                 0 => client.resolved_bitrate_kbps,
                 live => live,

--- a/src/session/connect.rs
+++ b/src/session/connect.rs
@@ -237,7 +237,7 @@ fn log_handshake(client: &NativeClient, negotiated: &Negotiated) {
     });
     tracing::info!(
         "connected: codec={} (offered=0x{:02x} preferred=0x{:02x}) \
-         compositor={:?} audio_ch={} color={:?} bitrate_kbps={} \
+         compositor={:?} audio_ch={} color={:?} wire_budget_kbps={} \
          decode_latency={} caps=0x{:02x} fp={fp_hex}",
         client.codec,
         negotiated.video_codecs,

--- a/src/session/pump.rs
+++ b/src/session/pump.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use punktfunk_core::client::{AudioPacket, NativeClient};
 use punktfunk_core::packet::{FLAG_SOF, USER_FLAG_RECOVERY_ANCHOR};
+use punktfunk_core::reanchor::DROP_CREDIT_WINDOW;
 use punktfunk_core::PunktfunkError;
 
 use crate::platform::webos::device::boost_current_thread;
@@ -62,6 +63,9 @@ struct VideoPump {
     is_hdr: bool,
     /// Core's cumulative drop count as of the last frame, to edge-detect new drops.
     last_dropped_seen: u64,
+    /// Frame-index gaps pre-cover the reassembler's delayed drop accounting.
+    drop_credit: u64,
+    drop_credit_expiry: Option<Instant>,
     heartbeat: Tick,
     video_log: Tick,
 }
@@ -75,6 +79,8 @@ impl VideoPump {
             stats,
             is_hdr,
             last_dropped_seen,
+            drop_credit: 0,
+            drop_credit_expiry: None,
             heartbeat: Tick::new(HEARTBEAT),
             video_log: Tick::new(VIDEO_LOG_INTERVAL),
         }
@@ -124,6 +130,9 @@ impl VideoPump {
             index: frame.frame_index,
             part: frame.part,
             reanchor: frame.flags & u32::from(FLAG_SOF) != 0 || frame.flags & USER_FLAG_RECOVERY_ANCHOR != 0,
+            // Parts repeat the AU flags. Count a recovery boundary once.
+            recovery_mark: frame.flags & punktfunk_core::packet::USER_FLAG_RECOVERY_POINT != 0
+                && frame.part.is_none_or(|part| part.first),
             loss: self.note_loss(frame),
         };
         match self.stage.submit(&wire) {
@@ -211,10 +220,31 @@ impl VideoPump {
         // bare "was there a gap" bool; `> 0` is the same predicate. Keep the width for the log
         // line — how many frames the hole swallowed is the number worth having when reading a
         // freeze report, not merely that one existed.
-        let gap_width = self.client.note_frame_index(frame.frame_index);
+        // Slice-progressive pieces repeat their AU index. Observe it once, on the first piece.
+        let au_first = frame.part.is_none_or(|part| part.first);
+        let gap_width = if au_first {
+            self.client.note_frame_index(frame.frame_index)
+        } else {
+            0
+        };
         let dropped_now = self.client.frames_dropped();
-        let dropped = dropped_now > self.last_dropped_seen;
+        let dropped_delta = dropped_now.saturating_sub(self.last_dropped_seen);
         self.last_dropped_seen = dropped_now;
+        let now = Instant::now();
+        if self.drop_credit_expiry.is_some_and(|expiry| now >= expiry) {
+            self.drop_credit = 0;
+            self.drop_credit_expiry = None;
+        }
+        if gap_width > 0 {
+            self.drop_credit = self.drop_credit.saturating_add(u64::from(gap_width));
+            self.drop_credit_expiry = Some(now + DROP_CREDIT_WINDOW);
+        }
+        let credited = dropped_delta.min(self.drop_credit);
+        self.drop_credit -= credited;
+        if self.drop_credit == 0 {
+            self.drop_credit_expiry = None;
+        }
+        let dropped = dropped_delta > credited;
         let lost = gap_width > 0 || dropped;
         if lost && !self.stage.holding() {
             // Logged alongside the freeze the sink reports next: a sequence hole and a frame the

--- a/src/session/stage/metrics.rs
+++ b/src/session/stage/metrics.rs
@@ -1,31 +1,7 @@
-//! The two latency figures the video stage derives from one render-queue depth, and the
-//! self-calibrating cushion both are read against.
+//! Video end-to-end estimation from NDL's render-queue depth.
 //!
 //! Free functions rather than [`VideoStage`](super::VideoStage) methods purely so they are
 //! testable: the stage owns a live NDL handle and cannot be built off-device.
-
-/// Render-buffer frames NDL holds as a *standing* present cushion, excluded from the ABR decode
-/// figure (see [`VideoStage::decode_us`]). NDL presents off its own clock, so a healthy session
-/// sits at 1-2 frames of depth indefinitely — lead, not backlog. Folded in raw it manufactures a
-/// constant 8-17ms of apparent decode latency, crossing `abr`'s 15ms decode-rise threshold and
-/// backing off bitrate for no real reason (observed on the CX 2026-08-10: 1440p120 driven from
-/// 25 Mbps to the 5 Mbps floor with zero loss and flat OWD). Subtracting it keeps the real
-/// signal — a queue that GROWS past this is genuine falling-behind — while dropping the constant.
-///
-/// Only a floor: the settled depth is NDL's business and one frame is 16.6ms at 60Hz, so a mode
-/// idling at three frames would reproduce the bug against a fixed two. The excluded depth is the
-/// rolling min over [`CUSHION_MIN_POLLS`], clamped into this..=[`CUSHION_MAX_FRAMES`] — this value
-/// covers only the first seconds, before that minimum has seen a settled queue.
-pub(super) const STANDING_CUSHION_FRAMES: u64 = 2;
-/// Polls whose minimum depth is the self-calibrating cushion (see [`STANDING_CUSHION_FRAMES`]).
-/// 20 × [`BACKLOG_POLL`] = 5s: long enough that `abr`'s two-window (1.5s) decode backoff still
-/// fires on a queue that genuinely grows, short enough to follow a mode or content change.
-pub(super) const CUSHION_MIN_POLLS: usize = 20;
-/// Ceiling on the self-calibrated cushion. Without it, a decoder that stays overloaded for longer
-/// than [`CUSHION_MIN_POLLS`] teaches the rolling minimum its own backlog and the signal goes
-/// quiet — the same baseline-absorption trap this fix exists to escape, just faster. Lead is a
-/// couple of frames by construction, so anything past this is queue, and queue must stay visible.
-pub(super) const CUSHION_MAX_FRAMES: u64 = 4;
 
 /// This frame's video end-to-end latency, in the shape [`punktfunk_core::audio::AvSync`] compares
 /// against: the instant it reaches the glass expressed in the HOST capture clock, minus its host
@@ -65,31 +41,4 @@ pub(super) fn video_e2e_ns(
         .checked_add(i128::from(pipeline_ns))?
         .checked_add(i128::from(clock_offset_ns))?;
     u64::try_from(glass_host_ns.checked_sub(i128::from(frame_pts_ns))?).ok()
-}
-
-/// The decode-stage latency reported to `punktfunk_core::abr`: submission time plus the part of
-/// NDL's render queue that is genuinely backlog. See [`VideoStage::decode_us`] for why the queue
-/// belongs in it at all, and [`STANDING_CUSHION_FRAMES`] for why `cushion` comes out first.
-///
-/// `submit_us` is the whole access unit's feed time, not the last slice's: on a slice-progressive
-/// session a picture is submitted in pieces, and the controller is comparing this against a
-/// per-picture budget.
-///
-/// Split out as a free function purely so it is testable — [`VideoStage`] owns a live NDL handle and
-/// cannot be built off-device.
-pub(super) fn decode_report_us(submit_us: u32, backlog: u64, cushion: u64, frame_interval_ns: u64) -> u32 {
-    let queued_ns = backlog.saturating_sub(cushion).saturating_mul(frame_interval_ns);
-    let decode_us = u64::from(submit_us).saturating_add(queued_ns / 1_000);
-    u32::try_from(decode_us).unwrap_or(u32::MAX)
-}
-
-/// The depth [`decode_report_us`] treats as present lead rather than backlog: the rolling minimum
-/// of recent poll samples, clamped into [`STANDING_CUSHION_FRAMES`]..=[`CUSHION_MAX_FRAMES`].
-/// Empty (no poll yet) yields the floor, never 0 — a session's first windows are exactly when the
-/// buffer is still filling and a raw fold does its damage.
-pub(super) fn cushion_frames(samples: impl Iterator<Item = u64>) -> u64 {
-    samples
-        .min()
-        .unwrap_or(0)
-        .clamp(STANDING_CUSHION_FRAMES, CUSHION_MAX_FRAMES)
 }

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -7,8 +7,7 @@
 //! answers to [`SinkResult::NeedKeyframe`] with `NativeClient::request_keyframe`.
 //!
 //! Two pieces sit in submodules because they are self-contained and independently testable:
-//! [`metrics`] (the ABR decode figure and the A/V video reference) and [`parts`] (slice-progressive
-//! reassembly).
+//! [`metrics`] (the A/V video reference) and [`parts`] (slice-progressive reassembly).
 
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -23,15 +22,12 @@ use crate::session::StreamStats;
 mod metrics;
 mod parts;
 
-use metrics::{cushion_frames, decode_report_us, video_e2e_ns, CUSHION_MIN_POLLS, STANDING_CUSHION_FRAMES};
+use metrics::video_e2e_ns;
 use parts::{AuParts, PartStep};
 
-/// Freeze duration after which we resume even without a clean re-anchor.
-const HOLD_GIVE_UP: Duration = Duration::from_secs(2);
 /// Feed calls slower than this suggest decoder backpressure rather than network loss.
 const FEED_BACKPRESSURE_WARN: Duration = Duration::from_millis(20);
-/// How often the sink refreshes NDL's render-buffer depth for the decode-latency signal —
-/// three samples per 750 ms ABR report window; see [`VideoStage::decode_us`].
+/// How often the sink refreshes NDL's render-buffer depth for diagnostics and A/V estimation.
 const BACKLOG_POLL: Duration = Duration::from_millis(250);
 /// One delivery off the transport, as the pump sees it — the stage decides what it means.
 pub struct WireFrame<'a> {
@@ -44,6 +40,8 @@ pub struct WireFrame<'a> {
     pub part: Option<punktfunk_core::session::FramePart>,
     /// This frame can restart decoding on its own (IDR, or an LTR recovery anchor).
     pub reanchor: bool,
+    /// One intra-refresh wave boundary. Two after loss prove a clean picture.
+    pub recovery_mark: bool,
     /// Loss was detected at or before this frame — a sequence gap, or a frame the transport
     /// dropped.
     pub loss: bool,
@@ -53,6 +51,7 @@ pub struct WireFrame<'a> {
 #[derive(Clone, Copy)]
 struct FrameFlags {
     reanchor: bool,
+    recovery_mark: bool,
     loss: bool,
     /// Host frame index, for logs only.
     index: u64,
@@ -81,7 +80,7 @@ pub enum SinkResult {
 
 /// Everything the sink needs to know up front.
 pub struct SinkConfig {
-    /// The host's frame cadence. Drives both the frame-interval grid and the backlog→latency fold.
+    /// The host's frame cadence. Drives the frame-interval grid and A/V backlog estimate.
     pub stream_hz: u32,
     /// Whether the host asked for decode-latency reports (its ABR controller).
     pub report_decode_latency: bool,
@@ -114,9 +113,8 @@ pub struct VideoStage {
     stats: Arc<StreamStats>,
     cfg: SinkConfig,
     /// The panel's actual drain cadence, reconciled against the stream rate. NDL drains at panel
-    /// cadence, so this, not the stream rate, is what converts a render-queue depth into time — for BOTH consumers of
-    /// that conversion ([`video_e2e_ns`] and [`VideoStage::decode_us`]), so one depth cannot mean two
-    /// different latencies.
+    /// cadence, so this, not the stream rate, converts render-queue depth into time for
+    /// [`video_e2e_ns`].
     frame_interval_ns: u64,
     /// NDL host-PTS→player-clock mapping — see `session::timeline::Pacing`.
     pacing: Pacing,
@@ -130,11 +128,6 @@ pub struct VideoStage {
     au_base_ns: Option<u64>,
     /// Last polled depth, `None` if that query failed — which must not read as an empty queue.
     backlog_cached: Option<u64>,
-    /// Recent poll depths, newest last — their minimum is the cushion the decode figure excludes
-    /// (see [`STANDING_CUSHION_FRAMES`]). Bounded at [`CUSHION_MIN_POLLS`].
-    backlog_recent: std::collections::VecDeque<u64>,
-    /// Cached [`Self::refresh_cushion`] result — read per presented frame, written per poll.
-    cushion_frames: u64,
     last_backlog_poll: Option<Instant>,
     last_keyframe_request: Option<Instant>,
     /// Submit time accumulated across the pieces of the AU currently being fed, so the overlay's
@@ -148,10 +141,11 @@ pub struct VideoStage {
     parts_fed: u64,
     /// Freeze-until-reanchor: while holding, frames are skipped rather than fed — the
     /// punch-through plane keeps the last good picture. Resumes on IDR / LTR-RFI recovery
-    /// anchor, or after [`HOLD_GIVE_UP`]. `Some` for exactly as long as the hold lasts (see
-    /// [`Self::holding`]), and not reset on cascading gaps so the give-up deadline can't be
-    /// pushed out indefinitely.
+    /// anchor, or two intra-refresh recovery marks. `Some` for exactly as long as the hold lasts
+    /// (see [`Self::holding`]).
     hold_started: Option<Instant>,
+    /// Intra-refresh wave boundaries observed since the latest loss.
+    recovery_marks: u32,
 }
 
 impl VideoStage {
@@ -178,11 +172,10 @@ impl VideoStage {
             au_base_ns: None,
             cfg,
             backlog_cached: None,
-            backlog_recent: std::collections::VecDeque::with_capacity(CUSHION_MIN_POLLS),
-            cushion_frames: STANDING_CUSHION_FRAMES,
             last_backlog_poll: None,
             last_keyframe_request: None,
             hold_started: None,
+            recovery_marks: 0,
             au_feed_us: 0,
             parts_fed: 0,
         }
@@ -241,29 +234,14 @@ impl VideoStage {
     fn begin_hold(&mut self) {
         self.stats.holding.store(true, Ordering::Relaxed);
         self.hold_started.get_or_insert_with(Instant::now);
-    }
-
-    /// The decode figure reported to the host's ABR controller. NDL's `play` is
-    /// decode-AND-present in one opaque call, so `submit_us` (the whole AU's feed time) is
-    /// *submission* time alone — a decoder quietly falling behind buffers frames internally and the
-    /// feed stays fast, which left the controller's decode-rise signal (`abr::DECODE_RISE_US`,
-    /// built precisely for "the decoder saturates before the link does") effectively
-    /// blind on this client. The render-buffer backlog IS that standing decode queue, so
-    /// it's folded in as queue-above-cushion × the drain interval (see [`decode_report_us`]).
-    /// Polled on a cadence rather than every frame — three samples per 750 ms ABR report window is
-    /// plenty, and assuming an NDL query is cheap enough for per-frame use is exactly the mistake
-    /// docs/NOTES.md warns against; between polls the cached depth is reused.
-    fn decode_us(&self, submit_us: u32, backlog: u64) -> u32 {
-        decode_report_us(submit_us, backlog, self.cushion_frames, self.frame_interval_ns)
+        self.recovery_marks = 0;
     }
 
     /// NDL's render-queue depth, refreshed on [`BACKLOG_POLL`]'s cadence and cached between polls.
     /// `None` is a failed query, not an empty queue.
     ///
-    /// Called unconditionally, because it has TWO consumers: the ABR decode figure
-    /// ([`Self::decode_us`]) and the A/V sync loop's video reference ([`video_e2e_ns`]). Polling it
-    /// only when the host asks for decode latency pins the depth at `0` against hosts that never
-    /// do, silently zeroing the queue term in the video reference.
+    /// Called unconditionally for diagnostics and the A/V video reference ([`video_e2e_ns`]).
+    /// It must not depend on whether the host asks for decode latency.
     fn poll_backlog(&mut self) -> Option<u64> {
         // A backend with no queue to read has no depth, and asking costs an FFI call per poll for
         // an answer that is always `None`.
@@ -273,18 +251,6 @@ impl VideoStage {
         if self.last_backlog_poll.is_none_or(|t| t.elapsed() >= BACKLOG_POLL) {
             self.last_backlog_poll = Some(Instant::now());
             self.backlog_cached = self.sink.queue_depth().map(u64::from);
-            // A freeze stops the pipeline, so a depth polled while held is not this mode's
-            // settled lead. Learning from it would clamp the cushion back to the floor for
-            // [`CUSHION_MIN_POLLS`] after every loss event — and at 60Hz one unaccounted frame is
-            // 16.6ms, straight back over the ABR's decode-rise threshold. The cached depth itself
-            // still updates: A/V sync wants the truth, only the learned cushion is held steady.
-            if let Some(depth) = self.backlog_cached.filter(|_| !self.holding()) {
-                if self.backlog_recent.len() == CUSHION_MIN_POLLS {
-                    self.backlog_recent.pop_front();
-                }
-                self.backlog_recent.push_back(depth);
-                self.cushion_frames = cushion_frames(self.backlog_recent.iter().copied());
-            }
         }
         self.backlog_cached
     }
@@ -332,15 +298,12 @@ impl VideoStage {
 
     /// Decoder backlog depth for the heartbeat/overlay, or `None` if NDL can't report one.
     ///
-    /// Polls ([`Self::poll_backlog`]) rather than querying NDL directly, so the depth the log prints
-    /// is the one the decode figure was computed from — a second, unsynchronized reading can
-    /// disagree with it — and every `NDL_DirectVideoGetRenderBufferLength` stays on one cadence.
+    /// Polls ([`Self::poll_backlog`]) rather than querying NDL directly so diagnostics and A/V sync
+    /// share one reading and every `NDL_DirectVideoGetRenderBufferLength` stays on one cadence.
     pub fn poll_backlog_depth(&mut self) -> Option<i32> {
         self.poll_backlog().map(|d| i32::try_from(d).unwrap_or(i32::MAX))
     }
 
-    /// Present one access unit, or decide not to. `pts_ns` is the host's capture-clock
-    /// PTS; the sink maps and paces it into the decoder's own clock domain.
     /// Present one delivery, or decide not to. The stage owns everything past the wire: how the
     /// pieces of an access unit fit together, whether the timeline holds, and what the decoder's
     /// clock domain calls this frame.
@@ -365,6 +328,7 @@ impl VideoStage {
         }
         let flags = FrameFlags {
             reanchor: frame.reanchor,
+            recovery_mark: frame.recovery_mark,
             loss: frame.loss || lost_parts,
             index: u64::from(frame.index),
             partial,
@@ -386,7 +350,7 @@ impl VideoStage {
 
     fn feed(&mut self, au: &[u8], pts_ns: u64, flags: FrameFlags) -> SinkResult {
         // Checked before the gate, not inside it: a dead decoder also fails every `flush` the hold
-        // path takes, so the hold would spend `HOLD_GIVE_UP` re-deciding this per frame.
+        // path takes, so the hold would keep re-deciding this per frame.
         if self.sink.is_dead() {
             return SinkResult::Dead;
         }
@@ -424,8 +388,7 @@ impl VideoStage {
             );
         }
 
-        // A failed query counts as no queue for both consumers below: neither the ABR figure nor the
-        // A/V reference has a better guess, and both already treat 0 as "nothing to add".
+        // A failed query counts as no queue for the A/V estimate; there is no better guess.
         let backlog = self.poll_backlog().unwrap_or(0);
         let (decode_us, failed_keyframe) = match play_result {
             Ok(()) if flags.partial => (None, false),
@@ -433,10 +396,11 @@ impl VideoStage {
                 // Only a frame NDL actually accepted is on its way to the glass. A failed feed is
                 // followed by a flush and a hold, where the reference would be meaningless.
                 self.publish_video_e2e(submit_realtime_ns, pts_ns, backlog);
-                let decode_us = self
-                    .cfg
-                    .report_decode_latency
-                    .then(|| self.decode_us(au_feed_us, backlog));
+                // NDL exposes no decoded-output callback. Its render-buffer depth is presentation
+                // lead, not decoder latency, and feeding it into ABR created false learned caps at
+                // 4K120. `play` duration is the only measured decoder-pressure signal available:
+                // when input backpressures, it rises naturally.
+                let decode_us = self.cfg.report_decode_latency.then_some(au_feed_us);
                 (decode_us, false)
             }
             Err(e) => (None, self.on_play_error(&e, &flags, base_ns)),
@@ -449,12 +413,14 @@ impl VideoStage {
         }
     }
 
-    /// The freeze-until-reanchor gate, run before every feed: opens a hold on fresh loss, keeps
-    /// frames out while one is up, and releases it on a re-anchor or [`HOLD_GIVE_UP`].
+    /// The freeze-until-reanchor gate, run before every feed.
     fn gate(&mut self, flags: &FrameFlags) -> HoldGate {
-        if flags.loss && !self.holding() {
+        if flags.loss {
+            let newly_holding = !self.holding();
             self.begin_hold();
-            tracing::warn!("loss (frame {}) — freezing", flags.index);
+            if newly_holding {
+                tracing::warn!("loss (frame {}) — freezing", flags.index);
+            }
             // NO FLUSH on the loss hold — this is the last structural difference from `ss4s`, which
             // never flushes mid-stream (its only recovery is unload+load) and does not lose its
             // Opus plane. Every flush here stops the pipeline: each one is followed by NDL
@@ -472,9 +438,12 @@ impl VideoStage {
                 request_keyframe: false,
             };
         };
+        if flags.recovery_mark {
+            self.recovery_marks = self.recovery_marks.saturating_add(1);
+        }
         let request_keyframe = self.take_keyframe_slot();
-        let gave_up = started.elapsed() >= HOLD_GIVE_UP;
-        if !flags.reanchor && !gave_up {
+        let recovered = flags.reanchor || self.recovery_marks >= punktfunk_core::reanchor::REANCHOR_MARKS_TO_LIFT;
+        if !recovered {
             return HoldGate::Skip(if request_keyframe {
                 SinkResult::NeedKeyframe
             } else {
@@ -482,16 +451,18 @@ impl VideoStage {
             });
         }
         tracing::info!(
-            "resuming after {:.0}ms (frame {}, reanchor={}, gave_up={gave_up})",
+            "resuming after {:.0}ms (frame {}, reanchor={}, recovery_marks={})",
             started.elapsed().as_secs_f32() * 1000.0,
             flags.index,
             flags.reanchor,
+            self.recovery_marks,
         );
-        // The real timeline just jumped (freeze then reanchor/give-up) — nothing about
+        // The real timeline just jumped (freeze then reanchor) — nothing about
         // the pre-hold accumulator is worth continuing.
         self.reset_timeline();
         self.stats.holding.store(false, Ordering::Relaxed);
         self.hold_started = None;
+        self.recovery_marks = 0;
         HoldGate::Feed { request_keyframe }
     }
 
@@ -516,9 +487,8 @@ impl VideoStage {
         // No hold: freeze-until-reanchor is mid-stream recovery, and at frame 0 there is no
         // last-good picture to freeze on. Worse, holding short-circuits `submit` before `play`,
         // the only caller of the feed-anyway escape, so the hold outlives its own cause — release
-        // then needs the host's reanchor or `HOLD_GIVE_UP`, both evaluated only when a frame
-        // arrives, and a static desktop sends none. Request a keyframe and let the next frame
-        // retry.
+        // then needs the host's reanchor, evaluated only when a frame arrives, and a static desktop
+        // sends none. Request a keyframe and let the next frame retry.
         if e.downcast_ref::<NotReady>().is_none() {
             if self.caps.flush {
                 let _ = self.sink.flush();


### PR DESCRIPTION
## Summary
- update punktfunk-core from v0.31.3 to v0.32.0 and adopt wire-budget terminology
- report measured NDL feed backpressure without treating presentation queue lead as decoder latency
- align frame-gap and recovery-point handling with current core semantics
- raise the startup capacity probe to 320 Mbps while retaining the 200 Mbps client ceiling

## Investigation
The observed 23-25 Mbps cap is the punktfunk-host v0.32.0 phantom-ceiling regression: a 1 kbps budget round-trip truncation is learned as an encoder ceiling. It is fixed upstream after the v0.32.0 tag by punktfunk commit 224ed86f. This PR does not add a speculative client workaround.

## Validation
- cargo test
- cargo clippy --all-targets (passes with one existing nonminimal_bool warning in src/services/store/mod.rs)
- git diff --check