### PR TITLE
Document host power, clarify webOS 4 fallback limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ video decode, and webOS packaging.
 - **DualSense** — adaptive triggers, lightbar, player LEDs, touchpad, gyro and rumble over
   Bluetooth (see the note below).
 - **Hosts** — LAN discovery (mDNS) or add a host by IP; PIN pairing with persisted trust, per-host settings.
+- **Host power** — Wake-on-LAN starts a sleeping host from the TV, and a paired host can be put to
+  sleep or shut down on exit when it grants those rights.
 - **Game mode (rooted TVs)** — optional setting that switches picture and sound to Game mode while
   streaming and restores the previous settings on exit.
 

--- a/packaging/description.html
+++ b/packaging/description.html
@@ -24,12 +24,15 @@
     <li style="margin-bottom: 6px;"><b>DualSense.</b> Adaptive triggers, lightbar, player LEDs, touchpad, gyro
       and rumble over Bluetooth. Older webOS kernels predate the PlayStation driver, so some features are
       unavailable there.</li>
+    <li style="margin-bottom: 6px;"><b>Host power.</b> Wake-on-LAN starts a sleeping host from the TV, and a
+      paired host can be put to sleep or shut down on exit when it grants those rights.</li>
     <li style="margin-bottom: 6px;"><b>Game mode (rooted TVs).</b> Optional setting that switches picture and
       sound to Game mode while streaming and restores the previous settings on exit.</li>
   </ul>
 
   <p style="margin: 0 0 12px;">
-    Requires webOS 5 or later. A fallback decode path covers webOS 3.5&ndash;4.x.
+    Best on webOS 5 or later. webOS 3.5&ndash;4.x is supported through a fallback decode path, with
+    limits: <b>no HDR</b> (SDR only), H.264 only (no HEVC) and stereo audio only.
   </p>
 
   <p style="margin: 0 0 12px;">


### PR DESCRIPTION
## Summary
- Add a Host power bullet to README and packaging/description.html (WoL, sleep/shutdown on exit, gated by host-granted rights)
- Rewrite the packaging compatibility paragraph: webOS 5+ is best, webOS 3.5-4.x fallback is SDR-only, H.264-only, stereo-only

## Test plan
- Docs only, no build required