### PR TITLE
Sweep card reveal as a diagonal wave

### DIFF
--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -187,6 +187,13 @@ impl<'a> GridLayout<'a> {
         self.row_offset_at(idx / self.columns)
     }
 
+    /// How many diagonal steps grid slot `idx` is from the top-left corner — the stagger the
+    /// reveal wave sweeps the screen on. Here rather than at the call site because the row and
+    /// column of a slot are this type's arithmetic, clamped column count included.
+    pub(crate) fn diagonal_step(&self, idx: usize) -> usize {
+        idx / self.columns + idx % self.columns
+    }
+
     /// What the sections add to the grid's total height — the offset its last row carries.
     pub(crate) fn total_extra(&self) -> i32 {
         self.placed().last().map_or(0, |p| p.y_offset)
@@ -258,30 +265,40 @@ pub(crate) struct GridScratch {
 }
 
 impl GridState {
-    /// Starts (or restarts) `pin_id`'s zoom at `at`. A card with no tile is not on screen
-    /// and has no pop to show; it gets its clock when `prepare_grid` builds it.
+    /// Starts (or restarts) `pin_id`'s pop at `at`. A card with no tile is not on screen
+    /// and has no arrival to show; it gets its clock when `prepare_grid` builds it.
     pub fn arm_card_pop(&mut self, pin_id: &str, at: Instant) {
-        if self.card_ids.arm_pop(pin_id, at) {
-            self.extend_pop_deadline(at);
+        self.arm_entrance(pin_id, tile::Entrance::pop(at), false);
+    }
+
+    /// Arms `pin_id`'s share of the reveal wave: a fade starting `delay` after `at`, which
+    /// the clock spends at zero progress (a future `Instant` reports no elapsed time). Never
+    /// restarts an arrival already under way.
+    pub fn arm_reveal_wave(&mut self, pin_id: &str, at: Instant, delay: Duration) {
+        self.arm_entrance(pin_id, tile::Entrance::reveal(at + delay), true);
+    }
+
+    fn arm_entrance(&mut self, pin_id: &str, entrance: tile::Entrance, if_idle: bool) {
+        let armed = if if_idle {
+            self.card_ids.arm_if_idle(pin_id, entrance)
+        } else {
+            self.card_ids.arm(pin_id, entrance)
+        };
+        if armed {
+            self.extend_pop_deadline(entrance.end());
         }
     }
 
-    /// [`arm_card_pop`](Self::arm_card_pop) for a card that may already be popping — a
-    /// reveal, which must not restart a zoom already under way.
-    pub fn arm_card_pop_if_idle(&mut self, pin_id: &str, at: Instant) {
-        if self.card_ids.arm_pop_if_idle(pin_id, at) {
-            self.extend_pop_deadline(at);
-        }
-    }
-
-    fn extend_pop_deadline(&mut self, at: Instant) {
-        let end = at + crate::app::CARD_POP;
+    /// Raises the redraw deadline to `end`. Never lowered: a deadline that is merely late
+    /// costs one extra frame of the redraw loop, where an early one would freeze an arrival
+    /// mid-way.
+    fn extend_pop_deadline(&mut self, end: Instant) {
         if self.card_pop_until.is_none_or(|until| until < end) {
             self.card_pop_until = Some(end);
         }
     }
 
-    /// Whether any card is still zooming in.
+    /// Whether any card is still arriving.
     pub fn card_pops_running(&self) -> bool {
         self.card_pop_until.is_some_and(|until| Instant::now() < until)
     }

--- a/src/app/hero.rs
+++ b/src/app/hero.rs
@@ -218,10 +218,7 @@ impl Hero {
 
     /// This frame's opacity factor, 0..=1: the fade-in, less the fade-out once that starts.
     pub(crate) fn opacity(&self) -> f32 {
-        let out = self
-            .fade_out
-            .map_or(0.0, |t| ui::animation::anim_frac(Some(t), HERO_FADE));
-        self.fade_in() * (1.0 - out)
+        self.fade_in() * (1.0 - self.fade_out_frac())
     }
 
     /// How far the hero has faded *in* — the factor every exit is scaled by, so a hero that
@@ -230,42 +227,66 @@ impl Hero {
         ui::animation::anim_frac(self.since, HERO_FADE)
     }
 
+    /// How far the exit has run, 0..=1. The uniform part of leaving, which the dissolve's
+    /// wave rides on top of.
+    fn fade_out_frac(&self) -> f32 {
+        // Not `anim_frac(self.fade_out, ..)`: an absent clock there means "finished", and an
+        // exit that has not started is the opposite of finished.
+        self.exit_secs(Instant::now()).map_or(0.0, |secs| {
+            ui::animation::ease((secs / HERO_FADE.as_secs_f32()).min(1.0))
+        })
+    }
+
+    /// Seconds into the exit at `now`, or `None` if it has not started — the one reading of
+    /// that clock, for the two curves that run off it (this fade and the dissolve's wave).
+    fn exit_secs(&self, now: Instant) -> Option<f32> {
+        self.fade_out
+            .map(|t| now.saturating_duration_since(t).as_secs_f32())
+    }
+
     /// Whether the exit is a dissolve into live video: the graphics plane is cleared
     /// transparent under it and the hero leaves on a diagonal wave, so the picture is
     /// uncovered gradually instead of the whole still cutting to it.
+    ///
+    /// Latched when the fade-out starts (see [`Self::faded_out`]), so it implies one is
+    /// running.
     pub(crate) fn dissolving(&self) -> bool {
-        self.over_video && self.fade_out.is_some()
+        self.over_video
     }
 
     /// The dimming over the backdrop as it leaves: its usual scrim deepening to black across
     /// [`HERO_FADE`]. The fade to dark the exit always had, now running underneath the wave —
     /// the art darkens where the wave has not reached it yet, and is gone where it has.
     pub(crate) fn exit_scrim(&self) -> f32 {
-        let out = self
-            .fade_out
-            .map_or(0.0, |t| ui::animation::anim_frac(Some(t), HERO_FADE));
+        let out = self.fade_out_frac();
         self.fade_in() * (HERO_SCRIM_ALPHA + (255.0 - HERO_SCRIM_ALPHA) * out)
     }
 
     /// This frame's dissolve mask: one byte of alpha per texel of a black
     /// [`HERO_MASK_W`]x[`HERO_MASK_H`] image, in RGBA order.
     ///
-    /// The wave runs on `(u + v)`, so it sweeps the diagonal from the top-left corner — the
+    /// The wave runs on `(x + y)`, so it sweeps the diagonal from the top-left corner — the
     /// direction the grid's cards arrive on — and every texel is on its own delayed
-    /// smoothstep. Written into a buffer kept across frames: this runs every frame of the
-    /// dissolve, and the allocator is the one thing on this hardware that has to be asked
-    /// for nothing in a loop.
+    /// smoothstep. Evaluated once per *diagonal* rather than once per texel: the value is a
+    /// function of `x + y` alone, so a row of the image is 23 of them rather than 2304.
+    ///
+    /// The buffer is kept across frames and only its alpha bytes are written — the colour is
+    /// black for the life of the dissolve, and this runs every frame of it.
     pub(crate) fn dissolve_mask(&mut self, now: Instant) -> (u32, u32, &[u8]) {
-        let start = self.fade_out;
         let px = (HERO_MASK_W * HERO_MASK_H) as usize * 4;
-        self.mask.clear();
-        self.mask.resize(px, 0);
+        if self.mask.len() != px {
+            self.mask.clear();
+            self.mask.resize(px, 0);
+        }
+        let elapsed = self.exit_secs(now).unwrap_or(f32::MAX);
+        let last = (HERO_MASK_W + HERO_MASK_H - 2) as f32;
+        let mut diagonal = [0u8; (HERO_MASK_W + HERO_MASK_H - 1) as usize];
+        for (d, a) in diagonal.iter_mut().enumerate() {
+            *a = (HERO_DISSOLVE_WAVE.frac_secs(elapsed, d as f32 / last) * 255.0) as u8;
+        }
         for y in 0..HERO_MASK_H {
-            let v = (y as f32 + 0.5) / HERO_MASK_H as f32;
             for x in 0..HERO_MASK_W {
-                let u = (x as f32 + 0.5) / HERO_MASK_W as f32;
-                let gone = HERO_DISSOLVE_WAVE.frac(start, (u + v) / 2.0, now);
-                self.mask[((y * HERO_MASK_W + x) * 4 + 3) as usize] = (gone * 255.0) as u8;
+                self.mask[((y * HERO_MASK_W + x) * 4 + 3) as usize] = diagonal[(x + y) as usize];
             }
         }
         (HERO_MASK_W, HERO_MASK_H, &self.mask)
@@ -280,11 +301,11 @@ impl Hero {
     /// Whether the loading screen is finished, so the streaming loop can take the screen.
     /// Also what starts the fade-out, once everything else it waits on is satisfied.
     ///
-    /// `presenting` is a frame having reached the decoder — NOT NDL's `PLAYING`, which lands
-    /// during the load with nothing decoded. With a hero to pan, the screen waits for it so the
+    /// `presented` is the panel having a picture (`ndl::presented`) — NOT NDL's `PLAYING`,
+    /// which lands during the load with nothing decoded. With a hero to pan, the screen waits for it so the
     /// fade-out is the last thing before the plane is uncovered; with none, `runtime::stream` holds
     /// the finished launch frame instead, on the same [`FIRST_FRAME_WAIT`] budget.
-    pub(crate) fn handover_ready(&mut self, launch_elapsed: Duration, connect: Connect, presenting: bool) -> bool {
+    pub(crate) fn handover_ready(&mut self, launch_elapsed: Duration, connect: Connect, presented: bool) -> bool {
         if launch_elapsed < LAUNCH_FADE {
             return false;
         }
@@ -299,7 +320,7 @@ impl Hero {
         // the end of the fade. So does a handshake that lands and then decodes nothing.
         let settled = match connect {
             Connect::Failed => true,
-            Connect::Done => presenting || self.first_frame_expired(),
+            Connect::Done => presented || self.first_frame_expired(),
             Connect::Pending => false,
         };
         if !self.showing() {
@@ -312,7 +333,7 @@ impl Hero {
         // Held until the launch resolves, then for the hero's own minimum and fade-out, so the
         // backdrop leaves the same way whether it runs into live video or into the error on the
         // menu behind it — never a hero cut mid-fade.
-        settled && self.since.is_some_and(|t| t.elapsed() >= HERO_MIN_SHOW) && self.faded_out(presenting)
+        settled && self.since.is_some_and(|t| t.elapsed() >= HERO_MIN_SHOW) && self.faded_out(presented)
     }
 
     /// Starts the first-frame budget on the first call and reports whether it has run out.

--- a/src/app/hero.rs
+++ b/src/app/hero.rs
@@ -43,6 +43,23 @@ pub const FIRST_FRAME_WAIT: Duration = Duration::from_secs(6);
 /// Only a backstop — `session::connect` has its own timeouts.
 pub const HERO_LOADING_MAX: Duration = Duration::from_secs(30);
 
+/// The backdrop's exit: the grid's reveal wave (`app::GRID_REVEAL_WAVE`) run the other way —
+/// same direction across the screen, same curve, fading out instead of in.
+///
+/// Split out of [`HERO_FADE`] rather than given its own numbers: the exit is what the hand-off
+/// waits on, so span plus fade has to be that duration, and two independent constants would
+/// only be a way for them to stop adding up.
+pub const HERO_DISSOLVE_WAVE: ui::animation::Wave = ui::animation::Wave {
+    span: Duration::from_millis(HERO_FADE.as_millis() as u64 * 2 / 5),
+    fade: Duration::from_millis(HERO_FADE.as_millis() as u64 * 3 / 5),
+};
+
+/// The dissolve mask's resolution. Tiny on purpose: it is stretched over the whole screen and
+/// bilinear filtering turns it into a continuous gradient, so the wave costs one small buffer
+/// per frame rather than a draw call per piece of the image.
+pub const HERO_MASK_W: u32 = 64;
+pub const HERO_MASK_H: u32 = 36;
+
 /// How much the hero is darkened once fully faded in, so it reads as a backdrop
 /// rather than as content.
 pub const HERO_SCRIM_ALPHA: f32 = 70.0;
@@ -109,6 +126,12 @@ pub(crate) struct Hero {
     since: Option<Instant>,
     /// When it started fading back out, i.e. when the stream became ready.
     fade_out: Option<Instant>,
+    /// [`Self::dissolve_mask`]'s buffer, kept across the frames of one dissolve.
+    mask: Vec<u8>,
+    /// Whether that fade-out began with a picture on the video plane behind it. Only then is
+    /// the exit a dissolve into live video; a failed connect (or a first frame that never
+    /// came) has nothing to dissolve into and leaves over the menu as it always did.
+    over_video: bool,
     /// When the wait for a decoded frame runs out, set the moment the connect finishes so the
     /// budget is bounded from there rather than from the launch. Handed to `runtime::stream`,
     /// whose reveal waits on the same signal and must not start the clock over.
@@ -198,7 +221,54 @@ impl Hero {
         let out = self
             .fade_out
             .map_or(0.0, |t| ui::animation::anim_frac(Some(t), HERO_FADE));
-        ui::animation::anim_frac(self.since, HERO_FADE) * (1.0 - out)
+        self.fade_in() * (1.0 - out)
+    }
+
+    /// How far the hero has faded *in* — the factor every exit is scaled by, so a hero that
+    /// never finished arriving does not brighten on its way out.
+    pub(crate) fn fade_in(&self) -> f32 {
+        ui::animation::anim_frac(self.since, HERO_FADE)
+    }
+
+    /// Whether the exit is a dissolve into live video: the graphics plane is cleared
+    /// transparent under it and the hero leaves on a diagonal wave, so the picture is
+    /// uncovered gradually instead of the whole still cutting to it.
+    pub(crate) fn dissolving(&self) -> bool {
+        self.over_video && self.fade_out.is_some()
+    }
+
+    /// The dimming over the backdrop as it leaves: its usual scrim deepening to black across
+    /// [`HERO_FADE`]. The fade to dark the exit always had, now running underneath the wave —
+    /// the art darkens where the wave has not reached it yet, and is gone where it has.
+    pub(crate) fn exit_scrim(&self) -> f32 {
+        let out = self
+            .fade_out
+            .map_or(0.0, |t| ui::animation::anim_frac(Some(t), HERO_FADE));
+        self.fade_in() * (HERO_SCRIM_ALPHA + (255.0 - HERO_SCRIM_ALPHA) * out)
+    }
+
+    /// This frame's dissolve mask: one byte of alpha per texel of a black
+    /// [`HERO_MASK_W`]x[`HERO_MASK_H`] image, in RGBA order.
+    ///
+    /// The wave runs on `(u + v)`, so it sweeps the diagonal from the top-left corner — the
+    /// direction the grid's cards arrive on — and every texel is on its own delayed
+    /// smoothstep. Written into a buffer kept across frames: this runs every frame of the
+    /// dissolve, and the allocator is the one thing on this hardware that has to be asked
+    /// for nothing in a loop.
+    pub(crate) fn dissolve_mask(&mut self, now: Instant) -> (u32, u32, &[u8]) {
+        let start = self.fade_out;
+        let px = (HERO_MASK_W * HERO_MASK_H) as usize * 4;
+        self.mask.clear();
+        self.mask.resize(px, 0);
+        for y in 0..HERO_MASK_H {
+            let v = (y as f32 + 0.5) / HERO_MASK_H as f32;
+            for x in 0..HERO_MASK_W {
+                let u = (x as f32 + 0.5) / HERO_MASK_W as f32;
+                let gone = HERO_DISSOLVE_WAVE.frac(start, (u + v) / 2.0, now);
+                self.mask[((y * HERO_MASK_W + x) * 4 + 3) as usize] = (gone * 255.0) as u8;
+            }
+        }
+        (HERO_MASK_W, HERO_MASK_H, &self.mask)
     }
 
     /// Whether an uploaded hero is on screen as the connecting backdrop. `since` is only ever
@@ -242,7 +312,7 @@ impl Hero {
         // Held until the launch resolves, then for the hero's own minimum and fade-out, so the
         // backdrop leaves the same way whether it runs into live video or into the error on the
         // menu behind it — never a hero cut mid-fade.
-        settled && self.since.is_some_and(|t| t.elapsed() >= HERO_MIN_SHOW) && self.faded_out()
+        settled && self.since.is_some_and(|t| t.elapsed() >= HERO_MIN_SHOW) && self.faded_out(presenting)
     }
 
     /// Starts the first-frame budget on the first call and reports whether it has run out.
@@ -259,9 +329,16 @@ impl Hero {
         self.first_frame_deadline
     }
 
-    /// Starts the fade-out (idempotent) and reports whether it has finished.
-    fn faded_out(&mut self) -> bool {
-        let since = *self.fade_out.get_or_insert_with(Instant::now);
+    /// Starts the fade-out (idempotent) and reports whether it has finished. `over_video` is
+    /// latched from the first call: what the exit dissolves into is decided when it begins.
+    fn faded_out(&mut self, over_video: bool) -> bool {
+        let since = match self.fade_out {
+            Some(t) => t,
+            None => {
+                self.over_video = over_video;
+                *self.fade_out.insert(Instant::now())
+            }
+        };
         since.elapsed() >= HERO_FADE
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -45,6 +45,12 @@ pub(crate) const CARD_GROWTH: f32 = 0.045;
 pub(crate) const LAUNCH_GROWTH: f32 = 3.5;
 pub(crate) const CARD_POP: Duration = Duration::from_millis(300);
 pub(crate) const CARD_POP_SHRINK: f32 = 0.14;
+/// The grid's first appearance after the spinner: one long, scale-free fade per card, so the
+/// whole screen reads as one surface arriving rather than a field of individually popping tiles.
+pub(crate) const CARD_REVEAL_FADE: Duration = Duration::from_millis(420);
+/// How much later each diagonal step (one column right, one row down) starts its fade — the
+/// wave that sweeps the reveal from the top-left corner to the bottom-right one.
+pub(crate) const CARD_REVEAL_WAVE_STEP: Duration = Duration::from_millis(38);
 pub(crate) const SCROLL_INDICATOR_HOLD: Duration = Duration::from_millis(700);
 pub(crate) const SCROLL_INDICATOR_FADE: Duration = Duration::from_millis(350);
 pub(crate) const SCROLL_INDICATOR_LIFETIME: Duration =

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -45,12 +45,13 @@ pub(crate) const CARD_GROWTH: f32 = 0.045;
 pub(crate) const LAUNCH_GROWTH: f32 = 3.5;
 pub(crate) const CARD_POP: Duration = Duration::from_millis(300);
 pub(crate) const CARD_POP_SHRINK: f32 = 0.14;
-/// The grid's first appearance after the spinner: one long, scale-free fade per card, so the
-/// whole screen reads as one surface arriving rather than a field of individually popping tiles.
-pub(crate) const CARD_REVEAL_FADE: Duration = Duration::from_millis(420);
-/// How much later each diagonal step (one column right, one row down) starts its fade — the
-/// wave that sweeps the reveal from the top-left corner to the bottom-right one.
-pub(crate) const CARD_REVEAL_WAVE_STEP: Duration = Duration::from_millis(38);
+/// The grid's first appearance after the spinner: one diagonal wave from the top-left corner,
+/// scale-free, so the whole screen reads as one surface arriving rather than as a field of
+/// individually popping cards. The launch backdrop leaves on the same motion (`app::hero`).
+pub(crate) const GRID_REVEAL_WAVE: ui::animation::Wave = ui::animation::Wave {
+    span: Duration::from_millis(380),
+    fade: Duration::from_millis(420),
+};
 pub(crate) const SCROLL_INDICATOR_HOLD: Duration = Duration::from_millis(700);
 pub(crate) const SCROLL_INDICATOR_FADE: Duration = Duration::from_millis(350);
 pub(crate) const SCROLL_INDICATOR_LIFETIME: Duration =

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -875,6 +875,14 @@ impl App {
         screen_h: u32,
         fonts: &ui::text::Fonts,
     ) -> ui::render::DrawList {
+        // The hero dissolving into live video is the whole frame: the menu, the launch card
+        // and the black it faded to are all behind the picture the wave is uncovering, and
+        // the graphics plane is cleared transparent under it (`App::frame_clear_color`).
+        if self.render.hero.dissolving() {
+            let mut cmds = Vec::new();
+            self.compose_hero(screen_w, screen_h, &mut cmds);
+            return cmds;
+        }
         let input = self.render_input();
         let mut cmds = Vec::new();
         let grid_x = ui::widgets::SIDEBAR_W as i32;
@@ -978,7 +986,14 @@ impl App {
     /// rather than from a lit image.
     fn compose_hero(&self, screen_w: u32, screen_h: u32, cmds: &mut ui::render::DrawList) {
         let Some(hero) = self.render.hero.visible() else { return };
-        let f = self.render.hero.opacity();
+        // Leaving over live video, the wave in the mask below is the fade — the image itself
+        // holds whatever it faded in to, so the two are not fighting over one alpha.
+        let dissolving = self.render.hero.dissolving();
+        let f = if dissolving {
+            self.render.hero.fade_in()
+        } else {
+            self.render.hero.opacity()
+        };
         cmds.push(DrawCmd::TexF {
             tile: tile::HERO,
             dst: hero::hero_pan_dst(
@@ -990,9 +1005,25 @@ impl App {
             ),
             alpha: (255.0 * f) as u8,
         });
+        // Two motions at once on the way out: the scrim deepens to black over the whole
+        // image while the wave takes it away piece by piece.
+        let scrim = if dissolving {
+            self.render.hero.exit_scrim()
+        } else {
+            hero::HERO_SCRIM_ALPHA * f
+        };
         cmds.push(DrawCmd::Fill {
             rect: Rect::new(0, 0, screen_w, screen_h),
-            color: crate::ui::render::Color::RGBA(0, 0, 0, (hero::HERO_SCRIM_ALPHA * f) as u8),
+            color: crate::ui::render::Color::RGBA(0, 0, 0, scrim as u8),
         });
+        if dissolving {
+            // Both of the above taken away again, per pixel, as the wave passes: the scrim
+            // goes with the art it was dimming, and what is left is the picture on the video
+            // plane behind the graphics plane.
+            cmds.push(DrawCmd::Erase {
+                tile: tile::HERO_MASK,
+                dst: Rect::new(0, 0, screen_w, screen_h),
+            });
+        }
     }
 }

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -875,24 +875,17 @@ impl App {
         screen_h: u32,
         fonts: &ui::text::Fonts,
     ) -> ui::render::DrawList {
-        // The hero dissolving into live video is the whole frame: the menu, the launch card
-        // and the black it faded to are all behind the picture the wave is uncovering, and
-        // the graphics plane is cleared transparent under it (`App::frame_clear_color`).
-        if self.render.hero.dissolving() {
-            let mut cmds = Vec::new();
-            self.compose_hero(screen_w, screen_h, &mut cmds);
-            return cmds;
-        }
         let input = self.render_input();
         let mut cmds = Vec::new();
         let grid_x = ui::widgets::SIDEBAR_W as i32;
         let available_w = screen_w.saturating_sub(ui::widgets::SIDEBAR_W);
         let columns = view::home::grid_columns(available_w);
 
-        // A screen that draws over the video plane composes nothing behind its own card: the
-        // sidebar, the grid and the status block are graphics that would cover the very thing
-        // the user is looking at (see `screens::over_video`).
-        if !screens::over_video(self.nav.screen) {
+        // Over the video plane nothing composes behind the card: the sidebar, the grid and the
+        // status block are graphics that would cover the very thing the user is looking at.
+        // The launch backdrop's dissolve is the same case — the menu it faded from is behind
+        // the picture the wave is uncovering (see `App::over_video_layers`).
+        if !self.over_video_layers() {
             cmds.push(DrawCmd::Tex {
                 tile: tile::SIDEBAR,
                 dst: Rect::new(0, 0, ui::widgets::SIDEBAR_W, screen_h),
@@ -954,23 +947,28 @@ impl App {
         // ratio never changes) while a black scrim blends in over it, both driven
         // by the same clock — the card keeps zooming for the whole fade.
         if let (Some(t), Some(idx)) = (self.launch_anim, self.launch_anim_idx) {
-            let f = ui::animation::anim_frac(Some(t), hero::LAUNCH_FADE);
-            let layout = self.library.layout(columns);
-            let base = view::home::scrolled_card_rect(idx, grid_x, available_w, layout, self.render.grid.scroll);
-            if let Some(card) = self
-                .pin_id_at_grid_idx(idx, columns)
-                .and_then(|pin_id| self.render.grid.card_ids.get(pin_id))
-            {
-                cmds.push(DrawCmd::Tex {
-                    tile: card,
-                    dst: ui::animation::zoom_rect(base, f, LAUNCH_GROWTH),
-                    alpha: 0xff,
+            // Both of these are the fade *to* the loading screen. Once the backdrop is
+            // dissolving off it again there is live video behind them, which a zooming card
+            // and a full-screen black would cover back up.
+            if !self.over_video_layers() {
+                let f = ui::animation::anim_frac(Some(t), hero::LAUNCH_FADE);
+                let layout = self.library.layout(columns);
+                let base = view::home::scrolled_card_rect(idx, grid_x, available_w, layout, self.render.grid.scroll);
+                if let Some(card) = self
+                    .pin_id_at_grid_idx(idx, columns)
+                    .and_then(|pin_id| self.render.grid.card_ids.get(pin_id))
+                {
+                    cmds.push(DrawCmd::Tex {
+                        tile: card,
+                        dst: ui::animation::zoom_rect(base, f, LAUNCH_GROWTH),
+                        alpha: 0xff,
+                    });
+                }
+                cmds.push(DrawCmd::Fill {
+                    rect: Rect::new(0, 0, screen_w, screen_h),
+                    color: crate::ui::render::Color::RGBA(0, 0, 0, (255.0 * f) as u8),
                 });
             }
-            cmds.push(DrawCmd::Fill {
-                rect: Rect::new(0, 0, screen_w, screen_h),
-                color: crate::ui::render::Color::RGBA(0, 0, 0, (255.0 * f) as u8),
-            });
             // With wide art for this game, the loading screen is that art instead of the
             // bare black: it fades in over the scrim above (so a hero arriving mid-
             // handshake still eases in rather than snapping), then drifts slowly left to

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -4,14 +4,14 @@
 //! focus pop and every fade is a texture-copy parameter here, never a re-raster (see
 //! `platform::webos::compositor`). Split out of `app/mod.rs` alongside `prepare`.
 use std::ops::Range;
+use std::time::Instant;
 
 use crate::app::grid::GridLayout;
 use crate::app::render::tile;
 use crate::app::render::SnapshotBody;
 use crate::app::screens;
 use crate::app::{
-    hero, render_input, view, App, HomeFocus, Screen, CARD_GROWTH, CARD_POP, CARD_POP_SHRINK, LAUNCH_GROWTH,
-    SCROLL_INDICATOR_FADE, SCROLL_INDICATOR_HOLD, SCROLL_INDICATOR_TILE_W, STATUS_BG_PAD,
+    hero, render_input, view, App, HomeFocus, Screen, CARD_GROWTH, LAUNCH_GROWTH, SCROLL_INDICATOR_FADE, SCROLL_INDICATOR_HOLD, SCROLL_INDICATOR_TILE_W, STATUS_BG_PAD,
 };
 use crate::ui;
 use crate::ui::cache::TileStore;
@@ -520,6 +520,8 @@ impl App {
         // and nothing else. A scale on the card's own alpha rather than a `Fill` over it — a
         // fill is a square rect and would square off the card's rounded corners.
         let unfixed = self.reordering_slots(layout);
+        // One clock read for the whole grid pass — every card's arrival is measured against it.
+        let now = Instant::now();
         let dimmed = 1.0 - f32::from(ui::theme::palette().scrim.a) / 255.0;
         for idx in visible {
             if Some(idx) == focused {
@@ -535,22 +537,27 @@ impl App {
                 continue; // not rasterized yet — outside the build window
             };
             let card = slot.id;
-            // A card that just landed is still zooming up to full size.
-            let pop = ui::animation::anim_frac(slot.pop, CARD_POP);
+            // A card that just landed is still fading (reveal) or zooming (later build) in.
+            let (pop, shrink) = tile::entrance_progress(slot.pop, now);
             let dim = if unfixed.as_ref().is_some_and(|s| s.contains(&idx)) {
                 dimmed
             } else {
                 1.0
             };
             let alpha = (255.0 * pop * dim) as u8;
+            // A fully transparent card — one the reveal wave has not reached — is two
+            // full-size blits and two alpha-mod changes that draw nothing.
+            if alpha == 0 {
+                continue;
+            }
             cmds.push(DrawCmd::Tex {
                 tile: tile::CARD_SHADOW,
-                dst: ui::animation::pop_in_rect(r.inflate(pad), pop, CARD_POP_SHRINK),
+                dst: ui::animation::pop_in_rect(r.inflate(pad), pop, shrink),
                 alpha,
             });
             cmds.push(DrawCmd::Tex {
                 tile: card,
-                dst: ui::animation::pop_in_rect(r, pop, CARD_POP_SHRINK),
+                dst: ui::animation::pop_in_rect(r, pop, shrink),
                 alpha,
             });
         }
@@ -585,7 +592,7 @@ impl App {
                 // an in-collection swap with nowhere to go is what does (see
                 // `App::swap_card_in_collection`).
                 let r = self.press_dip(Screen::Home).rect(card_rect(idx));
-                self.compose_focused_card(tiles, cmds, pin_id, r, pad);
+                self.compose_focused_card(tiles, cmds, pin_id, r, pad, now);
             }
         }
     }
@@ -605,7 +612,15 @@ impl App {
     /// focus pop and title strip (or the submenu panel a hold grew out of it), plus the pin
     /// badge. `r` is its unscaled rect — everything here scales about the card's own centre, so
     /// the pops can't fight over position.
-    fn compose_focused_card(&self, tiles: &TileStore, cmds: &mut Vec<DrawCmd>, pin_id: &str, r: Rect, pad: i32) {
+    fn compose_focused_card(
+        &self,
+        tiles: &TileStore,
+        cmds: &mut Vec<DrawCmd>,
+        pin_id: &str,
+        r: Rect,
+        pad: i32,
+        now: Instant,
+    ) {
         // The focus pop: the GPU scales the (unfocused) card tile up
         // around its center as the pop progresses, with the shared glow
         // tile fading in behind it at the same scale.
@@ -614,8 +629,8 @@ impl App {
             return; // not rasterized yet
         };
         let card = slot.id;
-        let pop = ui::animation::anim_frac(slot.pop, CARD_POP);
-        let popped = |base: Rect| ui::animation::pop_in_rect(base, pop, CARD_POP_SHRINK);
+        let (pop, shrink) = tile::entrance_progress(slot.pop, now);
+        let popped = |base: Rect| ui::animation::pop_in_rect(base, pop, shrink);
         // The card's total scale, for anything composited on top of it that has to
         // fold in the same transform about the card's centre rather than its own.
         // Shared with the pointer path (`card_menu_rows_rect`), so a click can't land

--- a/src/app/render/prepare_grid.rs
+++ b/src/app/render/prepare_grid.rs
@@ -14,7 +14,7 @@ use crate::app::library::Library;
 use crate::app::render::ctx::RenderCtx;
 use crate::app::render::tile;
 use crate::app::state::cardmenu::CardMenuRow;
-use crate::app::{view, App, HomeFocus, Screen};
+use crate::app::{view, App, HomeFocus, Screen, CARD_REVEAL_WAVE_STEP};
 use crate::ui;
 use crate::ui::cache;
 
@@ -495,7 +495,7 @@ impl App {
     /// is finally complete.
     fn advance_grid_reveal(
         &mut self,
-        mut build_window: std::ops::Range<usize>,
+        build_window: std::ops::Range<usize>,
         columns: usize,
         ctx: &mut RenderCtx<'_>,
     ) {
@@ -506,7 +506,8 @@ impl App {
             // earlier can still be waiting behind a re-dirtied sibling; requires `art_ready`
             // too so a placeholder built this tick can't count as revealed.
             let window_ready = || {
-                build_window.all(|idx| {
+                // Cloned rather than consumed: the reveal below sweeps the same indices.
+                build_window.clone().all(|idx| {
                     layout.pin_id_at(&self.library.games, idx).is_none_or(|id| {
                         self.render.grid.card_ids.get(id).is_some_and(|t| tiles.contains(t))
                             && art_ready(&self.library, layout, idx)
@@ -519,13 +520,20 @@ impl App {
             );
             match next_frame {
                 Some(idx) => updated.push(tile::spinner(idx)),
-                // Everything built behind the spinner becomes visible in this one frame, so
-                // it all zooms in off a single clock.
+                // Everything built behind the spinner becomes visible in this one frame. One
+                // clock each, offset along the grid's diagonal, so the screen fades in as a
+                // wave running from the top-left corner rather than as N separate pops.
+                // Cards resident but outside the window are off screen: no arrival to show,
+                // and by the time a scroll reaches them the wave is long over.
                 None if self.render.grid.reveal.is_revealed() => {
                     let now = Instant::now();
-                    let ids: Vec<String> = self.render.grid.card_ids.pin_ids().map(str::to_string).collect();
-                    for id in ids {
-                        self.render.grid.arm_card_pop_if_idle(&id, now);
+                    // Split borrow: the layout reads `library`, the arming writes `render`.
+                    let grid = &mut self.render.grid;
+                    for idx in build_window {
+                        if let Some(id) = layout.pin_id_at(&self.library.games, idx) {
+                            let delay = CARD_REVEAL_WAVE_STEP * layout.diagonal_step(idx) as u32;
+                            grid.arm_reveal_wave(id, now, delay);
+                        }
                     }
                 }
                 None => {}

--- a/src/app/render/prepare_grid.rs
+++ b/src/app/render/prepare_grid.rs
@@ -13,6 +13,7 @@ use crate::app::grid::{GridLayout, CARD_BUILD_BUDGET, CARD_BUILD_BURST, CARD_KEE
 use crate::app::library::Library;
 use crate::app::render::ctx::RenderCtx;
 use crate::app::render::tile;
+use crate::app::spinner::PageReady;
 use crate::app::state::cardmenu::CardMenuRow;
 use crate::app::{view, App, HomeFocus, Screen, GRID_REVEAL_WAVE};
 use crate::ui;
@@ -84,6 +85,9 @@ impl App {
             first_visible_row - CARD_PREFETCH_ROWS,
             first_visible_row + visible_rows + CARD_PREFETCH_ROWS,
         );
+        // What the reveal waits for and what its wave sweeps: the cards actually on screen,
+        // without the prefetch rows above and below them.
+        let page_window = window(first_visible_row, first_visible_row + visible_rows);
         let keep_window = window(
             first_visible_row - CARD_KEEP_ROWS,
             first_visible_row + visible_rows + CARD_KEEP_ROWS,
@@ -96,12 +100,12 @@ impl App {
         // and these all mutate `self.render` while reading it. Rebuilding is a slice reborrow
         // and an integer copy, so there is nothing to hoist.
         self.evict_cards_outside(keep_window, columns, ctx.tiles);
-        let pending = self.build_card_window(build_window.clone(), columns, card_w, card_h, ctx)?;
+        let pending = self.build_card_window(build_window, columns, card_w, card_h, ctx)?;
         self.prepare_focused_card_tiles(columns, card_w, card_h, pending, ctx)?;
         // Order against the reveal below doesn't matter: both only ensure tiles and record what
         // they rebuilt.
         self.prepare_grid_shared_tiles(card_w, card_h, ctx)?;
-        self.advance_grid_reveal(build_window, columns, ctx);
+        self.advance_grid_reveal(page_window, columns, ctx);
         Ok(())
     }
 
@@ -269,6 +273,8 @@ impl App {
             };
             let tile_id = self.render.grid.card_ids.id(&id);
             tiles.put(tile_id, cache::static_version(), tile);
+            // Past the reveal, a card entering the window is one card arriving on a settled
+            // grid — the wave is for the page the spinner was covering.
             if self.render.grid.reveal.is_revealed() {
                 self.render.grid.arm_card_pop(&id, Instant::now());
             }
@@ -491,60 +497,65 @@ impl App {
         Ok(())
     }
 
-    /// Advances the loading spinner, and pops the whole grid in at once on the frame the window
-    /// is finally complete.
-    fn advance_grid_reveal(
-        &mut self,
-        build_window: std::ops::Range<usize>,
-        columns: usize,
-        ctx: &mut RenderCtx<'_>,
-    ) {
+    /// Advances the loading spinner, and sweeps the whole page in on one wave the frame it is
+    /// finally complete.
+    fn advance_grid_reveal(&mut self, page_window: std::ops::Range<usize>, columns: usize, ctx: &mut RenderCtx<'_>) {
         let RenderCtx { tiles, updated, .. } = ctx;
         let layout = self.library.layout(columns);
-        if !self.render.grid.reveal.is_revealed() {
-            // Rechecks the whole window rather than trusting `!pending`, since a card built
-            // earlier can still be waiting behind a re-dirtied sibling; requires `art_ready`
-            // too so a placeholder built this tick can't count as revealed.
-            let window_ready = || {
-                // Cloned rather than consumed: the reveal below sweeps the same indices.
-                build_window.clone().all(|idx| {
-                    layout.pin_id_at(&self.library.games, idx).is_none_or(|id| {
-                        self.render.grid.card_ids.get(id).is_some_and(|t| tiles.contains(t))
-                            && art_ready(&self.library, layout, idx)
-                    })
-                })
-            };
-            let next_frame = self.render.grid.reveal.advance(
-                self.library_fetch_in_flight() || self.wake_wait_in_flight(),
-                window_ready,
-            );
-            match next_frame {
-                Some(idx) => updated.push(tile::spinner(idx)),
-                // Everything built behind the spinner becomes visible in this one frame. One
-                // clock each, offset along the grid's diagonal, so the screen fades in as a
-                // wave running from the top-left corner rather than as N separate pops.
-                // Cards resident but outside the window are off screen: no arrival to show,
-                // and by the time a scroll reaches them the wave is long over.
-                None if self.render.grid.reveal.is_revealed() => {
-                    let now = Instant::now();
-                    // Normalized over the window being revealed, so the sweep takes the wave's
-                    // span whatever the column count and however many rows were built.
-                    let last_step = build_window
-                        .clone()
-                        .last()
-                        .map_or(1, |idx| layout.diagonal_step(idx))
-                        .max(1) as f32;
-                    // Split borrow: the layout reads `library`, the arming writes `render`.
-                    let grid = &mut self.render.grid;
-                    for idx in build_window {
-                        if let Some(id) = layout.pin_id_at(&self.library.games, idx) {
-                            let delay = GRID_REVEAL_WAVE.delay(layout.diagonal_step(idx) as f32 / last_step);
-                            grid.arm_reveal_wave(id, now, delay);
-                        }
+        if self.render.grid.reveal.is_revealed() {
+            return;
+        }
+        // Rechecks the whole page rather than trusting `!pending`, since a card built earlier
+        // can still be waiting behind a re-dirtied sibling. Tiles and art are answered
+        // separately: art that never arrives is what the spinner's cap exists for, where a
+        // card with no tile yet is simply not ready to be revealed (see `PageReady`).
+        let page_ready = || {
+            let mut art_pending = false;
+            for idx in page_window.clone() {
+                let Some(id) = layout.pin_id_at(&self.library.games, idx) else {
+                    continue;
+                };
+                if !self.render.grid.card_ids.get(id).is_some_and(|t| tiles.contains(t)) {
+                    return PageReady::Building;
+                }
+                art_pending |= !art_ready(&self.library, layout, idx);
+            }
+            if art_pending {
+                PageReady::Tiles
+            } else {
+                PageReady::All
+            }
+        };
+        let next_frame = self.render.grid.reveal.advance(
+            self.library_fetch_in_flight() || self.wake_wait_in_flight(),
+            page_ready,
+        );
+        match next_frame {
+            Some(idx) => updated.push(tile::spinner(idx)),
+            // Everything built behind the spinner becomes visible in this one frame. One clock
+            // each, offset along the grid's diagonal, so the page fades in as a wave running
+            // from the top-left corner rather than as N separate pops. Cards outside the page
+            // are off screen: no arrival to show, and by the time a scroll reaches them the
+            // wave is long over.
+            None if self.render.grid.reveal.is_revealed() => {
+                let now = Instant::now();
+                // Normalized over the page, so the sweep takes the wave's span whatever the
+                // column count and however many rows fit on screen.
+                let last_step = page_window
+                    .clone()
+                    .last()
+                    .map_or(1, |idx| layout.diagonal_step(idx))
+                    .max(1) as f32;
+                // Split borrow: the layout reads `library`, the arming writes `render`.
+                let grid = &mut self.render.grid;
+                for idx in page_window {
+                    if let Some(id) = layout.pin_id_at(&self.library.games, idx) {
+                        let delay = GRID_REVEAL_WAVE.delay(layout.diagonal_step(idx) as f32 / last_step);
+                        grid.arm_reveal_wave(id, now, delay);
                     }
                 }
-                None => {}
             }
+            None => {}
         }
     }
 

--- a/src/app/render/prepare_grid.rs
+++ b/src/app/render/prepare_grid.rs
@@ -14,7 +14,7 @@ use crate::app::library::Library;
 use crate::app::render::ctx::RenderCtx;
 use crate::app::render::tile;
 use crate::app::state::cardmenu::CardMenuRow;
-use crate::app::{view, App, HomeFocus, Screen, CARD_REVEAL_WAVE_STEP};
+use crate::app::{view, App, HomeFocus, Screen, GRID_REVEAL_WAVE};
 use crate::ui;
 use crate::ui::cache;
 
@@ -527,11 +527,18 @@ impl App {
                 // and by the time a scroll reaches them the wave is long over.
                 None if self.render.grid.reveal.is_revealed() => {
                     let now = Instant::now();
+                    // Normalized over the window being revealed, so the sweep takes the wave's
+                    // span whatever the column count and however many rows were built.
+                    let last_step = build_window
+                        .clone()
+                        .last()
+                        .map_or(1, |idx| layout.diagonal_step(idx))
+                        .max(1) as f32;
                     // Split borrow: the layout reads `library`, the arming writes `render`.
                     let grid = &mut self.render.grid;
                     for idx in build_window {
                         if let Some(id) = layout.pin_id_at(&self.library.games, idx) {
-                            let delay = CARD_REVEAL_WAVE_STEP * layout.diagonal_step(idx) as u32;
+                            let delay = GRID_REVEAL_WAVE.delay(layout.diagonal_step(idx) as f32 / last_step);
                             grid.arm_reveal_wave(id, now, delay);
                         }
                     }

--- a/src/app/render/tile.rs
+++ b/src/app/render/tile.rs
@@ -146,16 +146,98 @@ pub struct CardIds {
     next: u32,
 }
 
-/// What one resident card holds: its tile, and when its zoom-in started.
+/// What one resident card holds: its tile, and the arrival it is playing.
 ///
-/// The pop clock lives here rather than in a second map keyed by the same string, because
+/// The entrance lives here rather than in a second map keyed by the same string, because
 /// `compose_grid` asks for both for every visible card on every frame — two hashes of one
 /// game id, where the card is resident or neither answer exists.
 #[derive(Clone, Copy)]
 pub struct CardSlot {
     pub id: TileId,
-    /// `None` for a card that is not animating; see `App::card_pop_frac`.
-    pub pop: Option<std::time::Instant>,
+    /// `None` for a card that is not animating.
+    pub pop: Option<Entrance>,
+}
+
+/// [`Entrance::progress`] for a slot that may not be animating: `(1.0, 0.0)` — full size,
+/// no scale to apply — when it is not.
+pub fn entrance_progress(entrance: Option<Entrance>, now: std::time::Instant) -> (f32, f32) {
+    entrance.map_or((1.0, 0.0), |e| e.progress(now))
+}
+
+/// A card arriving on screen: when it started, and which of the two arrivals it is.
+///
+/// Kind and clock together on the slot, rather than a grid-wide "a reveal is running" flag:
+/// a card built by a scroll while the reveal is still sweeping gets its own pop either way,
+/// and a global mode would compose it on the reveal's curve.
+#[derive(Clone, Copy)]
+pub struct Entrance {
+    pub start: std::time::Instant,
+    pub kind: EntranceKind,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum EntranceKind {
+    /// A card built into a grid already on screen: a short scale-up.
+    Pop,
+    /// The post-spinner reveal: a longer fade with no scale at all, staggered along the
+    /// grid's diagonal so the screen arrives as one sweep rather than as N separate pops.
+    Reveal,
+}
+
+impl Entrance {
+    pub fn pop(start: std::time::Instant) -> Self {
+        Self {
+            start,
+            kind: EntranceKind::Pop,
+        }
+    }
+
+    pub fn reveal(start: std::time::Instant) -> Self {
+        Self {
+            start,
+            kind: EntranceKind::Reveal,
+        }
+    }
+
+    /// How far this arrival has got at `now`, and the shrink its pop-in rides. Off a clock
+    /// the caller already read, rather than one `Instant::now()` per card per curve.
+    ///
+    /// The two arrivals differ only in curve, duration and shrink; smoothstep over the
+    /// reveal's longer fade because on a cubic ease-out a fade is near-opaque a sixth of the
+    /// way through, which lands as the pop it is meant to replace.
+    pub fn progress(self, now: std::time::Instant) -> (f32, f32) {
+        let clock = Some(self.start);
+        let dur = self.kind.duration();
+        let frac = match self.kind {
+            EntranceKind::Pop => crate::ui::animation::anim_frac_at(clock, dur, now),
+            EntranceKind::Reveal => crate::ui::animation::anim_frac_smooth_at(clock, dur, now),
+        };
+        (frac, self.kind.shrink())
+    }
+
+    /// When this arrival is over — what the redraw loop's deadline has to cover.
+    pub fn end(self) -> std::time::Instant {
+        self.start + self.kind.duration()
+    }
+}
+
+impl EntranceKind {
+    pub fn duration(self) -> std::time::Duration {
+        match self {
+            Self::Pop => crate::app::CARD_POP,
+            Self::Reveal => crate::app::CARD_REVEAL_FADE,
+        }
+    }
+
+    /// How far the card is scaled down at the start of this arrival. The reveal is a flat
+    /// cross-fade: a diagonal of cards each scaling on its own clock reads as noise, where
+    /// the same diagonal fading reads as one diffused sweep.
+    pub fn shrink(self) -> f32 {
+        match self {
+            Self::Pop => crate::app::CARD_POP_SHRINK,
+            Self::Reveal => 0.0,
+        }
+    }
 }
 
 /// Hand-written rather than derived: a derived `Default` would start `next` at 0, handing the
@@ -196,24 +278,24 @@ impl CardIds {
         self.slots.get(pin_id).copied()
     }
 
-    /// Starts `pin_id`'s zoom at `at`, reporting whether it took — a card with no slot is
-    /// not on screen, and gets its clock from [`id`](Self::id) when it is built.
-    pub fn arm_pop(&mut self, pin_id: &str, at: std::time::Instant) -> bool {
+    /// Starts `pin_id`'s arrival, reporting whether it took — a card with no slot is not on
+    /// screen, and gets its clock from [`id`](Self::id) when it is built.
+    pub fn arm(&mut self, pin_id: &str, entrance: Entrance) -> bool {
         match self.slots.get_mut(pin_id) {
             Some(slot) => {
-                slot.pop = Some(at);
+                slot.pop = Some(entrance);
                 true
             }
             None => false,
         }
     }
 
-    /// [`arm_pop`](Self::arm_pop) for a card that may already be popping — the reveal, which
-    /// must not restart a zoom already under way.
-    pub fn arm_pop_if_idle(&mut self, pin_id: &str, at: std::time::Instant) -> bool {
+    /// [`arm`](Self::arm) for a card that may already be arriving — the reveal, which must
+    /// not restart an arrival already under way.
+    pub fn arm_if_idle(&mut self, pin_id: &str, entrance: Entrance) -> bool {
         match self.slots.get_mut(pin_id) {
             Some(slot) if slot.pop.is_none() => {
-                slot.pop = Some(at);
+                slot.pop = Some(entrance);
                 true
             }
             _ => false,
@@ -233,11 +315,6 @@ impl CardIds {
         self.slots.clear();
         self.free.extend(ids.iter().copied());
         ids
-    }
-
-    /// Every pin id with a slot.
-    pub fn pin_ids(&self) -> impl Iterator<Item = &str> {
-        self.slots.keys().map(String::as_str)
     }
 
     /// Every resident card, as `(pin id, tile)` — what the eviction pass walks, so it can

--- a/src/app/render/tile.rs
+++ b/src/app/render/tile.rs
@@ -86,6 +86,10 @@ pub const MODAL_SHADOW: TileId = TileId(29);
 /// have held a baked shadow.
 pub const PANEL_SHADOW: TileId = TileId(30);
 
+/// The dissolve mask the launch's hero leaves behind: a small alpha ramp stretched over the
+/// screen, which `DrawCmd::Erase` subtracts from what is already drawn.
+pub const HERO_MASK: TileId = TileId(31);
+
 /// First id of the row band — one slot per on-screen row of whichever scrolling list is open
 /// (see [`list_row`]). Fixed rather than interned: the lists are short, their rows are
 /// addressed by position, and only one is up at a time.
@@ -210,6 +214,7 @@ impl Entrance {
         let dur = self.kind.duration();
         let frac = match self.kind {
             EntranceKind::Pop => crate::ui::animation::anim_frac_at(clock, dur, now),
+            // The wave's own curve — its stagger is already baked into `start`.
             EntranceKind::Reveal => crate::ui::animation::anim_frac_smooth_at(clock, dur, now),
         };
         (frac, self.kind.shrink())
@@ -225,7 +230,7 @@ impl EntranceKind {
     pub fn duration(self) -> std::time::Duration {
         match self {
             Self::Pop => crate::app::CARD_POP,
-            Self::Reveal => crate::app::CARD_REVEAL_FADE,
+            Self::Reveal => crate::app::GRID_REVEAL_WAVE.fade,
         }
     }
 

--- a/src/app/spinner.rs
+++ b/src/app/spinner.rs
@@ -6,8 +6,22 @@
 //! [`GridReveal::restart`]).
 use std::time::{Duration, Instant};
 
-/// Loading spinner timeout: failed fetches never become ready, so cap the wait.
+/// Loading spinner timeout: cover art that never arrives (a failed fetch) would hold the
+/// spinner forever, so cap the wait on it. Only on the art — see [`PageReady`].
 const SPINNER_MAX_WAIT: Duration = Duration::from_millis(900);
+
+/// How far the grid's first page has got: what the spinner is waiting for.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PageReady {
+    /// A card on the page has no tile yet. Never revealed in this state, cap or no cap: the
+    /// wave exists to open cards that are already built, and one arriving after it has passed
+    /// pops in over a screen that has finished animating.
+    Building,
+    /// Every card on the page is rasterized, but some are still placeholders waiting on art.
+    Tiles,
+    /// Nothing outstanding.
+    All,
+}
 
 /// Whether the grid's initial build for the current library has finished, and the spinner shown
 /// until it has.
@@ -68,19 +82,27 @@ impl GridReveal {
     }
 
     /// Advances the spinner one frame while the grid is still building, and reveals it once
-    /// `window_ready` says every card in the visible window has landed — or once the build has
-    /// outrun [`SPINNER_MAX_WAIT`].
+    /// `page` says the first page is complete — or, past [`SPINNER_MAX_WAIT`], once that page
+    /// is at least rasterized.
+    ///
+    /// The page, not the whole prefetch window: the wave reveals what is on screen, and the
+    /// rows below it have no arrival to show.
     ///
     /// `fetch_in_flight` covers the network round trip before there is anything to build: the
-    /// window check would find nothing outstanding and reveal an empty grid, and the deadline
+    /// page check would find nothing outstanding and reveal an empty grid, and the deadline
     /// must not be running either.
     ///
     /// Returns the spinner frame to upload, if it changed this tick.
-    pub fn advance(&mut self, fetch_in_flight: bool, window_ready: impl FnOnce() -> bool) -> Option<usize> {
+    pub fn advance(&mut self, fetch_in_flight: bool, page: impl FnOnce() -> PageReady) -> Option<usize> {
         let since = *self.since.get_or_insert_with(Instant::now);
         if !fetch_in_flight {
             let build_since = *self.build_since.get_or_insert_with(Instant::now);
-            if window_ready() || build_since.elapsed() >= SPINNER_MAX_WAIT {
+            let ready = match page() {
+                PageReady::All => true,
+                PageReady::Tiles => build_since.elapsed() >= SPINNER_MAX_WAIT,
+                PageReady::Building => false,
+            };
+            if ready {
                 self.reveal();
                 return None;
             }

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -322,13 +322,11 @@ impl App {
             .and_then(|(h, p)| self.hosts.known.iter().position(|k| k.host == *h && k.port == *p))
     }
 
-    /// Eased 0..=1 progress of pin id `id`'s zoom-in (see `tile::CardSlot::pop`)
+    /// Eased 0..=1 progress of pin id `id`'s arrival (see `tile::CardSlot::pop`)
     /// — 1.0, full size, for anything not animating.
     pub(crate) fn card_pop_frac(&self, id: &str) -> f32 {
-        ui::animation::anim_frac(
-            self.render.grid.card_ids.slot(id).and_then(|slot| slot.pop),
-            crate::app::CARD_POP,
-        )
+        let slot = self.render.grid.card_ids.slot(id).and_then(|slot| slot.pop);
+        crate::app::render::tile::entrance_progress(slot, std::time::Instant::now()).0
     }
 
     /// The largest useful `grid_scroll` for the current library/layout — 0 when

--- a/src/app/state/hostmenu.rs
+++ b/src/app/state/hostmenu.rs
@@ -72,8 +72,8 @@ fn host_menu_row(action: HostAction, paired: bool, power: Option<ExitAction>) ->
         // The hint goes in the value column like every other Action row's, rather than
         // being parenthesised into the label.
         HostAction::Connect => FocusRow::action_with_value(icons::ICON_TV, "Connect", "pairs first"),
-        HostAction::Pair => FocusRow::action(icons::ICON_LOCK, "Pair with PIN…"),
-        HostAction::SpeedTest => FocusRow::action(icons::ICON_SIGNAL, "Test network speed…"),
+        HostAction::Pair => FocusRow::action(icons::ICON_LOCK, "Pair with PIN"),
+        HostAction::SpeedTest => FocusRow::action(icons::ICON_SIGNAL, "Test network speed"),
         // The one row with a trailing button: Confirm acts now, the ⋯ holds this host's
         // power settings (`Screen::HostPower`). Same affordance and the same
         // Right-to-reach-it gesture as a sidebar host row's. Plain, never `danger()`: red is
@@ -82,7 +82,7 @@ fn host_menu_row(action: HostAction, paired: bool, power: Option<ExitAction>) ->
         HostAction::Power => {
             FocusRow::action(icons::ICON_POWER, power_row_label(power)).with_trailing(host_menu_trailing(action))
         }
-        HostAction::Edit => FocusRow::action(icons::ICON_EDIT, "Edit address…"),
+        HostAction::Edit => FocusRow::action(icons::ICON_EDIT, "Edit address"),
         HostAction::Forget => FocusRow::action(icons::ICON_DELETE, "Forget host").danger(),
     }
 }

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -42,7 +42,11 @@ impl App {
     /// background is what normally hides it. Clearing transparent instead leaves the graphics
     /// plane carrying only the card, with the picture showing through everywhere else.
     pub(crate) fn frame_clear_color(&self) -> crate::ui::render::Color {
-        if crate::app::screens::over_video(self.nav.screen) && self.hdr_pattern_presenting() {
+        // The launch's hero dissolves into the picture behind it (`app::hero`), so the plane
+        // has to be uncovered for the whole dissolve rather than at the hand-off.
+        if self.render.hero.dissolving()
+            || (crate::app::screens::over_video(self.nav.screen) && self.hdr_pattern_presenting())
+        {
             crate::ui::render::Color::RGBA(0, 0, 0, 0)
         } else {
             crate::ui::theme::palette().bg

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -35,18 +35,37 @@ impl App {
         changed
     }
 
+    /// Whether this frame composes only what belongs *over* the video plane: no sidebar, no
+    /// grid, no status block, no full-screen scrim. Two ways in — a screen that draws over a
+    /// running stream (`screens::over_video`), and the launch backdrop dissolving into the
+    /// picture it was covering (`app::hero`).
+    ///
+    /// Deliberately not [`Self::video_underlay`]: a calibration pattern that has not started
+    /// presenting yet still owns the screen, and composing the menu back in behind its card
+    /// for those seconds — undimmed, since `compose_modal` skips the scrim over video — is a
+    /// flash of the whole home screen that then vanishes when the first frame lands.
+    pub(crate) fn over_video_layers(&self) -> bool {
+        self.render.hero.dissolving() || crate::app::screens::over_video(self.nav.screen)
+    }
+
+    /// Whether the video plane is what the user is looking at this frame, with the graphics
+    /// plane an overlay on top of it — i.e. whether the frame is punched through to it.
+    ///
+    /// [`Self::over_video_layers`] and a plane actually carrying a picture: clearing
+    /// transparent with nothing behind it is a black screen, so the pattern's feed has to be
+    /// presenting before the hole is opened.
+    pub(crate) fn video_underlay(&self) -> bool {
+        self.render.hero.dissolving()
+            || (crate::app::screens::over_video(self.nav.screen) && self.hdr_pattern_presenting())
+    }
+
     /// What the frame is cleared to before the draw list runs.
     ///
-    /// Transparent while a screen is drawing over the video plane and that plane is actually
-    /// presenting (see `screens::over_video`): NDL is an *underlay*, and the menu's opaque
+    /// Transparent over the video plane: NDL is an *underlay*, and the menu's opaque
     /// background is what normally hides it. Clearing transparent instead leaves the graphics
-    /// plane carrying only the card, with the picture showing through everywhere else.
+    /// plane carrying only what is drawn over the picture.
     pub(crate) fn frame_clear_color(&self) -> crate::ui::render::Color {
-        // The launch's hero dissolves into the picture behind it (`app::hero`), so the plane
-        // has to be uncovered for the whole dissolve rather than at the hand-off.
-        if self.render.hero.dissolving()
-            || (crate::app::screens::over_video(self.nav.screen) && self.hdr_pattern_presenting())
-        {
+        if self.video_underlay() {
             crate::ui::render::Color::RGBA(0, 0, 0, 0)
         } else {
             crate::ui::theme::palette().bg

--- a/src/platform/webos/compositor.rs
+++ b/src/platform/webos/compositor.rs
@@ -23,9 +23,8 @@ use crate::ui::Painter;
 static BLEND_WARNED: std::sync::Once = std::sync::Once::new();
 
 /// The blend behind [`DrawCmd::Erase`]: `dst = dst * (1 - srcA)`, colour and alpha alike, so a
-/// mask subtracts what is already drawn instead of painting over it. Composed per call — it is
-/// a pure function of its six arguments, and SDL hands back a packed value rather than
-/// allocating anything.
+/// mask subtracts what is already drawn instead of painting over it. Composed once and cached
+/// on the `Compositor`; whether the renderer accepts it is the setter's answer.
 fn erase_blend() -> sdl2::sys::SDL_BlendMode {
     use sdl2::sys::{SDL_BlendFactor::*, SDL_BlendOperation::*};
     unsafe {
@@ -91,6 +90,8 @@ pub struct Compositor {
     /// The composed premultiplied blend mode, probed once — `None` until probed, `Some(None)`
     /// if the renderer refused it.
     premultiplied: Option<Option<sdl2::sys::SDL_BlendMode>>,
+    /// The composed erase blend mode, once composed (see [`DrawCmd::Erase`]).
+    erase: Option<sdl2::sys::SDL_BlendMode>,
     /// Everything [`DrawCmd::Frost`] needs, built the first frame one appears. `None` until
     /// then — but a focused grid card frosts its own title strip, so in the menu that is the
     /// first frame with focus, and a screen's worth of render target is allocated for the rest
@@ -452,6 +453,7 @@ impl Compositor {
             pool: Vec::new(),
             staging: Vec::new(),
             premultiplied: None,
+            erase: None,
             frost: None,
             next_gen: 0,
         }
@@ -856,22 +858,26 @@ impl Compositor {
                         .map_err(|e| anyhow::anyhow!("copy cropped {tile:?}: {e}"))?;
                 }
                 DrawCmd::Erase { tile, dst } => {
+                    // Resolved against the mask texture itself, not a probe: this arm runs on
+                    // the frame loop's ordinary path, which has no `TextureCreator` to make a
+                    // probe texture with — gating it on one is how this silently became a
+                    // fade to black.
+                    let mode = *self.erase.get_or_insert_with(erase_blend);
                     let Some(tex) = self.faded_tile(tile, 0xff) else {
                         continue;
                     };
-                    // Restored right after: every other command on this texture — and every
-                    // other texture — composites normally.
-                    let raw = tex.raw();
-                    let restore = unsafe { sdl2::sys::SDL_SetTextureBlendMode(raw, erase_blend()) } == 0;
+                    let erasing = set_raw_blend_mode(tex, mode);
                     canvas
                         .copy(tex, None, Some(to_sdl_rect(*dst)))
                         .map_err(|e| anyhow::anyhow!("erase {tile:?}: {e}"))?;
-                    if restore {
-                        unsafe { sdl2::sys::SDL_SetTextureBlendMode(raw, sdl2::sys::SDL_BlendMode::SDL_BLENDMODE_BLEND) };
+                    if erasing {
+                        // Restored right after: every other command on this texture — and
+                        // every other texture — composites normally.
+                        set_raw_blend_mode(tex, sdl2::sys::SDL_BlendMode::SDL_BLENDMODE_BLEND);
                     } else {
                         // No custom blend on this renderer: the mask blends normally instead,
-                        // so the dissolve fades to the mask's own black rather than to the
-                        // plane. Same shape, no punch-through.
+                        // so the dissolve fades to its own black rather than to the plane.
+                        // Once per process — this runs every frame of every dissolve.
                         BLEND_WARNED.call_once(|| {
                             tracing::warn!("SDL custom blend unsupported — hero dissolve falls back to fading to black");
                         });

--- a/src/platform/webos/compositor.rs
+++ b/src/platform/webos/compositor.rs
@@ -18,6 +18,28 @@ use crate::ui::render::{Color, Corners, DrawCmd, FrostMask, FrostPane, Rect, Til
 use crate::ui::theme::Glass;
 use crate::ui::Painter;
 
+/// Logged once per process: a renderer without custom blend modes cannot punch a hole in the
+/// graphics plane, and repeating that per frame would bury the log.
+static BLEND_WARNED: std::sync::Once = std::sync::Once::new();
+
+/// The blend behind [`DrawCmd::Erase`]: `dst = dst * (1 - srcA)`, colour and alpha alike, so a
+/// mask subtracts what is already drawn instead of painting over it. Composed per call — it is
+/// a pure function of its six arguments, and SDL hands back a packed value rather than
+/// allocating anything.
+fn erase_blend() -> sdl2::sys::SDL_BlendMode {
+    use sdl2::sys::{SDL_BlendFactor::*, SDL_BlendOperation::*};
+    unsafe {
+        sdl2::sys::SDL_ComposeCustomBlendMode(
+            SDL_BLENDFACTOR_ZERO,
+            SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
+            SDL_BLENDOPERATION_ADD,
+            SDL_BLENDFACTOR_ZERO,
+            SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
+            SDL_BLENDOPERATION_ADD,
+        )
+    }
+}
+
 fn to_sdl_rect(r: Rect) -> sdl2::rect::Rect {
     sdl2::rect::Rect::new(r.x(), r.y(), r.width(), r.height())
 }
@@ -728,6 +750,7 @@ impl Compositor {
                 }
                 // Through the bits: the fractional destination is the whole point of this variant,
                 // so rounding it here would let a sub-pixel pan reuse a stale capture.
+                DrawCmd::Erase { tile, dst } => (5u8, tile, gen(tile), rect_key(*dst)).hash(&mut h),
                 DrawCmd::TexF { tile, dst, alpha } => (
                     2u8,
                     tile,
@@ -831,6 +854,28 @@ impl Compositor {
                     canvas
                         .copy(tex, Some(to_sdl_rect(*src)), Some(to_sdl_rect(*dst)))
                         .map_err(|e| anyhow::anyhow!("copy cropped {tile:?}: {e}"))?;
+                }
+                DrawCmd::Erase { tile, dst } => {
+                    let Some(tex) = self.faded_tile(tile, 0xff) else {
+                        continue;
+                    };
+                    // Restored right after: every other command on this texture — and every
+                    // other texture — composites normally.
+                    let raw = tex.raw();
+                    let restore = unsafe { sdl2::sys::SDL_SetTextureBlendMode(raw, erase_blend()) } == 0;
+                    canvas
+                        .copy(tex, None, Some(to_sdl_rect(*dst)))
+                        .map_err(|e| anyhow::anyhow!("erase {tile:?}: {e}"))?;
+                    if restore {
+                        unsafe { sdl2::sys::SDL_SetTextureBlendMode(raw, sdl2::sys::SDL_BlendMode::SDL_BLENDMODE_BLEND) };
+                    } else {
+                        // No custom blend on this renderer: the mask blends normally instead,
+                        // so the dissolve fades to the mask's own black rather than to the
+                        // plane. Same shape, no punch-through.
+                        BLEND_WARNED.call_once(|| {
+                            tracing::warn!("SDL custom blend unsupported — hero dissolve falls back to fading to black");
+                        });
+                    }
                 }
                 DrawCmd::TexF { tile, dst, alpha } => {
                     let Some(tex) = self.faded_tile(tile, *alpha) else {

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -130,6 +130,7 @@ impl EventSeq {
     fn count(&self) -> u64 {
         self.seq.load(Ordering::SeqCst)
     }
+
 }
 
 static LOAD_COMPLETED: EventSeq = EventSeq::new();
@@ -148,6 +149,9 @@ static FRAME_FED: EventSeq = EventSeq::new();
 /// and there is no later callback that takes it back. Cleared only by [`arm_load`], which is to
 /// say by a NEW load.
 static FATAL: EventSeq = EventSeq::new();
+/// When the armed load's first frame was accepted — [`FRAME_FED`]'s clock, for the holds that
+/// are measured from the picture rather than from the load.
+static FIRST_FRAME_AT: Mutex<Option<Instant>> = Mutex::new(None);
 
 /// Records v2 load-state transitions so loads, feeds and the UI reveal can wait on them.
 extern "C" fn on_load_state(state: c_int, num: c_longlong, detail: *const c_char) {
@@ -193,6 +197,7 @@ extern "C" fn on_load_state(state: c_int, num: c_longlong, detail: *const c_char
 /// Takes the counters as the baseline for the load about to be issued. Call immediately before
 /// every load, and after an unload so [`playing`] stops reporting a dead one.
 fn arm_load() {
+    *FIRST_FRAME_AT.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = None;
     LOAD_COMPLETED.arm();
     PLAYING.arm();
     FRAME_FED.arm();
@@ -212,16 +217,42 @@ pub fn playing() -> bool {
     PLAYING.fired()
 }
 
-/// Whether a frame of the current load has reached the decoder: the plane has a picture and is
-/// safe to uncover. Both NDL generations report through this, so `runtime`'s reveal gate is
-/// generation-blind.
+/// Whether a frame of the current load has reached the decoder: the plane is safe to uncover.
+/// Both NDL generations report through this, so `runtime`'s reveal gate is generation-blind.
 pub fn presenting() -> bool {
     FRAME_FED.fired()
 }
 
+/// How long past its first accepted frame a load has a picture on the panel.
+///
+/// NDL reports no first-*present* event on either generation — v2 has load states only
+/// (`PLAYING` lands before anything is fed) and v1's frame callback is a pipeline-alive echo.
+/// What it does have is a standing present cushion: `DirectMedia` presents an access unit at
+/// its PTS, a couple of frames behind the feed (see `docs/NOTES.md` on present lead). So the
+/// first accepted frame is decode-queued, not visible, and anything crossfading to live video
+/// on [`presenting`] alone crossfades into black. Measured from that first frame, so it holds
+/// the *pipeline* only — waiting for the host's first delivery has its own budget
+/// (`app::hero::FIRST_FRAME_WAIT`).
+const FIRST_PICTURE_HOLD: Duration = Duration::from_millis(250);
+
+/// Whether the panel should be *showing* the current load, not just holding its first frame —
+/// what a crossfade from a still to live video has to wait for. See [`FIRST_PICTURE_HOLD`].
+pub fn presented() -> bool {
+    first_frame_at().is_some_and(|t| t.elapsed() >= FIRST_PICTURE_HOLD)
+}
+
+/// When the armed load's first frame was accepted, if one has been.
+fn first_frame_at() -> Option<Instant> {
+    *FIRST_FRAME_AT.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// Records the first frame of the armed load (see [`arm_load`]); `true` if it was the first.
 fn mark_frame_fed() -> bool {
-    FRAME_FED.bump_first()
+    let first = FRAME_FED.bump_first();
+    if first {
+        *FIRST_FRAME_AT.lock().unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Instant::now());
+    }
+    first
 }
 
 /// [`mark_frame_fed`] plus the log line both generations emit; `since` is the handle's load

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -130,7 +130,6 @@ impl EventSeq {
     fn count(&self) -> u64 {
         self.seq.load(Ordering::SeqCst)
     }
-
 }
 
 static LOAD_COMPLETED: EventSeq = EventSeq::new();

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -176,13 +176,13 @@ pub(super) fn run_inner() -> Result<()> {
         // Bounded — a host that never sends must not leave a stale menu frame up.
         let reveal_wait = Instant::now();
         let deadline = reveal_deadline(first_frame_deadline);
-        while !crate::platform::webos::ndl::presenting() && Instant::now() < deadline {
+        while !crate::platform::webos::ndl::presented() && Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(4));
         }
         tracing::info!(
-            "NDL reveal after {:?} (presenting={} playing={})",
+            "NDL reveal after {:?} (presented={} playing={})",
             reveal_wait.elapsed(),
-            crate::platform::webos::ndl::presenting(),
+            crate::platform::webos::ndl::presented(),
             crate::platform::webos::ndl::playing(),
         );
 

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -252,7 +252,10 @@ pub(super) fn run_ui_flow(
                 Some((h, _, _)) if !h.is_finished() => Connect::Pending,
                 _ => Connect::Done,
             };
-            let presenting = crate::platform::webos::ndl::presenting();
+            // `presented`, not `presenting`: the hero's exit crossfades into the video plane,
+            // and a frame merely accepted by NDL is still behind its present cushion — fading
+            // out on that lands the dissolve on black (see `ndl::FIRST_PICTURE_FRAMES`).
+            let presenting = crate::platform::webos::ndl::presented();
             if app.render.hero.handover_ready(t.elapsed(), connect, presenting) {
                 // Where the launch actually takes — not `confirm_grid_card`, which also fires
                 // for one that bounces into the Wake dialog or fails to pair. A failed launch
@@ -461,6 +464,20 @@ pub(super) fn run_ui_flow(
             } else if let Some(pm) = tiles.get(id) {
                 compositor.upload(texture_creator, id, pm, id == tile::SIDEBAR)?;
             }
+        }
+        // The launch backdrop's dissolve: its mask is the one texture that changes every frame
+        // it is up, so it is uploaded here rather than through the tile store (which caches by
+        // content) — a few KB, for the second or so the wave runs.
+        if app.render.hero.dissolving() {
+            let (mw, mh, px) = app.render.hero.dissolve_mask(Instant::now());
+            compositor.upload_raw(
+                texture_creator,
+                tile::HERO_MASK,
+                mw,
+                mh,
+                sdl2::pixels::PixelFormatEnum::ABGR8888,
+                px,
+            )?;
         }
         let mut cmds = app.draw_list(&tiles, display_mode.w as u32, display_mode.h as u32, fonts);
         // Appended into the same single draw list/present as the rest of the

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -254,9 +254,9 @@ pub(super) fn run_ui_flow(
             };
             // `presented`, not `presenting`: the hero's exit crossfades into the video plane,
             // and a frame merely accepted by NDL is still behind its present cushion — fading
-            // out on that lands the dissolve on black (see `ndl::FIRST_PICTURE_FRAMES`).
-            let presenting = crate::platform::webos::ndl::presented();
-            if app.render.hero.handover_ready(t.elapsed(), connect, presenting) {
+            // out on that lands the dissolve on black (see `ndl::FIRST_PICTURE_HOLD`).
+            let presented = crate::platform::webos::ndl::presented();
+            if app.render.hero.handover_ready(t.elapsed(), connect, presented) {
                 // Where the launch actually takes — not `confirm_grid_card`, which also fires
                 // for one that bounces into the Wake dialog or fails to pair. A failed launch
                 // must not reorder Library.
@@ -469,7 +469,7 @@ pub(super) fn run_ui_flow(
         // it is up, so it is uploaded here rather than through the tile store (which caches by
         // content) — a few KB, for the second or so the wave runs.
         if app.render.hero.dissolving() {
-            let (mw, mh, px) = app.render.hero.dissolve_mask(Instant::now());
+            let (mw, mh, px) = app.render.hero.dissolve_mask(frame_start);
             compositor.upload_raw(
                 texture_creator,
                 tile::HERO_MASK,

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -196,11 +196,14 @@ impl Wave {
         self.span.mul_f32(progress.clamp(0.0, 1.0))
     }
 
-    /// That element's 0..=1 progress at `now`, for a wave that started at `start`.
-    pub fn frac(self, start: Option<Instant>, progress: f32, now: Instant) -> f32 {
-        anim_frac_smooth_at(start.map(|t| t + self.delay(progress)), self.fade, now)
+    /// That element's 0..=1 progress, `elapsed` seconds into the wave. Seconds rather than
+    /// two `Instant`s because the callers evaluate one wave at many points of a frame (a
+    /// mask's texels, a window of cards): plain `f32` throughout, no `Duration` arithmetic
+    /// per point.
+    pub fn frac_secs(self, elapsed: f32, progress: f32) -> f32 {
+        let started = elapsed - self.span.as_secs_f32() * progress.clamp(0.0, 1.0);
+        smoothstep((started / self.fade.as_secs_f32()).clamp(0.0, 1.0))
     }
-
 }
 
 /// Scales `base` by `1.0 + growth * frac` around its own center — the GPU

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -173,6 +173,36 @@ pub fn anim_frac_smooth_at(anim: Option<Instant>, dur: Duration, now: Instant) -
     frac_at(anim, dur, now, smoothstep)
 }
 
+/// A staggered fade across a surface: one curve, started up to `span` later depending on how
+/// far along the sweep the element sits. Whoever owns the surface decides what `progress`
+/// means — a card's diagonal position in the grid, a texel's position in an image — and the
+/// motion is the same either way, which is the point: the library's cards arrive on one of
+/// these and the launch backdrop leaves on one, in the same direction.
+///
+/// Smoothstep rather than the cubic ease-out the pops use: over a long fade `1-(1-t)³` is
+/// near-opaque a sixth of the way through, which lands as a pop.
+#[derive(Clone, Copy)]
+pub struct Wave {
+    /// How much later the far end of the sweep starts than the near end.
+    pub span: Duration,
+    /// One element's own fade, once its turn comes.
+    pub fade: Duration,
+}
+
+impl Wave {
+    /// How long the element at `progress` (0 at the corner the wave starts from, 1 at the
+    /// opposite one) waits before its own fade begins.
+    pub fn delay(self, progress: f32) -> Duration {
+        self.span.mul_f32(progress.clamp(0.0, 1.0))
+    }
+
+    /// That element's 0..=1 progress at `now`, for a wave that started at `start`.
+    pub fn frac(self, start: Option<Instant>, progress: f32, now: Instant) -> f32 {
+        anim_frac_smooth_at(start.map(|t| t + self.delay(progress)), self.fade, now)
+    }
+
+}
+
 /// Scales `base` by `1.0 + growth * frac` around its own center — the GPU
 /// zoom-in technique behind every focus-pop in the app. The source tile is
 /// rasterized once, at its literal size; only this destination rect changes

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -145,10 +145,32 @@ pub fn anim_frac_smooth(anim: Option<Instant>, dur: Duration) -> f32 {
 }
 
 fn frac(anim: Option<Instant>, dur: Duration, curve: impl Fn(f32) -> f32) -> f32 {
+    // The clock is read only when there is an animation to measure — most calls, on most
+    // frames, are the `None` arm.
     match anim {
-        Some(t) => curve((t.elapsed().as_secs_f32() / dur.as_secs_f32()).min(1.0)),
+        Some(_) => frac_at(anim, dur, Instant::now(), curve),
         None => 1.0,
     }
+}
+
+/// [`frac`] against a clock the caller already read. Per-element loops (the grid's visible
+/// cards) take one `Instant::now()` for the frame rather than one per element per curve.
+fn frac_at(anim: Option<Instant>, dur: Duration, now: Instant, curve: impl Fn(f32) -> f32) -> f32 {
+    match anim {
+        // Saturating: a clock armed in the future (the reveal wave's stagger) has not started.
+        Some(t) => curve((now.saturating_duration_since(t).as_secs_f32() / dur.as_secs_f32()).min(1.0)),
+        None => 1.0,
+    }
+}
+
+/// [`anim_frac`] on a caller-held clock. See [`frac_at`].
+pub fn anim_frac_at(anim: Option<Instant>, dur: Duration, now: Instant) -> f32 {
+    frac_at(anim, dur, now, ease)
+}
+
+/// [`anim_frac_smooth`] on a caller-held clock. See [`frac_at`].
+pub fn anim_frac_smooth_at(anim: Option<Instant>, dur: Duration, now: Instant) -> f32 {
+    frac_at(anim, dur, now, smoothstep)
 }
 
 /// Scales `base` by `1.0 + growth * frac` around its own center — the GPU

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -161,6 +161,17 @@ pub enum DrawCmd {
         dst: RectF,
         alpha: u8,
     },
+    /// Subtracts `tile`'s alpha from what is already drawn, per pixel: `dst *= 1 - srcA` for
+    /// colour and alpha alike, so a fully opaque mask pixel leaves the target transparent.
+    ///
+    /// The one command that removes rather than adds. It is how a still dissolves into the
+    /// video plane underneath the graphics plane: alpha-mod is per *blit*, so shaping a fade
+    /// with it means splitting the image into pieces and showing their edges, where a mask
+    /// stretched over the whole image is a continuous gradient.
+    Erase {
+        tile: TileId,
+        dst: Rect,
+    },
     Fill {
         rect: Rect,
         color: Color,


### PR DESCRIPTION
## Summary
- Post-spinner card reveal is now a diffused fade sweeping diagonally top-left to bottom-right, staggered by row+column, instead of every card popping in independently.
- `Entrance{start, kind: Pop|Reveal}` on `CardSlot::pop` replaces the bare `Instant`; kind supplies duration, shrink and curve. Arming a clock in the future gives the stagger with no per-frame scheduling, so a card built by an in-flight scroll mid-reveal still gets its own pop.
- Compose does one `Instant::now()` per grid pass and skips fully transparent cards instead of drawing no-op blits.
- New constants `CARD_REVEAL_FADE` (420ms) and `CARD_REVEAL_WAVE_STEP` (38ms/diagonal step) in `src/app/mod.rs`.

## Test plan
- [x] `task docker:lint` (clippy -D warnings, cross toolchain)
- [ ] Verify on real TV; tune 420ms/38ms timings if needed