### PR TITLE
Revert sidebar glass material, use opaque fill

### DIFF
--- a/src/app/grid.rs
+++ b/src/app/grid.rs
@@ -16,21 +16,16 @@ use crate::app::spinner::GridReveal;
 use crate::app::view::home::{SECTION_GAP, SECTION_HEADING_H};
 use crate::core::model::GameEntry;
 
-/// Rows beyond viewport kept rasterized (prevents scroll stalls).
+/// Prefetch rows beyond viewport (prevents stalls).
 pub(crate) const CARD_PREFETCH_ROWS: i32 = 2;
-/// Rows beyond which tiles are dropped. Hysteresis prevents eviction oscillation.
+/// Rows beyond which tiles are dropped (hysteresis prevents oscillation).
 pub(crate) const CARD_KEEP_ROWS: i32 = 5;
-/// Rasterization time one frame will spend on card tiles before deferring the rest to the
-/// next. Checked *after* each card, so one is always built however slow the device — the
-/// window fills at whatever rate the hardware allows instead of at a rate picked for the
-/// slowest one. A fixed count of 1 (what this was) meant a 5x4 viewport took twenty frames
-/// to fill everywhere, which on a fast host is a third of a second of blank cards for no
-/// reason; on armv7 softfloat, where one card's text rasterization alone can cost most of a
-/// tick, this degrades back to exactly that one card.
+/// Budget per frame for card rasterization. Checked after each card so at least one always
+/// builds (window fills at hardware rate, not slowest-device rate). Fixed count of 1 meant a
+/// 5x4 viewport took 20 frames to fill; on armv7 softfloat this was still one card/tick.
 pub(crate) const CARD_BUILD_BUDGET: Duration = Duration::from_millis(6);
-/// Hard ceiling on cards per frame regardless of the clock: a host fast enough never to trip
-/// [`CARD_BUILD_BUDGET`] must still not rasterize *and upload* an unbounded batch in one tick,
-/// since the upload is charged to a later stage that the budget above cannot see.
+/// Ceiling regardless of clock: prevents unbounded rasterize+upload in one tick (upload
+/// charged to a later stage the budget can't see).
 pub(crate) const CARD_BUILD_BURST: usize = 8;
 
 /// Upper bound on grid sections: [`MAX_COLLECTIONS`](crate::core::model::MAX_COLLECTIONS)
