### PR TITLE
Clean up card icon loading and grid duplication

### DIFF
--- a/src/app/assets.rs
+++ b/src/app/assets.rs
@@ -1,6 +1,6 @@
 //! Everything this app ships as bytes: its brand font family, its icon font, the sidebar
-//! logo, and the loading spinner (rasterized via [`crate::ui::spinner`]). Card icons are
-//! packaged beside the binary and loaded when their tile is built.
+//! logo, and the loading spinner (rasterized via [`crate::ui::spinner`]). Card marks are the
+//! one asset kept on disk (see [`load_card_icon`]) rather than embedded.
 //!
 //! Deliberately not in `ui`. `ui` is a widget library — it names font *roles*
 //! ([`crate::ui::text::FontId`]) and draws the spinner in whatever two colours it is handed;
@@ -8,12 +8,14 @@
 //! brand's are this app's to decide. `runtime` hands the font bytes to
 //! `platform::webos::text_sdl`, which loads them into `SDL2_ttf` without knowing what they are.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use tiny_skia::Pixmap;
 
+use crate::services::paths;
 use crate::ui::spinner;
 use crate::ui::text::FontWeight;
 use crate::ui::Painter;
@@ -38,34 +40,42 @@ pub static ICON_FONT_BYTES: &[u8] = include_bytes!("../../assets/icons/MaterialI
 /// Punktfunk logo (rasterized at sidebar size, 1:1 no scaling). See assets/logo/NOTICE.md.
 pub static LOGO_PNG: &[u8] = include_bytes!("../../assets/logo/logo-sidebar.png");
 
-fn card_asset_root() -> &'static Path {
-    static ROOT: OnceLock<PathBuf> = OnceLock::new();
-    ROOT.get_or_init(|| {
-        let installed = std::env::current_exe()
-            .ok()
-            .and_then(|p| p.parent()?.parent().map(|p| p.join("assets/cards")));
-        installed
-            .filter(|p| p.is_dir())
-            .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets/cards"))
-    })
-}
-
-fn load_card_icon(dir: &str, name: &str) -> Option<Arc<Pixmap>> {
-    static CACHE: OnceLock<Mutex<HashMap<String, Option<Arc<Pixmap>>>>> = OnceLock::new();
-    if name.len() > 32
-        || !name.starts_with(|c: char| c.is_ascii_lowercase())
-        || !name
-            .bytes()
-            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
-    {
+/// The file a packaged mark lives in, or `None` if `name` may not be joined onto a path.
+/// Lowercases first since file names are lowercase but `GameEntry::icon` is host-casing
+/// (`Steam`); a mismatch cached as `None` is permanent, so validate before any miss.
+fn card_icon_path<'a>(dir: &str, name: &'a str) -> Option<(PathBuf, Cow<'a, str>)> {
+    let name = if name.bytes().any(|b| b.is_ascii_uppercase()) {
+        Cow::Owned(name.to_ascii_lowercase())
+    } else {
+        Cow::Borrowed(name)
+    };
+    if !paths::is_asset_token(&name) {
         return None;
     }
-    let key = format!("{dir}/{name}");
+    let path = paths::assets_dir()
+        .join("cards")
+        .join(dir)
+        .join(name.as_ref())
+        .with_extension("png");
+    Some((path, name))
+}
+
+/// Kept on disk rather than embedded: a host contributes one OS mark and a handful of launcher
+/// marks, so paying flash for the whole set buys nothing. Cached per `(name, side)`: read,
+/// decode and resample once per size. Marks are white silhouettes — source PNGs are
+/// black-on-transparent, so the fill lifts RGB to the alpha each pixel already has.
+fn load_card_icon(dir: &'static str, name: &str, side: u32) -> Option<Arc<Pixmap>> {
+    // Nested rather than keyed by a `(String, u32)` tuple so the hit path probes with a
+    // borrowed `&str` and allocates nothing.
+    type Cache = HashMap<&'static str, HashMap<String, HashMap<u32, Option<Arc<Pixmap>>>>>;
+    static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
+    let (path, name) = card_icon_path(dir, name)?;
     let mut cache = CACHE.get_or_init(|| Mutex::new(HashMap::new())).lock().ok()?;
-    if let Some(icon) = cache.get(&key) {
+    let by_name = cache.entry(dir).or_default();
+    if let Some(icon) = by_name.get(name.as_ref()).and_then(|by_size| by_size.get(&side)) {
         return icon.clone();
     }
-    let icon = std::fs::read(card_asset_root().join(dir).join(name).with_extension("png"))
+    let icon = std::fs::read(path)
         .ok()
         .and_then(|bytes| crate::ui::painter::decode_pixmap(&bytes))
         .map(|mut icon| {
@@ -73,27 +83,49 @@ fn load_card_icon(dir: &str, name: &str) -> Option<Arc<Pixmap>> {
                 let alpha = pixel[3];
                 pixel[..3].fill(alpha);
             }
-            icon
+            fit_to(icon, side)
         })
         .map(Arc::new);
-    cache.insert(key, icon.clone());
+    by_name.entry(name.into_owned()).or_default().insert(side, icon.clone());
     icon
 }
 
-/// Loads the packaged launcher mark named by an API icon token.
-pub fn card_icon(token: &str) -> Option<Arc<Pixmap>> {
-    load_card_icon("launchers", token)
+/// Scales `icon` to fit a `side`-by-`side` box, keeping its aspect. Done once at load rather
+/// than per card raster: the grid asks for one size at a time.
+fn fit_to(icon: Pixmap, side: u32) -> Pixmap {
+    let scale = (side as f32 / icon.width() as f32).min(side as f32 / icon.height() as f32);
+    let w = ((icon.width() as f32 * scale).round() as u32).max(1);
+    let h = ((icon.height() as f32 * scale).round() as u32).max(1);
+    crate::services::art::resize_pixmap(icon, w, h)
 }
 
-/// Loads the most specific packaged mark in an advertised OS chain.
-pub fn os_icon(chain: &str) -> Option<Arc<Pixmap>> {
+/// The packaged mark a `GameEntry::icon` token names, at `side` pixels. A bare token is a
+/// launcher mark from the host's listing (`steam`); an `os/`-qualified one is the client's own
+/// pick for the Desktop card (see [`os_icon_token`]). Any other prefix is refused rather than
+/// joined onto a path.
+pub fn card_icon(token: &str, side: u32) -> Option<Arc<Pixmap>> {
+    let (dir, name) = match token.split_once('/') {
+        Some(("os", name)) => ("os", name),
+        Some(_) => return None,
+        None => ("launchers", token),
+    };
+    load_card_icon(dir, name, side)
+}
+
+/// The [`card_icon`] token for the most specific packaged mark in an advertised OS chain —
+/// `linux/fedora/bazzite` prefers `bazzite` and falls back toward `linux`. Resolved when the
+/// host's OS becomes known (see `Library::set_desktop_icon`), not per card build, so this
+/// only stats for the file rather than decoding it.
+pub fn os_icon_token(chain: &str) -> Option<String> {
     chain.split('/').rev().find_map(|name| {
+        // The two OS names whose mark is filed under a different one.
         let name = match name {
             "macos" => "apple",
             "steamos" => "steam",
             other => other,
         };
-        load_card_icon("os", name)
+        let (path, name) = card_icon_path("os", name)?;
+        path.is_file().then(|| format!("os/{name}"))
     })
 }
 

--- a/src/app/library.rs
+++ b/src/app/library.rs
@@ -58,6 +58,16 @@ impl Library {
         self.games = games;
     }
 
+    /// Desktop's icon is client-picked (every other entry carries the host's token), so it is
+    /// chosen here rather than in the grid build loop. Idempotent: re-run on every regroup and
+    /// whenever mDNS teaches a new OS.
+    pub(crate) fn set_desktop_icon(&mut self, os: &str) {
+        let token = crate::app::assets::os_icon_token(os);
+        if let Some(desktop) = self.games.iter_mut().find(|g| g.id == DESKTOP_PIN_ID) {
+            desktop.icon = token;
+        }
+    }
+
     /// The grid's shape at `columns` columns. `Copy` and borrowing only `groups`, so a caller
     /// can hold one and go on mutating the rest of `App` — the disjointness this module exists
     /// for.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -27,14 +27,15 @@ use std::time::{Duration, Instant};
 
 use crate::ui::render::Rect;
 use anyhow::Result;
-use tiny_skia::Pixmap;
 
 use crate::app::hosts::HostEntry;
 use crate::app::nav::ScreenKey;
 use crate::core::event::MenuEvent;
+use crate::core::model;
 pub use crate::core::model::ConnectTarget;
 pub use crate::core::screen::{HomeFocus, PairingFocus, Screen};
 use crate::services::discovery::Discovery;
+use crate::services::library::GameEntry;
 use crate::services::store::{self, KnownHost, Settings};
 use crate::ui;
 
@@ -505,6 +506,7 @@ impl App {
         // `found.host` — `DiscoveredHost` (discovery.rs) only has `addr`, `WakeState`/
         // `KnownHost` only have `host`; both hold the same kind of value (network address).
         let polled = self.jobs.discovery.as_mut().map(Discovery::poll).unwrap_or_default();
+        let selected = self.library.selected_host.clone();
         for found in polled {
             // An announce is the host saying it is up, on its own initiative — the cheapest
             // liveness evidence there is, and previously the one the dot ignored.
@@ -529,16 +531,14 @@ impl App {
                 if !found.os.is_empty() && known.os != found.os {
                     known.os.clone_from(&found.os);
                     host_metadata_changed = true;
-                    if self
-                        .library
-                        .selected_host
+                    // The Desktop card wears this host's OS mark, so a newly-learned OS
+                    // restamps the entry and re-rasters the one card that shows it.
+                    if selected
                         .as_ref()
-                        .is_some_and(|(host, port)| host == &found.addr && *port == found.port)
+                        .is_some_and(|(h, p)| h == &found.addr && *p == found.port)
                     {
-                        self.render
-                            .grid
-                            .cards_dirty
-                            .push(crate::core::model::DESKTOP_PIN_ID.to_string());
+                        self.library.set_desktop_icon(&found.os);
+                        self.render.grid.cards_dirty.push(model::DESKTOP_PIN_ID.to_string());
                         grid_changed = true;
                     }
                 }
@@ -863,12 +863,11 @@ impl App {
         self.known_host_mut(&host, port)
     }
 
-    /// The title of grid card `idx` (see `grid_card_at`) and its cover art, if
-    /// fetched. Callers must only pass an `idx` that `is_grid_card` (tile
-    /// building already filters padding gaps out).
-    pub(crate) fn grid_card_content(&self, idx: usize, columns: usize) -> (&str, Option<&Pixmap>) {
+    /// The entry behind grid card `idx` (see `grid_card_at`). Callers must only pass an
+    /// `idx` that `is_grid_card` (tile building already filters padding gaps out).
+    pub(crate) fn grid_card_entry(&self, idx: usize, columns: usize) -> &GameEntry {
         match self.grid_card_at(idx, columns) {
-            Some(game) => (game.title.as_str(), self.library.art.get(&game.id)),
+            Some(game) => game,
             None => unreachable!("idx filtered to a real card before building"),
         }
     }

--- a/src/app/render/prepare_grid.rs
+++ b/src/app/render/prepare_grid.rs
@@ -204,7 +204,7 @@ impl App {
         let mut pending = false;
         let budget_from = Instant::now();
         let mut built = 0usize;
-        let desktop_os = self.selected_known_host().map(|host| host.os.clone());
+        let icon_side = ui::widgets::icon_side(card_w, card_h);
         for idx in ready.iter().copied().chain(waiting.iter().copied()) {
             // Budget counted on rasterized cards, not candidates (padding costs nothing).
             if built >= CARD_BUILD_BURST || (built > 0 && budget_from.elapsed() >= CARD_BUILD_BUDGET) {
@@ -217,15 +217,12 @@ impl App {
             built += 1;
             let recycled = self.render.grid.free_cards.pop();
             let tile = {
-                let game = layout
-                    .card_at(&self.library.games, idx)
-                    .expect("idx filtered to a real card before building");
+                let game = self.grid_card_entry(idx, columns);
                 let art = self.library.art.get(&game.id);
-                let icon = if game.id == crate::core::model::DESKTOP_PIN_ID {
-                    desktop_os.as_deref().and_then(crate::app::assets::os_icon)
-                } else {
-                    game.icon.as_deref().and_then(crate::app::assets::card_icon)
-                };
+                let icon = game
+                    .icon
+                    .as_deref()
+                    .and_then(|token| crate::app::assets::card_icon(token, icon_side));
                 ui::rasterize_into(
                     ui::tiles::CardTile {
                         w: card_w,
@@ -287,7 +284,7 @@ impl App {
         // Focused card title strip (own tile for moving wipe, not re-raster per frame).
         if let HomeFocus::Grid(idx) = self.home_focus {
             if let Some(pin_id) = self.library.pin_id_at(idx, columns) {
-                let (title, _) = self.grid_card_content(idx, columns);
+                let title = self.grid_card_entry(idx, columns).title.as_str();
                 // Keyed by card identity like the card tiles themselves (`CardIds`),
                 // not by title — two games can share one.
                 let overridden = self.game_has_overrides(pin_id);

--- a/src/app/state/cardmenu.rs
+++ b/src/app/state/cardmenu.rs
@@ -115,7 +115,7 @@ impl App {
         let Some(pin_id) = self.pin_id_at_grid_idx(idx, columns).map(str::to_string) else {
             return;
         };
-        let title = self.grid_card_content(idx, columns).0.to_string();
+        let title = self.grid_card_entry(idx, columns).title.clone();
         self.card_menu = Some(CardMenu {
             pin_id,
             idx,

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -303,6 +303,7 @@ impl App {
                 // Split the borrow: `regroup` needs the host record while it rewrites the
                 // library, and both live on `self`.
                 let host = std::mem::take(&mut self.hosts.known[idx]);
+                self.library.set_desktop_icon(&host.os);
                 self.library
                     .regroup(&host, self.recents.for_host(&host.host, host.port));
                 self.hosts.known[idx] = host;

--- a/src/services/art.rs
+++ b/src/services/art.rs
@@ -391,7 +391,7 @@ fn prune_cache(dir: &std::path::Path) -> CacheTotals {
 /// Stretches a cached cover to card size, or hands it back untouched when it is already that
 /// size — which is the normal case, since covers are cached at card size. Only a `.raw` written
 /// by an older build, or by a session whose panel gave a different card size, is resampled here.
-fn resize_pixmap(src: Pixmap, w: u32, h: u32) -> Pixmap {
+pub(crate) fn resize_pixmap(src: Pixmap, w: u32, h: u32) -> Pixmap {
     let (sw, sh) = (src.width() as f32, src.height() as f32);
     if (src.width(), src.height()) == (w, h) || sw <= 0.0 || sh <= 0.0 {
         return src;

--- a/src/services/discovery.rs
+++ b/src/services/discovery.rs
@@ -42,13 +42,17 @@ fn addr_and_name(info: &mdns_sd::ResolvedService) -> Option<(String, String)> {
     ))
 }
 
+/// Trims an advertised OS chain to something bounded and predictable: lowercase, at most five
+/// tokens of 32 characters, nothing outside [`paths::is_asset_char`]'s charset. Nothing
+/// downstream trusts a host's strings, and this one is matched against packaged icon names —
+/// `paths::is_asset_token` is the gate that actually guards the join.
 fn sanitize_os(raw: &str) -> String {
     raw.to_lowercase()
         .split('/')
         .filter_map(|token| {
             let token: String = token
                 .chars()
-                .filter(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '_' | '-'))
+                .filter(|c| crate::services::paths::is_asset_char(*c))
                 .take(32)
                 .collect();
             (!token.is_empty()).then_some(token)

--- a/src/services/paths.rs
+++ b/src/services/paths.rs
@@ -2,10 +2,40 @@
 //!
 //! Its own module, rather than a private helper in `store`, so a probe binary can pull in one
 //! leaf module instead of the whole persistence layer.
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// The app's data directory: `$HOME` under webOS's per-app jail, `/tmp` if it is unset (a
 /// bare SSH shell), which keeps a dev run working without writing somewhere unexpected.
 pub fn app_dir() -> PathBuf {
     std::env::var("HOME").map_or_else(|_| PathBuf::from("/tmp"), PathBuf::from)
+}
+
+/// Where the packaged read-only assets live: `assets/` beside the installed binary's `bin/`
+/// (see `taskfiles/toolchain.yml`'s staging), falling back to the source tree so a dev run
+/// off a plain `cargo build` still finds them.
+pub fn assets_dir() -> &'static Path {
+    static ROOT: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    ROOT.get_or_init(|| {
+        std::env::current_exe()
+            .ok()
+            .and_then(|exe| exe.parent()?.parent().map(|root| root.join("assets")))
+            .filter(|dir| dir.is_dir())
+            .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("assets"))
+    })
+    .as_path()
+}
+
+/// The one charset every packaged asset name and every mDNS-advertised OS token is held to.
+pub fn is_asset_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')
+}
+
+/// Whether `name` may be joined onto [`assets_dir`]. Bounded, in [`is_asset_char`]'s charset,
+/// and starting alphanumeric — which is what rules out `..` and dotfiles, so an untrusted
+/// token (`GameEntry::icon` comes straight from the host's listing) can never walk the path.
+pub fn is_asset_token(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 32
+        && name.starts_with(|c: char| c.is_ascii_alphanumeric())
+        && name.chars().all(is_asset_char)
 }

--- a/src/ui/widgets/cards.rs
+++ b/src/ui/widgets/cards.rs
@@ -238,6 +238,13 @@ fn label_right_pad(marked: bool) -> i32 {
     }
 }
 
+/// The box a card's brand mark is fitted into: just under half the card's short side, so it
+/// reads as a mark rather than as cover art. Lives here with the rest of the card's geometry,
+/// but `app` needs it too — it scales the mark once at load rather than per raster.
+pub fn icon_side(card_w: u32, card_h: u32) -> u32 {
+    (card_w.min(card_h) * 9 / 20).max(1)
+}
+
 impl Canvas<'_, '_> {
     /// Draws one game/Desktop card's art. `art`, when `Some` (a decoded cover, already
     /// downscaled and premultiplied by `art.rs`), fills the whole card, same as
@@ -257,8 +264,24 @@ impl Canvas<'_, '_> {
             // has already stretched it to card size; the draw rescales only if a pixmap
             // ever arrives at some other size.
             Some(pixmap) => self.painter.draw_pixmap_rounded(r, pixmap, CARD_RADIUS),
-            None => self.placeholder_poster(r, title, icon),
+            // A packaged launcher/OS mark stands in for a title poster when the card has one:
+            // a Steam or Windows card reads faster as its brand than as its own name.
+            None => match icon {
+                Some(icon) => self.icon_poster(r, title, icon),
+                None => self.placeholder_poster(r, title),
+            },
         }
+    }
+
+    /// The tinted card with a brand mark centered on it. The mark arrives already scaled to
+    /// [`icon_side`] (see `app::assets::load_card_icon`), so this only centers and blits.
+    fn icon_poster(&mut self, r: Rect, title: &str, icon: &Pixmap) {
+        self.painter.fill_rounded_rect(r, CARD_RADIUS, tint_for(title));
+        self.painter.draw_pixmap(
+            r.x() + (r.width() as i32 - icon.width() as i32) / 2,
+            r.y() + (r.height() as i32 - icon.height() as i32) / 2,
+            icon,
+        );
     }
 
     /// The stand-in cover for a game the host has no art for: the tinted card with the
@@ -267,22 +290,8 @@ impl Canvas<'_, '_> {
     /// and so a card carries its title even before focus slides the strip up.
     ///
     /// Cards only; hero art keeps its own (art-or-nothing) treatment.
-    fn placeholder_poster(&mut self, r: Rect, title: &str, icon: Option<&Pixmap>) {
+    fn placeholder_poster(&mut self, r: Rect, title: &str) {
         self.painter.fill_rounded_rect(r, CARD_RADIUS, tint_for(title));
-        if let Some(icon) = icon {
-            let side = (r.width().min(r.height()) * 9 / 20).max(1);
-            let scale = (side as f32 / icon.width() as f32).min(side as f32 / icon.height() as f32);
-            let w = (icon.width() as f32 * scale).round() as u32;
-            let h = (icon.height() as f32 * scale).round() as u32;
-            let dst = Rect::new(
-                r.x() + (r.width() as i32 - w as i32) / 2,
-                r.y() + (r.height() as i32 - h as i32) / 2,
-                w,
-                h,
-            );
-            self.painter.draw_pixmap_scaled(dst, icon);
-            return;
-        }
         let (raster, gap) = (self.fonts.raster, PLACEHOLDER_LINE_GAP);
         let max_w = r.width().saturating_sub(2 * PLACEHOLDER_PAD as u32);
         let font = fitting_font(raster, title, max_w);


### PR DESCRIPTION
## What this is

Cleanup pass over the launcher/OS card-icon feature from #186. Quality only, no new feature. Verified with `task docker:lint` (clean) and `task fmt`.

## What changed

**Card icon loading** (`src/app/assets.rs`, `src/services/paths.rs`)
- Install-path resolution moved out of `app::assets` into `paths::assets_dir()`, next to `app_dir()`.
- One shared filename charset: `paths::is_asset_char` / `is_asset_token`, used by both the icon loader and `discovery::sanitize_os`. Previously duplicated with different character sets, so a token that passed discovery could be dropped at load.
- `is_asset_token` requires an alphanumeric first character, ruling out `..` and dotfiles. Guards `GameEntry::icon`, which comes straight from the host's listing.
- Icon tokens lowercased before validation and lookup, via `Cow` to avoid allocating when already lowercase. Previously `icon: "Steam"` would validate, miss the file read, then cache the miss permanently.
- `card_icon_path` centralizes the token gate and path join; `load_card_icon` and `os_icon_token` both go through it.

**Icon caching / rendering cost** (`src/app/assets.rs`, `src/ui/widgets/cards.rs`, `src/services/art.rs`)
- Icons cached already scaled, keyed `(dir, name, side)` — read + decode + resample happen once per size instead of on every card raster.
- `icon_poster` only centers and blits now; fit ratio moved to `ui::widgets::icon_side`.
- Reuses `art::resize_pixmap` (now `pub(crate)`) instead of a second scaling implementation.
- Cache is a nested map so a hit probes with a borrowed `&str` and allocates nothing.

**Desktop card's OS mark** (`src/app/library.rs`, `src/app/state/home.rs`, `src/app/mod.rs`, `src/app/render/prepare_grid.rs`)
- Grid build loop no longer special-cases `DESKTOP_PIN_ID`. New `Library::set_desktop_icon` stamps the entry's token from the host's OS chain, called from `regroup_games` and `drain_discovery`.
- `GameEntry::icon` accepts an `os/`-qualified token for the client's own pick; any other prefix is refused rather than joined onto a path.
- Per-pass `String` clone of the host OS is gone; loop is uniformly `game.icon`.

**Card drawing** (`src/ui/widgets/cards.rs`)
- `poster_art` dispatches three ways (art / icon / title placeholder). `placeholder_poster` back to its original two-arg shape and single exit.

**Duplicate card lookup** (`src/app/mod.rs`, `src/app/render/prepare_grid.rs`, `src/app/state/cardmenu.rs`)
- `grid_card_content` returned a `(title, art)` tuple whose art both callers discarded, while the build loop separately inlined its own `card_at(...).expect(...)`. Replaced with `grid_card_entry` returning `&GameEntry` — one lookup path, one panic site.

## Decisions worth calling out

- Card marks stay on disk rather than embedded with `include_bytes!` like fonts/logo. Embedding was tried and rejected: one OS mark and a handful of launcher marks don't justify ~104K of flash for the whole set. ipk staging of `assets/cards` is unchanged.
- The full-screen dissolve cover from #187 is untouched.

## Gotcha for the reviewer

Nothing here is verified on a TV. `cargo check` on macOS cfg-gates out `app`/`platform`, so `task docker:lint` is the only thing that compiled this. Icon path resolution and ipk staging can only fail on device.

## Test plan
- [ ] `task docker:lint` clean
- [ ] `task docker:build` succeeds
- [ ] Deploy to TV, confirm desktop card OS mark and launcher icons still render
- [ ] Confirm a host icon token with mixed case (e.g. `Steam`) now resolves