### PR TITLE
Close wake modal on send, defer loading status, unify probe budgets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,8 @@ jobs:
         with:
           name: io.dyptan.punktfunk.webos
           path: dist/*.ipk
-          retention-days: ${{ github.event_name == 'release' && 90 || 7 }}
+          # Job hand-off only; release runs get the durable copy attached to the release.
+          retention-days: 7
 
   webosbrew:
     needs: package

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -53,6 +53,10 @@ pub(crate) const SCROLL_INDICATOR_LIFETIME: Duration =
 /// ambient (a load result, a wake report, a launch error) and none of them stay true
 /// forever, so the grid gets its bottom edge back instead of keeping stale text.
 pub(crate) const HOME_STATUS_LIFETIME: Duration = Duration::from_secs(15);
+
+/// How long a library fetch may run before its progress line is worth putting up — avoids
+/// flashing "Loading library…" for one frame on a fast fetch.
+pub(crate) const LIBRARY_STATUS_DELAY: Duration = Duration::from_secs(1);
 /// Wider than track for rounded caps not to clip.
 const SCROLL_INDICATOR_TILE_W: u32 = 10;
 
@@ -126,6 +130,9 @@ pub struct App {
     /// When the current status line went up, so `tick_animations` can expire it after
     /// `HOME_STATUS_LIFETIME`. Stamped by `set_home_status`, which every writer goes through.
     home_status_shown_at: Option<Instant>,
+    /// A status line waiting out [`LIBRARY_STATUS_DELAY`], see
+    /// [`set_home_status_delayed`](Self::set_home_status_delayed).
+    library_status_due: Option<(Instant, String)>,
     pub(crate) launch_ready: Option<ConnectTarget>,
     pub(crate) launch_anim: Option<Instant>,
     pub(crate) launch_anim_idx: Option<usize>,
@@ -191,10 +198,21 @@ impl App {
         self.keyboard_shown = shown;
     }
 
+    /// A Home status line shown only if the fetch is still running [`LIBRARY_STATUS_DELAY`]
+    /// later (`tick_animations` puts it up).
+    pub(crate) fn set_home_status_delayed(&mut self, line: String) {
+        self.set_home_status(None, false);
+        self.library_status_due = Some((Instant::now(), line));
+    }
+
     /// The Home status line. `sticky` marks a line that must survive the library reload a
     /// fresh menu entry starts — that reload clears the status on success, which otherwise
     /// wiped a launch error a second after the user landed back on the grid.
+    ///
+    /// Also drops any line still waiting out [`LIBRARY_STATUS_DELAY`] so it can't land on top
+    /// of a newer one.
     pub(crate) fn set_home_status(&mut self, status: Option<String>, sticky: bool) {
+        self.library_status_due = None;
         self.home_status_shown_at = status.is_some().then(Instant::now);
         self.home_status = status;
         self.home_status_sticky = sticky;
@@ -255,6 +273,7 @@ impl App {
             home_status_sticky: false,
             toast: None,
             home_status_shown_at: None,
+            library_status_due: None,
             launch_ready: None,
             launch_anim: None,
             launch_anim_idx: None,
@@ -557,7 +576,7 @@ impl App {
         // have run for minutes with no modal up, the bar's job is to report that the
         // host came back, not just that a fetch started.
         if let Some(name) = name {
-            self.set_home_status(Some(format!("{name} is back online — loading its library…")), false);
+            self.set_home_status_delayed(format!("{name} is back online — loading its library…"));
         }
     }
 
@@ -701,6 +720,17 @@ impl App {
         // Only the expiring frame reports `animating` — the idle branch's `wait_for_event`
         // still times out at `TICK_BUDGET`, so this runs on schedule without holding the
         // SoC at 60Hz for the whole 15s.
+        if let Some((_, line)) = self
+            .library_status_due
+            .take_if(|(t, _)| t.elapsed() >= LIBRARY_STATUS_DELAY)
+        {
+            // A fetch that already landed needs no line — and must not overwrite whatever
+            // `drain_games` put up instead. Only a line that actually goes up is a redraw.
+            if self.library_fetch_in_flight() {
+                self.set_home_status(Some(line), false);
+                animating = true;
+            }
+        }
         if self
             .home_status_shown_at
             .is_some_and(|t| t.elapsed() >= HOME_STATUS_LIFETIME)

--- a/src/app/render/key.rs
+++ b/src/app/render/key.rs
@@ -110,7 +110,6 @@ pub enum ModalShellKey<'a> {
     Wake {
         name: &'a str,
         mac_empty: bool,
-        sent: bool,
     },
     Pairing {
         digits: [u8; 4],

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -219,7 +219,6 @@ impl App {
             Screen::Wake => self.screens.wake.as_ref().map(|w| ModalShellKey::Wake {
                 name: &w.name,
                 mac_empty: w.mac.is_empty(),
-                sent: w.sent,
             }),
             Screen::Pairing => Some(ModalShellKey::Pairing {
                 digits: self.screens.pin_digits,

--- a/src/app/render/prepare_grid.rs
+++ b/src/app/render/prepare_grid.rs
@@ -513,11 +513,10 @@ impl App {
                     })
                 })
             };
-            let next_frame = self
-                .render
-                .grid
-                .reveal
-                .advance(self.library_fetch_in_flight(), window_ready);
+            let next_frame = self.render.grid.reveal.advance(
+                self.library_fetch_in_flight() || self.wake_wait_in_flight(),
+                window_ready,
+            );
             match next_frame {
                 Some(idx) => updated.push(tile::spinner(idx)),
                 // Everything built behind the spinner becomes visible in this one frame, so

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -421,8 +421,9 @@ impl App {
             .map_or_else(|| host.clone(), |h| h.name.clone());
         // Picking a host is the user's own action, so its progress replaces whatever the last
         // launch left on screen. The reload `App::new` starts is not this — it runs before
-        // `home_status_sticky` is ever set.
-        self.set_home_status(Some(format!("Loading library from {name}…")), false);
+        // `home_status_sticky` is ever set. The line waits out `LIBRARY_STATUS_DELAY` (`tick_animations`
+        // puts it up); the grid's spinner already says "working" in the meantime.
+        self.set_home_status_delayed(format!("Loading library from {name}…"));
         self.library.clear();
         // Dropping the loader stops its worker (its request channel closes), so a host
         // switch abandons in-flight fetches for the previous library.
@@ -446,6 +447,7 @@ impl App {
             mgmt_port,
             identity,
             fingerprint,
+            crate::services::budget::REQUEST,
         ));
     }
 
@@ -454,6 +456,13 @@ impl App {
     /// loading spinner running forever behind the Wake dialog.
     pub(crate) fn library_fetch_in_flight(&self) -> bool {
         self.jobs.games.is_some()
+    }
+
+    /// Whether a sent wake is being waited on with no modal up — the user pressed "Wake host"
+    /// (or `wol_auto` sent silently), so the grid keeps its spinner turning until the host
+    /// answers or `tick_wake` re-pops the dialog.
+    pub(crate) fn wake_wait_in_flight(&self) -> bool {
+        self.nav.screen != crate::app::Screen::Wake && self.screens.wake.as_ref().is_some_and(|w| w.sent && w.silent)
     }
 
     /// Drains `select_host`'s library fetch; switching hosts aborts old fetches safely.

--- a/src/app/state/wake.rs
+++ b/src/app/state/wake.rs
@@ -153,11 +153,18 @@ impl App {
         let mgmt_port = known
             .and_then(|h| h.mgmt_port)
             .unwrap_or(crate::services::library::DEFAULT_MGMT_PORT);
-        crate::services::library::load_games_async(host.to_string(), port, mgmt_port, identity.clone(), fingerprint)
+        crate::services::library::load_games_async(
+            host.to_string(),
+            port,
+            mgmt_port,
+            identity.clone(),
+            fingerprint,
+            crate::services::budget::PROBE,
+        )
     }
 
     /// Handles Wake modal events: direction moves between "Wake"/"Cancel" buttons.
-    /// Confirm sends or cancels. Back dismisses the modal (keeps wake running in bg).
+    /// Confirm sends and closes the modal, or cancels. Back dismisses it (wake runs on in bg).
     pub fn handle_wake_event(&mut self, ev: MenuEvent) {
         let Some(wake) = self.screens.wake.as_mut() else { return };
         // WHY: no MAC = no send/automate possible. Every event but Back is no-op.
@@ -165,7 +172,7 @@ impl App {
             return;
         }
         if ev == MenuEvent::Back {
-            self.dismiss_wake();
+            self.close_wake(false);
             return;
         }
         match ev {
@@ -173,22 +180,31 @@ impl App {
                 wake.focused = usize::from(wake.focused == 0);
                 self.render.modal.focus_anim = Some(Instant::now());
             }
-            MenuEvent::Confirm if wake.focused == 0 => Self::send_wake(wake),
-            MenuEvent::Confirm => {
-                self.dismiss_wake();
+            MenuEvent::Confirm if wake.focused == 0 => {
+                Self::send_wake(wake);
+                // Hand the wait to the grid's spinner; `tick_wake` re-pops the modal if the
+                // host is still down after `WAKE_RETRY_INTERVAL`. A packet that never went
+                // out keeps the modal up, since it carries the error text.
+                if wake.sent {
+                    self.close_wake(true);
+                    self.render.grid.reveal.restart();
+                }
             }
+            MenuEvent::Confirm => self.close_wake(false),
             MenuEvent::Back | MenuEvent::Secondary => {}
         }
     }
 
     /// Closes Wake modal. Sent wakes keep running in background (timers bring host back).
     /// Unsent wakes drop entirely, leaving error text behind.
-    fn dismiss_wake(&mut self) {
+    ///
+    /// `keep_waiting` sets `silent` so `tick_wake` may re-pop the prompt (pressing "Wake host"),
+    /// vs clearing it so it never comes back on its own (dismissing).
+    fn close_wake(&mut self, keep_waiting: bool) {
         self.nav.screen = Screen::Home;
         let status = match self.screens.wake.as_mut() {
             Some(wake) if wake.sent => {
-                // WHY: set silent=false so tick_wake won't re-pop the prompt after user dismisses.
-                wake.silent = false;
+                wake.silent = keep_waiting;
                 Some(Self::wake_home_status(wake))
             }
             _ => self.screens.wake.take().map(|w| w.reason),

--- a/src/app/view/wake.rs
+++ b/src/app/view/wake.rs
@@ -26,12 +26,11 @@ pub(crate) fn card_rect(screen_w: u32, screen_h: u32, wake: &WakeState, fonts: &
     }
 }
 
-/// Title varies: with a MAC it's an action ("Wake this host?"), without it it's state.
+/// Title varies: with a MAC it's an action ("Wake this host?"), without it it's state. The
+/// prompt never turns into a progress line — pressing Wake closes the modal instead.
 pub(crate) fn title(wake: &WakeState) -> &'static str {
     if wake.mac.is_empty() {
         "Host unreachable"
-    } else if wake.sent {
-        "Waking host…"
     } else {
         "Wake this host?"
     }
@@ -45,8 +44,6 @@ pub(crate) fn status_text(wake: &WakeState) -> String {
              can't be woken from here. It will reconnect automatically once it's back online.",
             wake.name
         )
-    } else if wake.sent {
-        format!("Wake signal sent to {}. Waiting for it to come back online…", wake.name)
     } else {
         format!("{} isn't responding. It may be powered off or asleep.", wake.name)
     }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -107,7 +107,7 @@ fn spawn_connect(
                 launch,
                 // A pinned host is reachable now or off, so a long budget would only hold the
                 // black launch scrim. Waiting on an operator is the pairing flow's job.
-                timeout: crate::services::budget::HANDSHAKE,
+                timeout: crate::services::budget::PROBE,
                 codec: settings.codec,
                 gamepad_type: settings.gamepad_type,
                 cursor_capture: settings.cursor_capture,

--- a/src/services/budget.rs
+++ b/src/services/budget.rs
@@ -2,21 +2,16 @@
 //! two different things depending on which screen is in front of it.
 use std::time::Duration;
 
-/// One handshake attempt against a host we already trust: it is either reachable now or it is off,
-/// and a long wait on a black launch scrim buys nothing. Also the per-request TCP connect budget.
-pub const HANDSHAKE: Duration = Duration::from_secs(5);
+/// One reach attempt against a host — a handshake, the reachability dot, the wake flow's
+/// "is it back yet?" probe — all asking "is it up *now*". On a LAN an up host answers well
+/// inside this; an off one fails fast. Also the per-request TCP connect budget.
+pub const PROBE: Duration = Duration::from_secs(3);
 
 /// A host that answered but isn't ready to stream yet: an unpinned connection waiting on the
 /// host's operator to approve this client, and a PIN handshake waiting on someone to walk to
 /// their PC. A shorter budget sent the user
 /// back to the menu with "couldn't connect" against a host that was merely still starting.
 pub const HOST_WAIT: Duration = Duration::from_secs(185);
-
-/// The ambient reachability dot's per-host budget. Short on purpose: an
-/// unreachable host on a LAN fails fast (no route / refused), and one slow enough to miss this is
-/// not meaningfully "available". Not [`HANDSHAKE`] — nobody is waiting on this answer, so it is
-/// allowed to be wrong about a sluggish host rather than hold the sweep open.
-pub const PROBE: Duration = Duration::from_secs(2);
 
 /// The exit action's whole budget — connect, mTLS handshake and POST together.
 ///
@@ -29,9 +24,9 @@ pub const EXIT_ACTION: Duration = Duration::from_millis(200);
 /// One host request that should already have an answer: a library listing, a `/launch`, a
 /// `/serverinfo`. Not a wait for the host to become ready — that is [`HOST_WAIT`], spent by re-trying
 /// requests with this budget rather than by stretching one of them.
-pub const REQUEST: Duration = Duration::from_secs(10);
+pub const REQUEST: Duration = PROBE.saturating_mul(3);
 
-/// Connect budget for the speed test's throwaway session. Longer than [`HANDSHAKE`] because the
+/// Connect budget for the speed test's throwaway session. Longer than [`PROBE`] because the
 /// host brings up a real encode session for it, and the user opened this screen expecting to wait —
 /// but not [`HOST_WAIT`]: a host that needs minutes here has already answered the question.
 pub const SPEED_TEST: Duration = Duration::from_secs(20);

--- a/src/services/library.rs
+++ b/src/services/library.rs
@@ -90,23 +90,25 @@ pub fn agent_within(
     let config = ureq::Agent::config_builder()
         // Connect is capped by the whole budget too: a 5 s connect inside a 200 ms request is
         // just a slower way to hit the same wall.
-        .timeout_connect(Some(budget.min(crate::services::budget::HANDSHAKE)))
+        .timeout_connect(Some(budget.min(crate::services::budget::PROBE)))
         .timeout_global(Some(budget))
         .build();
     Ok(ureq::Agent::with_parts(config, connector, DefaultResolver::default()))
 }
 
-/// One JSON GET on the management lane, errors pre-classified for the UI (401/403→NotPaired,
-/// a pin mismatch→PinMismatch, everything else by status). Every mgmt read goes through here,
-/// so the classification and the "couldn't read/parse" wording are stated once.
+/// One JSON GET on the management lane under an explicit whole-request `budget`, errors
+/// pre-classified for the UI (401/403→NotPaired, a pin mismatch→PinMismatch, everything else
+/// by status). Every mgmt read goes through here, so the classification and the "couldn't
+/// read/parse" wording are stated once.
 pub(crate) fn get_json<T: serde::de::DeserializeOwned>(
     addr: &str,
     mgmt_port: u16,
     identity: &(String, String),
     pin: Option<[u8; 32]>,
     path: &str,
+    budget: std::time::Duration,
 ) -> Result<T, LibraryError> {
-    let agent = agent(identity, pin)?;
+    let agent = agent_within(identity, pin, budget)?;
     let url = format!("{}{path}", base_url(addr, mgmt_port));
     let body = match agent.get(url.as_str()).call() {
         Ok(mut resp) => resp
@@ -124,8 +126,9 @@ pub(crate) fn fetch_games(
     mgmt_port: u16,
     identity: &(String, String),
     pin: Option<[u8; 32]>,
+    budget: std::time::Duration,
 ) -> Result<Vec<GameEntry>, LibraryError> {
-    get_json(addr, mgmt_port, identity, pin, "/api/v1/library")
+    get_json(addr, mgmt_port, identity, pin, "/api/v1/library", budget)
 }
 
 /// One `fetch_games` result with `host/port/mgmt_port` (so `drain_games` can start art loading).
@@ -136,20 +139,21 @@ pub struct GamesLoaded {
     pub result: Result<Vec<GameEntry>, LibraryError>,
 }
 
-/// Spawns background thread to run `fetch_games` (avoids UI freeze from network blocking).
-/// Safe to switch hosts before finish: receiver drop causes thread's send to fail.
+/// Spawns background thread to run `fetch_games` under `budget` (avoids UI freeze from network
+/// blocking). Safe to switch hosts before finish: receiver drop causes thread's send to fail.
 pub fn load_games_async(
     host: String,
     port: u16,
     mgmt_port: u16,
     identity: (String, String),
     fingerprint: Option<[u8; 32]>,
+    budget: std::time::Duration,
 ) -> std::sync::mpsc::Receiver<GamesLoaded> {
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::Builder::new()
         .name("punktfunk-webos-library".into())
         .spawn(move || {
-            let result = fetch_games(&host, mgmt_port, &identity, fingerprint);
+            let result = fetch_games(&host, mgmt_port, &identity, fingerprint, budget);
             let _ = tx.send(GamesLoaded {
                 host,
                 port,

--- a/src/services/power.rs
+++ b/src/services/power.rs
@@ -94,7 +94,15 @@ fn fetch_actions(
     identity: &(String, String),
     pin: Option<[u8; 32]>,
 ) -> Result<Vec<ActionInfo>, LibraryError> {
-    get_json::<ActionList>(addr, mgmt_port, identity, pin, "/api/v1/actions").map(|l| l.actions)
+    get_json::<ActionList>(
+        addr,
+        mgmt_port,
+        identity,
+        pin,
+        "/api/v1/actions",
+        crate::services::budget::REQUEST,
+    )
+    .map(|l| l.actions)
 }
 
 /// Invokes one action by id, blocking. `Ok(())` means the host accepted it (202) — not that it


### PR DESCRIPTION
## Summary
- Pressing "Wake host" now sends the packet and closes the modal, handing the wait to the grid's existing loading spinner instead of leaving the modal open with swapped text; `tick_wake` still re-pops it if the host is still down after `WAKE_RETRY_INTERVAL`.
- `App::set_home_status_delayed` defers the "Loading library..." status line by `LIBRARY_STATUS_DELAY` (1s) so it no longer flashes on every host click or wake success.
- `budget::HANDSHAKE` and `budget::PROBE` are merged into one `PROBE` (3s); `REQUEST` becomes `PROBE * 3` (9s). `get_json`/`load_games_async` now take the budget as a required parameter.
- Includes a small pre-existing `build.yml` tweak (comment + simplified artifact retention).

## Test plan
- [ ] `task docker:check` / `task docker:lint` (not run this branch — Docker unavailable locally; host `cargo check`/`cargo fmt` pass but cfg-gate out `app`/`platform`)
- [ ] Verify wake flow and delayed loading status on a real TV