@@ -110,8 +105,7 @@ impl<'a> GridLayout<'a> {
         let mut y_offset = 0;
         self.groups.iter().enumerate().map(move |(i, group)| {
             let rows = group.len.div_ceil(columns);
-            // Every heading takes a line; every one after the first also takes the gap that
-            // makes the block above it read as finished.
+            // Each heading takes one line; all but first add gap (visual block separation).
             y_offset += SECTION_HEADING_H + if i == 0 { 0 } else { SECTION_GAP };
             let placed = Placed {
                 group,
@@ -187,13 +181,6 @@ impl<'a> GridLayout<'a> {
         self.row_offset_at(idx / self.columns)
     }
 
-    /// How many diagonal steps grid slot `idx` is from the top-left corner — the stagger the
-    /// reveal wave sweeps the screen on. Here rather than at the call site because the row and
-    /// column of a slot are this type's arithmetic, clamped column count included.
-    pub(crate) fn diagonal_step(&self, idx: usize) -> usize {
-        idx / self.columns + idx % self.columns
-    }
-
     /// What the sections add to the grid's total height — the offset its last row carries.
     pub(crate) fn total_extra(&self) -> i32 {
         self.placed().last().map_or(0, |p| p.y_offset)
@@ -209,82 +196,48 @@ pub(crate) struct GridState {
     /// than by grid position because pinning a game reorders the grid, and keying by index would
     /// rebuild every tile after the moved one.
     pub card_ids: tile::CardIds,
-    /// When the last-armed card pop finishes — the one comparison `App::tick_animations`
-    /// needs, instead of walking every resident card's clock each frame to ask the same
-    /// question.
-    /// Never lowered by an eviction: a deadline that is merely late costs one extra frame
-    /// of the redraw loop, where one that is early would freeze a zoom mid-way.
+    /// When the last-armed card pop finishes (one comparison instead of walking every card).
+    /// Never lowered: late deadline costs one frame; early would freeze zoom mid-way.
     pub card_pop_until: Option<Instant>,
-    /// Current card size, derived from screen width in `App::advance_frame`. Screen geometry (the
-    /// event side reads it to size cover-art requests), not a rasterized tile.
+    /// Screen-derived card size, not rasterized.
     pub card_size: (u32, u32),
-    /// All card tiles are stale — the games list or the host changed. A fresh library load, so
-    /// `prepare_grid` also stands the reveal spinner back up.
+    /// All card tiles stale (games/host changed); also stands the reveal spinner up.
     pub dirty: bool,
-    /// Individual card tiles stale (cover art arrived), by pin id — cheaper than [`Self::dirty`]
-    /// when the layout is unchanged.
+    /// Individual card tiles stale (cover art), by pin id (cheaper than full dirty).
     pub cards_dirty: Vec<String>,
-    /// Card tiles still waiting to be rasterized inside the prefetch window. Keeps the main loop
-    /// ticking until the window is filled — without it the redraw-on-change loop would go idle
-    /// mid-build and leave blank cards on screen.
+    /// Cards waiting in prefetch window (keeps loop ticking until filled).
     pub tiles_pending: bool,
-    /// Scroll offset actually rendered this frame (px; 0 = row 0 at `view::home::GRID_TOP_Y`) —
-    /// eases toward [`Self::scroll_target`] each tick.
+    /// Scroll offset rendered this frame; eases toward `scroll_target`.
     pub scroll: i32,
     pub scroll_target: i32,
-    /// Where the grid is re-entered from the sidebar. Only ever consulted through the focus map,
-    /// which drops it when it no longer names a real card, so reorders and library reloads need no
-    /// invalidation of their own.
+    /// Grid re-entry from sidebar. Cleared by focus map when no longer valid.
     pub focus_last: usize,
-    /// Whether the initial build for the current library has finished, and the spinner shown until
-    /// it has.
+    /// Spinner state until initial build finishes.
     pub reveal: GridReveal,
-    /// `prepare_grid`'s per-frame working lists, kept across frames and cleared on entry.
-    /// All three are window-bounded, so this is not a scaling fix — it is the armv7 softfloat
-    /// allocator not being asked for three fresh collections on every frame of every scroll.
+    /// Per-frame scratch lists (window-bounded to avoid allocations every frame on armv7).
     pub scratch: GridScratch,
-    /// Card pixmaps freed by eviction, held for the next card built this frame. A scroll
-    /// evicts and builds in the same frame (see `prepare_grid`), and every card is exactly
-    /// [`Self::card_size`], so a recycled buffer never needs resizing — at 1080p each one is
-    /// ~360KB that would otherwise be freed and immediately reallocated.
+    /// Card pixmaps freed by eviction. Recycled for next build (avoids 360KB realloc at 1080p).
     pub free_cards: Vec<crate::ui::Painter>,
 }
 
-/// The lists `prepare_grid` refills each frame. Indices and ids only — nothing here borrows
-/// `games`, since it lives on `App` alongside it.
+/// Per-frame working lists. Indices/ids only; doesn't borrow `games`.
 #[derive(Default)]
 pub(crate) struct GridScratch {
-    /// Tiles inside the keep window, sorted, for the eviction test.
+    /// Tiles in keep window, sorted for eviction test.
     pub keep: Vec<crate::ui::render::TileId>,
-    /// Pin ids evicted this frame — owned, because releasing them mutates the map they
-    /// were read from.
+    /// Pin ids evicted (owned because releasing them mutates the map).
     pub dropped: Vec<String>,
-    /// Build candidates whose cover art has already arrived, and those still waiting.
+    /// Build candidates with/without cover art.
     pub ready: Vec<usize>,
     pub waiting: Vec<usize>,
 }
 
 impl GridState {
-    /// Starts (or restarts) `pin_id`'s pop at `at`. A card with no tile is not on screen
-    /// and has no arrival to show; it gets its clock when `prepare_grid` builds it.
+    /// Starts/restarts `pin_id`'s pop. Cards without tiles get their clock on build.
+    /// Grid's first appearance uses `GridReveal` mask instead (one surface, not per-card entrance).
     pub fn arm_card_pop(&mut self, pin_id: &str, at: Instant) {
-        self.arm_entrance(pin_id, tile::Entrance::pop(at), false);
-    }
-
-    /// Arms `pin_id`'s share of the reveal wave: a fade starting `delay` after `at`, which
-    /// the clock spends at zero progress (a future `Instant` reports no elapsed time). Never
-    /// restarts an arrival already under way.
-    pub fn arm_reveal_wave(&mut self, pin_id: &str, at: Instant, delay: Duration) {
-        self.arm_entrance(pin_id, tile::Entrance::reveal(at + delay), true);
-    }
-
-    fn arm_entrance(&mut self, pin_id: &str, entrance: tile::Entrance, if_idle: bool) {
-        let armed = if if_idle {
-            self.card_ids.arm_if_idle(pin_id, entrance)
-        } else {
-            self.card_ids.arm(pin_id, entrance)
-        };
-        if armed {
+        let entrance = tile::Entrance::pop(at);
+        if self.card_ids.arm(pin_id, entrance) {
             self.extend_pop_deadline(entrance.end());
         }
     }

--- a/src/app/hero.rs
+++ b/src/app/hero.rs
@@ -54,12 +54,6 @@ pub const HERO_DISSOLVE_WAVE: ui::animation::Wave = ui::animation::Wave {
     fade: Duration::from_millis(HERO_FADE.as_millis() as u64 * 3 / 5),
 };
 
-/// The dissolve mask's resolution. Tiny on purpose: it is stretched over the whole screen and
-/// bilinear filtering turns it into a continuous gradient, so the wave costs one small buffer
-/// per frame rather than a draw call per piece of the image.
-pub const HERO_MASK_W: u32 = 64;
-pub const HERO_MASK_H: u32 = 36;
-
 /// How much the hero is darkened once fully faded in, so it reads as a backdrop
 /// rather than as content.
 pub const HERO_SCRIM_ALPHA: f32 = 70.0;
@@ -94,54 +88,41 @@ pub fn hero_pan_dst(img_w: u32, img_h: u32, screen_w: u32, screen_h: u32, elapse
     }
 }
 
-/// How far the launch's connect has got, as the loading screen can see it.
+/// Launch connect progress as the loading screen sees it.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Connect {
-    /// Still running.
     Pending,
-    /// Finished with a session; whether it is decoding yet is `presenting`.
     Done,
-    /// Finished with an error, which the menu behind the hero is about to show.
     Failed,
 }
 
 #[derive(Default)]
 pub(crate) struct Hero {
-    /// The decoded image and the game id it belongs to. Several MB, and only one can ever
-    /// be on screen, so a newer one simply replaces it.
+    /// Decoded image and its game id (one on-screen, newer replaces).
     image: Option<(String, HeroImage)>,
-    /// Last id asked for (the focused card), so an image that arrives after focus has
-    /// moved on can be recognised as no longer useful.
+    /// Last requested id (focused card); recognize late arrivals as stale.
     wanted: Option<String>,
-    /// Id whose hero belongs on the connecting screen. `None` for Desktop.
+    /// Id for connecting screen hero (`None` for Desktop).
     target: Option<String>,
-    /// Whether this launch's hero is still in flight: the loading screen waits a moment for art on
-    /// its way, but must not delay a launch with nothing to wait for.
+    /// Whether launch hero is in-flight (wait for art in-hand, not nothing).
     expected: bool,
-    /// Id currently uploaded as `TileId::Hero`. Uploaded only once a launch starts —
-    /// browsing must not put a multi-MB texture on the GPU.
+    /// Id currently uploaded as `TileId::Hero` (only after launch starts).
     uploaded: Option<String>,
-    /// When the uploaded image started fading in. Its own clock, not the launch fade's: a
-    /// hero can land mid-handshake, and then it fades in from there.
+    /// When uploaded image started fading in (own clock, can land mid-handshake).
     since: Option<Instant>,
-    /// When it started fading back out, i.e. when the stream became ready.
+    /// When fade-out started (stream became ready).
     fade_out: Option<Instant>,
-    /// [`Self::dissolve_mask`]'s buffer, kept across the frames of one dissolve.
+    /// Buffer for `dissolve_mask`.
     mask: Vec<u8>,
-    /// Whether that fade-out began with a picture on the video plane behind it. Only then is
-    /// the exit a dissolve into live video; a failed connect (or a first frame that never
-    /// came) has nothing to dissolve into and leaves over the menu as it always did.
+    /// Whether fade-out started with video behind it (dissolve vs menu).
     over_video: bool,
-    /// When the wait for a decoded frame runs out, set the moment the connect finishes so the
-    /// budget is bounded from there rather than from the launch. Handed to `runtime::stream`,
-    /// whose reveal waits on the same signal and must not start the clock over.
+    /// Deadline for first decoded frame (shared with stream reveal).
     first_frame_deadline: Option<Instant>,
 }
 
 impl Hero {
-    /// Notes whose hero is worth keeping — the focused card, whose art is prefetched.
+    /// Note focused card to prefetch. Called per tile-prep, no-op case allocates nothing.
     pub(crate) fn want(&mut self, game_id: &str) {
-        // Called per tile-prep pass, so the usual no-op case allocates nothing.
         if self.wanted.as_deref() != Some(game_id) {
             self.wanted = Some(game_id.to_string());
         }
@@ -154,15 +135,12 @@ impl Hero {
         self.expected = false;
     }
 
-    /// Says this launch's hero is still being fetched, so the hand-off gives it a moment to
-    /// land. A game with none, or one whose hero is already in hand, must not spend that moment.
+    /// Signal hero still fetching (hand-off waits for art in-hand, not nothing).
     pub(crate) fn await_art(&mut self) {
         self.expected = true;
     }
 
-    /// Takes a freshly decoded image, and reports whether it was kept. A `false` means the
-    /// caller should let the loader forget it, so focusing that card again re-requests it
-    /// (from the disk cache by then) rather than never asking a second time.
+    /// Accept decoded image; false means caller should drop it (re-request on re-focus from cache).
     pub(crate) fn accept(&mut self, game_id: String, image: HeroImage) -> bool {
         let useful =
             self.wanted.as_deref() == Some(game_id.as_str()) || self.target.as_deref() == Some(game_id.as_str());
@@ -240,8 +218,7 @@ impl Hero {
     /// Seconds into the exit at `now`, or `None` if it has not started — the one reading of
     /// that clock, for the two curves that run off it (this fade and the dissolve's wave).
     fn exit_secs(&self, now: Instant) -> Option<f32> {
-        self.fade_out
-            .map(|t| now.saturating_duration_since(t).as_secs_f32())
+        self.fade_out.map(|t| now.saturating_duration_since(t).as_secs_f32())
     }
 
     /// Whether the exit is a dissolve into live video: the graphics plane is cleared
@@ -263,33 +240,13 @@ impl Hero {
     }
 
     /// This frame's dissolve mask: one byte of alpha per texel of a black
-    /// [`HERO_MASK_W`]x[`HERO_MASK_H`] image, in RGBA order.
-    ///
-    /// The wave runs on `(x + y)`, so it sweeps the diagonal from the top-left corner — the
-    /// direction the grid's cards arrive on — and every texel is on its own delayed
-    /// smoothstep. Evaluated once per *diagonal* rather than once per texel: the value is a
-    /// function of `x + y` alone, so a row of the image is 23 of them rather than 2304.
-    ///
-    /// The buffer is kept across frames and only its alpha bytes are written — the colour is
-    /// black for the life of the dissolve, and this runs every frame of it.
+    /// [`ui::animation::MASK_W`]x[`ui::animation::MASK_H`] image, in RGBA order — the colour
+    /// is black for the life of the dissolve, so only the ramp itself varies frame to frame.
+    /// See [`ui::animation::diagonal_mask`] for the shared texel loop.
     pub(crate) fn dissolve_mask(&mut self, now: Instant) -> (u32, u32, &[u8]) {
-        let px = (HERO_MASK_W * HERO_MASK_H) as usize * 4;
-        if self.mask.len() != px {
-            self.mask.clear();
-            self.mask.resize(px, 0);
-        }
         let elapsed = self.exit_secs(now).unwrap_or(f32::MAX);
-        let last = (HERO_MASK_W + HERO_MASK_H - 2) as f32;
-        let mut diagonal = [0u8; (HERO_MASK_W + HERO_MASK_H - 1) as usize];
-        for (d, a) in diagonal.iter_mut().enumerate() {
-            *a = (HERO_DISSOLVE_WAVE.frac_secs(elapsed, d as f32 / last) * 255.0) as u8;
-        }
-        for y in 0..HERO_MASK_H {
-            for x in 0..HERO_MASK_W {
-                self.mask[((y * HERO_MASK_W + x) * 4 + 3) as usize] = diagonal[(x + y) as usize];
-            }
-        }
-        (HERO_MASK_W, HERO_MASK_H, &self.mask)
+        ui::animation::diagonal_mask(&mut self.mask, [0, 0, 0], HERO_DISSOLVE_WAVE, elapsed, |frac| frac);
+        (ui::animation::MASK_W, ui::animation::MASK_H, &self.mask)
     }
 
     /// Whether an uploaded hero is on screen as the connecting backdrop. `since` is only ever

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -106,69 +106,39 @@ pub struct DropdownState {
 }
 
 pub struct App {
-    /// Which screen is up, which was before it, and where the cursor sits on each — see
-    /// [`nav::Nav`].
     pub(crate) nav: nav::Nav,
-    /// Every background job in flight — see [`jobs::Jobs`].
     pub(crate) jobs: jobs::Jobs,
-    /// The selected host's games, art and grid sections — see [`library::Library`].
     pub(crate) library: library::Library,
-    /// Every host the menu knows about — see [`hosts::HostsState`].
     pub(crate) hosts: hosts::HostsState,
-    /// The settings document and the UI editing it — see [`settingsui::SettingsUi`].
     pub(crate) settings_ui: settingsui::SettingsUi,
-    /// Per-screen payloads — see [`screens::slots::ScreenSlots`].
     pub(crate) screens: screens::slots::ScreenSlots,
-    /// Tiles, clocks, scroll windows and dirty flags — see [`render::state::RenderState`].
     pub(crate) render: render::state::RenderState,
     pub(crate) home_focus: HomeFocus,
     pub(crate) home_status: Option<String>,
-    /// Whether `home_status` is the reason the last launch bounced back to the menu, and so must
-    /// survive the library reload a fresh menu entry starts — that reload clears the status on
-    /// success, which wiped the error a second after the user landed back on the grid. Anything
-    /// the user's own actions produce replaces it as usual.
+    /// Must survive library reload (cleared on success, else error disappears after 1s).
     pub(crate) home_status_sticky: bool,
-    /// A one-shot toast the state machine wants shown, waiting for the loop that owns the
-    /// [`Notification`](crate::ui::widgets::Notification) to pick it up (`take_toast`). An
-    /// outbox rather than a call, since `App` has no handle on the overlay: this is the same
-    /// arrangement `launch_ready` uses for a launch.
+    /// One-shot toast, outbox since App has no overlay handle.
     pub(crate) toast: Option<String>,
-    /// When the current status line went up, so `tick_animations` can expire it after
-    /// `HOME_STATUS_LIFETIME`. Stamped by `set_home_status`, which every writer goes through.
     home_status_shown_at: Option<Instant>,
-    /// A status line waiting out [`LIBRARY_STATUS_DELAY`], see
-    /// [`set_home_status_delayed`](Self::set_home_status_delayed).
+    /// Status line waiting out `LIBRARY_STATUS_DELAY`.
     library_status_due: Option<(Instant, String)>,
     pub(crate) launch_ready: Option<ConnectTarget>,
     pub(crate) launch_anim: Option<Instant>,
     pub(crate) launch_anim_idx: Option<usize>,
-    /// The submenu raised over a held grid card's title strip (where the card lives, plus
-    /// its per-game settings). `None` when no card is held open.
+    /// Submenu over held card's title strip.
     pub(crate) card_menu: Option<state::cardmenu::CardMenu>,
-    /// Whether the card submenu's introduction (`state::cardmenu::INTRO_HINT`) is still owed —
-    /// set on the first launch of a build that stamped a new version into the document, spent
-    /// on the status line as soon as a library has actually landed to hold the cards it talks
-    /// about.
+    /// Intro hint owed on first launch after version bump.
     pub(crate) intro_hint_owed: bool,
-    /// When each host last launched each game — what orders the Library section (see
-    /// [`services::recents`](crate::services::recents)). Loaded once at startup; a cache, so
-    /// nothing here fails.
+    /// Per-host launch history (orders Library section). Cached at startup.
     pub(crate) recents: crate::services::recents::Recents,
-    /// Persists settings off UI thread to avoid blocking.
+    /// Off-thread settings persist.
     pub(crate) state_writer: store::StateWriter,
-    /// The attached pad's type per `gamepad::detect_type`, refreshed on hotplug in
-    /// `runtime::ui_flow`. `None` with no pad attached or an unrecognized one. Only meaningful
-    /// when `settings.gamepad_type` is `Auto` — an explicit pick doesn't need this to know what
-    /// it's driving, but the Controller row's `DualSense` caption does (see `settings_rows`).
+    /// Detected pad type (meaningful only if `gamepad_type` is Auto).
     pub(crate) detected_gamepad_type: Option<store::GamepadType>,
-    /// Whether webOS's on-screen keyboard is currently up, polled from
-    /// `SDL_IsScreenKeyboardShown` each tick by `main.rs` — it moves the address form out
-    /// from under the panel (see `App::keyboard_modal_card`).
+    /// webOS on-screen keyboard up (moves address form from under panel).
     pub(crate) keyboard_shown: bool,
     pub(crate) identity: (String, String),
-    /// When `tick_animations` last ran, so the eased scroll can advance by real elapsed time
-    /// instead of by a frame count (see `ui::animation::ease_scroll`). Every other animation
-    /// here is already clocked off its own `Instant`.
+    /// Last tick time (for real-time scroll easing, not frame-count based).
     last_tick: Option<Instant>,
 }
 
@@ -204,19 +174,13 @@ impl App {
         self.keyboard_shown = shown;
     }
 
-    /// A Home status line shown only if the fetch is still running [`LIBRARY_STATUS_DELAY`]
-    /// later (`tick_animations` puts it up).
+    /// Show status line only if fetch still running after `LIBRARY_STATUS_DELAY`.
     pub(crate) fn set_home_status_delayed(&mut self, line: String) {
         self.set_home_status(None, false);
         self.library_status_due = Some((Instant::now(), line));
     }
 
-    /// The Home status line. `sticky` marks a line that must survive the library reload a
-    /// fresh menu entry starts — that reload clears the status on success, which otherwise
-    /// wiped a launch error a second after the user landed back on the grid.
-    ///
-    /// Also drops any line still waiting out [`LIBRARY_STATUS_DELAY`] so it can't land on top
-    /// of a newer one.
+    /// Set Home status (sticky survives reload, cleared on success). Drops delayed line.
     pub(crate) fn set_home_status(&mut self, status: Option<String>, sticky: bool) {
         self.library_status_due = None;
         self.home_status_shown_at = status.is_some().then(Instant::now);
@@ -224,8 +188,7 @@ impl App {
         self.home_status_sticky = sticky;
     }
 
-    /// The open modal's scroll indicator this frame, on the same hold-then-fade as every
-    /// other self-expiring overlay. `None` once it is spent.
+    /// Open modal's scroll indicator (hold-then-fade like all self-expiring overlays).
     pub(crate) fn scroll_indicator_alpha(&self) -> Option<f32> {
         ui::fade::hold_alpha(
             self.render.scroll.shown_at?,
@@ -234,8 +197,7 @@ impl App {
         )
     }
 
-    /// The status line's opacity this frame, or `None` once it is spent — the toast's clock
-    /// ([`ui::fade::hold_alpha`]), so the two transient lines leave the screen the same way.
+    /// Status line opacity (same clock as toast, so lines leave screen identically).
     pub(crate) fn home_status_alpha(&self) -> Option<f32> {
         ui::fade::hold_alpha(
             self.home_status_shown_at?,
@@ -244,13 +206,12 @@ impl App {
         )
     }
 
-    /// Queues a transient toast. Replaces any still waiting — a second action before the loop
-    /// has ticked means the first is already stale.
+    /// Queue transient toast (replaces waiting ones; second action before tick = first stale).
     pub(crate) fn toast(&mut self, message: impl Into<String>) {
         self.toast = Some(message.into());
     }
 
-    /// Takes whatever [`toast`](Self::toast) queued, for the loop to hand its overlay.
+    /// Take queued toast for loop's overlay.
     pub fn take_toast(&mut self) -> Option<String> {
         self.toast.take()
     }
@@ -758,7 +719,10 @@ impl App {
             }
         }
         // Every frame of the fade out is a redraw; the frame after it is the clear.
-        if self.home_status_shown_at.is_some_and(|t| t.elapsed() >= HOME_STATUS_LIFETIME) {
+        if self
+            .home_status_shown_at
+            .is_some_and(|t| t.elapsed() >= HOME_STATUS_LIFETIME)
+        {
             if self.home_status_alpha().is_none() {
                 self.set_home_status(None, false);
             }
@@ -777,7 +741,7 @@ impl App {
         if self.card_menu.as_mut().is_some_and(state::cardmenu::CardMenu::tick) {
             animating = true;
         }
-        if self.render.grid.card_pops_running() {
+        if self.render.grid.card_pops_running() || self.render.grid.reveal.dissolving() {
             animating = true;
         }
         animating

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -176,14 +176,11 @@ impl App {
         });
     }
 
-    /// Nav column: pane and strip. Composed after grid (pane order matters for blur backdrop).
+    /// Nav column strip — opaque on every theme, so no frost pane under it.
     fn compose_sidebar(cmds: &mut Vec<DrawCmd>, screen_h: u32) {
-        let strip = Rect::new(0, 0, ui::widgets::SIDEBAR_W, screen_h);
-        // Square: three of the column's edges are the display's own.
-        Self::push_frost(cmds, strip, 0, 0xff);
         cmds.push(DrawCmd::Tex {
             tile: tile::SIDEBAR,
-            dst: strip,
+            dst: Rect::new(0, 0, ui::widgets::SIDEBAR_W, screen_h),
             alpha: 0xff,
         });
     }

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -18,11 +18,8 @@ use crate::ui;
 use crate::ui::cache::TileStore;
 use crate::ui::render::{DrawCmd, Rect};
 
-/// How tall each step of an edge fade's alpha ramp is. Every step is one `TexCropped` with its
-/// own alpha, and SDL cannot batch across an alpha-mod change, so this divides `SCROLL_FADE_H`
-/// (92px) into the command count each band costs *per frame it is on screen*: 8 gives ~12 steps
-/// a band, ~32 alpha apart. Fine enough to read as a gradient at TV distance, half the commands
-/// of the 4 it started at. Drop it back if banding shows on the panel.
+/// Height of each fade ramp step. SDL can't batch across alpha changes, so this divides
+/// `SCROLL_FADE_H` into draw commands: 8→~12 steps/band, ~32 alpha apart. Drop if banding shows.
 const FADE_STEP: u32 = 8;
 
 /// A scrolling viewport's two edge fade bands, top then bottom, each present only while there
@@ -46,9 +43,7 @@ impl App {
         }
     }
 
-    /// Modal family compose: the fade-in scrim + shell, scrollable content crop with
-    /// its edge fades, the dropdown overlay, the focused-widget zoom, and the scroll
-    /// indicator — all driven by the modal fade clock. Extracted from `draw_list`.
+    /// Compose open modal: fade scrim+shell, content crop with fades, dropdown, focus zoom, scroll indicator.
     fn compose_modal(
         &self,
         tiles: &TileStore,
@@ -80,36 +75,22 @@ impl App {
         } else {
             self.render.modal.fade.open_alpha()
         };
-        // `m` is what a cross-fade's leaving card is drawn as the inverse of (see `ModalFade`).
+        // m is cross-fade's leaving card inverse (see ModalFade).
         let closing = self
             .render
             .modal
             .prev
             .zip(self.render.modal.fade.closing_frame_against(m))
             .map(|(prev, (alpha, _))| (alpha, prev));
-        // The backdrop belongs to "a modal is up", not to either card: re-fading it
-        // mid-step would brighten the whole screen and read as a blink. It only fades when
-        // the modal layer itself appears or disappears.
+        // Backdrop is "modal up", not per-card; only fades when modal layer appears/disappears.
         let scrim = if closing.is_some() && !matches!(screen, Screen::Home) {
             1.0
         } else {
             m.max(closing.map_or(0.0, |(alpha, _)| alpha))
         };
-        // Every frost pane of this layer, *before* the scrim — the one ordering rule the
-        // whole effect rests on.
-        //
-        // The compositor captures its blur source once per frame, at the frame's first
-        // `DrawCmd::Frost`. So whatever precedes that pane is baked into every pane's blur and
-        // whatever follows it is not. With the scrim emitted first, a modal opened from the
-        // sidebar (no focused card, so its own pane is the first) blurred a *dimmed* screen,
-        // while the same modal opened from a card (whose title strip pushed the first pane
-        // already) blurred an undimmed one — the same code, two different-looking modals.
-        //
-        // Emitted under the scrim instead, every pane is a blur of the same undimmed backdrop
-        // and the scrim fill dims all of them equally on its way past. A uniform black
-        // composite commutes with a blur, so this is also the look the sidebar case always
-        // had. The invariant to keep: nothing that tints the whole screen may be pushed
-        // before a frost pane.
+        // Frost panes before scrim (compositor captures blur at first Frost; ordering matters
+        // to avoid two-phase blur of dimmed screen when opening from sidebar vs card).
+        // Invariant: nothing tinting whole screen before a frost pane.
         if !matches!(screen, Screen::Home) {
             let region = self.render.modal.tile_region.offset(0, ui::animation::modal_rise(m));
             Self::push_frost(cmds, region, ui::widgets::MODAL_RADIUS, (255.0 * m) as u8);
@@ -164,14 +145,7 @@ impl App {
         }
     }
 
-    /// The frosted-glass pane under a modal card: the compositor blurs what this frame has
-    /// already drawn and masks it to the card's own rounded shape, so the translucent
-    /// `Glass::panel` fill in the tile above lands on blurred backdrop rather than on a sharp
-    /// one. `tile_region` is the card exactly, so the pane is the card's own rounded shape.
-    ///
-    /// Menu only. The in-stream dialogs never reach here (`main.rs` composes those), which is
-    /// what keeps the frost off a frame whose video lives on a hardware plane the blur cannot
-    /// see anyway.
+    /// Frosted pane under modal card (blur masked to rounded shape). Menu only, not in-stream.
     fn push_frost(cmds: &mut Vec<DrawCmd>, tile_region: Rect, radius: i32, alpha: u8) {
         if alpha == 0 {
             return;
@@ -191,12 +165,7 @@ impl App {
         ))));
     }
 
-    /// A whole glass surface where nothing bakes its tint into a tile: the modal's pane, its
-    /// scrim and its `glass_fill` in one call, so a surface that claims to be the same
-    /// material as a modal card is made of the same three things rather than of a comment
-    /// saying so.
-    ///
-    /// The two fills are constants, so they flatten to the one the fade then scales.
+    /// Whole glass surface: pane+scrim+fill (one call, materials match card, not comments).
     fn push_glass_surface(cmds: &mut Vec<DrawCmd>, rect: Rect, radius: i32, alpha: f32) {
         Self::push_frost(cmds, rect, radius, (255.0 * alpha) as u8);
         cmds.push(DrawCmd::Fill {
@@ -207,14 +176,7 @@ impl App {
         });
     }
 
-    /// The nav column: its frosted pane and the translucent strip over it.
-    ///
-    /// Composed *after* the grid, not before it as an opaque strip was. A pane fixes the
-    /// frame's blur source at the point it appears, so a sidebar pane pushed first would
-    /// hand the focused card's strip, the status band and the modal a backdrop holding
-    /// nothing but the clear. The column and the grid never overlap, so the order between
-    /// them is free — what it costs is the strip's own pixels in a modal's blur, which the
-    /// modal covers with a scrim anyway.
+    /// Nav column: pane and strip. Composed after grid (pane order matters for blur backdrop).
     fn compose_sidebar(cmds: &mut Vec<DrawCmd>, screen_h: u32) {
         let strip = Rect::new(0, 0, ui::widgets::SIDEBAR_W, screen_h);
         // Square: three of the column's edges are the display's own.
@@ -226,18 +188,8 @@ impl App {
         });
     }
 
-    /// A panel's drop shadow, as nine stretched draws from one small atlas
-    /// ([`tile::MODAL_SHADOW`], [`tile::PANEL_SHADOW`]) instead of a panel-sized CPU blit
-    /// baked into the panel's own tile.
-    ///
-    /// The shadow is a blurred rounded rect, so it is exactly nine-sliceable: the corner
-    /// slices carry everything whose alpha varies and the centre is two flat pixels stretched
-    /// across the card's middle — the same interior the baked blit painted, which the card's
-    /// `0xc0` glass lets through. Measured on a 1190x924 card, that blit was 205ms of a 260ms
-    /// shell raster and it was paid on every open; these nine `copy` calls are the GPU's.
-    ///
-    /// Pushed immediately under its panel so the ordering a baked shadow had is kept: over
-    /// this layer's frost pane and its scrim, under the panel's own tile.
+    /// Panel drop shadow: nine stretched atlas draws instead of panel-sized CPU blit.
+    /// Nine-sliceable (corners carry alpha variance, centre is flat). GPU not CPU.
     fn push_shadow(cmds: &mut Vec<DrawCmd>, tile: ui::render::TileId, radius: i32, panel: Rect, alpha: u8) {
         ui::render::push_nine_slice(
             cmds,
@@ -249,9 +201,7 @@ impl App {
         );
     }
 
-    /// The open modal itself: its card, its scrollable content, an open dropdown and the
-    /// focused widget composited on top. `m` is the modal layer's own fade/rise progress —
-    /// everything here rides it rather than animating separately.
+    /// Open modal card, content, dropdown, focus widget. m is modal fade/rise (rides everything).
     fn compose_modal_card(
         &self,
         tiles: &TileStore,
@@ -261,14 +211,9 @@ impl App {
         m: f32,
         cmds: &mut Vec<DrawCmd>,
     ) {
-        // Paired as one argument to stay inside clippy's `too_many_arguments` limit.
         let (screen_w, screen_h) = (size.w, size.h);
         let dy = ui::animation::modal_rise(m);
-        // The tile now covers only the card region (see `prepare_modal`), so it
-        // composites there rather than full-screen. Opening plays the same motion
-        // `compose_modal`'s closing snapshot uses below, in reverse — fade + rise, no
-        // scale.
-        // Its frost pane went in ahead of the scrim (see `compose_modal`), at this same rect.
+        // Tile covers card region only; opening plays fade+rise (reverse of closing snapshot).
         let modal_base = self.render.modal.tile_region.offset(0, dy);
         Self::push_shadow(
             cmds,
@@ -621,6 +566,20 @@ impl App {
                 let r = self.press_dip(Screen::Home).rect(card_rect(idx));
                 self.compose_focused_card(tiles, cmds, pin_id, r, pad, now);
             }
+        }
+        // The reveal's dissolve: every card above is already fully built and drawn opaque —
+        // covered here by a background-coloured mask whose own alpha falls away as the wave
+        // passes, so the page uncovers as one surface instead of each card fading in on its
+        // own clock (see `spinner::GridReveal::dissolve_mask` for why this is a fading cover
+        // rather than the launch backdrop's erase-based technique).
+        if self.render.grid.reveal.dissolving() {
+            let cover_h = screen_h.saturating_sub(view::home::GRID_TOP_Y as u32);
+            let cover = Rect::new(grid_x, view::home::GRID_TOP_Y, available_w, cover_h);
+            cmds.push(DrawCmd::Tex {
+                tile: tile::GRID_REVEAL_MASK,
+                dst: cover,
+                alpha: 0xff,
+            });
         }
     }
 

--- a/src/app/render/prepare_grid.rs
+++ b/src/app/render/prepare_grid.rs
@@ -15,16 +15,12 @@ use crate::app::render::ctx::RenderCtx;
 use crate::app::render::tile;
 use crate::app::spinner::PageReady;
 use crate::app::state::cardmenu::CardMenuRow;
-use crate::app::{view, App, HomeFocus, Screen, GRID_REVEAL_WAVE};
+use crate::app::{view, App, HomeFocus, Screen};
 use crate::ui;
 use crate::ui::cache;
 
-/// Whether nothing more can arrive for this card: the cover is already in `library.art`, or the
-/// game never had one to fetch (no `library.art` entry either way). "Desktop" and the padding
-/// after a partial pinned row have no `games` entry and are always ready.
-///
-/// A free function rather than a closure so both the build pass and the reveal check can use it
-/// while `&mut self` is live elsewhere in the same frame.
+/// Nothing more can arrive for this card (cover in library.art or game has none).
+/// Free function so build pass and reveal check can use it while &mut self is live elsewhere.
 fn art_ready(library: &Library, layout: GridLayout, idx: usize) -> bool {
     layout.card_at(&library.games, idx).is_none_or(|game| {
         library.art.contains_key(&game.id) || (game.art.portrait.is_none() && game.art.header.is_none())
@@ -40,27 +36,19 @@ impl App {
             && self.render.grid.cards_dirty.is_empty()
     }
 
-    /// The card grid. Everything below the window arithmetic here is O(visible): the windows are
-    /// index ranges, and every pass iterates one of them rather than the library.
+    /// Grid rasterization. Everything below is O(visible) via index ranges, not library scans.
     pub(super) fn prepare_grid(&mut self, ctx: &mut RenderCtx<'_>) -> Result<()> {
         let (screen_w, screen_h) = (ctx.screen.w, ctx.screen.h);
-        // The same three numbers `advance_frame` sized `self.render.grid.card_size` from — the
-        // grid's whole geometry follows from the width it has to fill.
+        // Grid geometry from width (same three numbers as advance_frame).
         let available_w = screen_w.saturating_sub(ui::widgets::SIDEBAR_W);
         let columns = view::home::grid_columns(available_w);
         let (card_w, card_h) = view::home::grid_card_size(available_w, columns);
-        // Reset before the branch: it is only ever set inside it, and a stale `true` left
-        // behind by a host that has since been deselected would spin the render loop at
-        // full rate forever.
+        // Reset before branch (set only inside, stale true = full-rate render loop).
         self.render.grid.tiles_pending = false;
         if self.library.selected_host.is_none() {
             return self.prepare_no_host_tile(ctx);
         }
-        // Nothing behind an open modal can come into view: the grid neither scrolls nor
-        // moves focus while a modal owns input, so the whole windowed pass — the one cost
-        // here that scales with the window — is skipped unless a card was actually
-        // invalidated. The grid still composites under the modal's scrim from the tiles it
-        // already holds.
+        // Modal open: grid neither scrolls/focuses, so skip windowed pass unless invalidated.
         if self.grid_window_frozen() {
             return Ok(());
         }
@@ -93,30 +81,19 @@ impl App {
             first_visible_row + visible_rows + CARD_KEEP_ROWS,
         );
 
-        // Held by value, not re-derived per index — and, unlike the `App`
-        // helpers, it maps indices without borrowing all of `self`, so the art
-        // lookups below can sit next to `&mut self.jobs.art`.
-        // Rebuilt inside each helper rather than hoisted: a `GridLayout` borrows the library,
-        // and these all mutate `self.render` while reading it. Rebuilding is a slice reborrow
-        // and an integer copy, so there is nothing to hoist.
+        // Layout by value (maps indices without borrowing self). Rebuilt per helper.
         self.evict_cards_outside(keep_window, columns, ctx.tiles);
         let pending = self.build_card_window(build_window, columns, card_w, card_h, ctx)?;
         self.prepare_focused_card_tiles(columns, card_w, card_h, pending, ctx)?;
-        // Order against the reveal below doesn't matter: both only ensure tiles and record what
-        // they rebuilt.
         self.prepare_grid_shared_tiles(card_w, card_h, ctx)?;
         self.advance_grid_reveal(page_window, columns, ctx);
         Ok(())
     }
 
-    /// Drops the card tiles that can no longer be right — the whole set on a library or host
-    /// change, otherwise just the ones a pin toggle or an arriving cover invalidated.
+    /// Drop stale card tiles (whole set on library/host change, else just invalidated ones).
     fn release_stale_cards(&mut self, tiles: &mut ui::cache::TileStore) {
-        // A fresh library load is the only rebuild that also re-arms the spinner.
         if self.render.grid.dirty {
-            // Every existing texture is stale (different games, different host) —
-            // drop them rather than leaving them to be overwritten one by one,
-            // which would strand the tail of a longer previous library.
+            // Fresh library: drop all textures (stale), re-arm spinner (avoid stranding tail).
             for id in self.render.grid.card_ids.release_all() {
                 tiles.remove(id);
                 self.render.evicted_tiles.push(id);
@@ -124,36 +101,26 @@ impl App {
             self.render.grid.card_pop_until = None;
             self.render.grid.dirty = false;
             self.render.grid.cards_dirty.clear();
-            // Scrolling or re-pinning a card must not hide the already-visible
-            // grid behind the spinner again.
             self.render.grid.reveal.restart();
         } else {
+            // Texture stale only; slot/arrival stays. Release→build would re-pop on reveal.
             for id in std::mem::take(&mut self.render.grid.cards_dirty) {
-                if let Some(t) = self.render.grid.card_ids.release(&id) {
+                if let Some(t) = self.render.grid.card_ids.get(&id) {
                     tiles.remove(t);
                 }
             }
         }
     }
 
-    /// Frees every resident card outside the keep window, with its cover.
+    /// Free cards outside keep window (+ covers). Evict first, before new ones built.
     fn evict_cards_outside(
         &mut self,
         keep_window: std::ops::Range<usize>,
         columns: usize,
         tiles: &mut ui::cache::TileStore,
     ) {
-        // Evict first, so a long scroll frees textures in the same frame it needs new
-        // ones rather than a frame later.
-        //
-        // Driven off what is resident (`CardIds`) against the keep window, not off a scan
-        // of the whole library: the resident set is bounded by the window, so this costs
-        // the window twice over however large the library gets.
-        //
-        // By tile id rather than by pin id: the ids are `Copy` integers, so the keep set
-        // is a sorted window-sized vector and the test is a binary search — where a
-        // `HashSet<&str>` re-hashed every resident card's id string every frame. Both
-        // lists are `GridState` scratch, cleared and refilled rather than allocated.
+        // Off resident set (windowed), not whole library (no scaling with library size).
+        // By tile id: sorted vector + binary search vs HashSet re-hash every frame.
         let mut keep = std::mem::take(&mut self.render.grid.scratch.keep);
         keep.clear();
         let layout = self.library.layout(columns);
@@ -176,16 +143,13 @@ impl App {
         self.render.grid.scratch.keep = keep;
         for id in dropped.drain(..) {
             if let Some(t) = self.render.grid.card_ids.release(&id) {
-                // Kept for the cards built below: a scroll frees and needs the same
-                // card-sized pixmap in the same frame (see `GridState::free_cards`).
+                // Pixmap recycled for cards built this frame (avoids realloc on scroll).
                 if let Some(painter) = tiles.take(t) {
                     self.render.grid.free_cards.push(painter);
                 }
                 self.render.evicted_tiles.push(t);
             }
-            // Drop the decoded cover too — it is several times the size of the tile it
-            // feeds. Re-requested from the disk cache on scroll back. (Nothing to drop for
-            // the pinned "Desktop" entry, which has no art at all.)
+            // Drop decoded cover (several×tile size). Re-request from disk cache on scroll back.
             self.library.art.remove(&id);
             if let Some(loader) = &mut self.jobs.art {
                 loader.forget(&id);
@@ -194,9 +158,8 @@ impl App {
         self.render.grid.scratch.dropped = dropped;
     }
 
-    /// Rasterizes the cards in the build window, newest-needed first and on a time budget.
-    /// Returns whether it ran out of budget with work left — the caller holds off anything
-    /// that should wait for a settled grid.
+    /// Rasterize cards in build window (art-ready first, on time budget).
+    /// Returns true if budget ran out (caller defers settled-grid work).
     fn build_card_window(
         &mut self,
         build_window: std::ops::Range<usize>,
@@ -212,23 +175,19 @@ impl App {
             updated,
             ..
         } = ctx;
-        // Art-ready cards build first — building one before its cover arrives just
-        // burns a second budget slot re-dirtying it once the cover shows up. Two lists
-        // rather than one sorted one, and indices rather than ids: a candidate past the
-        // budget is never built, so nothing should be copied on its behalf.
+        // Art-ready first (avoid re-dirty when cover lands). Two lists, not sorted (indices).
+
         let mut ready = std::mem::take(&mut self.render.grid.scratch.ready);
         let mut waiting = std::mem::take(&mut self.render.grid.scratch.waiting);
         ready.clear();
         waiting.clear();
         let layout = self.library.layout(columns);
         for idx in build_window {
-            // Nothing to build or fetch art for in the padding after a partial
-            // pinned row.
+            // Nothing in padding after partial pinned row.
             let Some(id) = layout.pin_id_at(&self.library.games, idx) else {
                 continue;
             };
-            // Ask for this card's cover as it enters the window, not for the whole
-            // library at once (see `art::ArtLoader`).
+            // Request cover as it enters window (not whole library at once).
             if let (Some(loader), Some(game)) = (&mut self.jobs.art, layout.card_at(&self.library.games, idx)) {
                 loader.request(game);
             }
@@ -246,8 +205,7 @@ impl App {
         let budget_from = Instant::now();
         let mut built = 0usize;
         for idx in ready.iter().copied().chain(waiting.iter().copied()) {
-            // Counted on cards actually rasterized, not on candidates seen: the budget is
-            // a time budget, and skipping a padding slot costs none of it.
+            // Budget counted on rasterized cards, not candidates (padding costs nothing).
             if built >= CARD_BUILD_BURST || (built > 0 && budget_from.elapsed() >= CARD_BUILD_BUDGET) {
                 pending = true;
                 break;
@@ -271,18 +229,16 @@ impl App {
                     fonts,
                 )?
             };
-            let tile_id = self.render.grid.card_ids.id(&id);
+            // Existing slot: texture/arrival untouched (art refresh). New: gets slot here.
+            let (tile_id, is_new) = self.render.grid.card_ids.id_new(&id);
             tiles.put(tile_id, cache::static_version(), tile);
-            // Past the reveal, a card entering the window is one card arriving on a settled
-            // grid — the wave is for the page the spinner was covering.
-            if self.render.grid.reveal.is_revealed() {
+            // New card on settled grid: one arrival. Art refresh: no arrival (swap in place).
+            if is_new && self.render.grid.reveal.is_revealed() {
                 self.render.grid.arm_card_pop(&id, Instant::now());
             }
             updated.push(tile_id);
         }
-        // Anything still here evicted without a card being built in its place, so it is
-        // surplus rather than churn — held past the frame it would just be a cache of
-        // pixmaps nothing asked for.
+        // Anything left in free_cards was evicted with no replacement (surplus pixmaps).
         self.render.grid.free_cards.clear();
         self.render.grid.scratch.ready = ready;
         self.render.grid.scratch.waiting = waiting;
@@ -290,8 +246,7 @@ impl App {
         Ok(pending)
     }
 
-    /// The tiles that exist only for the focused card: its hero prefetch, its title strip and
-    /// the submenu panel a hold raises over it.
+    /// Focused card tiles: hero prefetch, title strip, submenu panel.
     fn prepare_focused_card_tiles(
         &mut self,
         columns: usize,
@@ -307,13 +262,7 @@ impl App {
             updated,
             ..
         } = ctx;
-        // Prefetch the focused card's hero, so the connecting screen has one ready the
-        // moment OK is pressed. Deduped in the loader, and the fetched bytes are
-        // disk-cached, so hovering back over a card costs no round trip.
-        //
-        // Only once the visible window has settled: the loader serves hero requests
-        // ahead of card art, so queueing one mid-scroll would put the cards the user is
-        // actually looking at behind a full-screen fetch and decode.
+        // Prefetch focused card's hero (ready on OK press). Only when window settled.
         if self.render.grid.reveal.is_revealed() && !pending {
             if let HomeFocus::Grid(focus_idx) = self.home_focus {
                 if let Some(game) = self.library.layout(columns).card_at(&self.library.games, focus_idx) {
@@ -325,11 +274,7 @@ impl App {
             }
         }
 
-        // The focused card's title strip: its own tile, so the wipe in `draw_list` is
-        // a moving source/destination rect rather than a re-rasterize per animation
-        // frame. Tint and title only — the blur under it is the compositor's (see
-        // `Canvas::poster_frost_panel`), so the card's art is in neither the tile nor
-        // its key, and finished art no longer rebuilds the strip.
+        // Focused card title strip (own tile for moving wipe, not re-raster per frame).
         if let HomeFocus::Grid(idx) = self.home_focus {
             if let Some(pin_id) = self.library.pin_id_at(idx, columns) {
                 let (title, _) = self.grid_card_content(idx, columns);
@@ -526,36 +471,16 @@ impl App {
                 PageReady::All
             }
         };
-        let next_frame = self.render.grid.reveal.advance(
-            self.library_fetch_in_flight() || self.wake_wait_in_flight(),
-            page_ready,
-        );
-        match next_frame {
-            Some(idx) => updated.push(tile::spinner(idx)),
-            // Everything built behind the spinner becomes visible in this one frame. One clock
-            // each, offset along the grid's diagonal, so the page fades in as a wave running
-            // from the top-left corner rather than as N separate pops. Cards outside the page
-            // are off screen: no arrival to show, and by the time a scroll reaches them the
-            // wave is long over.
-            None if self.render.grid.reveal.is_revealed() => {
-                let now = Instant::now();
-                // Normalized over the page, so the sweep takes the wave's span whatever the
-                // column count and however many rows fit on screen.
-                let last_step = page_window
-                    .clone()
-                    .last()
-                    .map_or(1, |idx| layout.diagonal_step(idx))
-                    .max(1) as f32;
-                // Split borrow: the layout reads `library`, the arming writes `render`.
-                let grid = &mut self.render.grid;
-                for idx in page_window {
-                    if let Some(id) = layout.pin_id_at(&self.library.games, idx) {
-                        let delay = GRID_REVEAL_WAVE.delay(layout.diagonal_step(idx) as f32 / last_step);
-                        grid.arm_reveal_wave(id, now, delay);
-                    }
-                }
-            }
-            None => {}
+        // Everything built behind the spinner becomes visible in this one frame: `reveal()`
+        // (inside `advance`) starts the dissolve that uncovers it — one mask, not an
+        // entrance per card (see `spinner::GridReveal::dissolve_mask`).
+        if let Some(idx) = self
+            .render
+            .grid
+            .reveal
+            .advance(self.library_fetch_in_flight() || self.wake_wait_in_flight(), page_ready)
+        {
+            updated.push(tile::spinner(idx));
         }
     }
 

--- a/src/app/render/tile.rs
+++ b/src/app/render/tile.rs
@@ -8,245 +8,141 @@
 //! and an interned band for grid cards (whose count is the library's, not a constant).
 use crate::ui::render::TileId;
 
-/// Focus-free sidebar strip: panel, brand mark, every row unfocused.
+/// Unfocused sidebar.
 pub const SIDEBAR: TileId = TileId(0);
-/// The focused sidebar row, composited over [`SIDEBAR`].
+/// Focused sidebar row.
 pub const FOCUS_ROW: TileId = TileId(1);
-/// The shared focus-ring glow (one card size at a time), drawn behind a focused card.
+/// Shared focus-ring glow (one card size at a time).
 pub const RING: TileId = TileId(2);
-/// The focused card's crisp lit edge, composited over its art.
+/// Focused card's lit edge.
 pub const CARD_OUTLINE: TileId = TileId(3);
-/// The open modal's shell — chrome, header, every widget drawn unfocused.
+/// Open modal shell (unfocused).
 pub const MODAL: TileId = TileId(5);
-/// The open modal's single focused, zoom-animated widget, composited over [`MODAL`].
+/// Open modal focused widget (zoom-animated).
 pub const MODAL_FOCUS: TileId = TileId(6);
-/// An open dropdown's option panel.
+/// Open dropdown panel.
 pub const DROPDOWN_OVERLAY: TileId = TileId(7);
-/// That dropdown's focused option, composited over [`DROPDOWN_OVERLAY`].
+/// Dropdown focused option.
 pub const DROPDOWN_FOCUS: TileId = TileId(8);
-/// Home's status line block.
+/// Home status line.
 pub const STATUS: TileId = TileId(9);
-/// The static "no host selected" hint.
+/// "No host selected" hint.
 pub const NO_HOST: TileId = TileId(10);
-/// Whichever scrollable modal's scroll indicator — one slot, versioned per screen.
+/// Scrollable modal scroll indicator.
 pub const SCROLL_INDICATOR: TileId = TileId(11);
-/// About's document, baked at full unscrolled height — one slot, versioned per screen, so
-/// scrolling inside the baked window invalidates nothing. Settings does not use it: its rows
-/// are a tile each (see [`list_row`]), so one changed value repaints one row.
+/// About document (baked full-height, scrolling inside doesn't invalidate).
 pub const SCROLL_CONTENT: TileId = TileId(12);
 // 13 and 14 were the scroll-edge ramp tiles. The fade now ramps the content's own alpha
 // (`compose::push_faded`), so there is no band tile to bake; the ids stay retired rather than
 // reused, since the rest of the table is written out by number.
-/// The connecting screen's wide backdrop. One slot: only one launch is ever in flight, and
-/// a new hero replaces the old texture rather than joining it.
+/// Connecting screen backdrop. One slot (only one launch in flight).
 pub const HERO: TileId = TileId(15);
 /// In-stream stats overlay.
 pub const STATS_OVERLAY: TileId = TileId(16);
 /// Transient toast.
 pub const NOTIFICATION: TileId = TileId(17);
-/// The log-tail overlay, in both the menu and the stream.
+/// Log-tail overlay (menu and stream).
 pub const LOG_OVERLAY: TileId = TileId(18);
-/// The in-stream disconnect confirm dialog, and its focused button.
+/// Disconnect confirm dialog and focused button.
 pub const DISCONNECT_DIALOG: TileId = TileId(19);
 pub const DISCONNECT_FOCUS_BUTTON: TileId = TileId(20);
-/// The focused card's title strip, wiped up over its bottom edge. One slot: only one
-/// card is focused at a time, and it is versioned by that card's identity.
+/// Focused card's title strip (wiped). One slot (only one card focused).
 pub const CARD_TITLE: TileId = TileId(21);
-/// The card drop shadow, drawn behind every card — identical on all of them, so it is one
-/// shared tile rather than a margin baked into each.
+/// Card drop shadow (shared, not baked into each).
 pub const CARD_SHADOW: TileId = TileId(22);
-/// The modal fading *out* — a snapshot of [`MODAL`] taken the frame it was left, so the
-/// entering modal can own [`MODAL`] while this one finishes (see `App::modal_prev`).
+/// Modal fading out (snapshot for cross-fade).
 pub const MODAL_PREV: TileId = TileId(23);
-/// That snapshot's scrolled content, for a leaving modal whose body lives outside its shell
-/// — About's [`SCROLL_CONTENT`] frozen, or the settings rows stitched into one buffer.
+/// Leaving modal's scrolled content (frozen).
 pub const MODAL_PREV_CONTENT: TileId = TileId(24);
-/// The focused card's submenu panel — [`CARD_TITLE`] grown to carry the Pin/Settings rows.
-/// Its own slot rather than a second shape for `CARD_TITLE`, so it can be baked ahead of the
-/// hold that shows it, along with the rows and title tiles keyed with it. The blur under it
-/// is the compositor's (`DrawCmd::Frost`); this tile is the glass tint alone.
+/// Focused card submenu panel (grown `CARD_TITLE`). Own slot to bake ahead.
 pub const CARD_MENU: TileId = TileId(25);
-/// That panel's row icons and labels, on their own transparent tile. Composited *after* the
-/// selection band, which is a translucent darkening: baked into [`CARD_MENU`] the text would
-/// be dimmed along with the frost, and the band is meant to slide under it.
+/// Submenu panel rows (transparent, under selection band).
 pub const CARD_MENU_ROWS: TileId = TileId(26);
-/// That panel's title line, likewise on its own transparent tile — it rides the top edge of
-/// the opening window, continuing up from where [`CARD_TITLE`] already had it.
+/// Submenu panel title line (transparent, rides opening window top).
 pub const CARD_MENU_TITLE: TileId = TileId(27);
-/// That panel's selection band, one row tall with the card's rounded bottom corners — used
-/// for the bottom row, whose band ends on that edge; higher rows are a plain square fill.
+/// Submenu panel selection band (one row tall).
 pub const CARD_MENU_BAND: TileId = TileId(28);
-/// The modal card's drop shadow, as a small nine-sliceable atlas rather than a card-sized
-/// blit baked into [`MODAL`]. Built once per style epoch and stretched to whatever card is
-/// open — see `ui::painter::shadow_atlas` for why the slices are exact, and
-/// `compose::push_shadow` for the nine draws that place it.
+/// Modal card drop shadow (nine-sliceable atlas, not baked).
 pub const MODAL_SHADOW: TileId = TileId(29);
-/// The same atlas at the smaller `CARD_RADIUS`, for the panels that are not the modal card —
-/// currently the dropdown popup, whose own tile is sized to the panel and so could never
-/// have held a baked shadow.
+/// Smaller atlas for non-modal panels (dropdown popup).
 pub const PANEL_SHADOW: TileId = TileId(30);
-
-/// The dissolve mask the launch's hero leaves behind: a small alpha ramp stretched over the
-/// screen, which `DrawCmd::Erase` subtracts from what is already drawn.
+/// Hero dissolve mask (alpha ramp, subtractive erase).
 pub const HERO_MASK: TileId = TileId(31);
+/// Grid dissolve mask (background cover, alpha falls away as wave passes).
+pub const GRID_REVEAL_MASK: TileId = TileId(32);
 
-/// First id of the row band — one slot per on-screen row of whichever scrolling list is open
-/// (see [`list_row`]). Fixed rather than interned: the lists are short, their rows are
-/// addressed by position, and only one is up at a time.
-const LIST_ROW_BASE: u32 = 32;
-/// Slots in that band. Settings' pages and a host's 21 collections are all far under this;
-/// [`list_row`] refuses anything past it rather than colliding with the section band.
+/// Row band base (one slot per on-screen row, fixed not interned).
+const LIST_ROW_BASE: u32 = 33;
 pub const LIST_ROW_SLOTS: usize = 32;
-
-/// First id of the grid's section-heading band — one slot per drawn section, addressed by
-/// position in grid order (see [`section`]). Not `ensure_static` like the old fixed
-/// "Pinned"/"Library" pair: the labels are user-typed collection names now, so each slot is
-/// versioned by the text it holds.
-const SECTION_BASE: u32 = 64;
-/// Slots in that band — every collection a host can have, plus the dynamic Library entry,
-/// rounded up so the band's width is a power of two and the spinner's ids stay out of reach.
+/// Section-heading band base (one slot per drawn section, versioned by text).
+const SECTION_BASE: u32 = 65;
 pub const SECTION_SLOTS: usize = crate::app::grid::MAX_GROUPS.next_power_of_two();
-
-/// First id of the spinner band. One per frame, so animation is a swap not an upload.
-const SPINNER_BASE: u32 = 96;
-/// First id of the grid-card band, interned by pin id (see [`CardIds`]).
+/// Spinner band base (one per frame, swap not upload).
+const SPINNER_BASE: u32 = 97;
+/// Grid-card band base (interned by pin id).
 const CARD_BASE: u32 = 256;
 
-/// The tile for on-screen list row `index`, or `None` past the band — a list longer than
-/// [`LIST_ROW_SLOTS`] draws its tail unbaked rather than reaching into the next band's ids.
+/// Tile for on-screen list row (None past band).
 pub fn list_row(index: usize) -> Option<TileId> {
     (index < LIST_ROW_SLOTS).then(|| TileId(LIST_ROW_BASE + index as u32))
 }
-
-/// The tile for grid section `index`, or `None` past the band — a grid with more sections
-/// than [`SECTION_SLOTS`] draws the tail's headings unbaked rather than reaching into the
-/// spinner's ids. [`MAX_GROUPS`](crate::app::grid::MAX_GROUPS) is well under it.
+/// Tile for grid section (None past band).
 pub fn section(index: usize) -> Option<TileId> {
     (index < SECTION_SLOTS).then(|| TileId(SECTION_BASE + index as u32))
 }
-
-/// The tile for spinner frame `idx`.
+/// Tile for spinner frame.
 pub fn spinner(idx: usize) -> TileId {
     TileId(SPINNER_BASE + idx as u32)
 }
-
-/// The spinner frame `id` stands for, if it is one — `runtime` uploads these from raw
-/// decoded pixels rather than from a rasterized painter, and needs to recognise them.
+/// Spinner frame index from id (runtime recognizes for raw pixel uploads).
 pub fn spinner_index(id: TileId) -> Option<usize> {
     (SPINNER_BASE..CARD_BASE)
         .contains(&id.0)
         .then(|| (id.0 - SPINNER_BASE) as usize)
 }
 
-/// Grid-card ids, interned by pin id.
-///
-/// Cards are keyed by identity rather than by grid position on purpose: pinning a game
-/// reorders the grid, and keying by index would rebuild every tile after the moved one.
-/// Slots are recycled, so a library refresh reuses the same small band rather than growing
-/// the id space for the life of the process.
+/// Grid-card ids (interned by pin id, not position, so pinning doesn't rebuild tail).
+/// Slots recycled on refresh (no id space growth).
 pub struct CardIds {
     slots: std::collections::HashMap<String, CardSlot>,
     free: Vec<TileId>,
     next: u32,
 }
 
-/// What one resident card holds: its tile, and the arrival it is playing.
-///
-/// The entrance lives here rather than in a second map keyed by the same string, because
-/// `compose_grid` asks for both for every visible card on every frame — two hashes of one
-/// game id, where the card is resident or neither answer exists.
+/// Resident card tile and entrance. Both here to avoid double hash per frame.
 #[derive(Clone, Copy)]
 pub struct CardSlot {
     pub id: TileId,
-    /// `None` for a card that is not animating.
+    /// None if not animating.
     pub pop: Option<Entrance>,
 }
-
-/// [`Entrance::progress`] for a slot that may not be animating: `(1.0, 0.0)` — full size,
-/// no scale to apply — when it is not.
+/// Progress for possibly-non-animating slot: (1.0, 0.0) when not animating.
 pub fn entrance_progress(entrance: Option<Entrance>, now: std::time::Instant) -> (f32, f32) {
     entrance.map_or((1.0, 0.0), |e| e.progress(now))
 }
 
-/// A card arriving on screen: when it started, and which of the two arrivals it is.
-///
-/// Kind and clock together on the slot, rather than a grid-wide "a reveal is running" flag:
-/// a card built by a scroll while the reveal is still sweeping gets its own pop either way,
-/// and a global mode would compose it on the reveal's curve.
+/// Card arrival: scale-up on grid. Not first appearance (that's `GridReveal` mask).
 #[derive(Clone, Copy)]
 pub struct Entrance {
     pub start: std::time::Instant,
-    pub kind: EntranceKind,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum EntranceKind {
-    /// A card built into a grid already on screen: a short scale-up.
-    Pop,
-    /// The post-spinner reveal: a longer fade with no scale at all, staggered along the
-    /// grid's diagonal so the screen arrives as one sweep rather than as N separate pops.
-    Reveal,
 }
 
 impl Entrance {
     pub fn pop(start: std::time::Instant) -> Self {
-        Self {
-            start,
-            kind: EntranceKind::Pop,
-        }
+        Self { start }
     }
-
-    pub fn reveal(start: std::time::Instant) -> Self {
-        Self {
-            start,
-            kind: EntranceKind::Reveal,
-        }
-    }
-
-    /// How far this arrival has got at `now`, and the shrink its pop-in rides. Off a clock
-    /// the caller already read, rather than one `Instant::now()` per card per curve.
-    ///
-    /// The two arrivals differ only in curve, duration and shrink; smoothstep over the
-    /// reveal's longer fade because on a cubic ease-out a fade is near-opaque a sixth of the
-    /// way through, which lands as the pop it is meant to replace.
+    /// Arrival progress and pop shrink. Uses caller's clock (no per-card `now()`).
     pub fn progress(self, now: std::time::Instant) -> (f32, f32) {
-        let clock = Some(self.start);
-        let dur = self.kind.duration();
-        let frac = match self.kind {
-            EntranceKind::Pop => crate::ui::animation::anim_frac_at(clock, dur, now),
-            // The wave's own curve — its stagger is already baked into `start`.
-            EntranceKind::Reveal => crate::ui::animation::anim_frac_smooth_at(clock, dur, now),
-        };
-        (frac, self.kind.shrink())
+        let frac = crate::ui::animation::anim_frac_at(Some(self.start), crate::app::CARD_POP, now);
+        (frac, crate::app::CARD_POP_SHRINK)
     }
-
-    /// When this arrival is over — what the redraw loop's deadline has to cover.
+    /// When arrival finishes (redraw loop deadline).
     pub fn end(self) -> std::time::Instant {
-        self.start + self.kind.duration()
+        self.start + crate::app::CARD_POP
     }
 }
 
-impl EntranceKind {
-    pub fn duration(self) -> std::time::Duration {
-        match self {
-            Self::Pop => crate::app::CARD_POP,
-            Self::Reveal => crate::app::GRID_REVEAL_WAVE.fade,
-        }
-    }
-
-    /// How far the card is scaled down at the start of this arrival. The reveal is a flat
-    /// cross-fade: a diagonal of cards each scaling on its own clock reads as noise, where
-    /// the same diagonal fading reads as one diffused sweep.
-    pub fn shrink(self) -> f32 {
-        match self {
-            Self::Pop => crate::app::CARD_POP_SHRINK,
-            Self::Reveal => 0.0,
-        }
-    }
-}
-
-/// Hand-written rather than derived: a derived `Default` would start `next` at 0, handing the
-/// first card a `TileId` already taken by one of the fixed tiles above.
+/// Hand-written (derived would start next at 0, collision with fixed tiles).
 impl Default for CardIds {
     fn default() -> Self {
         Self {
@@ -258,10 +154,10 @@ impl Default for CardIds {
 }
 
 impl CardIds {
-    /// `pin_id`'s tile, assigning a slot if it has none.
-    pub fn id(&mut self, pin_id: &str) -> TileId {
+    /// Get/assign `pin_id`'s tile and report if new (build path knows if re-rasterizing).
+    pub fn id_new(&mut self, pin_id: &str) -> (TileId, bool) {
         if let Some(slot) = self.slots.get(pin_id) {
-            return slot.id;
+            return (slot.id, false);
         }
         let id = self.free.pop().unwrap_or_else(|| {
             let id = TileId(self.next);
@@ -269,22 +165,18 @@ impl CardIds {
             id
         });
         self.slots.insert(pin_id.to_string(), CardSlot { id, pop: None });
-        id
+        (id, true)
     }
 
-    /// `pin_id`'s tile if it already has one. Read-only, for the paint path.
+    /// Get `pin_id`'s tile (read-only, paint path).
     pub fn get(&self, pin_id: &str) -> Option<TileId> {
         self.slots.get(pin_id).map(|slot| slot.id)
     }
-
-    /// `pin_id`'s tile *and* pop clock in one lookup — what the per-card composite path
-    /// wants, and the reason the two live together.
+    /// Get `pin_id`'s tile and pop clock (why they live together).
     pub fn slot(&self, pin_id: &str) -> Option<CardSlot> {
         self.slots.get(pin_id).copied()
     }
-
-    /// Starts `pin_id`'s arrival, reporting whether it took — a card with no slot is not on
-    /// screen, and gets its clock from [`id`](Self::id) when it is built.
+    /// Start `pin_id`'s arrival (false if no slot = not on screen yet).
     pub fn arm(&mut self, pin_id: &str, entrance: Entrance) -> bool {
         match self.slots.get_mut(pin_id) {
             Some(slot) => {
@@ -295,35 +187,20 @@ impl CardIds {
         }
     }
 
-    /// [`arm`](Self::arm) for a card that may already be arriving — the reveal, which must
-    /// not restart an arrival already under way.
-    pub fn arm_if_idle(&mut self, pin_id: &str, entrance: Entrance) -> bool {
-        match self.slots.get_mut(pin_id) {
-            Some(slot) if slot.pop.is_none() => {
-                slot.pop = Some(entrance);
-                true
-            }
-            _ => false,
-        }
-    }
-
-    /// Releases `pin_id`'s slot for reuse, returning the tile to drop.
+    /// Release `pin_id`'s slot for reuse.
     pub fn release(&mut self, pin_id: &str) -> Option<TileId> {
         let slot = self.slots.remove(pin_id)?;
         self.free.push(slot.id);
         Some(slot.id)
     }
-
-    /// Releases every slot, returning the tiles to drop — a fresh library.
+    /// Release all slots (fresh library).
     pub fn release_all(&mut self) -> Vec<TileId> {
         let ids: Vec<TileId> = self.slots.values().map(|slot| slot.id).collect();
         self.slots.clear();
         self.free.extend(ids.iter().copied());
         ids
     }
-
-    /// Every resident card, as `(pin id, tile)` — what the eviction pass walks, so it can
-    /// test the tile it already holds instead of re-hashing the id string.
+    /// Every resident card as (pin id, tile) (eviction pass tests without re-hash).
     pub fn entries(&self) -> impl Iterator<Item = (&str, TileId)> {
         self.slots.iter().map(|(id, slot)| (id.as_str(), slot.id))
     }

--- a/src/app/spinner.rs
+++ b/src/app/spinner.rs
@@ -1,5 +1,6 @@
 //! The grid's loading spinner: whether the grid has revealed yet, and the two clocks that
-//! decide it.
+//! decide it. Also the dissolve that follows: the same mask-and-erase technique as the
+//! launch backdrop's exit (`app::hero`), run over the card grid instead.
 //!
 //! Split out of `App` because the four fields are only ever moved together and the reasons they
 //! are *two* clocks rather than one are subtle enough to be worth a home of their own (see
@@ -10,14 +11,12 @@ use std::time::{Duration, Instant};
 /// spinner forever, so cap the wait on it. Only on the art — see [`PageReady`].
 const SPINNER_MAX_WAIT: Duration = Duration::from_millis(900);
 
-/// How far the grid's first page has got: what the spinner is waiting for.
+/// Grid first-page readiness (what spinner waits for).
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PageReady {
-    /// A card on the page has no tile yet. Never revealed in this state, cap or no cap: the
-    /// wave exists to open cards that are already built, and one arriving after it has passed
-    /// pops in over a screen that has finished animating.
+    /// Card has no tile; never revealed (wave opens built cards; late arrivals pop after).
     Building,
-    /// Every card on the page is rasterized, but some are still placeholders waiting on art.
+    /// All tiles rasterized, some waiting on art.
     Tiles,
     /// Nothing outstanding.
     All,
@@ -33,13 +32,14 @@ pub(crate) struct GridReveal {
     revealed: bool,
     /// The spinner frame currently uploaded, so an unchanged phase re-uploads nothing.
     frame: Option<usize>,
-    /// Feeds the spinner's rotation phase. Runs from the *fetch*, continuously, so the rotation
-    /// does not jump when the games land mid-spin.
+    /// Spinner rotation phase clock (runs from fetch; no jump when games land mid-spin).
     since: Option<Instant>,
-    /// What [`SPINNER_MAX_WAIT`] is measured against, armed on the first frame the grid has a
-    /// library to build from. Separate from `since` precisely because it must not run during the
-    /// fetch — the deadline must not expire on time the build never got.
+    /// Build deadline (separate from since; must not run during fetch).
     build_since: Option<Instant>,
+    /// Grid revealed clock; dissolve clock (None once wave done).
+    dissolve_since: Option<Instant>,
+    /// Buffer for `dissolve_mask`.
+    mask: Vec<u8>,
 }
 
 impl GridReveal {
@@ -60,39 +60,57 @@ impl GridReveal {
         self.since.map_or(0.0, |s| s.elapsed().as_secs_f32())
     }
 
-    /// Reveals the grid and stands the spinner down, clocks and all.
+    /// Reveal grid, stand down spinner, start dissolve (cards already built).
     pub fn reveal(&mut self) {
-        *self = Self::revealed();
+        let mask = std::mem::take(&mut self.mask);
+        *self = Self {
+            revealed: true,
+            dissolve_since: Some(Instant::now()),
+            mask,
+            ..Self::default()
+        };
     }
 
-    /// Stands the spinner back up for a fresh library.
-    ///
-    /// The build deadline always restarts — this rebuild *is* the build it times. The rotation
-    /// only restarts if the spinner was not already turning: a landing fetch triggers this on the
-    /// handover from waiting to building, and starting the phase over there reads as the spinner
-    /// visibly jumping.
+    /// Stand spinner back up for fresh library. Build deadline always restarts.
+    /// Rotation restarts only if not already spinning (avoids visible jump on fetch land).
     pub fn restart(&mut self) {
         let was_spinning = !self.revealed;
         self.revealed = false;
         self.build_since = None;
+        self.dissolve_since = None;
         if !was_spinning {
             self.since = None;
             self.frame = None;
         }
     }
 
-    /// Advances the spinner one frame while the grid is still building, and reveals it once
-    /// `page` says the first page is complete — or, past [`SPINNER_MAX_WAIT`], once that page
-    /// is at least rasterized.
-    ///
-    /// The page, not the whole prefetch window: the wave reveals what is on screen, and the
-    /// rows below it have no arrival to show.
-    ///
-    /// `fetch_in_flight` covers the network round trip before there is anything to build: the
-    /// page check would find nothing outstanding and reveal an empty grid, and the deadline
-    /// must not be running either.
-    ///
-    /// Returns the spinner frame to upload, if it changed this tick.
+    /// Reveal dissolve still running (gates mask upload and grid cover draw).
+    pub fn dissolving(&self) -> bool {
+        self.dissolve_since
+            .is_some_and(|t| t.elapsed() < crate::app::GRID_REVEAL_WAVE.span + crate::app::GRID_REVEAL_WAVE.fade)
+    }
+
+    /// Dissolve mask: background alpha falling opaque→zero as wave passes (cover, not erase).
+    /// Unlike hero backdrop (erases to uncover video), grid composites as ordinary alpha texture
+    /// because it has nothing to fall back to (cards are only content).
+    pub fn dissolve_mask(&mut self, now: Instant) -> (u32, u32, &[u8]) {
+        let bg = crate::ui::theme::palette().bg;
+        let elapsed = self
+            .dissolve_since
+            .map_or(f32::MAX, |t| now.saturating_duration_since(t).as_secs_f32());
+        crate::ui::animation::diagonal_mask(
+            &mut self.mask,
+            [bg.r, bg.g, bg.b],
+            crate::app::GRID_REVEAL_WAVE,
+            elapsed,
+            |revealed| 1.0 - revealed,
+        );
+        (crate::ui::animation::MASK_W, crate::ui::animation::MASK_H, &self.mask)
+    }
+
+    /// Advance spinner, reveal when page complete (or past `SPINNER_MAX_WAIT` if tiles ready).
+    /// Page only, not prefetch (wave reveals on-screen, rows below have no arrival).
+    /// `fetch_in_flight` prevents reveal during network wait. Returns frame to upload if changed.
     pub fn advance(&mut self, fetch_in_flight: bool, page: impl FnOnce() -> PageReady) -> Option<usize> {
         let since = *self.since.get_or_insert_with(Instant::now);
         if !fetch_in_flight {

--- a/src/app/view/sidebar.rs
+++ b/src/app/view/sidebar.rs
@@ -99,10 +99,8 @@ pub struct HostRowState {
 /// `selected_index` highlights the active/connected host; `online` is index-aligned with
 /// `entries`.
 ///
-/// The strip takes `glass_fill` and is left translucent: a glass look carries across the
-/// whole menu rather than stopping at the nav column, and the frosted pane the compose path
-/// pushes under it (`compose_sidebar`) is what the tint then sits on. No lit edge against
-/// the grid — a rule there reads as a seam.
+/// Opaque on every theme, glass included — no lit edge against the grid, a rule there
+/// reads as a seam.
 pub fn draw(
     c: &mut Canvas,
     entries: &[HostEntry],
@@ -113,7 +111,7 @@ pub fn draw(
     let screen_h = c.screen_h;
     c.painter.fill_rect(
         Rect::new(0, 0, ui::widgets::SIDEBAR_W, screen_h),
-        ui::theme::glass_fill(),
+        ui::theme::palette().panel,
     );
     // Logo is 1:1 (no runtime scaling); bundled at exact display size.
     if let Some(logo) = crate::app::assets::logo_pixmap() {

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -448,9 +448,8 @@ pub(super) fn run_ui_flow(
                     )?;
                 }
             } else if let Some(pm) = tiles.get(id) {
-                // The sidebar strip is the one tile that covers everything under it — and
-                // only where the look's panels are opaque (`ui::theme::panels_opaque`).
-                let opaque = id == tile::SIDEBAR && crate::ui::theme::panels_opaque();
+                // The sidebar strip is the one tile that covers everything under it.
+                let opaque = id == tile::SIDEBAR;
                 compositor.upload(texture_creator, id, pm, opaque)?;
             }
         }

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -65,39 +65,25 @@ pub(super) fn run_ui_flow(
     const TICK_BUDGET: Duration = Duration::from_millis(16);
     canvas.window_mut().show();
     let mut app = App::new(identity.clone());
-    // `ControllerDeviceAdded` fires once per connect, not per menu entry, so re-poll here
-    // or the Controller row stays stale after the first menu.
+    // Re-poll pad type (ControllerDeviceAdded fires once per connect, not per menu entry).
     app.set_gamepad_type(gamepad::detect_type(game_controller));
-    // The GPU tile cache is the render loop's, not App's — App holds only screen state
-    // Recreated per menu entry, same as `app`.
+    // GPU tile cache (render loop's, not App's). Recreated per menu entry.
     let mut tiles = crate::ui::cache::TileStore::new();
-    // Upload every spinner frame's GPU texture now, once, rather than letting each
-    // frame's first appearance create it lazily inside the render loop. The upload
-    // creates a *new* static texture (allocation, not just a pixel copy) the first
-    // time a `tile::spinner(idx)` is seen — done inline during the animation
-    // that meant the first spin cycle stalled once per unique frame, right when the
-    // spinner is supposed to look smooth. `clear_all` (stream handoff) drops these
-    // along with everything else, so this needs redoing on every re-entry here.
+    // Upload spinner frames upfront (avoids lazy allocation stall during first spin cycle).
     for idx in 0..crate::ui::spinner::FRAMES {
         upload_spinner(compositor, texture_creator, idx)?;
     }
-    // E.g. "the last connect attempt failed, and here's why" — shown on the
-    // Home screen the user just got dropped back onto (see `run_inner`'s
-    // connect-error path).
+    // Status from last connect attempt (sticky so reload progress doesn't erase it).
     if initial_status.is_some() {
-        // Set after `App::new`, which has already kicked off the library reload for the
-        // restored host — sticky so that reload's own progress line doesn't erase it.
         app.set_home_status(initial_status, true);
     }
-    // Same toast widget as the streaming loop's (`ui::widgets::Notification`);
-    // shown once, right as the Home screen re-appears.
+    // Toast widget (same as stream loop). Shown once as Home re-appears.
     let mut notif = crate::ui::widgets::Notification::new();
     let mut toast = super::toast::Toast::default();
     if let Some(msg) = initial_toast {
         notif.show(msg);
     }
-    // Rasterized-text cache (see `ui::text::TextCache` docs) — created once here and
-    // threaded down through every render call for the rest of this UI-flow's
+    // Rasterized-text cache (created once, threaded through every render call).
     // lifetime so repeat draws of the same (font, text, color) reuse an
     // already-rasterized+premultiplied `Pixmap` instead of re-rasterizing
     // freetype glyphs on every ~60fps tick.
@@ -476,6 +462,18 @@ pub(super) fn run_ui_flow(
             compositor.upload_raw(
                 texture_creator,
                 tile::HERO_MASK,
+                mw,
+                mh,
+                sdl2::pixels::PixelFormatEnum::ABGR8888,
+                px,
+            )?;
+        }
+        // The grid's own reveal dissolve — same reasoning as the hero mask above.
+        if app.render.grid.reveal.dissolving() {
+            let (mw, mh, px) = app.render.grid.reveal.dissolve_mask(frame_start);
+            compositor.upload_raw(
+                texture_creator,
+                tile::GRID_REVEAL_MASK,
                 mw,
                 mh,
                 sdl2::pixels::PixelFormatEnum::ABGR8888,

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -4,36 +4,21 @@ use std::time::{Duration, Instant};
 /// How long a focused widget takes to pop to its zoomed size.
 pub const FOCUS_POP: Duration = Duration::from_millis(140);
 
-/// The grid card's focus animation: how long the zoom, the glow bloom and the title
-/// strip's wipe take. One duration for all three so they land together — and the clock
-/// driving them (`App::focus_anim`) is cleared on it, so nothing may outlast it.
+/// Grid card focus animation (zoom, glow, title wipe). One duration so all land together.
 pub const CARD_FOCUS_POP: Duration = Duration::from_millis(160);
 
-/// How long a held card's submenu panel takes to climb the card. Named separately from
-/// [`CARD_FOCUS_POP`] (which it currently matches) because it answers a different question:
-/// the panel covers several times the title strip's travel, so if the rise ever needs its
-/// own timing this is the knob. Eased at both ends ([`anim_frac_smooth`]) so the long travel
-/// reads as one motion.
+/// Held card's submenu panel rise time. Named separately because it covers several times
+/// the title strip's travel; eased at both ends for one motion (not instant start).
 pub const CARD_MENU_RISE: Duration = CARD_FOCUS_POP;
 
-/// Fraction of the remaining distance one 16ms tick covers — the constant this ease was
-/// written with, kept as the unit [`ease_scroll`] expresses its rate in.
+/// Per-16ms-tick scroll distance fraction. Unit for `ease_scroll` rate.
 const SCROLL_STEP_PER_TICK: f64 = 0.35;
-
-/// The tick length [`SCROLL_STEP_PER_TICK`] is quoted at.
 pub const SCROLL_STEP_TICK: Duration = Duration::from_millis(16);
-
-/// A frame long enough that the scroll should resume rather than teleport: the app was
-/// stalled (or idle between animations), and covering the whole gap at once reads as a jump.
+/// Max frame dt before teleporting (app stalled; gap→whole distance reads as jump).
 const SCROLL_MAX_DT: Duration = Duration::from_millis(64);
 
-/// Advances an eased scroll by `dt`: cover ~35% of the remaining distance per 16ms, snapping
-/// when close so it terminates. Returns whether anything moved. Shared by the card grid and
-/// the scrolling modals' viewports so both lists feel identical.
-///
-/// Rate, not step-per-call: stepping a fixed fraction per *tick* made scroll speed a function
-/// of the achieved frame rate, so a frame that overran its budget slowed the motion itself
-/// rather than only its smoothness — and pinned the loop's tick budget in place.
+/// Ease scroll: cover ~35% per 16ms, snap when close. Returns true if moved.
+/// Rate-based (not step-per-tick) so overruns only smooth, not speed.
 pub fn ease_scroll(current: &mut i32, target: i32, dt: Duration) -> bool {
     let d = target - *current;
     if d == 0 {
@@ -56,30 +41,26 @@ pub fn ease_scroll(current: &mut i32, target: i32, dt: Duration) -> bool {
 /// How long a pressed button takes to spring back out of its dip.
 pub const PRESS_POP: Duration = Duration::from_millis(120);
 
-/// How far a pressed widget sinks, in px.
+/// Press drop distance (px).
 const PRESS_DROP: f32 = 5.0;
-
-/// How far a focused widget's tile grows while focused — the pop every composited focus
-/// tile rides (see [`focus_tile_rect`]).
+/// Focused widget tile growth (pop every focus tile rides).
 pub const FOCUS_GROWTH: f32 = 0.02;
-
-/// A button being pushed in. Same animation wherever a button lives, so only the clock
-/// belongs to its owner (`App`'s focused widget, the in-stream `ConfirmDialog`).
+/// Button press-in animation (same everywhere; clock owned by App/ConfirmDialog).
 #[derive(Default, Clone, Copy)]
 pub struct Press(Option<Instant>);
 
 impl Press {
-    /// Starts the dip. Purely visual — the action runs the moment the press arrives.
+    /// Start dip (visual only; action runs immediately).
     pub fn arm(&mut self) {
         self.0 = Some(Instant::now());
     }
 
-    /// Whether a dip is in flight — frames are owed while it is.
+    /// Dip in flight (frames owed while true).
     pub fn armed(self) -> bool {
         self.0.is_some()
     }
 
-    /// Whether an armed dip has played all the way out.
+    /// Armed dip played all the way out.
     pub fn landed(self) -> bool {
         self.0.is_some_and(|t| t.elapsed() >= PRESS_POP)
     }
@@ -89,64 +70,48 @@ impl Press {
         self.0.take().is_some()
     }
 
-    /// `base` pushed down by however far this press has got.
-    ///
-    /// A translation, not a scale: the tile blits 1:1, so its label and icon never
-    /// resample, and it reads the same on a narrow button as on a full-width row.
+    /// Base rect pushed down by press progress. Translation not scale (no resample).
     pub fn rect(self, base: Rect) -> Rect {
         base.offset(0, (PRESS_DROP * (1.0 - anim_frac(self.0, PRESS_POP))) as i32)
     }
 }
 
-/// Where a composited focus tile is drawn: the focus pop's zoom with any press dip on
-/// top. Every focus tile goes through this, so the two motions always compose alike.
+/// Focus tile position: focus pop zoom with press dip on top (every tile goes through this).
 pub fn focus_tile_rect(base: Rect, focus_anim: Option<Instant>, press: Press) -> Rect {
     press.rect(zoom_rect(base, anim_frac(focus_anim, FOCUS_POP), FOCUS_GROWTH))
 }
 
-/// How far a modal card slides down as it fades out (and up as it fades in), in px.
+/// Modal card slide distance (px).
 const MODAL_RISE: f32 = 26.0;
-
-/// How far a modal layer is still offset at fade progress `p` — the rise the entering card,
-/// the closing snapshot and the card's own frost pane all ride. Shared so the `App`'s
-/// `Screen` modals and the runtime-side confirm dialogs (which have no `App`) travel the
-/// same distance on the same curve.
+/// Modal layer offset at fade progress p (all modals/dialogs share for consistency).
 pub fn modal_rise(p: f32) -> i32 {
     ((1.0 - p) * MODAL_RISE) as i32
 }
 
-/// Cubic ease-out function.
+/// Cubic ease-out.
 pub fn ease(f: f32) -> f32 {
     1.0 - (1.0 - f).powi(3)
 }
-
-/// Eased at both ends, unlike [`ease`]'s instant start.
+/// Eased at both ends (not instant start like ease).
 pub fn smoothstep(f: f32) -> f32 {
     f * f * (3.0 - 2.0 * f)
 }
 
-/// Eased progress 0..=1 of animation; 1.0 when done/absent.
+/// Animation progress 0..=1; 1.0 when done/absent.
 pub fn anim_frac(anim: Option<Instant>, dur: Duration) -> f32 {
     frac(anim, dur, ease)
 }
-
-/// [`anim_frac`] on a cubic ease-*in* — the exact time-mirror of [`ease`]. Fade-ins use
-/// this so they read like the fade-outs (`1 - ease(p)`) played backwards; on ease-out a
-/// fade-in is already near-opaque a sixth of the way through, so it lands as a pop.
+/// Animation progress on cubic ease-in (mirror of ease; fade-in reads like backwards fade-out).
 pub fn anim_frac_in(anim: Option<Instant>, dur: Duration) -> f32 {
     frac(anim, dur, |f| f.powi(3))
 }
-
-/// [`anim_frac`] on [`smoothstep`]. For the grid card's focus pop: a cubic ease-out puts
-/// most of the scale change in the first frames, which at card size reads as a snap
-/// followed by a drift rather than one motion.
+/// Animation progress on smoothstep (grid card focus: avoids snap-then-drift look).
 pub fn anim_frac_smooth(anim: Option<Instant>, dur: Duration) -> f32 {
     frac(anim, dur, smoothstep)
 }
 
 fn frac(anim: Option<Instant>, dur: Duration, curve: impl Fn(f32) -> f32) -> f32 {
-    // The clock is read only when there is an animation to measure — most calls, on most
-    // frames, are the `None` arm.
+    // Clock read only when animating (most calls are None arm).
     match anim {
         Some(_) => frac_at(anim, dur, Instant::now(), curve),
         None => 1.0,
@@ -168,41 +133,66 @@ pub fn anim_frac_at(anim: Option<Instant>, dur: Duration, now: Instant) -> f32 {
     frac_at(anim, dur, now, ease)
 }
 
-/// [`anim_frac_smooth`] on a caller-held clock. See [`frac_at`].
-pub fn anim_frac_smooth_at(anim: Option<Instant>, dur: Duration, now: Instant) -> f32 {
-    frac_at(anim, dur, now, smoothstep)
-}
-
 /// A staggered fade across a surface: one curve, started up to `span` later depending on how
-/// far along the sweep the element sits. Whoever owns the surface decides what `progress`
-/// means — a card's diagonal position in the grid, a texel's position in an image — and the
-/// motion is the same either way, which is the point: the library's cards arrive on one of
-/// these and the launch backdrop leaves on one, in the same direction.
+/// far along the sweep a given point sits. Whoever owns the surface decides what `progress`
+/// means — a texel's position in an image — and the motion is the same either way, which is
+/// the point: the launch backdrop's exit and the grid's reveal both evaluate one of these over
+/// a small dissolve-mask texture, in the same direction.
 ///
-/// Smoothstep rather than the cubic ease-out the pops use: over a long fade `1-(1-t)³` is
+/// Smoothstep rather than the cubic ease-out a pop uses: over a long fade `1-(1-t)³` is
 /// near-opaque a sixth of the way through, which lands as a pop.
 #[derive(Clone, Copy)]
 pub struct Wave {
     /// How much later the far end of the sweep starts than the near end.
     pub span: Duration,
-    /// One element's own fade, once its turn comes.
+    /// One point's own fade, once its turn comes.
     pub fade: Duration,
 }
 
 impl Wave {
-    /// How long the element at `progress` (0 at the corner the wave starts from, 1 at the
-    /// opposite one) waits before its own fade begins.
-    pub fn delay(self, progress: f32) -> Duration {
-        self.span.mul_f32(progress.clamp(0.0, 1.0))
-    }
-
-    /// That element's 0..=1 progress, `elapsed` seconds into the wave. Seconds rather than
+    /// That point's 0..=1 progress, `elapsed` seconds into the wave. Seconds rather than
     /// two `Instant`s because the callers evaluate one wave at many points of a frame (a
     /// mask's texels, a window of cards): plain `f32` throughout, no `Duration` arithmetic
     /// per point.
     pub fn frac_secs(self, elapsed: f32, progress: f32) -> f32 {
         let started = elapsed - self.span.as_secs_f32() * progress.clamp(0.0, 1.0);
         smoothstep((started / self.fade.as_secs_f32()).clamp(0.0, 1.0))
+    }
+}
+
+/// Shared resolution for every diagonal dissolve mask (the launch backdrop's, the grid's):
+/// tiny, since each is stretched over its own target and bilinear filtering turns it into a
+/// continuous gradient.
+pub const MASK_W: u32 = 64;
+pub const MASK_H: u32 = 36;
+
+/// Fills `buf` (resized to `MASK_W`x`MASK_H` RGBA8 if needed) with `wave`'s diagonal ramp,
+/// `elapsed` seconds in: `rgb` in every texel's colour, `alpha_at(wave's 0..=1 frac at that
+/// texel)` in its alpha. The wave runs on `(x + y)`, sweeping from the top-left corner.
+///
+/// Evaluated once per *diagonal* rather than once per texel — the frac is a function of
+/// `x + y` alone, so a row of the mask is `MASK_W + MASK_H - 1` of them, not their product.
+/// The buffer is kept across frames by its caller and only overwritten here, since this runs
+/// every frame of a dissolve.
+pub fn diagonal_mask(buf: &mut Vec<u8>, rgb: [u8; 3], wave: Wave, elapsed: f32, alpha_at: impl Fn(f32) -> f32) {
+    let px = (MASK_W * MASK_H) as usize * 4;
+    if buf.len() != px {
+        buf.clear();
+        buf.resize(px, 0);
+    }
+    let last = (MASK_W + MASK_H - 2) as f32;
+    let mut diagonal = [0u8; (MASK_W + MASK_H - 1) as usize];
+    for (d, a) in diagonal.iter_mut().enumerate() {
+        *a = (255.0 * alpha_at(wave.frac_secs(elapsed, d as f32 / last))) as u8;
+    }
+    for y in 0..MASK_H {
+        for x in 0..MASK_W {
+            let i = ((y * MASK_W + x) * 4) as usize;
+            buf[i] = rgb[0];
+            buf[i + 1] = rgb[1];
+            buf[i + 2] = rgb[2];
+            buf[i + 3] = diagonal[(x + y) as usize];
+        }
     }
 }
 

--- a/src/ui/theme/mod.rs
+++ b/src/ui/theme/mod.rs
@@ -204,9 +204,3 @@ pub fn epoch() -> u64 {
 pub fn glass_fill() -> Color {
     glass().map_or(palette().panel, |g| g.panel)
 }
-
-/// Whether a panel filled with [`glass_fill`] covers what is under it — which is also what
-/// decides whether such a tile can be uploaded as an opaque texture.
-pub fn panels_opaque() -> bool {
-    glass_fill().a == 0xff
-}


### PR DESCRIPTION
## Summary
Reverts sidebar/nav column back to opaque fill (undoes glass material from #180). Solid nav reads better without lit edge/seam against grid.

