### PR TITLE
Smooth Home focus transitions

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -473,6 +473,7 @@ impl App {
         // Past the hosts are the two utility rows, which move with the list's length; a host
         // index only needs clamping into what's left.
         let i = if i >= before { i - before + now } else { i.min(now) };
+        // Content reanchoring preserves focus identity; it is not an interactive move.
         self.home_focus = HomeFocus::Sidebar(i);
     }
 
@@ -641,9 +642,11 @@ impl App {
             }
             match self.home_focus {
                 HomeFocus::Grid(_) => {
-                    self.home_focus = HomeFocus::Sidebar(self.sidebar_index_for_selected());
+                    self.set_home_focus(HomeFocus::Sidebar(self.sidebar_index_for_selected()));
                 }
-                HomeFocus::SidebarMenu(i) => self.home_focus = HomeFocus::Sidebar(i),
+                HomeFocus::SidebarMenu(i) => {
+                    self.set_home_focus(HomeFocus::Sidebar(i));
+                }
                 HomeFocus::Sidebar(_) => {}
             }
             return None;
@@ -667,7 +670,11 @@ impl App {
         animating |=
             ui::animation::ease_scroll(&mut self.render.modal.scroll_px, self.render.modal.scroll_target_px, dt);
         if let Some(t) = self.render.focus_anim {
-            if t.elapsed() >= ui::animation::CARD_FOCUS_POP {
+            let duration = match self.home_focus {
+                HomeFocus::Grid(_) => ui::animation::CARD_FOCUS_POP,
+                HomeFocus::Sidebar(_) | HomeFocus::SidebarMenu(_) => ui::animation::FOCUS_POP,
+            };
+            if t.elapsed() >= duration {
                 self.render.focus_anim = None;
             }
             animating = true;

--- a/src/app/pointer.rs
+++ b/src/app/pointer.rs
@@ -22,7 +22,7 @@ use crate::ui::render::Rect;
 /// the *row* under the pointer changed. Stepping onto a button a row carries (its ⋯, a
 /// collection's drag/rename/remove) leaves the row itself put, and a row that keeps focus
 /// must not replay its focus pop — the same rule the D-pad's `step_row_button` follows, and
-/// the one the sidebar's ⋯ has always had (`set_home_focus` pops only grid cards).
+/// the sidebar follows when focus moves between a host row and its own ⋯ button.
 #[derive(Clone, Copy)]
 struct HoverChange {
     any: bool,
@@ -42,7 +42,10 @@ impl HoverChange {
 
     /// A hover on a row list, where the row and the button it carries move independently.
     const fn split(row: bool, button: bool) -> Self {
-        Self { any: row || button, row }
+        Self {
+            any: row || button,
+            row,
+        }
     }
 }
 
@@ -262,21 +265,6 @@ impl App {
             // EditHost, About) and Settings with a dropdown open.
             _ => HoverChange::NONE,
         }
-    }
-
-    /// Sets `home_focus`, reporting whether it actually moved — the hover/click
-    /// helpers redraw only on a real change.
-    fn set_home_focus(&mut self, focus: HomeFocus) -> bool {
-        let changed = self.home_focus != focus;
-        self.home_focus = focus;
-        // The card's zoom, glow and title wipe all run off `focus_anim`, which the D-pad
-        // arms in `ensure_grid_visible`; armed here for every pointer path at once, or
-        // landing on a card with the Magic Remote renders it already finished. Only on a
-        // change: the pointer streams motion events and each would restart the clock.
-        if changed && matches!(focus, HomeFocus::Grid(_)) {
-            self.render.focus_anim = Some(Instant::now());
-        }
-        changed
     }
 
     /// The `(content viewport, pixel scroll offset)` an open dropdown anchors its
@@ -536,12 +524,12 @@ impl App {
                 if let Some(idx) =
                     view::sidebar::hit_test_menu_button(x, y, self.hosts.entries.len(), self.sidebar_len(), screen_h)
                 {
-                    self.home_focus = HomeFocus::SidebarMenu(idx);
+                    self.set_home_focus(HomeFocus::SidebarMenu(idx));
                     self.open_host_menu(idx);
                     return None;
                 }
                 if let Some(idx) = view::sidebar::hit_test_row(x, y, self.sidebar_len(), screen_h) {
-                    self.home_focus = HomeFocus::Sidebar(idx);
+                    self.set_home_focus(HomeFocus::Sidebar(idx));
                 } else {
                     let available_w = screen_w.saturating_sub(ui::widgets::SIDEBAR_W);
                     let columns = view::home::grid_columns(available_w);
@@ -551,7 +539,7 @@ impl App {
                     if !self.is_grid_card(idx, columns) {
                         return None;
                     }
-                    self.home_focus = HomeFocus::Grid(idx);
+                    self.set_home_focus(HomeFocus::Grid(idx));
                 }
             }
             // `?` bails if the click hit the gap between rows or outside the viewport —

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -40,6 +40,7 @@ impl App {
             status_alpha: self.home_status_alpha(),
             grid_reveal_ready: self.render.grid.reveal.is_revealed(),
             press: self.press_dip(Screen::Home),
+            focus_anim: self.render.focus_anim,
         }
     }
 
@@ -294,14 +295,13 @@ impl App {
         // The entering screen's only — the snapshot has its own focused row baked in.
         let focus_rect = self.modal_focus_rect(screen, screen_w, screen_h, fonts);
         if let Some(rect) = focus_rect {
-            let pad = ui::tiles::ROW_TILE_PAD;
-            let base = rect.inflate(pad).offset(0, dy);
+            let base = rect.offset(0, dy);
             // The zoom-in: same GPU-scale-around-center technique as the
             // grid's card focus pop (see above) — `modal_focus_tile` is
             // rasterized once at its literal size, never re-rendered for
             // this (except while `switch_anim` animates its content, see
             // `prepare_tiles`).
-            let dst = ui::animation::focus_tile_rect(base, self.render.modal.focus_anim, self.press_dip(screen));
+            let dst = ui::animation::focus_row_tile_rect(base, self.render.modal.focus_anim, self.press_dip(screen));
             let alpha = (255.0 * m) as u8;
             // In a scrolling modal the focused row can hang past the viewport's bottom
             // edge mid-glide (the crop lags the row offset by up to one stride), so it is
@@ -310,7 +310,7 @@ impl App {
             let tile_size = tiles.get(tile::MODAL_FOCUS).map(|p| (p.width(), p.height()));
             match (scroll_geom, tile_size) {
                 (Some((_, _, _, content)), Some((tw, th))) => {
-                    let viewport = content.inflate(pad).offset(0, dy);
+                    let viewport = content.inflate(ui::tiles::ROW_TILE_PAD).offset(0, dy);
                     if let Some((src, visible)) = Self::clip_tile(dst, viewport, tw, th) {
                         cmds.push(DrawCmd::TexCropped {
                             tile: tile::MODAL_FOCUS,
@@ -452,10 +452,9 @@ impl App {
         };
         if let Some(i) = sidebar_focus_row {
             let rect = view::sidebar::nav_row_rect(i, input.entries.len() + 2, screen_h);
-            let pad = ui::tiles::ROW_TILE_PAD;
-            cmds.push(DrawCmd::Tex {
+            cmds.push(DrawCmd::TexF {
                 tile: tile::FOCUS_ROW,
-                dst: input.press.rect(rect.inflate(pad)),
+                dst: ui::animation::focus_row_tile_rect_f(rect, input.focus_anim, input.press),
                 alpha: 0xff,
             });
         }
@@ -796,8 +795,8 @@ impl App {
                     // and then the card's transform on top of that. The inset the band is
                     // drawn at (`CARD_MENU_BAND_INSET`) is what the growth spends, so a
                     // focused row stays within the cover art.
-                    let popped = ui::animation::focus_tile_rect(
-                        band.inflate(pad),
+                    let popped = ui::animation::focus_row_tile_rect(
+                        band,
                         self.card_menu.as_ref().and_then(|m| m.focus_anim),
                         ui::animation::Press::default(),
                     );

--- a/src/app/render_input.rs
+++ b/src/app/render_input.rs
@@ -22,4 +22,6 @@ pub struct RenderInput<'a> {
     pub grid_reveal_ready: bool,
     /// The focused row's press dip (see `App::press`) — the sidebar's rows are buttons.
     pub press: crate::ui::animation::Press,
+    /// Focus-pop clock shared by Home's focused grid card and sidebar row.
+    pub focus_anim: Option<std::time::Instant>,
 }

--- a/src/app/state/addhost.rs
+++ b/src/app/state/addhost.rs
@@ -51,13 +51,13 @@ impl App {
         );
         self.persist();
         self.rebuild_entries();
-        self.home_focus = HomeFocus::Sidebar(
+        self.set_home_focus(HomeFocus::Sidebar(
             self.hosts
                 .entries
                 .iter()
                 .position(|e| e.host() == host && e.port() == port)
                 .unwrap_or(0),
-        );
+        ));
         self.nav.screen = Screen::Home;
     }
     /// Shared by `AddHost` and `EditHost`.

--- a/src/app/state/cardmenu.rs
+++ b/src/app/state/cardmenu.rs
@@ -169,8 +169,7 @@ impl App {
             if let Some(menu) = self.card_menu.as_mut() {
                 menu.idx = idx;
             }
-            self.home_focus = HomeFocus::Grid(idx);
-            self.render.grid.focus_last = idx;
+            self.set_home_focus(HomeFocus::Grid(idx));
             // A swap onto another row would otherwise leave the card half off screen.
             self.ensure_grid_visible(idx, columns, screen_w, screen_h);
         }

--- a/src/app/state/edithost.rs
+++ b/src/app/state/edithost.rs
@@ -78,13 +78,13 @@ impl App {
         if self.library.selected_host.as_ref() == Some(&(old.host.clone(), old.port)) {
             self.library.selected_host = Some((host.clone(), port));
         }
-        self.home_focus = HomeFocus::Sidebar(
+        self.set_home_focus(HomeFocus::Sidebar(
             self.hosts
                 .entries
                 .iter()
                 .position(|e| e.host() == host && e.port() == port)
                 .unwrap_or(0),
-        );
+        ));
         self.screens.edit_host_index = None;
         self.render.sidebar_dirty = true;
         self.render.grid.dirty = true;

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -18,7 +18,30 @@ use std::time::Instant;
 const GROUP_SIDEBAR: u8 = 0;
 const GROUP_GRID: u8 = 1;
 
+fn sidebar_row(focus: HomeFocus) -> Option<usize> {
+    match focus {
+        HomeFocus::Sidebar(index) | HomeFocus::SidebarMenu(index) => Some(index),
+        HomeFocus::Grid(_) => None,
+    }
+}
+
 impl App {
+    /// Applies an interactive Home focus transition and its visual state.
+    pub(crate) fn set_home_focus(&mut self, focus: HomeFocus) -> bool {
+        let previous = self.home_focus;
+        if previous == focus {
+            return false;
+        }
+        self.home_focus = focus;
+        if let HomeFocus::Grid(index) = focus {
+            self.render.grid.focus_last = index;
+        }
+        if matches!(focus, HomeFocus::Grid(_)) || sidebar_row(previous) != sidebar_row(focus) {
+            self.render.focus_anim = Some(Instant::now());
+        }
+        true
+    }
+
     /// Total sidebar nav positions: host rows + "+ Add host" + "Settings".
     pub(crate) fn sidebar_len(&self) -> usize {
         self.hosts.entries.len() + 2
@@ -157,9 +180,8 @@ impl App {
         else {
             return;
         };
-        self.home_focus = next;
+        self.set_home_focus(next);
         if let HomeFocus::Grid(idx) = next {
-            self.render.grid.focus_last = idx;
             self.ensure_grid_visible(idx, columns, screen_w, screen_h);
         }
     }
@@ -262,8 +284,7 @@ impl App {
 
         self.regroup_games();
         if let Some(new_idx) = self.grid_idx_for_pin_id(id, columns) {
-            self.home_focus = HomeFocus::Grid(new_idx);
-            self.render.grid.focus_last = new_idx;
+            self.set_home_focus(HomeFocus::Grid(new_idx));
             self.ensure_grid_visible(new_idx, columns, screen_w, screen_h);
         }
         // Only the card that moved pops. Every other card slides one slot along — a shift the
@@ -342,14 +363,12 @@ impl App {
 
     /// Scrolls the grid (via `grid_scroll_target` — the rendered offset eases
     /// toward it, see `tick_animations`) just far enough that focused card `idx`,
-    /// including its focus-ring halo, will be fully on screen; also starts the
-    /// focus pop, since this is called on exactly the moves that change grid
-    /// focus. Clamped to the grid's real extent.
+    /// including its focus-ring halo, will be fully on screen. Clamped to the
+    /// grid's real extent.
     pub(crate) fn ensure_grid_visible(&mut self, idx: usize, columns: usize, screen_w: u32, screen_h: u32) {
         /// Focus ring + `inflate` overhang around a focused card, plus a little
         /// breathing room.
         const FOCUS_MARGIN: i32 = 16;
-        self.render.focus_anim = Some(Instant::now());
         let available_w = screen_w.saturating_sub(ui::widgets::SIDEBAR_W);
         let card = self.unscrolled_card_rect(idx, columns, ui::widgets::SIDEBAR_W as i32, available_w);
         let viewport = (view::home::GRID_TOP_Y, screen_h as i32 - view::home::GRID_PAD);
@@ -397,6 +416,7 @@ impl App {
         self.library.clear();
         self.jobs.cancel_library();
         self.set_home_status(None, false);
+        // Teardown establishes the next stable focus before Home is drawn again.
         self.home_focus = HomeFocus::Sidebar(0);
         self.render.grid.focus_last = 0;
         self.render.grid.dirty = true;
@@ -498,7 +518,7 @@ impl App {
                 // navigated off that row, so a late fetch can't yank them.
                 if matches!(self.home_focus, HomeFocus::Sidebar(i) if Some(i) == self.sidebar_index_of_selected_host())
                 {
-                    self.home_focus = HomeFocus::Grid(0);
+                    self.set_home_focus(HomeFocus::Grid(0));
                 }
                 if !self.home_status_sticky {
                     self.set_home_status(None, false);

--- a/src/app/view/sidebar.rs
+++ b/src/app/view/sidebar.rs
@@ -13,8 +13,7 @@ pub const TOP_Y: i32 = 216;
 /// [`TOP_Y`], then "Settings" pinned to the bottom of the panel — a spacer slot between
 /// them is what "pinned" means, so it stays put regardless of how many hosts are known.
 ///
-/// One split, read by the painter, both hit tests and `home_focus_map` alike; nothing
-/// recomputes a row's position from an index formula of its own.
+/// One split, read by the painter, hit tests and `home_focus_map` alike.
 pub fn nav_rows(row_count: usize, screen_h: u32) -> Vec<Rect> {
     let column = Rect::new(
         ui::widgets::SIDEBAR_PAD,
@@ -30,7 +29,6 @@ pub fn nav_rows(row_count: usize, screen_h: u32) -> Vec<Rect> {
     let mut rects = ui::layout::Layout::vertical(slots)
         .gap(ui::widgets::SIDEBAR_ROW_GAP)
         .split(column);
-    // Drop the spacer, leaving one rect per nav position.
     rects.remove(above);
     rects.truncate(row_count);
     rects
@@ -165,7 +163,7 @@ pub fn draw_host_row(c: &mut Canvas, rect: Rect, name: &str, state: &HostRowStat
     // Badged onto the icon's corner rather than given its own column: it needs no layout
     // of its own, and a presence dot on the thing it describes is a well-worn idiom.
     if let Some(online) = online {
-        let icon = ui::widgets::sidebar_icon_rect(ui::widgets::focus_zoom(rect, focused));
+        let icon = ui::widgets::sidebar_icon_rect(rect);
         let cx = icon.right() as f32 - 1.0;
         let cy = icon.bottom() as f32 - 2.0;
         // A ring of panel background first, so the dot reads as separate from the glyph
@@ -202,16 +200,6 @@ pub struct FocusedRowTile<'a> {
     pub online: Option<bool>,
 }
 
-impl FocusedRowTile<'_> {
-    /// The row's own size, before the padding [`TileWidget::size`] adds.
-    fn row_size() -> (u32, u32) {
-        (
-            ui::widgets::SIDEBAR_W - 2 * ui::widgets::SIDEBAR_PAD as u32,
-            ui::widgets::SIDEBAR_ROW_H,
-        )
-    }
-}
-
 impl ui::Widget for FocusedRowTile<'_> {
     fn render(self, area: ui::render::Rect, c: &mut ui::Canvas) -> Result<()> {
         let rect = area.inflate(-ui::tiles::ROW_TILE_PAD);
@@ -238,7 +226,10 @@ impl ui::Widget for FocusedRowTile<'_> {
 
 impl ui::TileWidget for FocusedRowTile<'_> {
     fn size(&self, _fonts: &ui::text::Fonts) -> (u32, u32) {
-        let (w, h) = Self::row_size();
-        ui::tiles::padded_size(w, h, ui::tiles::ROW_TILE_PAD)
+        ui::tiles::padded_size(
+            ui::widgets::SIDEBAR_W - 2 * ui::widgets::SIDEBAR_PAD as u32,
+            ui::widgets::SIDEBAR_ROW_H,
+            ui::tiles::ROW_TILE_PAD,
+        )
     }
 }

--- a/src/runtime/input.rs
+++ b/src/runtime/input.rs
@@ -333,13 +333,7 @@ impl ConfirmDialog {
         // Same open/close motion as the `App`'s `Screen` modals (see `compose_modal`):
         // the shared rise, same curve in both directions, no scale.
         let dy = crate::ui::animation::modal_rise(m);
-        let pad = crate::ui::tiles::ROW_TILE_PAD;
-        let base = crate::ui::render::Rect::new(
-            btn_rect.x() - pad,
-            btn_rect.y() - pad + dy,
-            btn_rect.width() + 2 * pad as u32,
-            btn_rect.height() + 2 * pad as u32,
-        );
+        let base = btn_rect.offset(0, dy);
         let shell_dst = crate::ui::render::Rect::new(0, dy, w, h);
         // Pane first, scrim second, shell tile third — the same order `App::compose_modal`
         // keeps, and for the same reason: the compositor captures its blur source at the
@@ -366,9 +360,9 @@ impl ConfirmDialog {
             dst: shell_dst,
             alpha: (255.0 * m) as u8,
         });
-        cmds.push(DrawCmd::Tex {
+        cmds.push(DrawCmd::TexF {
             tile: tile::DISCONNECT_FOCUS_BUTTON,
-            dst: crate::ui::animation::focus_tile_rect(base, self.focus_anim, self.press),
+            dst: crate::ui::animation::focus_row_tile_rect_f(base, self.focus_anim, self.press),
             alpha: (255.0 * m) as u8,
         });
         Ok(())

--- a/src/services/store/mod.rs
+++ b/src/services/store/mod.rs
@@ -99,7 +99,7 @@ fn seed_desktop_capture(state: &mut Persisted) {
     };
     for host in &mut state.known_hosts {
         let untouched = host.games.values().all(|g| g.over.is_empty());
-        if !untouched || !host.games.get(DESKTOP_PIN_ID).is_some_and(|g| g.legacy_pin.is_some()) {
+        if !untouched || host.games.get(DESKTOP_PIN_ID).is_none_or(|g| g.legacy_pin.is_none()) {
             continue;
         }
         host.edit_overrides(DESKTOP_PIN_ID, |over| over.cursor_capture = Some(capture));

--- a/src/ui/animation.rs
+++ b/src/ui/animation.rs
@@ -1,4 +1,4 @@
-use crate::ui::render::Rect;
+use crate::ui::render::{Rect, RectF};
 use std::time::{Duration, Instant};
 
 /// How long a focused widget takes to pop to its zoomed size.
@@ -72,13 +72,39 @@ impl Press {
 
     /// Base rect pushed down by press progress. Translation not scale (no resample).
     pub fn rect(self, base: Rect) -> Rect {
-        base.offset(0, (PRESS_DROP * (1.0 - anim_frac(self.0, PRESS_POP))) as i32)
+        base.offset(0, self.offset() as i32)
+    }
+
+    fn offset(self) -> f32 {
+        PRESS_DROP * (1.0 - anim_frac(self.0, PRESS_POP))
     }
 }
 
 /// Focus tile position: focus pop zoom with press dip on top (every tile goes through this).
-pub fn focus_tile_rect(base: Rect, focus_anim: Option<Instant>, press: Press) -> Rect {
-    press.rect(zoom_rect(base, anim_frac(focus_anim, FOCUS_POP), FOCUS_GROWTH))
+/// A focused row/button tile includes transparent shadow padding around its layout rect.
+pub fn focus_row_tile_rect(rect: Rect, focus_anim: Option<Instant>, press: Press) -> Rect {
+    let dst = focus_row_scaled_rect(rect, focus_anim);
+    press.rect(Rect::new(dst.x as i32, dst.y as i32, dst.w as u32, dst.h as u32))
+}
+
+/// Subpixel counterpart for whole-texture row tiles, avoiding stepped 2% zooms.
+pub fn focus_row_tile_rect_f(rect: Rect, focus_anim: Option<Instant>, press: Press) -> RectF {
+    let mut dst = focus_row_scaled_rect(rect, focus_anim);
+    dst.y += press.offset();
+    dst
+}
+
+fn focus_row_scaled_rect(rect: Rect, focus_anim: Option<Instant>) -> RectF {
+    let base = rect.inflate(crate::ui::tiles::ROW_TILE_PAD);
+    let scale = zoom_scale(anim_frac(focus_anim, FOCUS_POP), FOCUS_GROWTH);
+    let w = base.width() as f32 * scale;
+    let h = base.height() as f32 * scale;
+    RectF {
+        x: base.x() as f32 + (base.width() as f32 - w) / 2.0,
+        y: base.y() as f32 + (base.height() as f32 - h) / 2.0,
+        w,
+        h,
+    }
 }
 
 /// Modal card slide distance (px).

--- a/src/ui/widgets/cards.rs
+++ b/src/ui/widgets/cards.rs
@@ -8,7 +8,7 @@ pub const CARD_RADIUS: i32 = 10;
 pub const MODAL_RADIUS: i32 = 20;
 
 /// Approximate moonlight-tv's 2% focus zoom by inflating rect from center.
-pub fn focus_zoom(rect: Rect, focused: bool) -> Rect {
+fn focus_zoom(rect: Rect, focused: bool) -> Rect {
     if !focused {
         return rect;
     }
@@ -69,19 +69,8 @@ impl Painter {
         r
     }
 
-    /// Card painted only when focused (no background for unfocused). Used by rows/buttons.
-    pub fn selectable(&mut self, rect: Rect, focused: bool) -> Rect {
-        let r = focus_zoom(rect, focused);
-        if focused {
-            self.card_shadow(r, CARD_RADIUS);
-            self.fill_rounded_rect(r, CARD_RADIUS, palette().surface);
-        }
-        r
-    }
-
-    /// Same as [`selectable`](Self::selectable) but never inflates: settings rows are
-    /// rasterized once at their literal size, and `app::App`'s draw-list building animates
-    /// the zoom-in itself by GPU-scaling the whole focused-row tile around its
+    /// Focus card that never inflates. Rows are rasterized once at their literal size;
+    /// `app::App`'s draw-list animates the zoom by GPU-scaling the focused-row tile around its
     /// center (same technique as the grid's card focus-pop) — a CPU-baked inflate
     /// here would fight that, since the rasterized content would then need
     /// re-rendering every animation frame instead of just repositioning.

--- a/src/ui/widgets/sidebar.rs
+++ b/src/ui/widgets/sidebar.rs
@@ -44,15 +44,15 @@ pub fn sidebar_menu_button_rect(row_rect: Rect) -> Rect {
 
 impl Painter {
     /// A selectable row with optional selection highlighting. When focused, shows
-    /// the full card with shadow and zoom. When selected (but not focused), shows a
+    /// the full fixed-size card; the compositor supplies its zoom. When selected, shows a
     /// subtle background. When neither, shows no background.
     fn selectable_with_selection(&mut self, rect: Rect, focused: bool, selected: bool) -> Rect {
-        let r = self.selectable(rect, focused);
+        self.selectable_fixed(rect, focused);
         if !focused && selected {
             let selected_bg = Color::RGBA(0x2b, 0x21, 0x48, 0x40);
-            self.fill_rounded_rect(r, CARD_RADIUS, selected_bg);
+            self.fill_rounded_rect(rect, CARD_RADIUS, selected_bg);
         }
-        r
+        rect
     }
 }
 


### PR DESCRIPTION
Smooths Home focus transitions across sidebar, grid, pointer, menus, and async library handoff.

Centralizes padded focus placement and fixed-size sidebar rasterization. Reuses row and card timing with subpixel destinations.

Cleans up duplicate geometry and fixes ARM lint issues.

Validation:
- `task docker:lint`
- `cargo test`
- `git diff HEAD --check`