### PR TITLE
Give Home status band and sidebar the glass material

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -47,9 +47,8 @@ pub(crate) const CARD_POP: Duration = Duration::from_millis(300);
 pub(crate) const CARD_POP_SHRINK: f32 = 0.14;
 pub(crate) const SCROLL_INDICATOR_HOLD: Duration = Duration::from_millis(700);
 pub(crate) const SCROLL_INDICATOR_FADE: Duration = Duration::from_millis(350);
-pub(crate) const SCROLL_INDICATOR_LIFETIME: Duration =
-    Duration::from_millis(SCROLL_INDICATOR_HOLD.as_millis() as u64 + SCROLL_INDICATOR_FADE.as_millis() as u64);
-/// How long a Home status line stays up before it clears itself. Every line here is
+/// How long a Home status line stays up at full opacity before it fades out. The fade
+/// itself is [`OVERLAY_FADE`], the same curve the toast notification leaves on. Every line here is
 /// ambient (a load result, a wake report, a launch error) and none of them stay true
 /// forever, so the grid gets its bottom edge back instead of keeping stale text.
 pub(crate) const HOME_STATUS_LIFETIME: Duration = Duration::from_secs(15);
@@ -216,6 +215,26 @@ impl App {
         self.home_status_shown_at = status.is_some().then(Instant::now);
         self.home_status = status;
         self.home_status_sticky = sticky;
+    }
+
+    /// The open modal's scroll indicator this frame, on the same hold-then-fade as every
+    /// other self-expiring overlay. `None` once it is spent.
+    pub(crate) fn scroll_indicator_alpha(&self) -> Option<f32> {
+        ui::fade::hold_alpha(
+            self.render.scroll.shown_at?,
+            SCROLL_INDICATOR_HOLD,
+            SCROLL_INDICATOR_FADE,
+        )
+    }
+
+    /// The status line's opacity this frame, or `None` once it is spent — the toast's clock
+    /// ([`ui::fade::hold_alpha`]), so the two transient lines leave the screen the same way.
+    pub(crate) fn home_status_alpha(&self) -> Option<f32> {
+        ui::fade::hold_alpha(
+            self.home_status_shown_at?,
+            HOME_STATUS_LIFETIME,
+            crate::ui::fade::OVERLAY_FADE,
+        )
     }
 
     /// Queues a transient toast. Replaces any still waiting — a second action before the loop
@@ -731,15 +750,15 @@ impl App {
                 animating = true;
             }
         }
