### PR TITLE
Blue button raises on-screen keyboard mid-stream

### DIFF
--- a/src/platform/webos/input.rs
+++ b/src/platform/webos/input.rs
@@ -100,6 +100,7 @@ impl StickMenuNav {
 /// [`WEBOS_RED_KEYCODE`].
 pub const WEBOS_GREEN_SCANCODE: i32 = 487;
 pub const WEBOS_YELLOW_SCANCODE: i32 = 488;
+pub const WEBOS_BLUE_SCANCODE: i32 = 489;
 
 /// webOS Home key (`SDL_SCANCODE_WEBOS_HOME = 384`). Polled to re-open the launcher once
 /// `KEYS_HOME` capture stops the OS doing it. A USB keyboard's Super key is Home-class and

--- a/src/platform/webos/keyboard.rs
+++ b/src/platform/webos/keyboard.rs
@@ -249,6 +249,79 @@ pub fn key_event(scancode: Scancode, pressed: bool) -> Option<InputEvent> {
     Some(raw_key_event(vk_code(scancode)?, pressed))
 }
 
+/// `VK_SHIFT` — generic, not sided, since the host only cares that some shift is down while the
+/// bracketed key press lands.
+const VK_SHIFT: u32 = 0x10;
+
+/// US-QWERTY `char` -> `(Scancode, needs_shift)`, for everything that isn't a letter (letters
+/// are their own case below). Unshifted/shifted pairs share one arm so the two can't drift
+/// apart the way two separate tables could.
+fn char_scancode(c: char) -> Option<(Scancode, bool)> {
+    Some(match c {
+        '0' | ')' => (Scancode::Num0, c == ')'),
+        '1' | '!' => (Scancode::Num1, c == '!'),
+        '2' | '@' => (Scancode::Num2, c == '@'),
+        '3' | '#' => (Scancode::Num3, c == '#'),
+        '4' | '$' => (Scancode::Num4, c == '$'),
+        '5' | '%' => (Scancode::Num5, c == '%'),
+        '6' | '^' => (Scancode::Num6, c == '^'),
+        '7' | '&' => (Scancode::Num7, c == '&'),
+        '8' | '*' => (Scancode::Num8, c == '*'),
+        '9' | '(' => (Scancode::Num9, c == '('),
+        ' ' => (Scancode::Space, false),
+        ';' | ':' => (Scancode::Semicolon, c == ':'),
+        '=' | '+' => (Scancode::Equals, c == '+'),
+        ',' | '<' => (Scancode::Comma, c == '<'),
+        '-' | '_' => (Scancode::Minus, c == '_'),
+        '.' | '>' => (Scancode::Period, c == '>'),
+        '/' | '?' => (Scancode::Slash, c == '?'),
+        '`' | '~' => (Scancode::Grave, c == '~'),
+        '[' | '{' => (Scancode::LeftBracket, c == '{'),
+        '\\' | '|' => (Scancode::Backslash, c == '|'),
+        ']' | '}' => (Scancode::RightBracket, c == '}'),
+        '\'' | '"' => (Scancode::Apostrophe, c == '"'),
+        _ => return None,
+    })
+}
+
+/// US-QWERTY `char` -> `(vk_code, needs_shift)`, off the same `vk_code` table a real scancode
+/// forwards through — one VK table, not a second one hand-copied by `char` instead of
+/// `Scancode`. Only the printable set an on-screen keyboard commits as text; Enter/Backspace/
+/// arrows etc. arrive as ordinary scancode `KeyDown`/`KeyUp` (see the module doc on
+/// `runtime::input::text_input_screen`), not through this path.
+fn char_vk(c: char) -> Option<(u32, bool)> {
+    match c {
+        // ASCII and VK agree on A-Z by construction (both are `0x41..=0x5A`), so this skips
+        // `vk_code`/`Scancode` entirely rather than a coincidence worth hiding behind them.
+        'a'..='z' => return Some((c.to_ascii_uppercase() as u32, false)),
+        'A'..='Z' => return Some((c as u32, true)),
+        _ => {}
+    }
+    let (sc, shift) = char_scancode(c)?;
+    Some((vk_code(sc)?, shift))
+}
+
+/// Turns one `Event::TextInput`'s committed string (from the webOS on-screen keyboard) into the
+/// key down/up sequence a real keyboard typing it would have produced, shift bracketed around
+/// characters that need it. Characters with no US-QWERTY key (emoji, non-Latin scripts the OSK
+/// may still commit) are silently dropped — there's no VK for them to forward.
+pub fn text_key_events(text: &str) -> Vec<InputEvent> {
+    // 4 events/char covers the shifted case (shift down, key down, key up, shift up); the
+    // common unshifted case just leaves the extra capacity unused.
+    let mut events = Vec::with_capacity(text.len() * 4);
+    for (vk, shift) in text.chars().filter_map(char_vk) {
+        if shift {
+            events.push(raw_key_event(VK_SHIFT, true));
+        }
+        events.push(raw_key_event(vk, true));
+        events.push(raw_key_event(vk, false));
+        if shift {
+            events.push(raw_key_event(VK_SHIFT, false));
+        }
+    }
+    events
+}
+
 /// Same wire event from an already-mapped VK — for [`super::evdev`], whose keys come
 /// off evdev and never pass through an SDL scancode.
 pub fn raw_key_event(code: u32, pressed: bool) -> InputEvent {

--- a/src/runtime/input.rs
+++ b/src/runtime/input.rs
@@ -375,13 +375,88 @@ impl ConfirmDialog {
     }
 }
 
-/// Rising-edge detect on a raw webOS scancode (polled since these sit outside
-/// rust-sdl2's `Scancode` enum). `prev` carries the last-frame state across calls.
-fn scancode_rising_edge(scancode: i32, prev: &mut bool) -> bool {
-    let down = crate::platform::webos::input::webos_scancode_down(scancode);
+/// Edge-trigger bookkeeping shared by every scancode/keycode poll in both loops: `down` (with
+/// whatever gating — a dialog owning input, say — the caller wants folded in already) becomes
+/// `fired` exactly once per physical press, `prev` carrying state across calls. Split from
+/// [`scancode_rising_edge`] so a caller that needs to gate `down` on something besides the raw
+/// key state (the streaming loop's colour buttons, skipped while its disconnect dialog is open)
+/// isn't left re-deriving this bookkeeping itself.
+pub(super) fn rising_edge(down: bool, prev: &mut bool) -> bool {
     let fired = down && !*prev;
     *prev = down;
     fired
+}
+
+/// Rising-edge detect on a raw webOS scancode (polled since these sit outside
+/// rust-sdl2's `Scancode` enum). `prev` carries the last-frame state across calls.
+fn scancode_rising_edge(scancode: i32, prev: &mut bool) -> bool {
+    rising_edge(crate::platform::webos::input::webos_scancode_down(scancode), prev)
+}
+
+/// Wraps webOS's on-screen keyboard (`SDL_StartTextInput`/`Stop`/`SetTextInputRect`, driving
+/// `zwp_text_input_v3` — see `text_input_screen`'s doc) for the two loops that raise it:
+/// `run_ui_flow` declaratively, from which screen is open, and `stream` from a button press
+/// with no equivalent "wants text" screen state to read. One place for the SDL toggle-semantics
+/// workaround `raise` needs, instead of two copies free to drift apart.
+pub(super) struct TextInputController {
+    util: sdl2::keyboard::TextInputUtil,
+    /// This app's own belief about whether it last asked for text input — not necessarily
+    /// what the compositor is showing right now; webOS's IME can dismiss the panel (Back)
+    /// without this app hearing about it. Only [`Self::set_active`] treats this as trustworthy
+    /// (it owns every off transition); [`Self::raise`] deliberately never reads it.
+    active: bool,
+}
+
+impl TextInputController {
+    pub(super) fn new(util: sdl2::keyboard::TextInputUtil) -> Self {
+        Self { util, active: false }
+    }
+
+    pub(super) fn has_screen_keyboard_support(&self) -> bool {
+        self.util.has_screen_keyboard_support()
+    }
+
+    pub(super) fn is_shown(&self, window: &sdl2::video::Window) -> bool {
+        self.util.is_screen_keyboard_shown(window)
+    }
+
+    /// Declarative form (`run_ui_flow`'s): active exactly while `want` is true, a no-op unless
+    /// `want` changed since the last call. `rect`, when given, anchors the panel to a text
+    /// field on the way up — `run_ui_flow` skips it when the field itself isn't on screen yet.
+    pub(super) fn set_active(&mut self, want: bool, rect: Option<sdl2::rect::Rect>) {
+        if want == self.active {
+            return;
+        }
+        self.active = want;
+        if want {
+            if let Some(r) = rect {
+                self.util.set_rect(r);
+            }
+            self.util.start();
+        } else {
+            self.util.stop();
+        }
+        tracing::debug!("text input requested: {want}");
+    }
+
+    /// Button-triggered form (`stream`'s): unconditionally (re)raises the panel at `rect`,
+    /// regardless of what this app currently believes. SDL's own idea of text input stays
+    /// "started" from the first raise onward for the whole loop, even across a Back dismissal
+    /// this app never hears about — so a bare `start()` on a later press is a no-op against
+    /// state SDL already considers unchanged, and the panel never re-shows. `stop()`
+    /// immediately before it forces a real disable→enable transition every single press.
+    pub(super) fn raise(&mut self, rect: sdl2::rect::Rect) {
+        self.util.set_rect(rect);
+        self.util.stop();
+        self.util.start();
+        self.active = true;
+    }
+
+    /// Cleanup at loop exit — harmless if already stopped.
+    pub(super) fn stop(&mut self) {
+        self.util.stop();
+        self.active = false;
+    }
 }
 
 /// The webOS EXIT gesture (a held Back, delivered as `WEBOS_EXIT_SCANCODE`).

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::platform::webos::device;
 use crate::platform::webos::input::{
-    webos_scancode_down as key_down, WEBOS_EXIT_SCANCODE, WEBOS_GREEN_SCANCODE, WEBOS_HOME_SCANCODE,
-    WEBOS_YELLOW_SCANCODE,
+    webos_scancode_down as key_down, WEBOS_BLUE_SCANCODE, WEBOS_EXIT_SCANCODE, WEBOS_GREEN_SCANCODE,
+    WEBOS_HOME_SCANCODE, WEBOS_YELLOW_SCANCODE,
 };
 
 /// How long the finished launch frame is held waiting for the first frame to reach the decoder
@@ -289,6 +289,12 @@ pub(super) fn run_inner() -> Result<()> {
         let mut green_held = key_down(WEBOS_GREEN_SCANCODE);
         let mut yellow_held = key_down(WEBOS_YELLOW_SCANCODE);
         let mut home_held = key_down(WEBOS_HOME_SCANCODE);
+        let mut blue_held = key_down(WEBOS_BLUE_SCANCODE);
+        // On-screen keyboard, raised by Blue mid-stream — there's no text field to declare
+        // "wants text" during a stream, so this drives `TextInputController` by button instead
+        // of by screen the way `run_ui_flow` does. Hiding is Back's job (webOS's IME dismisses
+        // on it).
+        let mut text_input = TextInputController::new(canvas.window().subsystem().text_input());
         // Transient toasts. `overlay_was_active` catches the fade-out edge so the canvas gets
         // wiped once; `stats_dst`/`log_dst` recomposite each frame at their own slower cadence.
         let mut notif = crate::ui::widgets::Notification::new();
@@ -442,6 +448,13 @@ pub(super) fn run_inner() -> Result<()> {
                             connected.send_input(&ev);
                         }
                     }
+                    // Committed text off the on-screen keyboard (Blue toggles it — see above);
+                    // it has no scancode of its own, only the string the IME composed.
+                    Event::TextInput { text, .. } => {
+                        for ev in keyboard::text_key_events(&text) {
+                            connected.send_input(&ev);
+                        }
+                    }
                     // Magic Remote Red — the right button (see `RemoteButtons::red`). Like Back
                     // it carries only a keycode (see `WEBOS_RED_KEYCODE`); `repeat: false` so the
                     // OS's auto-repeat while it's held doesn't restate the press.
@@ -591,13 +604,13 @@ pub(super) fn run_inner() -> Result<()> {
             if home_key_fired(&mut home_held) {
                 crate::platform::webos::luna::launch_home();
             }
-            // Green button: stats-overlay toggle, edge-detected via raw scancode poll (the
-            // safe SDL2 event API can't see this key). Skipped while the dialog owns input.
-            let green_down = !disconnect.is_open()
-                && crate::platform::webos::input::webos_scancode_down(
-                    crate::platform::webos::input::WEBOS_GREEN_SCANCODE,
-                );
-            if green_down && !green_held {
+            // Colour buttons: edge-detected via raw scancode poll (the safe SDL2 event API
+            // can't see these keys), skipped while the dialog owns input. `rising_edge` is the
+            // one place that bookkeeping lives — see its doc for why it's not
+            // `scancode_rising_edge` directly.
+            let dialog_open = disconnect.is_open();
+            // Green: stats-overlay toggle.
+            if rising_edge(!dialog_open && key_down(WEBOS_GREEN_SCANCODE), &mut green_held) {
                 stats_enabled = !stats_enabled;
                 overlay_last = None; // force an immediate redraw
                 if stats_enabled {
@@ -606,14 +619,9 @@ pub(super) fn run_inner() -> Result<()> {
                     stats_fade.close(());
                 }
             }
-            green_held = green_down;
-            // Yellow button: log-tail overlay Off -> Live -> Frozen -> Off, same edge-detect
-            // as Green above; also handled in `run_ui_flow` for non-streaming screens.
-            let yellow_down = !disconnect.is_open()
-                && crate::platform::webos::input::webos_scancode_down(
-                    crate::platform::webos::input::WEBOS_YELLOW_SCANCODE,
-                );
-            if yellow_down && !yellow_held {
+            // Yellow: log-tail overlay Off -> Live -> Frozen -> Off; also handled in
+            // `run_ui_flow` for non-streaming screens.
+            if rising_edge(!dialog_open && key_down(WEBOS_YELLOW_SCANCODE), &mut yellow_held) {
                 let was_on = log_overlay_state() != LogOverlayState::Off;
                 cycle_log_overlay();
                 let now_on = log_overlay_state() != LogOverlayState::Off;
@@ -624,7 +632,23 @@ pub(super) fn run_inner() -> Result<()> {
                     log_fade.close(());
                 }
             }
-            yellow_held = yellow_down;
+            // Blue: raises the on-screen keyboard, so a game needing text (chat, a search box)
+            // doesn't require dropping back to the menu. Hiding is Back's job — webOS's IME
+            // dismisses on it, and `TextInputController::raise` never reads this app's own
+            // "active" belief, so there's no stuck-closed state Blue could get stuck reading.
+            if rising_edge(!dialog_open && key_down(WEBOS_BLUE_SCANCODE), &mut blue_held) {
+                // webOS's IME won't raise the panel off an `enable()` with no rectangle set
+                // yet — `run_ui_flow` always sets one first for the same reason. There's no
+                // text field to anchor to mid-stream, so a fixed strip near the bottom does.
+                let w = 400i32.min(display_mode.w);
+                text_input.raise(sdl2::rect::Rect::new(
+                    (display_mode.w - w) / 2,
+                    display_mode.h - 120,
+                    w as u32,
+                    60,
+                ));
+                tracing::debug!("on-screen keyboard requested");
+            }
             // Connection-issue toast: fires on the rising edge of a freeze-until-reanchor hold
             // (dropped/gapped frames — see `session::pump`), which is the same "network
             // trouble" signal the stats overlay's "Beat" line reads, just edge-triggered here so
@@ -928,6 +952,8 @@ pub(super) fn run_inner() -> Result<()> {
             // added latency near zero; the wakeup rate is noise even on this SoC.
             std::thread::sleep(Duration::from_millis(2));
         };
+        // Harmless if Back already dismissed it, or it was never raised this stream.
+        text_input.stop();
 
         // Trigger resistance is firmware state that outlives the session — hand the pad back
         // first or a game that ended with R2 stiff leaves it stiff on the TV home screen.

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -105,12 +105,11 @@ pub(super) fn run_ui_flow(
     let mut input = UiInput::default();
     // Owned handle (it just clones the video subsystem's refcount), so taking it
     // here doesn't hold a borrow on `canvas` for the rest of the loop.
-    let text_input = canvas.window().subsystem().text_input();
+    let mut text_input = TextInputController::new(canvas.window().subsystem().text_input());
     tracing::info!(
         "on-screen keyboard support: {}",
         text_input.has_screen_keyboard_support()
     );
-    let mut text_input_active = false;
     // Redraw-on-change: outside a running animation (which the tick below asks
     // `App` about separately), pixels only ever change in reaction to an SDL
     // event or a discovery/art/library background result — anything else is a
@@ -355,30 +354,18 @@ pub(super) fn run_ui_flow(
             }
         }
         // Track actual keyboard state (user can dismiss while field focused; moves card).
-        let keyboard_shown = text_input.is_screen_keyboard_shown(canvas.window());
+        let keyboard_shown = text_input.is_shown(canvas.window());
         if keyboard_shown != app.keyboard_shown {
             app.set_keyboard_shown(keyboard_shown);
             dirty = true;
             tracing::debug!("on-screen keyboard shown: {keyboard_shown}");
         }
-        // Toggle text input (edge-triggered; SDL doesn't tolerate repeated calls).
+        // Toggle text input off screen state — a no-op unless it actually changed.
         let wants_text = text_input_screen(app.nav.screen);
-        if wants_text != text_input_active {
-            text_input_active = wants_text;
-            if wants_text {
-                if let Some(r) = app.address_field_rect(display_mode.w as u32, display_mode.h as u32, fonts) {
-                    text_input.set_rect(sdl2::rect::Rect::new(r.x(), r.y(), r.width(), r.height()));
-                }
-                text_input.start();
-            } else {
-                text_input.stop();
-            }
-            // Log both; separate SDL callbacks — some drivers implement only one.
-            tracing::debug!(
-                "text input requested: {wants_text} (keyboard shown: {})",
-                text_input.is_screen_keyboard_shown(canvas.window())
-            );
-        }
+        let rect = app
+            .address_field_rect(display_mode.w as u32, display_mode.h as u32, fonts)
+            .map(|r| sdl2::rect::Rect::new(r.x(), r.y(), r.width(), r.height()));
+        text_input.set_active(wants_text, rect);
         // Five reasons to render: dirty, animations running, tiles pending,
         // spinner animating, or log overlay due for refresh (~2Hz).
         // 16ms sleep when none holds keeps SoC idle.
@@ -549,9 +536,7 @@ pub(super) fn run_ui_flow(
             std::thread::sleep(TICK_BUDGET - elapsed);
         }
     }
-    if text_input_active {
-        text_input.stop();
-    }
+    text_input.stop();
     Ok(match connect_handle {
         Some((handle, settings, gamepad_auto)) => UiOutcome::Launch(ConnectOutcome {
             handle,


### PR DESCRIPTION
## Summary

Blue button now opens the on-screen keyboard during game streaming (previously only available in menu text-entry screens). Typed text is forwarded to the host via synthetic VK key sequences. Text input lifecycle is managed through a shared `TextInputController` that both menu and streaming loops use, fixing edge cases around IME dismissal and panel re-opening.

## Changes

- **Remote input** (`src/platform/webos/input.rs`): added `WEBOS_BLUE_SCANCODE` (489), alongside the existing Green (487)/Yellow (488) raw-scancode constants.
- **Streaming loop** (`src/runtime/stream.rs`): Blue button now raises webOS's on-screen keyboard mid-stream. No programmatic close — Back (webOS's IME behavior) handles dismissal.
- **Text forwarding** (`src/platform/webos/keyboard.rs`): added `text_key_events()` to convert on-screen keyboard's committed text into synthetic VK key down/up sequences for the host. Reused existing `vk_code` table to avoid duplicating magic numbers.
- **Shared text input** (`src/runtime/input.rs`): new `TextInputController` wraps SDL's `TextInputUtil` for consistent lifecycle management across both UI and streaming loops. Encapsulates the `stop()`-before-`start()` pattern needed to work around SDL's text-input state persistence across IME dismissals this app has no visibility into.
- **Loop integration** (`src/runtime/ui_flow.rs`, `src/runtime/stream.rs`): both loops now use `TextInputController` instead of managing `TextInputUtil` locally.

## Why

Blue-button keyboard access was requested for in-game chat/search. First attempts toggled the panel, which left internal state desynchronized after Back-dismissals (webOS's IME closes the panel silently). The fix eliminates toggle logic — Blue unconditionally raises via `TextInputController::raise`, which always stops then starts to overcome SDL's text-input-started caching.

Typed text wasn't reaching the host initially because the on-screen keyboard commits via `Event::TextInput` (different from physical key events), so a separate `text_key_events()` forwarding path was needed.

## Test Plan

- [x] `task docker:check` passes
- [x] `task docker:lint` passes
- [ ] Blue button raises the on-screen keyboard during streaming (requires real device)
- [ ] Typed text reaches the host correctly (requires real device)
- [ ] Back button closes the keyboard (webOS behavior, not this app's responsibility)
- [ ] Second Blue press reopens keyboard after dismissal (requires real device)

## Known Limitations

- `text_key_events()` only covers printable ASCII (US-QWERTY); non-Latin/accented characters are silently dropped.
- This feature requires a real webOS TV device to verify; local testing only confirms compilation.