### PR TITLE
Reveal entire game grid together

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -11802,7 +11802,7 @@ DEALINGS IN THE SOFTWARE.
 ----------------------------------------------------------------------------
 The following license (LICENSE) applies to: zlib-rs 0.6.7
 ----------------------------------------------------------------------------
-(C) 2024 Trifecta Tech Foundation
+(C) 2024 Trifecta Tech Foundation 
 
 This software is provided 'as-is', without any express or implied
 warranty. In no event will the authors be held liable for any damages
@@ -11871,3 +11871,4 @@ freely, subject to the following restrictions:
 2. Altered source versions must be plainly marked as such, and must not be
    misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.
+

--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -569,8 +569,7 @@ impl App {
         // own clock (see `spinner::GridReveal::dissolve_mask` for why this is a fading cover
         // rather than the launch backdrop's erase-based technique).
         if self.render.grid.reveal.dissolving() {
-            let cover_h = screen_h.saturating_sub(view::home::GRID_TOP_Y as u32);
-            let cover = Rect::new(grid_x, view::home::GRID_TOP_Y, available_w, cover_h);
+            let cover = Rect::new(grid_x, 0, available_w, screen_h);
             cmds.push(DrawCmd::Tex {
                 tile: tile::GRID_REVEAL_MASK,
                 dst: cover,


### PR DESCRIPTION
## Summary

- Extend the reveal mask across the full game grid pane.
- Reveal collection headings with their cards.
- Keep the sidebar outside the masked area.
- Include current third-party notice formatting updates.

## Testing

- `cargo test --workspace`