-        if self
-            .home_status_shown_at
-            .is_some_and(|t| t.elapsed() >= HOME_STATUS_LIFETIME)
-        {
-            self.set_home_status(None, false);
+        // Every frame of the fade out is a redraw; the frame after it is the clear.
+        if self.home_status_shown_at.is_some_and(|t| t.elapsed() >= HOME_STATUS_LIFETIME) {
+            if self.home_status_alpha().is_none() {
+                self.set_home_status(None, false);
+            }
             animating = true;
         }
-        if let Some(t) = self.render.scroll.shown_at {
-            if t.elapsed() >= SCROLL_INDICATOR_LIFETIME {
+        if self.render.scroll.shown_at.is_some() {
+            if self.scroll_indicator_alpha().is_none() {
                 self.render.scroll.shown_at = None;
             }
             animating = true;

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -11,7 +11,7 @@ use crate::app::render::SnapshotBody;
 use crate::app::screens;
 use crate::app::{
     hero, render_input, view, App, HomeFocus, Screen, CARD_GROWTH, CARD_POP, CARD_POP_SHRINK, LAUNCH_GROWTH,
-    SCROLL_INDICATOR_FADE, SCROLL_INDICATOR_HOLD, SCROLL_INDICATOR_TILE_W, STATUS_BG_PAD,
+    SCROLL_INDICATOR_TILE_W, STATUS_BG_PAD,
 };
 use crate::ui;
 use crate::ui::cache::TileStore;
@@ -39,7 +39,7 @@ impl App {
             home_focus: self.home_focus,
             entries: &self.hosts.entries,
             host_selected: self.library.selected_host.is_some(),
-            has_status: self.home_status.is_some(),
+            status_alpha: self.home_status_alpha(),
             grid_reveal_ready: self.render.grid.reveal.is_revealed(),
             press: self.press_dip(Screen::Home),
         }
@@ -111,19 +111,20 @@ impl App {
         // before a frost pane.
         if !matches!(screen, Screen::Home) {
             let region = self.render.modal.tile_region.offset(0, ui::animation::modal_rise(m));
-            self.push_frost(cmds, region, (255.0 * m) as u8);
+            Self::push_frost(cmds, region, ui::widgets::MODAL_RADIUS, (255.0 * m) as u8);
         }
         if let Some((alpha, prev)) = closing {
-            self.push_frost(
+            Self::push_frost(
                 cmds,
                 prev.region.offset(0, ui::animation::modal_rise(alpha)),
+                ui::widgets::MODAL_RADIUS,
                 (255.0 * alpha) as u8,
             );
         }
         if scrim > 0.0 {
             cmds.push(DrawCmd::Fill {
                 rect: Rect::new(0, 0, screen_w, screen_h),
-                color: crate::ui::render::Color::RGBA(0, 0, 0, (f32::from(ui::theme::palette().scrim.a) * scrim) as u8),
+                color: ui::theme::palette().scrim.with_alpha_scaled(scrim),
             });
         }
         if !matches!(screen, Screen::Home) {
@@ -170,7 +171,7 @@ impl App {
     /// Menu only. The in-stream dialogs never reach here (`main.rs` composes those), which is
     /// what keeps the frost off a frame whose video lives on a hardware plane the blur cannot
     /// see anyway.
-    fn push_frost(&self, cmds: &mut Vec<DrawCmd>, tile_region: Rect, alpha: u8) {
+    fn push_frost(cmds: &mut Vec<DrawCmd>, tile_region: Rect, radius: i32, alpha: u8) {
         if alpha == 0 {
             return;
         }
@@ -180,13 +181,48 @@ impl App {
         cmds.push(DrawCmd::Frost(Box::new(ui::render::FrostPane::whole(
             tile_region,
             ui::render::FrostMask {
-                radius: ui::widgets::MODAL_RADIUS,
+                radius,
                 corners: ui::render::Corners::All,
             },
             glass.blur,
             alpha,
             Some(ui::theme::palette().panel),
         ))));
+    }
+
+    /// A whole glass surface where nothing bakes its tint into a tile: the modal's pane, its
+    /// scrim and its `glass_fill` in one call, so a surface that claims to be the same
+    /// material as a modal card is made of the same three things rather than of a comment
+    /// saying so.
+    ///
+    /// The two fills are constants, so they flatten to the one the fade then scales.
+    fn push_glass_surface(cmds: &mut Vec<DrawCmd>, rect: Rect, radius: i32, alpha: f32) {
+        Self::push_frost(cmds, rect, radius, (255.0 * alpha) as u8);
+        cmds.push(DrawCmd::Fill {
+            rect,
+            color: ui::theme::glass_fill()
+                .over(ui::theme::palette().scrim)
+                .with_alpha_scaled(alpha),
+        });
+    }
+
+    /// The nav column: its frosted pane and the translucent strip over it.
+    ///
+    /// Composed *after* the grid, not before it as an opaque strip was. A pane fixes the
+    /// frame's blur source at the point it appears, so a sidebar pane pushed first would
+    /// hand the focused card's strip, the status band and the modal a backdrop holding
+    /// nothing but the clear. The column and the grid never overlap, so the order between
+    /// them is free — what it costs is the strip's own pixels in a modal's blur, which the
+    /// modal covers with a scrim anyway.
+    fn compose_sidebar(cmds: &mut Vec<DrawCmd>, screen_h: u32) {
+        let strip = Rect::new(0, 0, ui::widgets::SIDEBAR_W, screen_h);
+        // Square: three of the column's edges are the display's own.
+        Self::push_frost(cmds, strip, 0, 0xff);
+        cmds.push(DrawCmd::Tex {
+            tile: tile::SIDEBAR,
+            dst: strip,
+            alpha: 0xff,
+        });
     }
 
     /// A panel's drop shadow, as nine stretched draws from one small atlas
@@ -365,22 +401,12 @@ impl App {
                 alpha: dd_alpha,
             });
         }
-        // Whichever modal is scrollable, its indicator — full opacity for
-        // `SCROLL_INDICATOR_HOLD`, then a linear fade over `SCROLL_INDICATOR_FADE`
-        // (names kept from when only Settings had one; every scrollable modal now
-        // shares the same timing and the same `self.render.scroll.shown_at` clock, since
-        // only one is ever open at a time).
+        // Whichever modal is scrollable, its indicator (names kept from when only Settings
+        // had one; every scrollable modal now shares the same timing and the same
+        // `self.render.scroll.shown_at` clock, since only one is ever open at a time).
         if let Some((total, visible, card, content)) = scroll_geom {
             if total > visible {
-                let scroll_alpha = self.render.scroll.shown_at.map_or(0.0, |t| {
-                    let elapsed = t.elapsed();
-                    if elapsed < SCROLL_INDICATOR_HOLD {
-                        1.0
-                    } else {
-                        let fading = (elapsed - SCROLL_INDICATOR_HOLD).as_secs_f32();
-                        1.0 - (fading / SCROLL_INDICATOR_FADE.as_secs_f32()).clamp(0.0, 1.0)
-                    }
-                });
+                let scroll_alpha = self.scroll_indicator_alpha().unwrap_or(0.0);
                 if scroll_alpha > 0.0 {
                     // Sits nearer the card's edge than the content's, so it doesn't
                     // overlap a Settings row's dropdown pill/slider/switch. The `26`
@@ -870,12 +896,6 @@ impl App {
         // sidebar, the grid and the status block are graphics that would cover the very thing
         // the user is looking at (see `screens::over_video`).
         if !screens::over_video(self.nav.screen) {
-            cmds.push(DrawCmd::Tex {
-                tile: tile::SIDEBAR,
-                dst: Rect::new(0, 0, ui::widgets::SIDEBAR_W, screen_h),
-                alpha: 0xff,
-            });
-
             if !input.host_selected {
                 if let Some(p) = tiles.get(tile::NO_HOST) {
                     cmds.push(DrawCmd::Tex {
@@ -904,24 +924,26 @@ impl App {
             } else {
                 self.compose_grid(tiles, ui::render::Size::new(screen_w, screen_h), &mut cmds);
             }
-            if input.has_status {
+            if let Some(alpha) = input.status_alpha {
                 if let Some(p) = tiles.get(tile::STATUS) {
                     let line_h = fonts.raster.height(fonts.label) + 6;
                     let box_h = 2 * line_h as u32 + 2 * STATUS_BG_PAD as u32;
                     let box_y = screen_h as i32 - box_h as i32;
-                    cmds.push(DrawCmd::Fill {
-                        rect: Rect::new(grid_x, box_y, available_w, box_h),
-                        color: ui::theme::palette().scrim,
-                    });
+                    let a = (255.0 * alpha) as u8;
+                    let block = Rect::new(grid_x, box_y, available_w, box_h);
+                    // Square-cornered: the band is a full-width cut across the bottom edge,
+                    // not a card.
+                    Self::push_glass_surface(&mut cmds, block, 0, alpha);
                     let y = box_y + (box_h as i32 - p.height() as i32) / 2;
                     cmds.push(DrawCmd::Tex {
                         tile: tile::STATUS,
                         dst: Rect::new(grid_x + view::home::GRID_PAD, y, p.width(), p.height()),
-                        alpha: 0xff,
+                        alpha: a,
                     });
                 }
             }
 
+            Self::compose_sidebar(&mut cmds, screen_h);
             Self::compose_sidebar_focus(&input, screen_h, &mut cmds);
         }
 

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -41,7 +41,8 @@ impl App {
         // Kept on the `sidebar_dirty` flag rather than a content version: the strip is
         // built from every entry plus its reachability, and hashing all of that once a
         // frame would cost more than the flag the event side already maintains.
-        if self.render.sidebar_dirty || !tiles.contains(tile::SIDEBAR) {
+        let styled_at = ui::theme::epoch();
+        if self.render.sidebar_dirty || self.render.sidebar_styled_at != styled_at || !tiles.contains(tile::SIDEBAR) {
             let selected = self.sidebar_index_of_selected_host();
             let entries = &self.hosts.entries;
             let reach = self.reachability_list();
@@ -73,6 +74,7 @@ impl App {
                 },
             )?;
             self.render.sidebar_dirty = false;
+            self.render.sidebar_styled_at = styled_at;
             tiles.remove(tile::FOCUS_ROW); // row content may have changed under it
             updated.push(tile::SIDEBAR);
         }

--- a/src/app/render/state.rs
+++ b/src/app/render/state.rs
@@ -33,6 +33,10 @@ pub(crate) struct RenderState {
     pub(crate) hover_close: bool,
     pub(crate) sidebar_gen: u64,
     pub(crate) sidebar_dirty: bool,
+    /// The theme epoch the sidebar strip was baked in. Its own field because the strip is
+    /// versioned by `sidebar_gen` rather than by `cache::version`, so the epoch that stales
+    /// every other tile passes it by — and its fill is one of the things a look changes.
+    pub(crate) sidebar_styled_at: u64,
     /// Tiles whose GPU texture this frame released — drained by the render loop, which does
     /// the actual `drop_tile`. Nothing to do with the style: a Theme pick stales tiles through
     /// `ui::theme::epoch` folded into every cache version, not through this list.
@@ -55,6 +59,7 @@ impl Default for RenderState {
             hover_close: false,
             sidebar_gen: 0,
             sidebar_dirty: true,
+            sidebar_styled_at: crate::ui::theme::epoch(),
             evicted_tiles: Vec::new(),
             modal: modal::ModalState::default(),
             // Hand-written, not derived: `GridState`'s own `Default` starts the tile-id counter

--- a/src/app/render_input.rs
+++ b/src/app/render_input.rs
@@ -15,8 +15,9 @@ pub struct RenderInput<'a> {
     pub entries: &'a [HostEntry],
     /// A host is selected (grid has content rather than the "no host" hint).
     pub host_selected: bool,
-    /// `home_status` is set (the bottom status block is drawn).
-    pub has_status: bool,
+    /// The bottom status block's opacity, or `None` where no line is up (see
+    /// `App::home_status_alpha`).
+    pub status_alpha: Option<f32>,
     /// The grid's cards are built and revealed (past the load spinner).
     pub grid_reveal_ready: bool,
     /// The focused row's press dip (see `App::press`) — the sidebar's rows are buttons.

--- a/src/app/view/sidebar.rs
+++ b/src/app/view/sidebar.rs
@@ -95,9 +95,14 @@ pub struct HostRowState {
     pub online: Option<bool>,
 }
 
-/// Draws sidebar: flat panel + logo + host rows + "Add host" + Settings (bottom-pinned).
+/// Draws sidebar: the panel + logo + host rows + "Add host" + Settings (bottom-pinned).
 /// `selected_index` highlights the active/connected host; `online` is index-aligned with
 /// `entries`.
+///
+/// The strip takes `glass_fill` and is left translucent: a glass look carries across the
+/// whole menu rather than stopping at the nav column, and the frosted pane the compose path
+/// pushes under it (`compose_sidebar`) is what the tint then sits on. No lit edge against
+/// the grid — a rule there reads as a seam.
 pub fn draw(
     c: &mut Canvas,
     entries: &[HostEntry],
@@ -108,7 +113,7 @@ pub fn draw(
     let screen_h = c.screen_h;
     c.painter.fill_rect(
         Rect::new(0, 0, ui::widgets::SIDEBAR_W, screen_h),
-        ui::theme::palette().panel,
+        ui::theme::glass_fill(),
     );
     // Logo is 1:1 (no runtime scaling); bundled at exact display size.
     if let Some(logo) = crate::app::assets::logo_pixmap() {

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -459,7 +459,10 @@ pub(super) fn run_ui_flow(
                     )?;
                 }
             } else if let Some(pm) = tiles.get(id) {
-                compositor.upload(texture_creator, id, pm, id == tile::SIDEBAR)?;
+                // The sidebar strip is the one tile that covers everything under it — and
+                // only where the look's panels are opaque (`ui::theme::panels_opaque`).
+                let opaque = id == tile::SIDEBAR && crate::ui::theme::panels_opaque();
+                compositor.upload(texture_creator, id, pm, opaque)?;
             }
         }
         let mut cmds = app.draw_list(&tiles, display_mode.w as u32, display_mode.h as u32, fonts);

--- a/src/ui/fade.rs
+++ b/src/ui/fade.rs
@@ -12,6 +12,23 @@ use std::time::{Duration, Instant};
 /// the same.
 pub const OVERLAY_FADE: Duration = Duration::from_millis(400);
 
+/// A self-expiring overlay's opacity: opaque until `hold` has passed since `shown`, then a
+/// `fade`-long fade out, and `None` once it is spent — the caller's cue to drop whatever it
+/// was showing.
+///
+/// One curve for everything that puts itself away (the toast, the Home status line, a
+/// modal's scroll indicator), for the same reason the modals share [`ModalFade`]: three
+/// copies of this shape had already drifted into two different curves, one of them linear
+/// for no stated reason.
+pub fn hold_alpha(shown: Instant, hold: Duration, fade: Duration) -> Option<f32> {
+    if shown.elapsed() >= hold + fade {
+        return None;
+    }
+    // `Instant::elapsed` saturates at zero, so the fade's clock reads as unstarted — and the
+    // alpha as a flat 1.0 — for the whole hold.
+    Some(1.0 - anim_frac(Some(shown + hold), fade))
+}
+
 /// Modal open. Short: the card is the response to a keypress, and delay there reads as
 /// a slow TV, not as an animation.
 pub const MODAL_FADE: Duration = Duration::from_millis(75);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -40,7 +40,6 @@ pub use widget::{rasterize, rasterize_into, StatefulWidget, TileWidget, Widget};
 /// text cache, the layout solver and two neighbouring widgets in the same function; making
 /// each of those a qualified path buys nothing inside the library that draws them all.
 pub(crate) mod prelude {
-    pub(crate) use crate::ui::animation::*;
     pub(crate) use crate::ui::fade::*;
     pub(crate) use crate::ui::focus::Dir;
     pub(crate) use crate::ui::layout::*;

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -128,6 +128,35 @@ impl Color {
             a: self.a,
         }
     }
+
+    /// `self` composited over `below` — source-over, straight alpha. Two constant layers
+    /// compose to one, so a surface built by stacking fills can be flattened into the single
+    /// fill that draws it.
+    #[must_use]
+    pub fn over(self, below: Self) -> Self {
+        let (sa, ba) = (f32::from(self.a) / 255.0, f32::from(below.a) / 255.0);
+        let a = sa + ba * (1.0 - sa);
+        if a <= 0.0 {
+            return Self::RGBA(0, 0, 0, 0);
+        }
+        let c = |s: u8, b: u8| ((f32::from(s) * sa + f32::from(b) * ba * (1.0 - sa)) / a) as u8;
+        Self {
+            r: c(self.r, below.r),
+            g: c(self.g, below.g),
+            b: c(self.b, below.b),
+            a: (a * 255.0) as u8,
+        }
+    }
+
+    /// `self` with its alpha scaled by `f` — a fill riding a fade, without the caller
+    /// unpacking the colour to reach one channel.
+    #[must_use]
+    pub fn with_alpha_scaled(self, f: f32) -> Self {
+        Self {
+            a: (f32::from(self.a) * f.clamp(0.0, 1.0)) as u8,
+            ..self
+        }
+    }
 }
 
 /// One cached tile's identity: an opaque number the *app* assigns.

--- a/src/ui/theme/mod.rs
+++ b/src/ui/theme/mod.rs
@@ -204,3 +204,9 @@ pub fn epoch() -> u64 {
 pub fn glass_fill() -> Color {
     glass().map_or(palette().panel, |g| g.panel)
 }
+
+/// Whether a panel filled with [`glass_fill`] covers what is under it — which is also what
+/// decides whether such a tile can be uploaded as an opaque texture.
+pub fn panels_opaque() -> bool {
+    glass_fill().a == 0xff
+}

--- a/src/ui/widgets/notification.rs
+++ b/src/ui/widgets/notification.rs
@@ -1,7 +1,7 @@
 //! Reusable transient toast notifications for the streaming overlay: a short message that
 //! appears for a fixed hold then fades out. Styled like the stats overlay panel (same glass
-//! background/radius, see [`render_notification_tile`]); the fade reuses the app-wide
-//! [`anim_frac`] easing so it matches the modals' curve. One slot — a new [`Notification::show`]
+//! background/radius, see [`render_notification_tile`]); the hold and fade are
+//! [`hold_alpha`]'s, shared with the menu's status line. One slot — a new [`Notification::show`]
 //! replaces whatever is on screen.
 
 use crate::ui::prelude::*;
@@ -23,7 +23,7 @@ impl Notification {
         Self { active: None }
     }
 
-    /// Show `text` from now: full opacity for [`HOLD`], then an [`OVERLAY_FADE`] fade.
+    /// Show `text` from now: full opacity for [`HOLD`], then an [`OVERLAY_FADE`] fade out.
     pub fn show(&mut self, text: impl Into<String>) {
         self.active = Some((text.into(), Instant::now()));
     }
@@ -31,18 +31,12 @@ impl Notification {
     /// `(text, alpha)` to draw this tick, or `None` once fully faded. Clears the slot on
     /// expiry, so a return flipping to `None` marks the on→off edge for the caller.
     pub fn frame(&mut self) -> Option<(String, f32)> {
-        let shown = self.active.as_ref()?.1;
-        let elapsed = shown.elapsed();
-        if elapsed >= HOLD + OVERLAY_FADE {
+        let (text, shown) = self.active.as_ref()?;
+        let Some(alpha) = hold_alpha(*shown, HOLD, OVERLAY_FADE) else {
             self.active = None;
             return None;
-        }
-        let alpha = if elapsed < HOLD {
-            1.0
-        } else {
-            (1.0 - anim_frac(Some(shown + HOLD), OVERLAY_FADE)).clamp(0.0, 1.0)
         };
-        Some((self.active.as_ref()?.0.clone(), alpha))
+        Some((text.clone(), alpha))
     }
 }
 


### PR DESCRIPTION
## Summary
- Status line at the bottom of the game grid draws with the same frost pane plus scrim/glass_fill tint as a dialog modal, square corners, and fades out with the toast's hold-then-fade curve instead of cutting.
- Extracted that curve to `ui::fade::hold_alpha`, now the single implementation behind the toast, the status band, and the modal scroll indicator (its hand-rolled linear fade is gone).
- Sidebar column now draws in glass too, composed after the grid and status band since the compositor latches a frame's blur source at its first frost pane. Strip opacity comes from a new `ui::theme::panels_opaque()`; the strip has its own generation counter checked against `theme::epoch()`.
- Added `Color::with_alpha_scaled`/`Color::over` so the band's scrim and tint flatten into a single fill.

## Test plan
- [x] `task docker:lint` clean (CI runs with `-D warnings`)
- [x] `/code-review` low found nothing