### PR TITLE
Harden the NDL v2 load path and audio-plane gating

### DIFF
--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -322,6 +322,52 @@ match `webosbrew/webos-userland` field-for-field, including the explicit trailin
 whole struct is memcpy'd into a fixed-size union arm, so **any implicit padding in a `repr(C)`
 struct handed to NDL is uninitialized stack on the wire**.
 
+⚠ **The audio-enabled load gets a LONGER wait than the video-only one** (`AUDIO_LOAD_TIMEOUT` 6 s
+vs `LOAD_COMPLETE_TIMEOUT` 2 s). Giving up on it is not "a few held frames", it is the fallback to
+a video-only load, i.e. an unpaced session — so the wait is sized for the slowest load that still
+confirms, not for the first frame. Issue #188 was exactly this: a 2025 QNED (webOS 10, `k24n`)
+needed ~2.4 s to complete a 4K120 HEVC HDR load, timed out against the 2 s it then shared with the
+video-only wait, fell back, and streamed with delay accumulating for the whole session (RAM to
+~500 MB, late frames to ~1300). 4K60 and 1440p120 loaded inside 2 s on the same TV and were fine,
+which is why the mode looked like the variable. A CX confirms in ~40 ms, so no healthy unit waits.
+Both waits bail early on `ndl::fatal()`, so the budget is only ever spent on a load still plausibly
+coming. The fallback warns that the picture will not be paced — read the log for that line before
+theorising about any later delay symptom.
+
+The load blocks `session::connect` between the handshake and the first `next_frame`, so anything
+timing a launch has to cover it: worst case is `AUDIO_LOAD_TIMEOUT` + `CALLBACK_SETTLE` × 2 +
+`LOAD_COMPLETE_TIMEOUT` ≈ 8.8 s. `app::hero` is fine (its `FIRST_FRAME_WAIT` only starts once
+connect returns, under a 30 s `HERO_LOADING_MAX` backstop), but `hdr_pattern`'s `PRESENT_DEADLINE`
+runs from `Playback::start` and had to be raised with it.
+
+⚠ **The prime's stamps and the player clock share one origin — `load_instant` is the load CALL.**
+NDL's PTS domain starts there (§ top of this section), and `prime_audio` already counted from it,
+but `load_instant` used to be stamped *after* the load wait. The two domains then differed by the
+load's duration D, and every consumer carried a correction for it: the metronome re-added the
+prime's ceiling as a permanent base, the offload route floored its first D ms of real packets onto
+one stamp, and `plane_lead` in the heartbeat reported the gap on top of the depth. Worse, the
+offload route's REAL lead was `PLANE_LEAD_MS − D`, i.e. ≈ 0 on a CX — the one thing that constant
+exists to prevent. D was small enough on a CX (~40 ms) to hide all of it; raising
+`AUDIO_LOAD_TIMEOUT` made it routinely seconds, which is what forced the fix. One origin removes
+every correction. `last_real_feed_ms` is seeded with the clock at construction rather than 0, since
+the clock already reads D by then.
+
+⚠ **The silent metronome's cushion is `METRONOME_LEAD_MS` (80 ms), not `PLANE_LEAD_MS` (40 ms).**
+**Do the arithmetic in one domain before touching it.** The old metronome stamped
+`ceiling + now_old + PLANE_LEAD_MS`; the ceiling was `D + PLANE_LEAD_MS` and the old clock started
+D late, so D cancels and the stamps sat `2 * PLANE_LEAD_MS` = **80 ms** ahead of the load call on
+every unit — not `PLANE_LEAD_MS + D`. `plane_lead` read 120 on a CX only because it was taken
+against that same lagging clock, which is the trap: the depth the 4K120 5.1 smoothness was actually
+confirmed on is 80 ms. The constant is pinned there — same cushion as shipped, now explicit and
+identical on every unit and mode rather than falling out of how long a TV took to load. Do not
+drift it in either direction as a side effect of other work: under 80 is the known stutter risk,
+and over it is cheap (a silent plane is free to hold, the real audio being on SDL, so unlike
+`PLANE_LEAD_MS` it costs no lip sync) but still an unmeasured change to the parameter high-refresh
+smoothness turns on. It IS the deliberate knob for a TV still stuttering at high refresh: walk it
+UP against `plane_lead`, which now reports the real depth. The offload route's *fill* still targets
+`PLANE_LEAD_MS`, because it must match what `play_audio` targets or the resuming real packets floor
+onto the fill's ceiling.
+
 ⚠ **The prime is what completes the load.** An audio-enabled load does not report `LOADCOMPLETED`
 until its audio plane has received a packet — but the pumps that would send one don't spawn until
 `session::connect` returns, which is after the load wait. That deadlock read as a whole session of
@@ -459,8 +505,9 @@ cure, back again the moment real audio displaced the metronome. (Found on the si
 route, but the mechanism is the plane's, so it applies to offload identically.)
 
 Fixed by `PLANE_LEAD_MS` (= the same 40 ms), added to every real stamp in `play_audio`. The clock
-plane targets the same figure, so silence and real audio meet at the same lead and neither pushes
-the other's ceiling. NDL takes no depth argument, so a stamp in the future is the only way to ask it
+plane's *fill* targets the same figure, so silence and real audio meet at the same lead and neither
+pushes the other's ceiling (the metronome, which never shares a plane with real audio, holds
+`METRONOME_LEAD_MS` instead — see above). NDL takes no depth argument, so a stamp in the future is the only way to ask it
 for one. This is the same job the deleted SDL `JitterPolicy` did with its
 25 ms ring (adaptive to 90 under underruns); the route removed that ring and put nothing in its
 place. Cost is lip sync, `PLANE_LEAD_MS` behind the picture, roughly cancelling the trim's ~36 ms —

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -303,9 +303,8 @@ question:
 it yields to the real stream and only fills in after 300 ms with no packet, since a host that stops
 sending would otherwise starve the plane and freeze the picture.
 
-A set that refuses the audio plane ends up video-only and gives up pacing with it — at the load
-itself when it fails outright, otherwise at the verdict past the first frame (below); the session
-log names which of the routes it took. **NDL v1 has
+A set that refuses the audio plane outright ends up video-only at the load and gives up pacing with
+it; the session log names which of the routes it took. **NDL v1 has
 no Opus audio type at all**, so webOS 4 has no pacing reference — the lever there would be gating
 frame release at feed time, which is not built.
 
@@ -332,32 +331,51 @@ the plane inside the load wait, where nothing can feed a frame — the pumps do 
 `session::connect` returns — so on the QNED every session read a healthy plane as refused, fell
 back to video-only, and ran unpaced. That is issue #188's delay; longer waits don't help.
 
-So the plane is asked for and then **judged past the first frame**: `AUDIO_PRIME_BUDGET` (500 ms)
-buys only the fast confirmation a CX gives, an unconfirmed load starts the stream anyway, and
-`v2::PLANE_VERDICT` (750 ms after the first accepted frame) is where a plane that really was
-refused is given up — the load is then re-issued without its audio arm, because a load whose audio
-config was rejected keeps accepting frames into a pipeline that never runs, with no error on any
-call. **That re-load is stepped by the video feed, one frame at a time** (`begin_reload` /
-`advance_reload`), never inline and never on a thread of its own: inline it blocks the pump for the
-whole 400-800 ms settle and the receive queue fills behind it, and a second thread inside NDL is
-what `LEAKED_THREADS` exists to refuse. Each frame advances the state machine, is answered with
-`NotReady`, and goes back to draining the queue.
+So the plane is **asked for and then kept, confirmed or not**. `AUDIO_PRIME_BUDGET` (500 ms) buys
+only the fast confirmation a CX gives; a load that does not answer inside it is taken anyway and
+the metronome carries on feeding the plane, which on an ingest-gated set is what eventually
+produces the callback. `run_clock_plane` is therefore **deliberately not gated on `LOADCOMPLETED`**
+— it is the prime's continuation, feeding the same plane through the same call, and gating it
+would leave the plane unfed from the end of the prime until the first video frame. On the QNED
+that is seconds, and it covers the ~100 ms of ingest that sets NDL's standing present cushion.
+
+⚠ **There is no mid-session verdict and no in-session re-load.** One was written for #188 and
+reverted: it could not be right, because the plane question is resolution-independent (NDL's
+`VideoInfo` carries no framerate at all) while #188 is 4K120-HDR-only on a set where 4K60 and
+1440p120 are fine. It also had to re-apply HDR metadata to the new pipeline, which is the
+mode-drop documented under *Video decode* above — the fallback could cause what it was meant to
+fix. A load whose audio config the pipeline rejects outright still fails at the load and falls
+back there, which is the only fallback that exists.
+
+What survives of the verdict is the **log line**, not the recovery: `v2::PLANE_CONFIRM_GRACE`
+(750 ms past the first accepted frame) is where an unconfirmed plane gets named. That window is
+the one place the two readings separate — before a frame, "no callback" is a healthy ingest-gated
+set *and* a pipeline that rejected the Opus config asynchronously, and the second accepts every
+frame into a decoder that never runs. Nothing is recovered, deliberately: a set that does this has
+not been measured, and acting on the guess is what #188 already cost. If that WARN ever shows up
+in a report, THAT is the set to build a fallback for.
 
 The route is picked from the PROVEN plane (`AudioPlane::accepts_stream`), not from one that was
-merely asked for: an unproven plane is still worth keeping fed — that is the pacing — but the
-session's only audio must not ride something the verdict can still take away, since the route
-cannot be re-picked by then. Both load waits bail early on `ndl::fatal()`. Every path that
-loses the plane warns that the picture will not be paced — grep the log for that line before
-theorising about any later delay.
+merely asked for: an unconfirmed plane paces the picture perfectly well, but the session's only
+audio must not ride one that may never work, and the route cannot be re-picked once the stream is
+running. Only a session that means to put REAL audio there pays for the answer: `plane_budget`
+charges the offload route `AUDIO_PROVE_BUDGET` (2 s) and every other session the short one, since
+on an ingest-gated set the extra wait is pure black screen and buys nothing. A downgrade off
+offload is worse than either route on its own — `AudioRoutePref::max_channels` has already clamped
+the handshake to stereo on the strength of the request — so the `audio path:` line names it
+explicitly. Both load waits bail early on `ndl::fatal()`. Every path that loses the plane warns
+that the picture will not be paced — grep the log for that line before theorising about any later
+delay.
 
-Audio feeds gate on the `LOADCOMPLETED` latch itself, never on `feed_unblocked`: that flag is the
-VIDEO feed's gate and latches optimistically once frames have to flow regardless. A packet fed to a
-plane before NDL confirms it costs the session its audio outright.
+The REAL audio feed gates on the `LOADCOMPLETED` latch itself, never on `feed_unblocked`: that flag
+is the VIDEO feed's gate and latches optimistically once frames have to flow regardless. Real audio
+on a plane NDL has not confirmed costs the session its sound outright — whereas silence on one is
+free, which is the whole reason the two feeds gate differently.
 
 The load blocks `session::connect` between the handshake and the first `next_frame`, so anything
-timing a launch has to cover it — now `AUDIO_PRIME_BUDGET` at worst, rather than the ~4.8 s a
-rejected plane used to cost there; what a refused plane costs instead is a settle plus a second
-load *after* frames are flowing. `app::hero` is fine (its `FIRST_FRAME_WAIT` only starts once
+timing a launch has to cover it — now `AUDIO_PRIME_BUDGET` at worst on the software route
+(`AUDIO_PROVE_BUDGET` on offload), rather than the ~4.8 s an unconfirmed plane used to cost when
+the load wait was the verdict. `app::hero` is fine (its `FIRST_FRAME_WAIT` only starts once
 connect returns, under a 30 s `HERO_LOADING_MAX` backstop), but `hdr_pattern`'s `PRESENT_DEADLINE`
 runs from `Playback::start` and must stay above the whole sequence.
 

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -330,10 +330,7 @@ video-only load misses the 2 s `LOAD_COMPLETE_TIMEOUT`, then confirms the instan
 gives up and feeds. A CX reports it ~40 ms after the load with no frame at all. The old code judged
 the plane inside the load wait, where nothing can feed a frame — the pumps do not spawn until
 `session::connect` returns — so on the QNED every session read a healthy plane as refused, fell
-back to video-only, and ran unpaced. That is issue #188's delay. Waiting longer changes nothing
-(6 s of silence primed, same result) and only buys black screen plus a receive backlog deep enough
-to force a flush at first frame (three `receive backlog stopped draining` warns, 90 frames
-dropped).
+back to video-only, and ran unpaced. That is issue #188's delay; longer waits don't help.
 
 So the plane is asked for and then **judged past the first frame**: `AUDIO_PRIME_BUDGET` (500 ms)
 buys only the fast confirmation a CX gives, an unconfirmed load starts the stream anyway, and

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -303,8 +303,9 @@ question:
 it yields to the real stream and only fills in after 300 ms with no packet, since a host that stops
 sending would otherwise starve the plane and freeze the picture.
 
-A set that refuses the audio-enabled load falls back to video-only inside `NdlVideo::load` and
-gives up pacing with it; the session log names which of the routes it took. **NDL v1 has
+A set that refuses the audio plane ends up video-only and gives up pacing with it — at the load
+itself when it fails outright, otherwise at the verdict past the first frame (below); the session
+log names which of the routes it took. **NDL v1 has
 no Opus audio type at all**, so webOS 4 has no pacing reference — the lever there would be gating
 frame release at feed time, which is not built.
 
@@ -322,25 +323,46 @@ match `webosbrew/webos-userland` field-for-field, including the explicit trailin
 whole struct is memcpy'd into a fixed-size union arm, so **any implicit padding in a `repr(C)`
 struct handed to NDL is uninitialized stack on the wire**.
 
-⚠ **A set that refuses the audio plane cannot be rescued by waiting longer — measured, issue
-#188.** The audio-enabled wait (`AUDIO_LOAD_TIMEOUT`) is a separate constant from the video-only
-one (`LOAD_COMPLETE_TIMEOUT`) because the two failures cost differently: giving up on the plane is
-not "a few held frames", it is the fallback to a video-only load and therefore an unpaced session.
-But both are 2 s, because raising one was tried on device and did nothing. A 2025 QNED (webOS 10,
-`k24n`) fails an audio-enabled 4K120 HEVC HDR load at 2 s and fails it identically at 6 s
-(`no LOADCOMPLETED within 6s of priming 6040ms of silence`), while the video-only retry that
-follows confirms in ~2.04 s. A CX confirms in ~40 ms. Nothing measured sits in between, so the
-distribution is bimodal — works almost instantly, or never — and the extra seconds only buy black
-screen plus a receive backlog deep enough to force a flush at first frame (three `receive backlog
-stopped draining` warns at 6 s, 90 frames dropped). **If a set is unpaced, the plane config is the
-thing to change, not the wait.** Both waits bail early on `ndl::fatal()`. The fallback warns that
-the picture will not be paced — grep the log for that line before theorising about any later delay.
+⚠ **`LOADCOMPLETED` is not reported against the same thing on every set, so it cannot be the test
+for the audio plane before a frame is fed — measured, issue #188.** A 2025 QNED (webOS 10, `k24n`)
+reports it **26 ms after the first access unit reaches the decoder, and never before**: its
+video-only load misses the 2 s `LOAD_COMPLETE_TIMEOUT`, then confirms the instant `ensure_loaded`
+gives up and feeds. A CX reports it ~40 ms after the load with no frame at all. The old code judged
+the plane inside the load wait, where nothing can feed a frame — the pumps do not spawn until
+`session::connect` returns — so on the QNED every session read a healthy plane as refused, fell
+back to video-only, and ran unpaced. That is issue #188's delay. Waiting longer changes nothing
+(6 s of silence primed, same result) and only buys black screen plus a receive backlog deep enough
+to force a flush at first frame (three `receive backlog stopped draining` warns, 90 frames
+dropped).
+
+So the plane is asked for and then **judged past the first frame**: `AUDIO_PRIME_BUDGET` (500 ms)
+buys only the fast confirmation a CX gives, an unconfirmed load starts the stream anyway, and
+`v2::PLANE_VERDICT` (750 ms after the first accepted frame) is where a plane that really was
+refused is given up — the load is then re-issued without its audio arm, because a load whose audio
+config was rejected keeps accepting frames into a pipeline that never runs, with no error on any
+call. **That re-load is stepped by the video feed, one frame at a time** (`begin_reload` /
+`advance_reload`), never inline and never on a thread of its own: inline it blocks the pump for the
+whole 400-800 ms settle and the receive queue fills behind it, and a second thread inside NDL is
+what `LEAKED_THREADS` exists to refuse. Each frame advances the state machine, is answered with
+`NotReady`, and goes back to draining the queue.
+
+The route is picked from the PROVEN plane (`AudioPlane::accepts_stream`), not from one that was
+merely asked for: an unproven plane is still worth keeping fed — that is the pacing — but the
+session's only audio must not ride something the verdict can still take away, since the route
+cannot be re-picked by then. Both load waits bail early on `ndl::fatal()`. Every path that
+loses the plane warns that the picture will not be paced — grep the log for that line before
+theorising about any later delay.
+
+Audio feeds gate on the `LOADCOMPLETED` latch itself, never on `feed_unblocked`: that flag is the
+VIDEO feed's gate and latches optimistically once frames have to flow regardless. A packet fed to a
+plane before NDL confirms it costs the session its audio outright.
 
 The load blocks `session::connect` between the handshake and the first `next_frame`, so anything
-timing a launch has to cover it: a rejected plane costs `AUDIO_LOAD_TIMEOUT` + `CALLBACK_SETTLE` ×
-2 + `LOAD_COMPLETE_TIMEOUT` ≈ 4.8 s. `app::hero` is fine (its `FIRST_FRAME_WAIT` only starts once
+timing a launch has to cover it — now `AUDIO_PRIME_BUDGET` at worst, rather than the ~4.8 s a
+rejected plane used to cost there; what a refused plane costs instead is a settle plus a second
+load *after* frames are flowing. `app::hero` is fine (its `FIRST_FRAME_WAIT` only starts once
 connect returns, under a 30 s `HERO_LOADING_MAX` backstop), but `hdr_pattern`'s `PRESENT_DEADLINE`
-runs from `Playback::start` and must stay above it.
+runs from `Playback::start` and must stay above the whole sequence.
 
 ⚠ **The prime's stamps and the player clock share one origin — `load_instant` is the load CALL.**
 NDL's PTS domain starts there (§ top of this section), and `prime_audio` already counted from it,
@@ -350,7 +372,7 @@ prime's ceiling as a permanent base, the offload route floored its first D ms of
 one stamp, and `plane_lead` in the heartbeat reported the gap on top of the depth. Worse, the
 offload route's REAL lead was `PLANE_LEAD_MS − D`, i.e. ≈ 0 on a CX — the one thing that constant
 exists to prevent. D was small enough on a CX (~40 ms) to hide all of it; raising
-`AUDIO_LOAD_TIMEOUT` made it routinely seconds, which is what forced the fix. One origin removes
+a load wait long enough to matter made it routinely seconds, which is what forced the fix. One origin removes
 every correction. `last_real_feed_ms` is seeded with the clock at construction rather than 0, since
 the clock already reads D by then.
 
@@ -406,7 +428,7 @@ So audio is now stamped `player_clock + PLANE_LEAD_MS` and the host PTS is ignor
 whatever the host PTS does across a freeze, so a resumed run lands where an uninterrupted one would
 have, and `last_audio_pts_ms` is left with nothing to do but absorb reordering. The clock plane
 targets the same figure, so the two feeders share the ceiling without either driving it.
-`load_confirmed` is the plane's start gate, which is what the video plane's latch used to double as.
+The plane's start gate is the `LOADCOMPLETED` latch itself; `feed_unblocked` is the video feed's own gate and must not be read as the pipeline's state (above).
 
 ⚠ **The ratchet was real and was NOT the mute.** Measured after the change, under a deliberately
 saturated airlink (276 Mb/s of competing download against a 188 Mb/s stream): 32 re-anchors,

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -322,23 +322,25 @@ match `webosbrew/webos-userland` field-for-field, including the explicit trailin
 whole struct is memcpy'd into a fixed-size union arm, so **any implicit padding in a `repr(C)`
 struct handed to NDL is uninitialized stack on the wire**.
 
-⚠ **The audio-enabled load gets a LONGER wait than the video-only one** (`AUDIO_LOAD_TIMEOUT` 6 s
-vs `LOAD_COMPLETE_TIMEOUT` 2 s). Giving up on it is not "a few held frames", it is the fallback to
-a video-only load, i.e. an unpaced session — so the wait is sized for the slowest load that still
-confirms, not for the first frame. Issue #188 was exactly this: a 2025 QNED (webOS 10, `k24n`)
-needed ~2.4 s to complete a 4K120 HEVC HDR load, timed out against the 2 s it then shared with the
-video-only wait, fell back, and streamed with delay accumulating for the whole session (RAM to
-~500 MB, late frames to ~1300). 4K60 and 1440p120 loaded inside 2 s on the same TV and were fine,
-which is why the mode looked like the variable. A CX confirms in ~40 ms, so no healthy unit waits.
-Both waits bail early on `ndl::fatal()`, so the budget is only ever spent on a load still plausibly
-coming. The fallback warns that the picture will not be paced — read the log for that line before
-theorising about any later delay symptom.
+⚠ **A set that refuses the audio plane cannot be rescued by waiting longer — measured, issue
+#188.** The audio-enabled wait (`AUDIO_LOAD_TIMEOUT`) is a separate constant from the video-only
+one (`LOAD_COMPLETE_TIMEOUT`) because the two failures cost differently: giving up on the plane is
+not "a few held frames", it is the fallback to a video-only load and therefore an unpaced session.
+But both are 2 s, because raising one was tried on device and did nothing. A 2025 QNED (webOS 10,
+`k24n`) fails an audio-enabled 4K120 HEVC HDR load at 2 s and fails it identically at 6 s
+(`no LOADCOMPLETED within 6s of priming 6040ms of silence`), while the video-only retry that
+follows confirms in ~2.04 s. A CX confirms in ~40 ms. Nothing measured sits in between, so the
+distribution is bimodal — works almost instantly, or never — and the extra seconds only buy black
+screen plus a receive backlog deep enough to force a flush at first frame (three `receive backlog
+stopped draining` warns at 6 s, 90 frames dropped). **If a set is unpaced, the plane config is the
+thing to change, not the wait.** Both waits bail early on `ndl::fatal()`. The fallback warns that
+the picture will not be paced — grep the log for that line before theorising about any later delay.
 
 The load blocks `session::connect` between the handshake and the first `next_frame`, so anything
-timing a launch has to cover it: worst case is `AUDIO_LOAD_TIMEOUT` + `CALLBACK_SETTLE` × 2 +
-`LOAD_COMPLETE_TIMEOUT` ≈ 8.8 s. `app::hero` is fine (its `FIRST_FRAME_WAIT` only starts once
+timing a launch has to cover it: a rejected plane costs `AUDIO_LOAD_TIMEOUT` + `CALLBACK_SETTLE` ×
+2 + `LOAD_COMPLETE_TIMEOUT` ≈ 4.8 s. `app::hero` is fine (its `FIRST_FRAME_WAIT` only starts once
 connect returns, under a 30 s `HERO_LOADING_MAX` backstop), but `hdr_pattern`'s `PRESENT_DEADLINE`
-runs from `Playback::start` and had to be raised with it.
+runs from `Playback::start` and must stay above it.
 
 ⚠ **The prime's stamps and the player clock share one origin — `load_instant` is the load CALL.**
 NDL's PTS domain starts there (§ top of this section), and `prime_audio` already counted from it,

--- a/src/core/media.rs
+++ b/src/core/media.rs
@@ -168,4 +168,14 @@ pub trait AudioPlane: AudioSink {
     /// thread. `yields_to_real` leaves the plane to whatever pump is feeding it and fills in only
     /// once that stops.
     fn run_keepalive(&self, stop: &AtomicBool, yields_to_real: bool);
+
+    /// Whether the session's REAL audio may ride this plane, as opposed to only a keepalive.
+    ///
+    /// A plane can exist without being proven: a backend may accept the request and confirm it
+    /// later, or never. Keeping it fed costs nothing if it turns out not to be there, but routing
+    /// the session's only audio onto it does — that is a silent session — so the two questions are
+    /// asked separately and the route takes the conservative one.
+    fn accepts_stream(&self) -> bool {
+        true
+    }
 }

--- a/src/platform/webos/hdr_pattern.rs
+++ b/src/platform/webos/hdr_pattern.rs
@@ -31,16 +31,9 @@ const FRAME_TIME: Duration = Duration::from_millis(100);
 /// never presents cannot block the thread.
 const MAX_QUEUE_FRAMES: i32 = 2;
 
-/// How long the plane may go without presenting before the screen stops waiting for it.
-///
-/// Measured from [`Playback::start`], so it has to cover the NDL load this thread does FIRST, not
-/// just the feed. That load is what sets the floor: an audio-enabled load that does not confirm
-/// spends `AUDIO_PRIME_BUDGET` here, and a plane that turns out to be refused costs a settle and a
-/// whole second load once frames are flowing (`v2::NdlVideo::reload_video_only`). At the old 3 s
-/// this screen reported "the plane rejected the stream" while a load was still working through
-/// that sequence. Left with headroom over the measured worst case rather than trimmed to it: the
-/// cost of being late here is a slow calibration screen, and the cost of being early is a false
-/// verdict.
+/// Timeout for first frame to appear. Covers NDL load (audio-prime budget + possible video-only
+/// retry); old 3s caused false "plane rejected" verdict mid-load. Headroom over worst case: late
+/// costs slow screen, early costs false verdict.
 const PRESENT_DEADLINE: Duration = Duration::from_secs(10);
 /// How long the feed thread is given to notice `stop` and return — the same ceiling, for the same
 /// reason, as a stream's teardown.

--- a/src/platform/webos/hdr_pattern.rs
+++ b/src/platform/webos/hdr_pattern.rs
@@ -31,15 +31,18 @@ const FRAME_TIME: Duration = Duration::from_millis(100);
 /// never presents cannot block the thread.
 const MAX_QUEUE_FRAMES: i32 = 2;
 
-/// Timeout for first frame to appear. Covers NDL load (audio-prime budget + possible video-only
-/// retry); old 3s caused false "plane rejected" verdict mid-load. Headroom over worst case: late
-/// costs slow screen, early costs false verdict.
-const PRESENT_DEADLINE: Duration = Duration::from_secs(10);
+/// How long the plane may go without presenting before the screen stops waiting for it.
+///
+/// Must clear the worst-case load, or it fires mid-load and tells the user the plane was rejected
+/// while it is still coming up. A plane the pipeline refuses outright costs the prime budget, an
+/// unload, the retry settle (up to 800 ms) and then the video-only load's own 2 s wait — about
+/// 3.3 s — so the old 3 s could never clear it. Erring long is the cheap direction: late costs a
+/// slow screen, early costs a wrong answer.
+const PRESENT_DEADLINE: Duration = Duration::from_secs(5);
 /// How long the feed thread is given to notice `stop` and return — the same ceiling, for the same
 /// reason, as a stream's teardown.
 const JOIN_TIMEOUT: Duration = crate::services::join::SHUTDOWN_JOIN_TIMEOUT;
 
-/// What to show: a background field and the patches on it, in 10-bit narrow-range luma codes.
 pub struct Pattern {
     pub background: u16,
     pub patches: Vec<Patch>,
@@ -81,22 +84,20 @@ impl Playback {
         })
     }
 
-    /// Replaces what is on screen. Dropped silently if the feed has already gone — the caller's
-    /// own `presenting`/`stalled` reporting is what surfaces that.
+    /// Dropped silently if the feed has already gone — the caller's own `presenting`/`stalled`
+    /// reporting surfaces that.
     pub fn show(&self, meta: HdrMeta, pattern: Pattern) {
         let _ = self.tx.send((meta, pattern));
     }
 
-    /// Whether a frame has actually reached the decoder, which is also the gate on punching the
-    /// menu's background through to the video plane. Read from NDL, which has one plane — this is
-    /// per-process, and only meaningful because nothing else can be playing while it is up.
+    /// Whether a frame has reached the decoder. Per-process only; only meaningful because nothing
+    /// else can play while this is up.
     #[must_use]
     pub fn presenting(&self) -> bool {
         ndl::presenting()
     }
 
-    /// Nothing has presented and the deadline has passed — the plane rejected the stream, or
-    /// there is no plane. The screen says so rather than sitting on black.
+    /// Plane rejected the stream, or there is no plane. Screen reports it rather than sitting on black.
     #[must_use]
     pub fn stalled(&self) -> bool {
         !self.presenting() && self.started.elapsed() > PRESENT_DEADLINE
@@ -123,7 +124,9 @@ fn run(stop: &Arc<AtomicBool>, rx: &mpsc::Receiver<Command>, meta: HdrMeta, patt
         hevc::WIDTH as i32,
         hevc::HEIGHT as i32,
         NdlCodec::H265,
-        true,
+        // The short budget: this screen never routes real audio, it only needs the plane fed so
+        // NDL paces the pattern. An unconfirmed plane does that (see `NdlVideo::run_clock_plane`).
+        Some(ndl::AUDIO_PRIME_BUDGET),
     )?);
     let color = ColorInfo {
         primaries: ColorInfo::CP_BT2020,
@@ -142,7 +145,6 @@ fn run(stop: &Arc<AtomicBool>, rx: &mpsc::Receiver<Command>, meta: HdrMeta, patt
         .context("spawn HDR pattern clock plane")?;
 
     let result = feed(&video, stop, rx, meta, color, pattern);
-    // Releases the clock plane whether the feed ended cleanly or not.
     stop.store(true, Ordering::Relaxed);
     if let Some(clock) = clock {
         let _ = clock.join();

--- a/src/platform/webos/hdr_pattern.rs
+++ b/src/platform/webos/hdr_pattern.rs
@@ -34,12 +34,13 @@ const MAX_QUEUE_FRAMES: i32 = 2;
 /// How long the plane may go without presenting before the screen stops waiting for it.
 ///
 /// Measured from [`Playback::start`], so it has to cover the NDL load this thread does FIRST, not
-/// just the feed. That load is what sets the floor: a REJECTED audio-enabled load spends
-/// `AUDIO_LOAD_TIMEOUT`, then a settle, then `LOAD_COMPLETE_TIMEOUT` on the video-only retry — on
-/// the 2025 QNED of issue #188, ~4.8 s before the first frame. At the old 3 s this screen reported
-/// "the plane rejected the stream" while a load was still working through that sequence. Left with
-/// headroom over the measured worst case rather than trimmed to it: the cost of being late here is
-/// a slow calibration screen, and the cost of being early is a false verdict.
+/// just the feed. That load is what sets the floor: an audio-enabled load that does not confirm
+/// spends `AUDIO_PRIME_BUDGET` here, and a plane that turns out to be refused costs a settle and a
+/// whole second load once frames are flowing (`v2::NdlVideo::reload_video_only`). At the old 3 s
+/// this screen reported "the plane rejected the stream" while a load was still working through
+/// that sequence. Left with headroom over the measured worst case rather than trimmed to it: the
+/// cost of being late here is a slow calibration screen, and the cost of being early is a false
+/// verdict.
 const PRESENT_DEADLINE: Duration = Duration::from_secs(10);
 /// How long the feed thread is given to notice `stop` and return — the same ceiling, for the same
 /// reason, as a stream's teardown.

--- a/src/platform/webos/hdr_pattern.rs
+++ b/src/platform/webos/hdr_pattern.rs
@@ -34,10 +34,12 @@ const MAX_QUEUE_FRAMES: i32 = 2;
 /// How long the plane may go without presenting before the screen stops waiting for it.
 ///
 /// Measured from [`Playback::start`], so it has to cover the NDL load this thread does FIRST, not
-/// just the feed. That load is what sets the floor: an audio-enabled load waits `AUDIO_LOAD_TIMEOUT`
-/// (6 s) and a rejected one then falls back through a settle plus `LOAD_COMPLETE_TIMEOUT`. At the
-/// old 3 s this screen reported "the plane rejected the stream" while a slow but perfectly healthy
-/// load was still priming — the 2025 QNED of issue #188 takes ~2.4 s to complete one.
+/// just the feed. That load is what sets the floor: a REJECTED audio-enabled load spends
+/// `AUDIO_LOAD_TIMEOUT`, then a settle, then `LOAD_COMPLETE_TIMEOUT` on the video-only retry — on
+/// the 2025 QNED of issue #188, ~4.8 s before the first frame. At the old 3 s this screen reported
+/// "the plane rejected the stream" while a load was still working through that sequence. Left with
+/// headroom over the measured worst case rather than trimmed to it: the cost of being late here is
+/// a slow calibration screen, and the cost of being early is a false verdict.
 const PRESENT_DEADLINE: Duration = Duration::from_secs(10);
 /// How long the feed thread is given to notice `stop` and return — the same ceiling, for the same
 /// reason, as a stream's teardown.

--- a/src/platform/webos/hdr_pattern.rs
+++ b/src/platform/webos/hdr_pattern.rs
@@ -32,7 +32,13 @@ const FRAME_TIME: Duration = Duration::from_millis(100);
 const MAX_QUEUE_FRAMES: i32 = 2;
 
 /// How long the plane may go without presenting before the screen stops waiting for it.
-const PRESENT_DEADLINE: Duration = Duration::from_secs(3);
+///
+/// Measured from [`Playback::start`], so it has to cover the NDL load this thread does FIRST, not
+/// just the feed. That load is what sets the floor: an audio-enabled load waits `AUDIO_LOAD_TIMEOUT`
+/// (6 s) and a rejected one then falls back through a settle plus `LOAD_COMPLETE_TIMEOUT`. At the
+/// old 3 s this screen reported "the plane rejected the stream" while a slow but perfectly healthy
+/// load was still priming — the 2025 QNED of issue #188 takes ~2.4 s to complete one.
+const PRESENT_DEADLINE: Duration = Duration::from_secs(10);
 /// How long the feed thread is given to notice `stop` and return — the same ceiling, for the same
 /// reason, as a stream's teardown.
 const JOIN_TIMEOUT: Duration = crate::services::join::SHUTDOWN_JOIN_TIMEOUT;

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -80,26 +80,25 @@ const STATE_ERROR: c_int = 0x12;
 /// but a model that never delivers the callback must still stream.
 const LOAD_COMPLETE_TIMEOUT: Duration = Duration::from_millis(2_000);
 
-/// The bound for an AUDIO-ENABLED load. Kept separate from [`LOAD_COMPLETE_TIMEOUT`] because the
-/// two failures cost differently — giving up here falls back to a video-only load, and a
-/// video-only load has no pacing reference at all (§ "NDL's audio plane"), so its lead grows for
-/// the whole session — but measured to the same value.
+/// How long an AUDIO-ENABLED load primes its plane while waiting for `LOADCOMPLETED` before it
+/// stops waiting and lets the session start. Kept separate from [`LOAD_COMPLETE_TIMEOUT`] because
+/// it is not the same question: this one only buys the FAST confirmation, and it is no longer the
+/// verdict on the plane.
 ///
-/// ⚠ **Raising it does NOT rescue a set whose plane is refused. Measured on device 2026-09-02,
-/// issue #188.** A 2025 QNED (webOS 10, `k24n`) fails an audio-enabled 4K120 HEVC HDR load at 2 s
-/// and fails it identically at 6 s — `no LOADCOMPLETED within 6s of priming 6040ms of silence` —
-/// while the video-only retry that follows confirms in ~2.04 s. The plane is REJECTED there, not
-/// slow. A CX confirms in ~40 ms, and nothing measured anywhere sits in between, so no value here
-/// turns a failing set into a working one. The extra seconds only buy black screen and a deeper
-/// receive backlog for the session to flush at first frame (three `receive backlog stopped
-/// draining` warns at 6 s, 90 frames dropped). Fixing such a set has to mean the plane config, not
-/// the wait.
-const AUDIO_LOAD_TIMEOUT: Duration = Duration::from_millis(2_000);
+/// ⚠ **`LOADCOMPLETED` is not always reported before the first video frame. Measured on device
+/// 2026-09-02, issue #188.** A 2025 QNED (webOS 10, `k24n`) reports it 26 ms after the first access
+/// unit reaches the decoder and never before: its video-only load misses the 2 s wait above, then
+/// confirms the instant `v2::NdlVideo::ensure_loaded` gives up and feeds. An audio-enabled load
+/// waiting on that callback with no video fed therefore waits forever — 6 s of silence changed
+/// nothing — and the plane it gave up on had never been refused. A CX confirms in ~40 ms with no
+/// frame at all, which is what this budget is sized for. The verdict on the plane moved past the
+/// first frame, where both kinds of set can answer it (`v2`'s `PLANE_VERDICT`); the seconds spent
+/// here bought only black screen and a receive backlog to flush (three `receive backlog stopped
+/// draining` warns at 6 s, 90 frames dropped).
+const AUDIO_PRIME_BUDGET: Duration = Duration::from_millis(500);
 
-/// Grace for a rejected load's callbacks to land before the video-only retry arms. The callback
-/// carries nothing identifying its load, so separating the two in TIME is the only way to stop a
-/// stale `LOADCOMPLETED` satisfying the retry's wait — and feeding an unloaded decoder is what
-/// turns a launch black.
+/// Grace for a rejected load's callbacks to land before the retry arms — see [`RetrySettle`],
+/// which is where that wait is spent and why it exists.
 const CALLBACK_SETTLE: Duration = Duration::from_millis(400);
 
 /// Poll interval for the two waits below (startup path only).
@@ -139,12 +138,15 @@ impl EventSeq {
         self.base.store(self.seq.load(Ordering::SeqCst), Ordering::SeqCst);
     }
 
+    /// `Acquire`, not `SeqCst`: the feeds read this per packet and per frame, and all it has to
+    /// order is the callback's own `bump` against this reader. No third party observes the two
+    /// counters in a total order.
     fn fired(&self) -> bool {
-        self.seq.load(Ordering::SeqCst) > self.base.load(Ordering::SeqCst)
+        self.seq.load(Ordering::Acquire) > self.base.load(Ordering::Acquire)
     }
 
     fn count(&self) -> u64 {
-        self.seq.load(Ordering::SeqCst)
+        self.seq.load(Ordering::Acquire)
     }
 }
 
@@ -307,32 +309,68 @@ fn unload_count() -> u64 {
     UNLOAD_COMPLETED.count()
 }
 
-/// Lets the rejected audio-enabled load's callbacks land before the video-only retry is armed:
-/// waits for its `UNLOADCOMPLETED`, then a fixed settle for anything still in flight behind it.
-/// `unloads_before` is [`unload_count`] from before the rejected load was attempted: the caller's
-/// own teardown may have unloaded already, and a spent callback must not be waited out.
-fn settle_before_retry(unloads_before: u64) {
-    poll_until(CALLBACK_SETTLE, || UNLOAD_COMPLETED.count() != unloads_before);
-    std::thread::sleep(CALLBACK_SETTLE);
+/// The wait between a rejected load's unload and the retry's load: its `UNLOADCOMPLETED` first,
+/// then [`CALLBACK_SETTLE`] for anything still in flight behind it. The callback carries nothing
+/// identifying its load, so separating the two in TIME is the only way to stop a stale one
+/// satisfying the retry's wait — and feeding an unloaded decoder is what turns a launch black.
+///
+/// Split from the sleeping loop below it because the same policy has two callers with opposite
+/// constraints: `v2::NdlVideo::load`'s fallback can block the launch thread, while the re-load a
+/// refused plane triggers mid-session must not block the video feed and steps this one frame at a
+/// time instead.
+pub(super) struct RetrySettle {
+    unloads_before: u64,
+    started: Instant,
+    unload_seen: Option<Instant>,
 }
 
-/// Blocks until the armed load's `LOADCOMPLETED` lands. Returns `false` on timeout.
-///
-/// `budget` is the caller's, not a constant here: what a load can afford to wait is a property of
-/// the load — see [`AUDIO_LOAD_TIMEOUT`] — and `v2::NdlVideo::try_load` picks it at the same branch
-/// that picks the waiter.
-fn wait_load_completed(budget: Duration) -> bool {
+impl RetrySettle {
+    /// Start the wait. `unloads_before` is [`unload_count`] from before the rejected load was
+    /// attempted: the caller's own teardown may have unloaded already, and a spent callback must
+    /// not be waited out.
+    pub(super) fn after_unload(unloads_before: u64) -> Self {
+        Self {
+            unloads_before,
+            started: Instant::now(),
+            unload_seen: None,
+        }
+    }
+
+    /// Whether the retry may be armed. Poll it; it latches the callback's arrival on the way.
+    pub(super) fn ready(&mut self) -> bool {
+        if self.unload_seen.is_none() && UNLOAD_COMPLETED.count() != self.unloads_before {
+            self.unload_seen = Some(Instant::now());
+        }
+        // A callback that never comes must not stall the retry for good, so the grace starts at
+        // the latest when its own budget is spent. `elapsed` on a future instant is zero, which is
+        // exactly "not yet".
+        let from = self.unload_seen.unwrap_or(self.started + CALLBACK_SETTLE);
+        from.elapsed() >= CALLBACK_SETTLE
+    }
+}
+
+/// [`RetrySettle`], slept out — for the load path, which has a thread to spend on it.
+fn settle_before_retry(unloads_before: u64) {
+    let mut settle = RetrySettle::after_unload(unloads_before);
+    while !settle.ready() {
+        std::thread::sleep(POLL);
+    }
+}
+
+/// Blocks up to [`LOAD_COMPLETE_TIMEOUT`] for the armed load's `LOADCOMPLETED`. Returns `false` on
+/// timeout. The audio-enabled load has its own wait — see `v2::NdlVideo::prime_audio`.
+fn wait_load_completed() -> bool {
     // Ends on [`FATAL`] as well, for the same reason `v2::NdlVideo::prime_audio` does: a reported
     // fatal state is the one answer that will not change by waiting, and the budget is only worth
     // spending while the load is still plausibly coming.
-    poll_until(budget, || LOAD_COMPLETED.fired() || fatal());
+    poll_until(LOAD_COMPLETE_TIMEOUT, || LOAD_COMPLETED.fired() || fatal());
     if LOAD_COMPLETED.fired() {
         return true;
     }
     if fatal() {
-        tracing::warn!("NDL load reported a fatal state — not waiting out the rest of {budget:?}");
+        tracing::warn!("NDL load reported a fatal state — not waiting out the rest of {LOAD_COMPLETE_TIMEOUT:?}");
     } else {
-        tracing::warn!("NDL load: no LOADCOMPLETED within {budget:?} — holding the first frames");
+        tracing::warn!("NDL load: no LOADCOMPLETED within {LOAD_COMPLETE_TIMEOUT:?} — holding the first frames");
     }
     false
 }

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -80,25 +80,12 @@ const STATE_ERROR: c_int = 0x12;
 /// but a model that never delivers the callback must still stream.
 const LOAD_COMPLETE_TIMEOUT: Duration = Duration::from_millis(2_000);
 
-/// How long an AUDIO-ENABLED load primes its plane while waiting for `LOADCOMPLETED` before it
-/// stops waiting and lets the session start. Kept separate from [`LOAD_COMPLETE_TIMEOUT`] because
-/// it is not the same question: this one only buys the FAST confirmation, and it is no longer the
-/// verdict on the plane.
-///
-/// ⚠ **`LOADCOMPLETED` is not always reported before the first video frame. Measured on device
-/// 2026-09-02, issue #188.** A 2025 QNED (webOS 10, `k24n`) reports it 26 ms after the first access
-/// unit reaches the decoder and never before: its video-only load misses the 2 s wait above, then
-/// confirms the instant `v2::NdlVideo::ensure_loaded` gives up and feeds. An audio-enabled load
-/// waiting on that callback with no video fed therefore waits forever — 6 s of silence changed
-/// nothing — and the plane it gave up on had never been refused. A CX confirms in ~40 ms with no
-/// frame at all, which is what this budget is sized for. The verdict on the plane moved past the
-/// first frame, where both kinds of set can answer it (`v2`'s `PLANE_VERDICT`); the seconds spent
-/// here bought only black screen and a receive backlog to flush (three `receive backlog stopped
-/// draining` warns at 6 s, 90 frames dropped).
+/// Timeout for audio-enabled load's prime phase. Separate from [`LOAD_COMPLETE_TIMEOUT`] because
+/// the verdict moved to [`PLANE_VERDICT`]. Issue #188: QNED reports LOADCOMPLETED only after first
+/// frame fed (not before); old 6s timeout caused 6s of black; sized for CX which confirms ~40ms.
 const AUDIO_PRIME_BUDGET: Duration = Duration::from_millis(500);
 
-/// Grace for a rejected load's callbacks to land before the retry arms — see [`RetrySettle`],
-/// which is where that wait is spent and why it exists.
+/// Grace for rejected load's callbacks before retry (see [`RetrySettle`]).
 const CALLBACK_SETTLE: Duration = Duration::from_millis(400);
 
 /// Poll interval for the two waits below (startup path only).
@@ -138,9 +125,7 @@ impl EventSeq {
         self.base.store(self.seq.load(Ordering::SeqCst), Ordering::SeqCst);
     }
 
-    /// `Acquire`, not `SeqCst`: the feeds read this per packet and per frame, and all it has to
-    /// order is the callback's own `bump` against this reader. No third party observes the two
-    /// counters in a total order.
+    /// Acquire, not `SeqCst`: only needs to order this read against the callback's bump.
     fn fired(&self) -> bool {
         self.seq.load(Ordering::Acquire) > self.base.load(Ordering::Acquire)
     }
@@ -309,15 +294,9 @@ fn unload_count() -> u64 {
     UNLOAD_COMPLETED.count()
 }
 
-/// The wait between a rejected load's unload and the retry's load: its `UNLOADCOMPLETED` first,
-/// then [`CALLBACK_SETTLE`] for anything still in flight behind it. The callback carries nothing
-/// identifying its load, so separating the two in TIME is the only way to stop a stale one
-/// satisfying the retry's wait — and feeding an unloaded decoder is what turns a launch black.
-///
-/// Split from the sleeping loop below it because the same policy has two callers with opposite
-/// constraints: `v2::NdlVideo::load`'s fallback can block the launch thread, while the re-load a
-/// refused plane triggers mid-session must not block the video feed and steps this one frame at a
-/// time instead.
+/// Wait policy for a rejected load's unload+settle before retry. Split from the sleeping loop
+/// because `v2::NdlVideo::load` can block the launch thread, while mid-session reloads must not
+/// block the video feed.
 pub(super) struct RetrySettle {
     unloads_before: u64,
     started: Instant,
@@ -325,9 +304,7 @@ pub(super) struct RetrySettle {
 }
 
 impl RetrySettle {
-    /// Start the wait. `unloads_before` is [`unload_count`] from before the rejected load was
-    /// attempted: the caller's own teardown may have unloaded already, and a spent callback must
-    /// not be waited out.
+    /// Start the wait. `unloads_before` is the pre-load unload count to ignore stale callbacks.
     pub(super) fn after_unload(unloads_before: u64) -> Self {
         Self {
             unloads_before,
@@ -336,20 +313,18 @@ impl RetrySettle {
         }
     }
 
-    /// Whether the retry may be armed. Poll it; it latches the callback's arrival on the way.
+    /// Whether the retry may be armed. Polls and latches the callback's arrival.
     pub(super) fn ready(&mut self) -> bool {
         if self.unload_seen.is_none() && UNLOAD_COMPLETED.count() != self.unloads_before {
             self.unload_seen = Some(Instant::now());
         }
-        // A callback that never comes must not stall the retry for good, so the grace starts at
-        // the latest when its own budget is spent. `elapsed` on a future instant is zero, which is
-        // exactly "not yet".
+        // If callback never comes, grace deadline is when the budget itself expires.
         let from = self.unload_seen.unwrap_or(self.started + CALLBACK_SETTLE);
         from.elapsed() >= CALLBACK_SETTLE
     }
 }
 
-/// [`RetrySettle`], slept out — for the load path, which has a thread to spend on it.
+/// Sleep through a `RetrySettle` (for the load path with a thread to block on).
 fn settle_before_retry(unloads_before: u64) {
     let mut settle = RetrySettle::after_unload(unloads_before);
     while !settle.ready() {
@@ -360,9 +335,7 @@ fn settle_before_retry(unloads_before: u64) {
 /// Blocks up to [`LOAD_COMPLETE_TIMEOUT`] for the armed load's `LOADCOMPLETED`. Returns `false` on
 /// timeout. The audio-enabled load has its own wait — see `v2::NdlVideo::prime_audio`.
 fn wait_load_completed() -> bool {
-    // Ends on [`FATAL`] as well, for the same reason `v2::NdlVideo::prime_audio` does: a reported
-    // fatal state is the one answer that will not change by waiting, and the budget is only worth
-    // spending while the load is still plausibly coming.
+    // Also exits on FATAL: it won't change by waiting, unlike pending callbacks.
     poll_until(LOAD_COMPLETE_TIMEOUT, || LOAD_COMPLETED.fired() || fatal());
     if LOAD_COMPLETED.fired() {
         return true;

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -80,6 +80,16 @@ const STATE_ERROR: c_int = 0x12;
 /// but a model that never delivers the callback must still stream.
 const LOAD_COMPLETE_TIMEOUT: Duration = Duration::from_millis(2_000);
 
+/// The bound for an AUDIO-ENABLED load, where giving up costs far more than a few held frames:
+/// the fallback is a video-only load, and a video-only load has no pacing reference at all
+/// (§ "NDL's audio plane"), so its lead grows for the whole session. That is issue #188 — a 2025
+/// QNED (webOS 10, `k24n`) needed ~2.4 s to complete a 4K120 HEVC HDR load, timed out at the 2 s
+/// this used to share with the video-only wait, and streamed unpaced; 4K60 and 1440p120 loaded
+/// inside 2 s on the same TV and were fine. A CX completes in ~40 ms, so nothing healthy waits.
+/// The cost is paid only by a unit whose plane genuinely never confirms: a longer black screen
+/// before the fallback, and [`v2::NdlVideo::prime_audio`] gives that time back on a fatal state.
+const AUDIO_LOAD_TIMEOUT: Duration = Duration::from_millis(6_000);
+
 /// Grace for a rejected load's callbacks to land before the video-only retry arms. The callback
 /// carries nothing identifying its load, so separating the two in TIME is the only way to stop a
 /// stale `LOADCOMPLETED` satisfying the retry's wait — and feeding an unloaded decoder is what
@@ -301,12 +311,24 @@ fn settle_before_retry(unloads_before: u64) {
 }
 
 /// Blocks until the armed load's `LOADCOMPLETED` lands. Returns `false` on timeout.
-fn wait_load_completed() -> bool {
-    let completed = poll_until(LOAD_COMPLETE_TIMEOUT, || LOAD_COMPLETED.fired());
-    if !completed {
-        tracing::warn!("NDL load: no LOADCOMPLETED within {LOAD_COMPLETE_TIMEOUT:?} — holding the first frames");
+///
+/// `budget` is the caller's, not a constant here: what a load can afford to wait is a property of
+/// the load — see [`AUDIO_LOAD_TIMEOUT`] — and `v2::NdlVideo::try_load` picks it at the same branch
+/// that picks the waiter.
+fn wait_load_completed(budget: Duration) -> bool {
+    // Ends on [`FATAL`] as well, for the same reason `v2::NdlVideo::prime_audio` does: a reported
+    // fatal state is the one answer that will not change by waiting, and the budget is only worth
+    // spending while the load is still plausibly coming.
+    poll_until(budget, || LOAD_COMPLETED.fired() || fatal());
+    if LOAD_COMPLETED.fired() {
+        return true;
     }
-    completed
+    if fatal() {
+        tracing::warn!("NDL load reported a fatal state — not waiting out the rest of {budget:?}");
+    } else {
+        tracing::warn!("NDL load: no LOADCOMPLETED within {budget:?} — holding the first frames");
+    }
+    false
 }
 
 /// Count of video/audio pump threads leaked past `SHUTDOWN_JOIN_TIMEOUT` (see

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -56,7 +56,6 @@ impl NdlCodec {
         }
     }
 
-    /// From `punktfunk_core::quic::CODEC_*` wire bit.
     pub fn from_wire(codec: u8) -> Option<Self> {
         match codec {
             punktfunk_core::quic::CODEC_H264 => Some(Self::H264),
@@ -80,15 +79,28 @@ const STATE_ERROR: c_int = 0x12;
 /// but a model that never delivers the callback must still stream.
 const LOAD_COMPLETE_TIMEOUT: Duration = Duration::from_millis(2_000);
 
-/// Timeout for audio-enabled load's prime phase. Separate from [`LOAD_COMPLETE_TIMEOUT`] because
-/// the verdict moved to [`PLANE_VERDICT`]. Issue #188: QNED reports LOADCOMPLETED only after first
-/// frame fed (not before); old 6s timeout caused 6s of black; sized for CX which confirms ~40ms.
-const AUDIO_PRIME_BUDGET: Duration = Duration::from_millis(500);
+/// How long an audio-enabled load is primed while waiting for `LOADCOMPLETED` (see
+/// `v2::NdlVideo::prime_audio`). Sized for a set that answers promptly — a CX confirms in ~40 ms
+/// — because a set that answers at all answers fast, and one that does not is not waiting on
+/// time. Issue #188: a 2025 QNED reports the callback only once a video FRAME has been fed, which
+/// cannot happen inside this wait, so every ms past a prompt answer is black screen bought for
+/// nothing. The plane is not judged by this wait; see [`AUDIO_PROVE_BUDGET`].
+pub const AUDIO_PRIME_BUDGET: Duration = Duration::from_millis(500);
 
-/// Grace for rejected load's callbacks before retry (see [`RetrySettle`]).
+/// The budget a session spends when it intends to put its REAL audio on the plane, i.e. the user
+/// asked for the offload route. Longer than [`AUDIO_PRIME_BUDGET`] on purpose: an unconfirmed
+/// plane costs that session the route outright (`AudioPlane::accepts_stream`), and the route is
+/// picked once, before a frame has been fed, so an answer arriving later cannot be used. Every
+/// other session takes the short budget and loses nothing by it — the metronome rides an
+/// unconfirmed plane happily, and that is what paces the picture.
+pub const AUDIO_PROVE_BUDGET: Duration = LOAD_COMPLETE_TIMEOUT;
+
+/// Grace for a rejected load's callbacks to land before the video-only retry arms. The callback
+/// carries nothing identifying its load, so separating the two in TIME is the only way to stop a
+/// stale `LOADCOMPLETED` satisfying the retry's wait — and feeding an unloaded decoder is what
+/// turns a launch black.
 const CALLBACK_SETTLE: Duration = Duration::from_millis(400);
 
-/// Poll interval for the two waits below (startup path only).
 const POLL: Duration = Duration::from_millis(2);
 
 /// A process-global NDL event, counted rather than flagged: a late event still increments, so it
@@ -112,7 +124,6 @@ impl EventSeq {
         self.seq.fetch_add(1, Ordering::SeqCst);
     }
 
-    /// Bump only if this load hasn't seen the event yet; `true` when this call was the first.
     fn bump_first(&self) -> bool {
         if self.fired() {
             return false;
@@ -214,7 +225,7 @@ pub fn fatal() -> bool {
     FATAL.fired()
 }
 
-/// `PLAYING` for the current load. Diagnostics only — see [`PLAYING`].
+/// Diagnostics only — see [`PLAYING`].
 pub fn playing() -> bool {
     PLAYING.fired()
 }
@@ -243,12 +254,10 @@ pub fn presented() -> bool {
     first_frame_at().is_some_and(|t| t.elapsed() >= FIRST_PICTURE_HOLD)
 }
 
-/// When the armed load's first frame was accepted, if one has been.
 fn first_frame_at() -> Option<Instant> {
     *FIRST_FRAME_AT.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
-/// Records the first frame of the armed load (see [`arm_load`]); `true` if it was the first.
 fn mark_frame_fed() -> bool {
     let first = FRAME_FED.bump_first();
     if first {
@@ -257,8 +266,6 @@ fn mark_frame_fed() -> bool {
     first
 }
 
-/// [`mark_frame_fed`] plus the log line both generations emit; `since` is the handle's load
-/// instant. Returns whether this was the armed load's first frame.
 fn mark_frame_fed_logged(backend: &str, since: Instant) -> bool {
     let first = mark_frame_fed();
     if first {
@@ -289,47 +296,17 @@ fn poll_until(limit: Duration, done: impl Fn() -> bool) -> bool {
     true
 }
 
-/// `UNLOADCOMPLETED` count, for [`settle_before_retry`]'s baseline.
 fn unload_count() -> u64 {
     UNLOAD_COMPLETED.count()
 }
 
-/// Wait policy for a rejected load's unload+settle before retry. Split from the sleeping loop
-/// because `v2::NdlVideo::load` can block the launch thread, while mid-session reloads must not
-/// block the video feed.
-pub(super) struct RetrySettle {
-    unloads_before: u64,
-    started: Instant,
-    unload_seen: Option<Instant>,
-}
-
-impl RetrySettle {
-    /// Start the wait. `unloads_before` is the pre-load unload count to ignore stale callbacks.
-    pub(super) fn after_unload(unloads_before: u64) -> Self {
-        Self {
-            unloads_before,
-            started: Instant::now(),
-            unload_seen: None,
-        }
-    }
-
-    /// Whether the retry may be armed. Polls and latches the callback's arrival.
-    pub(super) fn ready(&mut self) -> bool {
-        if self.unload_seen.is_none() && UNLOAD_COMPLETED.count() != self.unloads_before {
-            self.unload_seen = Some(Instant::now());
-        }
-        // If callback never comes, grace deadline is when the budget itself expires.
-        let from = self.unload_seen.unwrap_or(self.started + CALLBACK_SETTLE);
-        from.elapsed() >= CALLBACK_SETTLE
-    }
-}
-
-/// Sleep through a `RetrySettle` (for the load path with a thread to block on).
+/// Lets the rejected audio-enabled load's callbacks land before the video-only retry is armed:
+/// waits for its `UNLOADCOMPLETED`, then a fixed settle for anything still in flight behind it.
+/// `unloads_before` is [`unload_count`] from before the rejected load was attempted: the caller's
+/// own teardown may have unloaded already, and a spent callback must not be waited out.
 fn settle_before_retry(unloads_before: u64) {
-    let mut settle = RetrySettle::after_unload(unloads_before);
-    while !settle.ready() {
-        std::thread::sleep(POLL);
-    }
+    poll_until(CALLBACK_SETTLE, || UNLOAD_COMPLETED.count() != unloads_before);
+    std::thread::sleep(CALLBACK_SETTLE);
 }
 
 /// Blocks up to [`LOAD_COMPLETE_TIMEOUT`] for the armed load's `LOADCOMPLETED`. Returns `false` on
@@ -377,9 +354,8 @@ impl Drop for LeakGuard {
     }
 }
 
-/// Marks one NDL-touching thread as leaked until the returned guard drops — which the caller must
-/// arrange to happen when that same thread actually finishes, however late. Leaking the guard
-/// (`mem::forget`) is the deliberate "nothing will ever tell us it recovered" case.
+/// Caller must arrange the guard to drop when the thread actually finishes, however late.
+/// Leaking it (`mem::forget`) means recovery is never signalled.
 #[must_use = "NDL stays poisoned until this guard drops — hold it until the wedged thread returns"]
 pub fn poison() -> LeakGuard {
     if LEAKED_THREADS.fetch_add(1, Ordering::SeqCst) == 0 {
@@ -391,9 +367,7 @@ pub fn poison() -> LeakGuard {
     LeakGuard(())
 }
 
-/// `Err` while any leaked thread might still be live (see [`LEAKED_THREADS`]). One gate, one
-/// wording: every `load()` enforces it and `session::connect` checks it early to avoid holding a
-/// host session slot for a connect that can only end here.
+/// Checked early by `session::connect` to avoid holding a host slot for a connect that can only fail.
 pub fn ensure_not_poisoned() -> Result<()> {
     if LEAKED_THREADS.load(Ordering::SeqCst) > 0 {
         bail!("NDL is still tearing down a wedged decode thread from the previous session — try reconnecting shortly");
@@ -419,8 +393,6 @@ fn ensure_init(app_id: &str, api2: bool) -> Result<()> {
     Ok(())
 }
 
-/// The app id NDL is initialised with. Overridable for dev builds installed under another id —
-/// NDL keys its session on the caller's app id, so a mismatch fails the load.
 /// Widest layout the TV's audio output will actually pass **right now**, or `None` where it
 /// cannot be asked.
 ///
@@ -462,9 +434,6 @@ pub fn audio_output_width() -> Option<u8> {
 /// for the same reason: a stream whose audio decodes in software, and the HDR calibration feed.
 /// It lives here so the boost comes with it — this is a 20 ms metronome holding the depth NDL
 /// paces on, and at nice 0 it competes with the boosted decode threads on a 2-3 core `SoC`.
-///
-/// `yields_to_real` is the difference between the two audio paths — see
-/// [`v2::NdlVideo::run_clock_plane`].
 pub fn spawn_clock_plane(
     plane: std::sync::Arc<dyn crate::core::media::AudioPlane>,
     stop: std::sync::Arc<AtomicBool>,
@@ -478,6 +447,8 @@ pub fn spawn_clock_plane(
         })
 }
 
+/// Overridable for dev builds. NDL keys its session on the caller's app id, so a mismatch fails
+/// the load.
 pub fn app_id() -> String {
     std::env::var("APPID").unwrap_or_else(|_| "io.dyptan.punktfunk.webos".into())
 }

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -80,15 +80,21 @@ const STATE_ERROR: c_int = 0x12;
 /// but a model that never delivers the callback must still stream.
 const LOAD_COMPLETE_TIMEOUT: Duration = Duration::from_millis(2_000);
 
-/// The bound for an AUDIO-ENABLED load, where giving up costs far more than a few held frames:
-/// the fallback is a video-only load, and a video-only load has no pacing reference at all
-/// (§ "NDL's audio plane"), so its lead grows for the whole session. That is issue #188 — a 2025
-/// QNED (webOS 10, `k24n`) needed ~2.4 s to complete a 4K120 HEVC HDR load, timed out at the 2 s
-/// this used to share with the video-only wait, and streamed unpaced; 4K60 and 1440p120 loaded
-/// inside 2 s on the same TV and were fine. A CX completes in ~40 ms, so nothing healthy waits.
-/// The cost is paid only by a unit whose plane genuinely never confirms: a longer black screen
-/// before the fallback, and [`v2::NdlVideo::prime_audio`] gives that time back on a fatal state.
-const AUDIO_LOAD_TIMEOUT: Duration = Duration::from_millis(6_000);
+/// The bound for an AUDIO-ENABLED load. Kept separate from [`LOAD_COMPLETE_TIMEOUT`] because the
+/// two failures cost differently — giving up here falls back to a video-only load, and a
+/// video-only load has no pacing reference at all (§ "NDL's audio plane"), so its lead grows for
+/// the whole session — but measured to the same value.
+///
+/// ⚠ **Raising it does NOT rescue a set whose plane is refused. Measured on device 2026-09-02,
+/// issue #188.** A 2025 QNED (webOS 10, `k24n`) fails an audio-enabled 4K120 HEVC HDR load at 2 s
+/// and fails it identically at 6 s — `no LOADCOMPLETED within 6s of priming 6040ms of silence` —
+/// while the video-only retry that follows confirms in ~2.04 s. The plane is REJECTED there, not
+/// slow. A CX confirms in ~40 ms, and nothing measured anywhere sits in between, so no value here
+/// turns a failing set into a working one. The extra seconds only buy black screen and a deeper
+/// receive backlog for the session to flush at first frame (three `receive backlog stopped
+/// draining` warns at 6 s, 90 frames dropped). Fixing such a set has to mean the plane config, not
+/// the wait.
+const AUDIO_LOAD_TIMEOUT: Duration = Duration::from_millis(2_000);
 
 /// Grace for a rejected load's callbacks to land before the video-only retry arms. The callback
 /// carries nothing identifying its load, so separating the two in TIME is the only way to stop a

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -246,7 +246,10 @@ impl NdlVideo {
         // LOADCOMPLETED, and an audio-enabled load will not report it until its audio plane has
         // seen a packet, which is what the prime supplies.
         // Budget and waiter are picked at the same branch: what a load can afford to wait is a
-        // property of the load, and the two differ by 3x.
+        // property of the load, not of whichever waiter it happens to reach. The two budgets are
+        // equal today (see `AUDIO_LOAD_TIMEOUT` for the measurement that made them equal) and are
+        // still named apart, because giving up on the plane and giving up on the picture are not
+        // the same failure.
         let (primed_pts_ms, confirmed) = if audio {
             Self::prime_audio(fns, load_instant, AUDIO_LOAD_TIMEOUT)
         } else {
@@ -271,7 +274,10 @@ impl NdlVideo {
     ///
     /// `load_instant` is the caller's, not re-derived here: these stamps ARE the player clock's
     /// domain, and handing the origin down is what makes that a value rather than a coincidence of
-    /// two adjacent `Instant::now()` calls (see the field).
+    /// two adjacent `Instant::now()` calls (see the field). `budget` is measured from it too, so it
+    /// bounds the whole load — the `NDL_DirectMediaLoad` call included — rather than just the
+    /// priming after it. That is the figure `LOADCOMPLETED` is relative to, and it means a set
+    /// that blocks inside the load call cannot spend the budget twice.
     ///
     /// An audio-enabled load will not report until its audio plane has received data, but the
     /// pumps that would supply it don't spawn until `session::connect` returns — i.e. until this
@@ -292,7 +298,7 @@ impl NdlVideo {
         let mut pts_ms = 0;
         while !LOAD_COMPLETED.fired() {
             // A reported fatal state is the one answer that will not change by waiting, so the
-            // long budget above is spent only while the load is still plausibly coming.
+            // budget is spent only while the load is still plausibly coming.
             if super::fatal() {
                 tracing::warn!("NDL load reported a fatal state after {pts_ms}ms of silence");
                 return (pts_ms, false);

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -13,18 +13,32 @@ use anyhow::{bail, Result};
 
 use crate::core::media::{AudioFormat, AudioPlane, AudioSink, MediaClock, NotReady, Samples, VideoSink, VideoSinkCaps};
 
-use super::{arm_load, ensure_init, ensure_not_poisoned, ffi, settle_before_retry, wait_load_completed, RetrySettle};
-use super::{lock_ffi, mark_frame_fed_logged, NdlCodec, AUDIO_PRIME_BUDGET, LOAD_COMPLETED, LOAD_COMPLETE_TIMEOUT};
+use super::{arm_load, ensure_init, ensure_not_poisoned, ffi, settle_before_retry, wait_load_completed};
+use super::{
+    lock_ffi, mark_frame_fed_logged, NdlCodec, AUDIO_PRIME_BUDGET, AUDIO_PROVE_BUDGET, LOAD_COMPLETED,
+    LOAD_COMPLETE_TIMEOUT,
+};
 
-/// Hold timeout measured from load call (overlaps wait, doesn't stack). A backstop, not live
-/// path: `load()` always spends whole budget first. On sets reporting LOADCOMPLETED after first
-/// frame, this hold would prevent it.
+/// How long past the `NDL_DirectMediaLoad` CALL [`NdlVideo::ensure_loaded`] holds frames while
+/// `LOADCOMPLETED` is missing.
+///
+/// Measured from `load_instant`, which is the load call itself, so this window OVERLAPS the load's
+/// own wait rather than stacking on it: a unit whose callback never comes would otherwise eat the
+/// load budget and then this one before the first frame.
+///
+/// **A backstop, not a live path** for a set that confirms during the load — `load()` has already
+/// spent a longer budget by the time a frame gets here. It IS the live path on a set that reports
+/// `LOADCOMPLETED` only once a frame has been fed, where holding forever is the deadlock: nothing
+/// confirms until something feeds.
 const FEED_ANYWAY_AFTER: Duration = Duration::from_millis(300);
 
 // Const assert because debug assertions don't run on release (CI and TV use release builds).
+// Every budget a load can be issued with, since the hold must overlap the wait rather than stack
+// on it whichever one the session picked (`session::pipeline::plane_budget`).
 const _: () = assert!(
     FEED_ANYWAY_AFTER.as_millis() < LOAD_COMPLETE_TIMEOUT.as_millis()
         && FEED_ANYWAY_AFTER.as_millis() < AUDIO_PRIME_BUDGET.as_millis()
+        && FEED_ANYWAY_AFTER.as_millis() < AUDIO_PROVE_BUDGET.as_millis()
 );
 
 /// One empty Opus frame — `mariotaku/ss4s`'s `opus_empty_frame_211`. Its TOC declares STEREO,
@@ -80,9 +94,22 @@ const PRIME_RETRY: Duration = Duration::from_millis(20);
 /// encodes silence into the same continuous 5 ms datagrams. Only a dead host capture gaps this wide.
 const REAL_FEED_GRACE_MS: i64 = 300;
 
-/// Verdict timeout past first frame. QNED reports callback only when ingesting (not during
-/// load). Early=broken plane (the bug); late=black then video-only reload.
-const PLANE_VERDICT: Duration = Duration::from_millis(750);
+/// How long past the first accepted frame an audio-enabled load has to report `LOADCOMPLETED`
+/// before the plane is called refused **in the log**. Diagnostic only — nothing is recovered.
+///
+/// This is the one window where the two indistinguishable cases separate. Before a frame is fed,
+/// "no callback yet" means either a healthy ingest-gated set or a pipeline that rejected the Opus
+/// config asynchronously (which then accepts every frame into a decoder that never runs — a whole
+/// black session with no error on any call). After a frame, a healthy set answers: the measured
+/// QNED takes 26 ms. Generous against that, since the cost of being early is a false alarm in the
+/// log and the cost of being late is nothing.
+///
+/// **Deliberately not a fallback.** Recovering means unloading and re-loading mid-session, which
+/// was written for issue #188 and reverted: it re-applies HDR metadata to the new pipeline, and
+/// mode re-entry on that path is itself a suspected cause of #188 (docs/NOTES.md § "NDL's audio
+/// plane"). Until a set is measured that genuinely refuses the plane this way, the honest move is
+/// to name it rather than to act on a guess — the whole of #188 was a misread of this signal.
+const PLANE_CONFIRM_GRACE: Duration = Duration::from_millis(750);
 
 /// The audio plane every V2 load asks for: Opus, stereo, 48 kHz.
 ///
@@ -104,23 +131,6 @@ fn plane_config() -> ffi::AudioUnion {
     .to_union()
 }
 
-/// Arm the load counters and issue one `NDL_DirectMediaLoad`, returning the instant it was called
-/// — which is the origin of NDL's PTS domain (see [`NdlVideo::load_instant`]).
-///
-/// The only place that knows how a V2 load is issued: [`NdlVideo::try_load`] builds a handle
-/// around it, [`NdlVideo::advance_reload`] re-issues one under a handle that already exists,
-/// and neither should own a second copy of the `DataInfo`/callback/arming order.
-fn issue_load(fns: &'static ffi::V2, video: ffi::VideoInfo, audio: bool) -> Result<Instant> {
-    let mut info = ffi::DataInfo {
-        video,
-        audio: if audio { plane_config() } else { ffi::AudioUnion::SILENT },
-    };
-    arm_load();
-    let load_instant = Instant::now();
-    fns.load(&mut info, Some(super::on_load_state))?;
-    Ok(load_instant)
-}
-
 /// One loaded NDL v2 video decode session. Dropping unloads it (not `NDL_DirectMediaQuit`).
 pub struct NdlVideo {
     fns: &'static ffi::V2,
@@ -136,15 +146,9 @@ pub struct NdlVideo {
     /// player clock is already at the load duration when the session starts, which is what
     /// `last_real_feed_ms` is seeded against.
     load_instant: Instant,
-    /// What the load asked the video plane for, kept so [`Self::begin_reload`] can re-issue
-    /// the same load without its audio arm.
-    video: ffi::VideoInfo,
-    /// Whether this load has an audio plane. Cleared by [`Self::begin_reload`] when the plane
-    /// turns out to be refused — and with it goes the picture's pacing reference.
-    ///
-    /// Atomic because the verdict is taken mid-session, on the video thread, while the audio
-    /// feeders read it.
-    audio: AtomicBool,
+    /// Whether this load asked for an audio plane — the picture's pacing reference. Fixed for the
+    /// life of the handle: the plane a load was given is the plane it keeps.
+    audio: bool,
     /// Highest audio stamp fed so far (ms), shared by [`Self::play_audio`] and the clock plane so
     /// neither can hand NDL a timestamp going backwards — NDL reads a rewind as a seek and mutes
     /// the rest of the session.
@@ -172,33 +176,14 @@ pub struct NdlVideo {
     /// PIPELINE, rather than about this gate, wants [`Self::plane_ready`] instead: feeding the
     /// audio plane early costs the session its audio permanently.
     feed_unblocked: AtomicBool,
-    /// Player-clock ms the video feed's hold is measured FROM — 0 for the original load, restamped
-    /// by [`Self::begin_reload`]. `load_instant` cannot serve: it stays anchored to the first
-    /// load (it is the session's media clock), so after a reload it already reads well past
-    /// [`FEED_ANYWAY_AFTER`] and the reissued load would get no hold at all.
-    feed_hold_from_ms: AtomicI64,
-    /// Player-clock ms at which an unconfirmed load's plane is declared refused, stamped on the
-    /// first accepted frame — see [`PLANE_VERDICT`]. Meaningless until then, and read only while
-    /// [`Self::verdict_settled`] is false.
-    verdict_deadline_ms: AtomicI64,
-    /// Latches once the plane question has an answer, either way, so the per-frame path costs one
-    /// relaxed load for the rest of the session.
-    verdict_settled: AtomicBool,
-    /// The re-load a refused plane triggers, `Some` while one is in flight.
-    ///
-    /// **The teardown a refused plane needs is an unload, a settle and a load — none of which may
-    /// happen inline on the feed thread.** Blocking it for the settle (400-800 ms) stops the pump
-    /// pulling frames, and a receive queue that fills is the `receive backlog stopped draining`
-    /// flush the load-time wait used to cause, moved mid-session. A thread of its own would be
-    /// worse: a second thread inside NDL is the one thing this module refuses (`LEAKED_THREADS`).
-    /// So the sequence is stepped by the video feed itself — each frame advances it, is answered
-    /// with [`NotReady`], and goes back to draining the queue. A `Mutex` rather than atomics
-    /// because nothing reads it off the hot path: [`Self::ensure_loaded`] returns before it.
-    reload: Mutex<Option<RetrySettle>>,
-    /// Whether the load itself confirmed the plane, which is what makes it safe to put the
-    /// session's only audio on — see [`AudioPlane::accepts_stream`]. A plane still awaiting its
-    /// verdict is worth keeping fed (that is the pacing) but must not be the audio path: if it is
-    /// refused, [`Self::begin_reload`] takes it away and the route has already been picked.
+    /// Player-clock ms at which an unconfirmed plane gets its log line, stamped on the first
+    /// accepted frame; `i64::MAX` before that and once spent — see [`PLANE_CONFIRM_GRACE`].
+    plane_check_ms: AtomicI64,
+    /// Whether the load itself confirmed the plane within its budget, which is what makes it safe
+    /// to put the session's only audio on — see [`AudioPlane::accepts_stream`]. An unconfirmed
+    /// plane is still worth keeping fed (that is the pacing, and it is what produces the
+    /// confirmation on an ingest-gated set), but it must not be the only audio path: nothing
+    /// downstream can re-pick the route once the session is running.
     plane_proven: bool,
     /// HDR mastering metadata that arrived before the video plane had taken a frame.
     /// `NDL_DirectVideoSetHDRInfo` returns success against a pipeline that isn't ingesting yet
@@ -221,8 +206,12 @@ pub struct NdlVideo {
 
 impl NdlVideo {
     /// Load NDL video stream. Calls `NDL_DirectMediaInit` on first use.
-    /// Audio request is a probe: fails silently on unsupported models, retries video-only.
-    pub fn load(app_id: &str, width: i32, height: i32, codec: NdlCodec, audio: bool) -> Result<Self> {
+    ///
+    /// `audio` is the plane's prime budget, or `None` for a video-only load. The budget is how
+    /// long the load waits for `LOADCOMPLETED` before starting the stream unconfirmed — see
+    /// [`super::AUDIO_PRIME_BUDGET`] and [`super::AUDIO_PROVE_BUDGET`]. The audio request itself
+    /// is a probe: it fails silently on unsupported models, which retries video-only.
+    pub fn load(app_id: &str, width: i32, height: i32, codec: NdlCodec, audio: Option<Duration>) -> Result<Self> {
         ensure_not_poisoned()?;
         let fns = ffi::v2()?;
         ensure_init(app_id, true)?;
@@ -232,7 +221,7 @@ impl NdlVideo {
             kind: codec.ndl_type(),
             unknown1: 0,
         };
-        if audio {
+        if let Some(budget) = audio {
             // The plane is asked for here, but NOT judged here. `NDL_DirectMediaLoad` returning 0
             // is only "request accepted" — an Opus config the pipeline rejects fails
             // asynchronously and then accepts every fed frame into a pipeline that is not running,
@@ -241,15 +230,17 @@ impl NdlVideo {
             // not the test for it: a 2025 QNED does not report the callback until a frame has been
             // fed, and nothing can feed one until this returns and the pumps spawn. Judging here
             // gave that set a video-only fallback on every session, i.e. no pacing reference at
-            // all, which is issue #188. So an accepted load is taken unconfirmed and the verdict
-            // moves past the first frame — see [`PLANE_VERDICT`] and [`Self::begin_reload`].
+            // all, which is issue #188. So an accepted load is taken unconfirmed: the metronome
+            // rides it (that is the pacing, and on such a set it is what produces the
+            // confirmation), while the session's REAL audio only rides a confirmed one
+            // ([`Self::plane_proven`]).
             //
             // A hard `Err` is still answered here: there is no handle to defer with. The unload
             // first is what a failed load needs before a retry (a failed load may hold decoder
             // resources, docs/NOTES.md), and the snapshot precedes the attempt so a settle cannot
             // wait out an `UNLOADCOMPLETED` already spent.
             let unloads_before = super::unload_count();
-            match Self::try_load(fns, video, true) {
+            match Self::try_load(fns, video, Some(budget)) {
                 Ok(loaded) => return Ok(loaded),
                 // Loud, because a video-only load streams unpaced for the rest of the session
                 // (issue #188) and every later symptom reads as something else.
@@ -262,7 +253,7 @@ impl NdlVideo {
             // land BEFORE arming below rather than racing them.
             settle_before_retry(unloads_before);
         }
-        Self::try_load(fns, video, false)
+        Self::try_load(fns, video, None)
     }
 
     /// One `NDL_DirectMediaLoad` attempt, given its budget to report `LOADCOMPLETED` — priming
@@ -270,43 +261,57 @@ impl NdlVideo {
     ///
     /// An audio-enabled attempt that does not confirm is still returned: unconfirmed is a normal
     /// state for one, not a failure (see [`Self::load`]).
-    fn try_load(fns: &'static ffi::V2, video: ffi::VideoInfo, audio: bool) -> Result<Self> {
-        let load_instant = issue_load(fns, video, audio)?;
+    fn try_load(fns: &'static ffi::V2, video: ffi::VideoInfo, audio: Option<Duration>) -> Result<Self> {
+        let mut info = ffi::DataInfo {
+            video,
+            audio: if audio.is_some() {
+                plane_config()
+            } else {
+                ffi::AudioUnion::SILENT
+            },
+        };
+        arm_load();
+        // The instant of the CALL is the origin of NDL's PTS domain — see [`Self::load_instant`].
+        let load_instant = Instant::now();
+        fns.load(&mut info, Some(super::on_load_state))?;
         // `ret == 0` is "request accepted", not "pipeline ready" — the first feed still needs
         // LOADCOMPLETED, and an audio-enabled load will not report it until its audio plane has
         // seen a packet, which is what the prime supplies. The two waits are different questions,
         // not one budget twice: the audio one buys a fast confirmation and gives up cheaply, the
         // video one is the picture's own bound.
-        let (primed_pts_ms, confirmed) = if audio {
-            Self::prime_audio(fns, load_instant)
-        } else {
-            (0, wait_load_completed())
+        let (primed_pts_ms, confirmed) = match audio {
+            Some(budget) => Self::prime_audio(fns, load_instant, budget),
+            None => (0, wait_load_completed()),
         };
+        // FATAL is not "unconfirmed", it is gone — and unconfirmed is the only state an
+        // audio-enabled load is allowed to be taken in. Answering it here is what keeps the audio
+        // request a PROBE: `load()` unloads and retries video-only, which is the whole point of
+        // asking for a plane optimistically. Left as `Ok`, the session would instead be torn down
+        // by `is_dead()` on a set that would have streamed perfectly well without the plane.
+        if audio.is_some() && super::fatal() {
+            bail!("NDL reported a fatal state during the audio-enabled load");
+        }
         Ok(Self {
             fns,
             load_instant,
-            video,
-            audio: AtomicBool::new(audio),
+            audio: audio.is_some(),
             last_audio_pts_ms: AtomicI64::new(primed_pts_ms),
             last_real_feed_ms: AtomicI64::new(load_instant.elapsed().as_millis() as i64),
             feed_unblocked: AtomicBool::new(confirmed),
-            feed_hold_from_ms: AtomicI64::new(0),
-            verdict_deadline_ms: AtomicI64::new(i64::MAX),
-            // A video-only load has no plane to judge, and a confirmed one has already answered.
-            verdict_settled: AtomicBool::new(!audio || confirmed),
-            reload: Mutex::new(None),
-            plane_proven: audio && confirmed,
+            plane_check_ms: AtomicI64::new(i64::MAX),
+            plane_proven: audio.is_some() && confirmed,
             pending_hdr: Mutex::new(None),
             applied_hdr: Mutex::new(None),
         })
     }
 
     /// Feed silent Opus packets until the audio-enabled load reports `LOADCOMPLETED`, bounded by
-    /// [`AUDIO_PRIME_BUDGET`]. Returns the highest stamp fed and whether the load confirmed.
+    /// `budget`. Returns the highest stamp fed and whether the load confirmed.
     ///
-    /// Not confirming is not a verdict. Sets differ in what they report the callback against, and
-    /// one that reports it against video ingest cannot answer inside this wait at all — see
-    /// [`AUDIO_PRIME_BUDGET`] and [`PLANE_VERDICT`].
+    /// Not confirming is not a refusal. Sets differ in what they report the callback against, and
+    /// one that reports it against video ingest cannot answer inside this wait at all — so the
+    /// handle is taken unconfirmed and [`Self::run_clock_plane`] continues this prime, which is
+    /// what eventually produces the callback. See [`AUDIO_PRIME_BUDGET`].
     ///
     /// `load_instant` is the caller's, not re-derived here: these stamps ARE the player clock's
     /// domain, and handing the origin down is what makes that a value rather than a coincidence of
@@ -318,8 +323,9 @@ impl NdlVideo {
     /// An audio-enabled load will not report until its audio plane has received data, but the
     /// pumps that would supply it don't spawn until `session::connect` returns — i.e. until this
     /// wait is over. That deadlock is the whole black-picture-with-sound bug, so the load window
-    /// feeds itself. (The VIDEO half of the same deadlock is why the wait is no longer the
-    /// verdict: nothing here can feed a frame, and some sets report only once one has been.)
+    /// feeds itself. (The VIDEO half of the same deadlock is why a load that does not confirm here
+    /// is still taken: nothing in this wait can feed a FRAME, and some sets report only once one
+    /// has been.)
     ///
     /// A burst at a time, because a packet fed before the plane exists may be dropped silently
     /// (`NDL_DirectAudioPlay` reports success either way).
@@ -330,7 +336,7 @@ impl NdlVideo {
     /// the player-clock domain: the ceiling sits exactly [`PRIME_LEAD`] packets above the clock,
     /// the same lead every later feeder targets, so the clock overtakes it within one lead however
     /// long the load took.
-    fn prime_audio(fns: &'static ffi::V2, load_instant: Instant) -> (i64, bool) {
+    fn prime_audio(fns: &'static ffi::V2, load_instant: Instant, budget: Duration) -> (i64, bool) {
         let silence = &OPUS_SILENCE[..];
         let mut pts_ms = 0;
         while !LOAD_COMPLETED.fired() {
@@ -340,12 +346,12 @@ impl NdlVideo {
                 tracing::warn!("NDL load reported a fatal state after {pts_ms}ms of silence");
                 return (pts_ms, false);
             }
-            if load_instant.elapsed() >= AUDIO_PRIME_BUDGET {
+            if load_instant.elapsed() >= budget {
                 // INFO, not WARN: on a set that reports the callback against video ingest this is
-                // every session's normal path, and the plane is judged later (`PLANE_VERDICT`).
+                // every session's normal path, and the metronome carries the plane from here.
                 tracing::info!(
-                    "NDL load: no LOADCOMPLETED within {AUDIO_PRIME_BUDGET:?} of priming {pts_ms}ms of silence \
-                     — starting the stream and judging the plane after the first frame"
+                    "NDL load: no LOADCOMPLETED within {budget:?} of priming {pts_ms}ms of silence \
+                     — starting the stream, the clock plane carries the prime from here"
                 );
                 return (pts_ms, false);
             }
@@ -372,14 +378,14 @@ impl NdlVideo {
         (pts_ms, true)
     }
 
-    /// Whether this load has an audio plane — the picture's only pacing reference, see
-    /// [`Self::run_clock_plane`]. False means the plane was refused, either at the load itself or
-    /// at the verdict past the first frame ([`Self::begin_reload`]).
+    /// Whether this load asked for an audio plane — the picture's only pacing reference, see
+    /// [`Self::run_clock_plane`]. False only for a load that was refused one outright, which is
+    /// a session with no pacing reference at all.
     ///
-    /// The session reads this once, to pick its audio route, and a later reload cannot un-pick it:
-    /// what it loses then is the pacing, which is the same thing a refusal at load costs.
+    /// Not the same question as "may the real stream ride it" — that is
+    /// [`AudioPlane::accepts_stream`], and it is the stricter of the two.
     pub fn has_audio_plane(&self) -> bool {
-        self.audio.load(Ordering::Relaxed)
+        self.audio
     }
 
     /// Feed one Opus packet to the audio plane, stamped on the PLAYER clock.
@@ -472,7 +478,20 @@ impl NdlVideo {
     /// a pure metronome, the only feed. On (NDL offload): the real stream is the metronome, and
     /// this fills in only after [`REAL_FEED_GRACE_MS`] without a packet — a dead host capture,
     /// which would otherwise starve the plane and freeze the picture.
+    ///
+    /// **Deliberately NOT gated on `LOADCOMPLETED`.** This is [`Self::prime_audio`]'s continuation
+    /// under a different budget, feeding the same plane through the same call, and the prime is
+    /// not gated either — NDL's own requirement is that the plane be fed, and on an ingest-gated
+    /// set feeding it is what eventually produces the callback. Gating here would leave the plane
+    /// unfed from the end of the prime until the first video frame, which on such a set is seconds,
+    /// and covers the ~100 ms of ingest that sets NDL's standing present cushion. Only the REAL
+    /// stream waits for the callback ([`Self::play_audio`]): silence is recoverable, misrouted
+    /// audio is not.
     pub fn run_clock_plane(&self, stop: &std::sync::atomic::AtomicBool, yields_to_real: bool) {
+        if !self.audio {
+            tracing::info!("NDL clock plane: the load has no audio plane — nothing to pace against");
+            return;
+        }
         // A fill on the offload route must target exactly what [`Self::play_audio`] targets, or
         // the real packets that resume are floored onto the fill's higher ceiling and pinned to
         // one stamp for the length of it. The metronome is the only feed on its route and answers
@@ -485,19 +504,6 @@ impl NdlVideo {
         };
         let mut filling = false;
         while !stop.load(Ordering::Relaxed) {
-            // Same gate as [`Self::play_audio`], for the same reason: the plane exists once NDL
-            // says so. The prime holds it through the load window, and on a set that confirms
-            // only after the first video frame this is the wait for that frame — bounded, because
-            // a load that never confirms loses the plane at [`PLANE_VERDICT`], which clears the
-            // other half of the gate for good.
-            if !self.plane_ready() {
-                if !self.audio.load(Ordering::Relaxed) {
-                    tracing::info!("NDL clock plane: the load has no audio plane — nothing to pace against");
-                    return;
-                }
-                super::poll_until(PRIME_RETRY, || self.plane_ready());
-                continue;
-            }
             let now_ms = (self.elapsed_ns() / 1_000_000) as i64;
             // Any stretch the plane went unfed — the wait above, or a yielded run whose real
             // stream stopped — is time the ceiling did not advance through. Carry it forward
@@ -560,115 +566,15 @@ impl NdlVideo {
         self.load_instant.elapsed().as_nanos() as u64
     }
 
-    /// Whether there is an audio plane to feed: this load asked for one AND NDL has confirmed it.
+    /// Whether the REAL stream may ride the plane: this load asked for one AND NDL has confirmed
+    /// it. The silent metronome does not ask this — see [`Self::run_clock_plane`].
     ///
-    /// Both halves matter. The callback latch alone is not enough — [`Self::begin_reload`]
-    /// leaves a pipeline that confirms normally and has no audio arm, and feeding that is a silent
-    /// session. [`Self::feed_unblocked`] is not the latch: that one is the video feed's gate and
-    /// latches optimistically (see [`Self::play_audio`]).
+    /// Both halves matter. The callback latch alone is not enough: a video-only load confirms
+    /// normally and has no audio arm, and feeding that is a silent session. [`Self::feed_unblocked`]
+    /// is not the latch either — that one is the video feed's gate and latches optimistically
+    /// (see [`Self::play_audio`]).
     fn plane_ready(&self) -> bool {
-        self.audio.load(Ordering::Relaxed) && LOAD_COMPLETED.fired()
-    }
-
-    /// The audio plane's verdict, taken past the first accepted frame — see [`PLANE_VERDICT`].
-    ///
-    /// Runs at the tail of every [`Self::play`], so it settles into one relaxed load: both answers
-    /// are terminal (a confirmed plane stays confirmed for the load, a refused one is already
-    /// gone), and the deadline is an integer on the handle's own clock rather than the global
-    /// first-frame mutex the callback thread also takes.
-    ///
-    /// `Err(NotReady)` is the reload's own signal, not a failure: the sink answers it with a
-    /// keyframe request and no flush, which is exactly what the pipeline underneath just became.
-    fn check_plane_verdict(&self) -> Result<()> {
-        if self.verdict_settled.load(Ordering::Relaxed) {
-            return Ok(());
-        }
-        if self.plane_ready() {
-            self.verdict_settled.store(true, Ordering::Relaxed);
-            return Ok(());
-        }
-        // Frames are flowing (this runs after one was accepted) and NDL still has not confirmed
-        // the load. On every set measured, that is now conclusive.
-        if (self.elapsed_ns() / 1_000_000) as i64 <= self.verdict_deadline_ms.load(Ordering::Relaxed) {
-            return Ok(());
-        }
-        tracing::warn!(
-            "NDL: no LOADCOMPLETED {PLANE_VERDICT:?} after the first frame — the audio plane was \
-             refused, reloading video-only, the picture will not be paced"
-        );
-        self.verdict_settled.store(true, Ordering::Relaxed);
-        self.begin_reload();
-        Err(NotReady.into())
-    }
-
-    /// Give up the audio plane: unload now, and let the frames that follow carry the rest.
-    ///
-    /// The alternative to re-loading is a black session: a load whose audio config the pipeline
-    /// rejected keeps ACCEPTING frames and never runs, with no error on any call (see
-    /// [`Self::load`]). Only the timing of that fallback changed when the verdict moved past the
-    /// first frame — not the need for it.
-    ///
-    /// Clearing `audio` FIRST is what parks the audio feeders: it is half of [`Self::plane_ready`],
-    /// so neither the clock plane nor [`Self::play_audio`] can burst into a pipeline that is being
-    /// torn down — and it stays cleared across the re-load, which the callback latch does not.
-    fn begin_reload(&self) {
-        self.audio.store(false, Ordering::Relaxed);
-        self.feed_unblocked.store(false, Ordering::Relaxed);
-        let mut slot = self.reload();
-        let unloads_before = super::unload_count();
-        {
-            let _ffi = lock_ffi();
-            self.fns.unload();
-        }
-        *slot = Some(RetrySettle::after_unload(unloads_before));
-    }
-
-    /// Step a re-load in flight; `true` while this frame must still be held.
-    ///
-    /// `load_instant` is deliberately NOT restamped by any of this. It is the session's media
-    /// clock, which everything upstream has already anchored the host PTS onto, so moving it would
-    /// jump that clock backwards mid-stream. The new pipeline's own PTS domain starts at zero
-    /// under stamps that are already seconds in, which is inert here precisely because of what is
-    /// being given up: with no audio plane NDL presents at feed cadence and pays no attention to
-    /// the stamps.
-    fn advance_reload(&self) -> bool {
-        {
-            let mut slot = self.reload();
-            let Some(settle) = slot.as_mut() else { return false };
-            if !settle.ready() {
-                return true;
-            }
-            *slot = None;
-        }
-        // Whatever the panel was put in for the old pipeline has to be re-applied to the new one,
-        // and only once it is ingesting (see [`Self::pending_hdr`]). `issue_load` re-arms
-        // `presenting()`, so the replay lands on the reloaded pipeline's first frame. Locks in
-        // `replay_pending_hdr`'s order — pending, then applied — so the two cannot deadlock.
-        {
-            let mut pending = self.pending_hdr();
-            let mut applied = self.applied_hdr.lock().unwrap_or_else(PoisonError::into_inner);
-            // A pending value is NEWER than the applied one, so it wins; `applied` is cleared
-            // either way, the reload having reset the panel.
-            let last = applied.take();
-            if pending.is_none() {
-                *pending = last;
-            }
-        }
-        // The new load's own hold starts here, not at `load_instant` — which by now reads seconds,
-        // and would let the very next frame feed a pipeline that has not reported anything.
-        self.feed_hold_from_ms
-            .store((self.elapsed_ns() / 1_000_000) as i64, Ordering::Relaxed);
-        let _ffi = lock_ffi();
-        if let Err(e) = issue_load(self.fns, self.video, false) {
-            tracing::error!("NDL video-only re-load failed ({e:#}) — the session has no decoder left");
-        }
-        // Held one more frame either way: the load has only just been issued.
-        true
-    }
-
-    /// Guard on the re-load slot (see [`Self::reload`]).
-    fn reload(&self) -> MutexGuard<'_, Option<RetrySettle>> {
-        self.reload.lock().unwrap_or_else(PoisonError::into_inner)
+        self.audio && LOAD_COMPLETED.fired()
     }
 
     /// `Err` while this load hasn't reported `LOADCOMPLETED`: the sink then flushes, holds and
@@ -679,12 +585,7 @@ impl NdlVideo {
         if self.feed_unblocked.load(Ordering::Relaxed) {
             return Ok(());
         }
-        if self.advance_reload() {
-            return Err(NotReady.into());
-        }
-        let elapsed = self.load_instant.elapsed().saturating_sub(Duration::from_millis(
-            self.feed_hold_from_ms.load(Ordering::Relaxed) as u64,
-        ));
+        let elapsed = self.load_instant.elapsed();
         if LOAD_COMPLETED.fired() {
             tracing::info!("NDL LOADCOMPLETED landed {elapsed:?} after load");
         } else if elapsed >= FEED_ANYWAY_AFTER {
@@ -698,7 +599,6 @@ impl NdlVideo {
         Ok(())
     }
 
-    /// Guard on the deferred-HDR slot (see [`Self::pending_hdr`]).
     fn pending_hdr(&self) -> MutexGuard<'_, Option<ffi::HdrInfo>> {
         self.pending_hdr.lock().unwrap_or_else(PoisonError::into_inner)
     }
@@ -751,13 +651,31 @@ impl NdlVideo {
         // Outside the FFI guard — `replay_pending_hdr` takes it again, and it isn't reentrant.
         if first_frame {
             self.replay_pending_hdr();
-            let now_ms = (self.elapsed_ns() / 1_000_000) as i64;
-            self.verdict_deadline_ms
-                .store(now_ms + PLANE_VERDICT.as_millis() as i64, Ordering::Relaxed);
+            // Only an unconfirmed plane has anything left to answer for.
+            if self.audio && !LOAD_COMPLETED.fired() {
+                let now_ms = (self.elapsed_ns() / 1_000_000) as i64;
+                self.plane_check_ms
+                    .store(now_ms + PLANE_CONFIRM_GRACE.as_millis() as i64, Ordering::Relaxed);
+            }
         }
-        // Also outside it, and after the feed: the verdict is about what feeding produced, and the
-        // reload it may trigger takes the guard itself.
-        self.check_plane_verdict()
+        self.check_plane_confirmed();
+        Ok(())
+    }
+
+    /// Name a plane that never confirmed, once, past [`PLANE_CONFIRM_GRACE`]. Costs one relaxed
+    /// load per frame until it fires, then nothing for the rest of the session.
+    fn check_plane_confirmed(&self) {
+        let deadline = self.plane_check_ms.load(Ordering::Relaxed);
+        if deadline == i64::MAX || (self.elapsed_ns() / 1_000_000) as i64 <= deadline {
+            return;
+        }
+        self.plane_check_ms.store(i64::MAX, Ordering::Relaxed);
+        if self.plane_ready() {
+            return;
+        }
+        // Loud: nothing is recovered, so this line is the only trace. What it can and cannot mean
+        // is on [`PLANE_CONFIRM_GRACE`].
+        tracing::warn!("NDL: no LOADCOMPLETED {PLANE_CONFIRM_GRACE:?} after the first frame — the audio plane was likely refused, the picture will not be paced");
     }
 
     /// Apply HDR mastering metadata. `meta` and `color` use the same SEI-standard

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -16,23 +16,12 @@ use crate::core::media::{AudioFormat, AudioPlane, AudioSink, MediaClock, NotRead
 use super::{arm_load, ensure_init, ensure_not_poisoned, ffi, settle_before_retry, wait_load_completed, RetrySettle};
 use super::{lock_ffi, mark_frame_fed_logged, NdlCodec, AUDIO_PRIME_BUDGET, LOAD_COMPLETED, LOAD_COMPLETE_TIMEOUT};
 
-/// How long past the `NDL_DirectMediaLoad` CALL [`NdlVideo::ensure_loaded`] holds frames while
-/// `LOADCOMPLETED` is missing.
-///
-/// Measured from the load call, so it overlaps the load wait rather than stacking on it: a unit
-/// whose callback never comes would otherwise eat `LOAD_COMPLETE_TIMEOUT` + this before the first
-/// frame. Overlapped, the wait alone already spends the grace and the first feed goes straight
-/// through.
-///
-/// **A backstop, not a live path**, which is what the assert below pins: `load()` always spends a
-/// whole load budget first, so the first `ensure_loaded` feeds and [`NotReady`] is never
-/// constructed. Holding frames past it would be worse than useless on a set that reports
-/// `LOADCOMPLETED` only once a frame has been fed — there, the hold is the thing preventing the
-/// confirmation.
+/// Hold timeout measured from load call (overlaps wait, doesn't stack). A backstop, not live
+/// path: `load()` always spends whole budget first. On sets reporting LOADCOMPLETED after first
+/// frame, this hold would prevent it.
 const FEED_ANYWAY_AFTER: Duration = Duration::from_millis(300);
 
-// Asserted in `const`, not `debug_assert`'d at the branch: CI and the TV both run release, where a
-// debug assertion over three compile-time constants is never evaluated at all.
+// Const assert because debug assertions don't run on release (CI and TV use release builds).
 const _: () = assert!(
     FEED_ANYWAY_AFTER.as_millis() < LOAD_COMPLETE_TIMEOUT.as_millis()
         && FEED_ANYWAY_AFTER.as_millis() < AUDIO_PRIME_BUDGET.as_millis()
@@ -77,21 +66,8 @@ const PRIME_LEAD: i64 = 8;
 /// `plane_lead` in the video heartbeat, which is the only place the depth is observable.
 const PLANE_LEAD_MS: i64 = PRIME_LEAD * PRIME_PACKET_MS;
 
-/// Standing depth the SILENT METRONOME holds, i.e. the software route's cushion — deeper than
-/// [`PLANE_LEAD_MS`], which is the real stream's.
-///
-/// **A preserved measurement, not a derivation.** It is exactly the depth the 4K120 5.1 smoothness
-/// was confirmed on — the old metronome's stamps worked out to `2 * PLANE_LEAD_MS` ahead of the
-/// load call once the arithmetic is done in ONE domain, NOT `PLANE_LEAD_MS + load_duration`. Do
-/// that arithmetic before touching this; docs/NOTES.md § "NDL's audio plane" has it written out,
-/// along with the lagging-clock reading that made `plane_lead` report the wrong figure.
-///
-/// Kept at parity deliberately, in both directions. Under it is the known stutter risk. Over it is
-/// cheap — a silent plane costs nothing to hold, the real audio being on SDL, so unlike
-/// [`PLANE_LEAD_MS`] depth here is not a lip-sync trade — but it is still an unmeasured change to
-/// the one parameter high-refresh smoothness turns on, and this fix is not the place to make one.
-/// It IS the knob for a TV that still stutters at high refresh: walk it UP against `plane_lead` in
-/// the video heartbeat, which now reports the real depth.
+/// Standing depth the silent metronome holds (software route). Preserved measurement from 4K120
+/// 5.1, not derivable as `PLANE_LEAD_MS + load_duration` — see docs/NOTES.md § "NDL's audio plane".
 const METRONOME_LEAD_MS: i64 = 2 * PLANE_LEAD_MS;
 
 /// Gap between prime bursts. Polled through, not slept through — the callback lands mid-gap,
@@ -104,17 +80,8 @@ const PRIME_RETRY: Duration = Duration::from_millis(20);
 /// encodes silence into the same continuous 5 ms datagrams. Only a dead host capture gaps this wide.
 const REAL_FEED_GRACE_MS: i64 = 300;
 
-/// How long past the FIRST ACCEPTED FRAME an audio-enabled load has to report `LOADCOMPLETED`
-/// before its plane is declared refused and [`NdlVideo::begin_reload`] gives it up.
-///
-/// This is where the verdict has to be taken, not in the load wait: on a 2025 QNED the callback
-/// does not come until a frame has been fed (see [`AUDIO_PRIME_BUDGET`]), so a load judged before
-/// then is judged on a question the set cannot answer yet. Past the first frame both kinds of set
-/// can: the QNED answered 26 ms after it, and a CX has answered long before it.
-///
-/// Generous against that 26 ms, because the two outcomes are not symmetric. Early costs a working
-/// plane — the pacing reference the whole session depends on, and the bug this is. Late costs a
-/// few hundred ms of black on a set that really did refuse the config, which then reloads.
+/// Verdict timeout past first frame. QNED reports callback only when ingesting (not during
+/// load). Early=broken plane (the bug); late=black then video-only reload.
 const PLANE_VERDICT: Duration = Duration::from_millis(750);
 
 /// The audio plane every V2 load asks for: Opus, stereo, 48 kHz.
@@ -680,8 +647,11 @@ impl NdlVideo {
         {
             let mut pending = self.pending_hdr();
             let mut applied = self.applied_hdr.lock().unwrap_or_else(PoisonError::into_inner);
-            if let Some(info) = applied.take() {
-                *pending = Some(info);
+            // A pending value is NEWER than the applied one, so it wins; `applied` is cleared
+            // either way, the reload having reset the panel.
+            let last = applied.take();
+            if pending.is_none() {
+                *pending = last;
             }
         }
         // The new load's own hold starts here, not at `load_instant` — which by now reads seconds,

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -14,21 +14,29 @@ use anyhow::{bail, Result};
 use crate::core::media::{AudioFormat, AudioPlane, AudioSink, MediaClock, NotReady, Samples, VideoSink, VideoSinkCaps};
 
 use super::{arm_load, ensure_init, ensure_not_poisoned, ffi, settle_before_retry, wait_load_completed};
-use super::{lock_ffi, mark_frame_fed_logged, NdlCodec, LOAD_COMPLETED};
+use super::{lock_ffi, mark_frame_fed_logged, NdlCodec, AUDIO_LOAD_TIMEOUT, LOAD_COMPLETED, LOAD_COMPLETE_TIMEOUT};
 
 /// How long past the `NDL_DirectMediaLoad` CALL [`NdlVideo::ensure_loaded`] holds frames while
 /// `LOADCOMPLETED` is missing.
 ///
-/// Measured from `load_requested`, not `load_instant`: the latter is stamped after
-/// `wait_load_completed`, so timing the grace from it stacks the two windows and a unit whose
-/// callback never comes eats `LOAD_COMPLETE_TIMEOUT` + this before the first frame — three seconds
-/// of black on a CX, for a callback that provably was not going to arrive. Overlapping them means
-/// the wait alone already spends the grace, so the first feed goes straight through.
+/// Measured from the load call, so it overlaps the load wait rather than stacking on it: a unit
+/// whose callback never comes would otherwise eat `LOAD_COMPLETE_TIMEOUT` + this before the first
+/// frame. Overlapped, the wait alone already spends the grace and the first feed goes straight
+/// through.
 ///
-/// **A backstop, not a live path.** `load()` already waits `LOAD_COMPLETE_TIMEOUT` (longer than
-/// this), so the first `ensure_loaded` always feeds and [`NotReady`] is never constructed.
-/// Kept because it is what would make an early return from that wait safe.
+/// **A backstop, not a live path.** `load()` already spends a whole load budget
+/// ([`AUDIO_LOAD_TIMEOUT`] or [`LOAD_COMPLETE_TIMEOUT`], both longer than this), so the first
+/// `ensure_loaded` always feeds and [`NotReady`] is never constructed. Kept because it is what
+/// would make an early return from that wait safe.
 const FEED_ANYWAY_AFTER: Duration = Duration::from_millis(1_000);
+
+// The grace above is a backstop only while it stays under whichever load budget was spent first.
+// Asserted in `const`, not `debug_assert`'d at the branch: CI and the TV both run release, where a
+// debug assertion over three compile-time constants is never evaluated at all.
+const _: () = assert!(
+    FEED_ANYWAY_AFTER.as_millis() < LOAD_COMPLETE_TIMEOUT.as_millis()
+        && FEED_ANYWAY_AFTER.as_millis() < AUDIO_LOAD_TIMEOUT.as_millis()
+);
 
 /// One empty Opus frame — `mariotaku/ss4s`'s `opus_empty_frame_211`. Its TOC declares STEREO,
 /// matching the load; the generic `0xF8 0xFF 0xFE` declares mono. (A CX took both.)
@@ -43,8 +51,8 @@ const PRIME_PACKET_MS: i64 = 5;
 const PRIME_LEAD: i64 = 8;
 
 /// Lead the REAL stream's stamps carry over the player clock, i.e. the audio queue depth NDL is
-/// left holding — [`PRIME_LEAD`] packets, the same depth the metronome maintains while it is the
-/// only feed.
+/// left holding — [`PRIME_LEAD`] packets, and what the prime's ceiling already sits at. The sole
+/// feed on the software route holds [`METRONOME_LEAD_MS`] instead, which is deeper.
 ///
 /// **This is not a sync tweak, it is what keeps the picture paced.** NDL regulates the video plane
 /// against its audio renderer, and the renderer's clock only advances smoothly while it has data
@@ -54,8 +62,9 @@ const PRIME_LEAD: i64 = 8;
 /// introduced to fix, back again the moment real audio displaced the metronome. Adding a constant
 /// here restores the depth without interleaving silence into the real stream.
 ///
-/// The clock plane targets the same figure, which is what lets the two feeders share
-/// [`NdlVideo::last_audio_pts_ms`] without either driving it.
+/// The clock plane targets the same figure WHEN IT SHARES THE PLANE with the real stream (the
+/// offload route's fill), which is what lets the two feeders share [`NdlVideo::last_audio_pts_ms`]
+/// without either driving it. As the sole feed it holds [`METRONOME_LEAD_MS`] instead.
 ///
 /// **The SDL path does the same thing, in its own currency** — `platform::webos::audio` primes and
 /// holds a 25 ms ring ahead of the speaker for exactly this reason: a renderer needs data queued
@@ -67,6 +76,26 @@ const PRIME_LEAD: i64 = 8;
 /// picture ~36 ms earlier, so it roughly cancels — walk the value down on device against
 /// `plane_lead` in the video heartbeat, which is the only place the depth is observable.
 const PLANE_LEAD_MS: i64 = PRIME_LEAD * PRIME_PACKET_MS;
+
+/// Standing depth the SILENT METRONOME holds, i.e. the software route's cushion — deeper than
+/// [`PLANE_LEAD_MS`], which is the real stream's.
+///
+/// **A preserved measurement, not a derivation.** The metronome used to re-add the prime's ceiling
+/// as a base, so its stamp was `ceiling + now_old + PLANE_LEAD_MS`. Work that out in ONE domain
+/// and the load duration D cancels: the ceiling was `D + PLANE_LEAD_MS` and the old clock itself
+/// started D late, so the stamps sat `2 * PLANE_LEAD_MS` ahead of the load call on every unit —
+/// NOT `PLANE_LEAD_MS + D`. (Reading it as `+ D` is what the old `plane_lead` reported, because
+/// that figure was taken against the same lagging clock.) So this is exactly the depth the 4K120
+/// 5.1 smoothness was confirmed on, now explicit and identical on every unit and mode instead of
+/// falling out of how long a TV took to load.
+///
+/// Kept at parity deliberately, in both directions. Under it is the known stutter risk. Over it is
+/// cheap — a silent plane costs nothing to hold, the real audio being on SDL, so unlike
+/// [`PLANE_LEAD_MS`] depth here is not a lip-sync trade — but it is still an unmeasured change to
+/// the one parameter high-refresh smoothness turns on, and this fix is not the place to make one.
+/// It IS the knob for a TV that still stutters at high refresh: walk it UP against `plane_lead` in
+/// the video heartbeat, which now reports the real depth.
+const METRONOME_LEAD_MS: i64 = 2 * PLANE_LEAD_MS;
 
 /// Gap between prime bursts. Polled through, not slept through — the callback lands mid-gap,
 /// and this is launch-path time, i.e. black screen.
@@ -102,11 +131,17 @@ fn plane_config() -> ffi::AudioUnion {
 pub struct NdlVideo {
     fns: &'static ffi::V2,
     /// PTS in ms since load (NDL's local clock, not wall-clock or host capture clock).
+    ///
+    /// ⚠ **Stamped at the `NDL_DirectMediaLoad` CALL, not after the load wait**, so it shares its
+    /// zero with [`Self::prime_audio`]'s stamps — which count from the same call, because that is
+    /// where NDL's own PTS domain starts. Stamping it after the wait instead put the prime a whole
+    /// load duration ahead of the player clock, and every consumer then had to correct for that
+    /// gap: the metronome carried the prime's ceiling as a permanent base, the offload route
+    /// floored its first load-duration of real packets onto a single stamp, and `plane_lead`
+    /// reported the gap instead of the depth. One origin removes all three. It also means the
+    /// player clock is already at the load duration when the session starts, which is what
+    /// `last_real_feed_ms` is seeded against.
     load_instant: Instant,
-    /// When `NDL_DirectMediaLoad` was issued — earlier than `load_instant` by however long
-    /// `wait_load_completed` blocked. Only [`FEED_ANYWAY_AFTER`] is measured from it; the PTS
-    /// domain stays on `load_instant`.
-    load_requested: Instant,
     /// Whether this load got an audio plane. False on a video-only load, i.e. one whose
     /// audio-enabled attempt was rejected — and with it goes the picture's pacing reference.
     audio: bool,
@@ -114,17 +149,19 @@ pub struct NdlVideo {
     /// neither can hand NDL a timestamp going backwards — NDL reads a rewind as a seek and mutes
     /// the rest of the session.
     ///
-    /// It is a floor, never a driver: both feeders target the player clock plus
-    /// [`PLANE_LEAD_MS`], so the ceiling can only ever be at most one lead ahead of real time and
-    /// cannot ratchet away from it.
+    /// It is a floor, never a driver: every feeder targets the player clock plus its route's lead
+    /// ([`PLANE_LEAD_MS`], or [`METRONOME_LEAD_MS`] where the metronome is the only feed), so the
+    /// ceiling can only ever be that one lead ahead of real time and cannot ratchet away from it.
     last_audio_pts_ms: AtomicI64,
     /// Player-clock ms at the last REAL packet fed by [`Self::play_audio`].
     /// [`Self::run_clock_plane`] reads it to stay off the plane while the real stream carries it.
     ///
-    /// Starts at 0 (the load instant), NOT a sentinel: the grace then runs from session start, so
-    /// an offloaded session whose audio arrives normally never feeds a single silent packet. The
-    /// sentinel made every such session open by bursting silence to a ceiling a whole prime ahead
-    /// of the real timeline, and the real packets that followed were all floored onto it.
+    /// Seeded with the player clock at construction, NOT 0 and NOT a sentinel: `load_instant` is
+    /// the load CALL, so the clock already reads the load's duration by the time the session
+    /// starts, and a 0 here would read as that many ms since the last real packet — tripping
+    /// [`REAL_FEED_GRACE_MS`] before the first one arrives and opening every offloaded session
+    /// with a spurious "host capture is likely dead". Seeded, the grace runs from session start,
+    /// so an offloaded session whose audio arrives normally never feeds a silent packet.
     last_real_feed_ms: AtomicI64,
     /// `false` while `LOADCOMPLETED` still hasn't been seen for this load. Latched once, so the
     /// steady-state feed path costs one relaxed load.
@@ -176,11 +213,16 @@ impl NdlVideo {
             // at the end of the match: a snapshot taken after it would miss that
             // `UNLOADCOMPLETED` and wait out the settle for a callback already spent.
             let unloads_before = super::unload_count();
-            match Self::try_load(fns, video, true) {
+            let why = match Self::try_load(fns, video, true) {
                 Ok(loaded) if loaded.load_confirmed.load(Ordering::Relaxed) => return Ok(loaded),
-                Ok(_) => tracing::warn!("NDL audio-enabled load failed (no LOADCOMPLETED) — retrying video-only"),
-                Err(e) => tracing::warn!("NDL audio-enabled load failed ({e:#}) — retrying video-only"),
-            }
+                Ok(_) => "no LOADCOMPLETED".to_string(),
+                Err(e) => format!("{e:#}"),
+            };
+            // Loud, because a video-only load streams unpaced for the rest of the session
+            // (issue #188) and every later symptom reads as something else.
+            tracing::warn!(
+                "NDL audio-enabled load failed ({why}) — retrying video-only, the picture will not be paced"
+            );
             // Best-effort cleanup of the rejected load.
             fns.unload();
             // The rejected load's callbacks are indistinguishable from the retry's, so let them
@@ -198,23 +240,24 @@ impl NdlVideo {
             audio: if audio { plane_config() } else { ffi::AudioUnion::SILENT },
         };
         arm_load();
-        let load_requested = Instant::now();
+        let load_instant = Instant::now();
         fns.load(&mut info, Some(super::on_load_state))?;
         // `ret == 0` is "request accepted", not "pipeline ready" — the first feed still needs
         // LOADCOMPLETED, and an audio-enabled load will not report it until its audio plane has
         // seen a packet, which is what the prime supplies.
+        // Budget and waiter are picked at the same branch: what a load can afford to wait is a
+        // property of the load, and the two differ by 3x.
         let (primed_pts_ms, confirmed) = if audio {
-            Self::prime_audio(fns)
+            Self::prime_audio(fns, load_instant, AUDIO_LOAD_TIMEOUT)
         } else {
-            (0, wait_load_completed())
+            (0, wait_load_completed(LOAD_COMPLETE_TIMEOUT))
         };
         Ok(Self {
             fns,
-            load_instant: Instant::now(),
-            load_requested,
+            load_instant,
             audio,
             last_audio_pts_ms: AtomicI64::new(primed_pts_ms),
-            last_real_feed_ms: AtomicI64::new(0),
+            last_real_feed_ms: AtomicI64::new(load_instant.elapsed().as_millis() as i64),
             load_confirmed: AtomicBool::new(confirmed),
             pending_hdr: Mutex::new(None),
             applied_hdr: Mutex::new(None),
@@ -222,7 +265,13 @@ impl NdlVideo {
     }
 
     /// Feed silent Opus packets until the audio-enabled load reports `LOADCOMPLETED`, bounded by
-    /// `LOAD_COMPLETE_TIMEOUT`. Returns the highest stamp fed and whether the load confirmed.
+    /// `budget` — longer than the video-only wait, because the fallback this wait gives up to is
+    /// an unpaced session rather than a few held frames. Returns the highest stamp fed and whether
+    /// the load confirmed.
+    ///
+    /// `load_instant` is the caller's, not re-derived here: these stamps ARE the player clock's
+    /// domain, and handing the origin down is what makes that a value rather than a coincidence of
+    /// two adjacent `Instant::now()` calls (see the field).
     ///
     /// An audio-enabled load will not report until its audio plane has received data, but the
     /// pumps that would supply it don't spawn until `session::connect` returns — i.e. until this
@@ -232,27 +281,30 @@ impl NdlVideo {
     /// A burst at a time, because a packet fed before the plane exists may be dropped silently
     /// (`NDL_DirectAudioPlay` reports success either way).
     ///
-    /// The highest stamp is handed to `last_audio_pts_ms`: the prime runs BEFORE `load_instant`,
-    /// so its stamps already sit a lead ahead of where the player clock starts, and without that
-    /// floor the first real packet would read as a rewind — which mutes the session permanently
-    /// (see [`Self::play_audio`]). It costs a few early packets their exact stamp, bounded by
-    /// [`PRIME_LEAD`], and the player clock overtakes it within one lead.
-    fn prime_audio(fns: &'static ffi::V2) -> (i64, bool) {
+    /// The highest stamp is handed to `last_audio_pts_ms` as the floor, without which the first
+    /// real packet would read as a rewind — which mutes the session permanently (see
+    /// [`Self::play_audio`]). Because `load_instant` is the load call, these stamps are already in
+    /// the player-clock domain: the ceiling sits exactly [`PRIME_LEAD`] packets above the clock,
+    /// the same lead every later feeder targets, so the clock overtakes it within one lead however
+    /// long the load took.
+    fn prime_audio(fns: &'static ffi::V2, load_instant: Instant, budget: Duration) -> (i64, bool) {
         let silence = &OPUS_SILENCE[..];
-        let start = Instant::now();
         let mut pts_ms = 0;
         while !LOAD_COMPLETED.fired() {
-            if start.elapsed() >= super::LOAD_COMPLETE_TIMEOUT {
-                tracing::warn!(
-                    "NDL load: no LOADCOMPLETED within {:?} of priming {pts_ms}ms of silence",
-                    super::LOAD_COMPLETE_TIMEOUT
-                );
+            // A reported fatal state is the one answer that will not change by waiting, so the
+            // long budget above is spent only while the load is still plausibly coming.
+            if super::fatal() {
+                tracing::warn!("NDL load reported a fatal state after {pts_ms}ms of silence");
+                return (pts_ms, false);
+            }
+            if load_instant.elapsed() >= budget {
+                tracing::warn!("NDL load: no LOADCOMPLETED within {budget:?} of priming {pts_ms}ms of silence");
                 return (pts_ms, false);
             }
             // Stamps track wall-clock, topped up to PRIME_LEAD packets ahead of it — so the burst
             // per gap is however many 5 ms packets that gap consumed, and the ceiling stays a
             // fixed lead over real time. That ceiling is the floor real audio is pinned to.
-            let target_ms = start.elapsed().as_millis() as i64 + PRIME_LEAD * PRIME_PACKET_MS;
+            let target_ms = load_instant.elapsed().as_millis() as i64 + PRIME_LEAD * PRIME_PACKET_MS;
             {
                 let _ffi = lock_ffi();
                 while pts_ms < target_ms {
@@ -267,7 +319,7 @@ impl NdlVideo {
         }
         tracing::info!(
             "NDL audio prime: LOADCOMPLETED after {:?} ({pts_ms}ms of silence)",
-            start.elapsed()
+            load_instant.elapsed()
         );
         (pts_ms, true)
     }
@@ -296,9 +348,9 @@ impl NdlVideo {
     /// below is left with nothing to do but absorb reordering.
     ///
     /// Every stamp carries [`PLANE_LEAD_MS`] on top of it, so NDL always holds that much audio
-    /// ahead of its renderer — read that constant before touching this arithmetic. The clock plane
-    /// targets the same figure, which is what lets the two feeders share the ceiling without
-    /// either pushing it.
+    /// ahead of its renderer — read that constant before touching this arithmetic. The clock
+    /// plane's FILL targets the same figure, which is what lets the two feeders share the ceiling
+    /// without either pushing it; the metronome, which never shares a plane with this, does not.
     ///
     /// **Both planes are still in one time base** — NDL synchronises them against each other, and
     /// the video plane's own stamps are the player clock too (`session::timeline::Pacing` maps the
@@ -365,25 +417,15 @@ impl NdlVideo {
     /// this fills in only after [`REAL_FEED_GRACE_MS`] without a packet — a dead host capture,
     /// which would otherwise starve the plane and freeze the picture.
     pub fn run_clock_plane(&self, stop: &std::sync::atomic::AtomicBool, yields_to_real: bool) {
-        // Continue the prime's stamps instead of restarting from the player clock: the prime runs
-        // BEFORE `load_instant`, so its ceiling already sits a whole prime ahead, and targeting the
-        // raw clock would feed nothing until it caught up — dead exactly at session start. The
-        // resulting constant offset from the video timeline costs a metronome nothing.
-        // On the offload route the real stream owns the ceiling, so a fill targets exactly what
-        // [`Self::play_audio`] targets and carries no base of its own: `burst_silence` floors on
-        // the ceiling the stream left, and adding the prime's base on top of that raised it by one
-        // `PLANE_LEAD_MS` per fill episode — recovered audio then floored onto the jump and pinned
-        // to a single stamp for the length of it, the ratchet this path exists to avoid.
-        //
-        // The metronome route is the only feed, so it continues the prime's stamps instead of
-        // restarting from the player clock: the prime runs BEFORE `load_instant`, so its ceiling
-        // already sits a whole prime ahead and targeting the raw clock would feed nothing until the
-        // clock caught up — dead exactly at session start. The constant offset costs a metronome
-        // nothing.
-        let base_ms = if yields_to_real {
-            0
+        // A fill on the offload route must target exactly what [`Self::play_audio`] targets, or
+        // the real packets that resume are floored onto the fill's higher ceiling and pinned to
+        // one stamp for the length of it. The metronome is the only feed on its route and answers
+        // to nothing else, so it holds the deeper [`METRONOME_LEAD_MS`] cushion. Neither carries a
+        // base of its own — see the `load_instant` field for why one is no longer needed.
+        let lead_ms = if yields_to_real {
+            PLANE_LEAD_MS
         } else {
-            self.last_audio_pts_ms.load(Ordering::Relaxed)
+            METRONOME_LEAD_MS
         };
         let mut pts_ms = self.last_audio_pts_ms.load(Ordering::Relaxed);
         let mut filling = false;
@@ -404,7 +446,7 @@ impl NdlVideo {
                 );
                 filling = true;
             }
-            match self.burst_silence(pts_ms, base_ms + now_ms + PLANE_LEAD_MS) {
+            match self.burst_silence(pts_ms, now_ms + lead_ms) {
                 Ok(fed_to) => pts_ms = fed_to,
                 Err(e) => {
                     // Dead for the session; the picture keeps running unpaced, as it did before
@@ -419,9 +461,14 @@ impl NdlVideo {
     }
 
     /// How far the audio plane's stamps currently run ahead of the player clock, in ms — the queue
-    /// depth NDL paces the picture on ([`PLANE_LEAD_MS`]), and the only observable proxy for it.
-    /// Reads the ceiling, so it reports whichever feed last raised it. Sagging towards zero under
-    /// real audio is the stutter signature.
+    /// depth NDL paces the picture on, and the only observable proxy for it. Reads the ceiling, so
+    /// it reports whichever feed last raised it. Sagging towards zero under real audio is the
+    /// stutter signature.
+    ///
+    /// ⚠ **Which target it should read depends on the route**: [`METRONOME_LEAD_MS`] (80) on the
+    /// software route, where the silent metronome is the only feed, and [`PLANE_LEAD_MS`] (40) on
+    /// offload, where the real stream owns the plane. A software session reading 40 is as wrong as
+    /// an offloaded one reading 80.
     pub fn audio_plane_lead_ms(&self) -> i64 {
         self.last_audio_pts_ms.load(Ordering::Relaxed) - (self.elapsed_ns() / 1_000_000) as i64
     }
@@ -440,12 +487,12 @@ impl NdlVideo {
         if self.load_confirmed.load(Ordering::Relaxed) {
             return Ok(());
         }
-        let elapsed = self.load_requested.elapsed();
+        let elapsed = self.load_instant.elapsed();
         if LOAD_COMPLETED.fired() {
             tracing::info!("NDL LOADCOMPLETED landed {elapsed:?} after load");
         } else if elapsed >= FEED_ANYWAY_AFTER {
-            // Real elapsed, not the constant — `load()` has already spent
-            // `LOAD_COMPLETE_TIMEOUT` by the time a frame gets here.
+            // Real elapsed, not the constant — `load()` has already spent a whole load budget by
+            // the time a frame gets here.
             tracing::warn!("NDL: still no LOADCOMPLETED {elapsed:?} after the load — feeding anyway");
         } else {
             return Err(NotReady.into());

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -13,8 +13,8 @@ use anyhow::{bail, Result};
 
 use crate::core::media::{AudioFormat, AudioPlane, AudioSink, MediaClock, NotReady, Samples, VideoSink, VideoSinkCaps};
 
-use super::{arm_load, ensure_init, ensure_not_poisoned, ffi, settle_before_retry, wait_load_completed};
-use super::{lock_ffi, mark_frame_fed_logged, NdlCodec, AUDIO_LOAD_TIMEOUT, LOAD_COMPLETED, LOAD_COMPLETE_TIMEOUT};
+use super::{arm_load, ensure_init, ensure_not_poisoned, ffi, settle_before_retry, wait_load_completed, RetrySettle};
+use super::{lock_ffi, mark_frame_fed_logged, NdlCodec, AUDIO_PRIME_BUDGET, LOAD_COMPLETED, LOAD_COMPLETE_TIMEOUT};
 
 /// How long past the `NDL_DirectMediaLoad` CALL [`NdlVideo::ensure_loaded`] holds frames while
 /// `LOADCOMPLETED` is missing.
@@ -24,18 +24,18 @@ use super::{lock_ffi, mark_frame_fed_logged, NdlCodec, AUDIO_LOAD_TIMEOUT, LOAD_
 /// frame. Overlapped, the wait alone already spends the grace and the first feed goes straight
 /// through.
 ///
-/// **A backstop, not a live path.** `load()` already spends a whole load budget
-/// ([`AUDIO_LOAD_TIMEOUT`] or [`LOAD_COMPLETE_TIMEOUT`], both longer than this), so the first
-/// `ensure_loaded` always feeds and [`NotReady`] is never constructed. Kept because it is what
-/// would make an early return from that wait safe.
-const FEED_ANYWAY_AFTER: Duration = Duration::from_millis(1_000);
+/// **A backstop, not a live path**, which is what the assert below pins: `load()` always spends a
+/// whole load budget first, so the first `ensure_loaded` feeds and [`NotReady`] is never
+/// constructed. Holding frames past it would be worse than useless on a set that reports
+/// `LOADCOMPLETED` only once a frame has been fed — there, the hold is the thing preventing the
+/// confirmation.
+const FEED_ANYWAY_AFTER: Duration = Duration::from_millis(300);
 
-// The grace above is a backstop only while it stays under whichever load budget was spent first.
 // Asserted in `const`, not `debug_assert`'d at the branch: CI and the TV both run release, where a
 // debug assertion over three compile-time constants is never evaluated at all.
 const _: () = assert!(
     FEED_ANYWAY_AFTER.as_millis() < LOAD_COMPLETE_TIMEOUT.as_millis()
-        && FEED_ANYWAY_AFTER.as_millis() < AUDIO_LOAD_TIMEOUT.as_millis()
+        && FEED_ANYWAY_AFTER.as_millis() < AUDIO_PRIME_BUDGET.as_millis()
 );
 
 /// One empty Opus frame — `mariotaku/ss4s`'s `opus_empty_frame_211`. Its TOC declares STEREO,
@@ -80,14 +80,11 @@ const PLANE_LEAD_MS: i64 = PRIME_LEAD * PRIME_PACKET_MS;
 /// Standing depth the SILENT METRONOME holds, i.e. the software route's cushion — deeper than
 /// [`PLANE_LEAD_MS`], which is the real stream's.
 ///
-/// **A preserved measurement, not a derivation.** The metronome used to re-add the prime's ceiling
-/// as a base, so its stamp was `ceiling + now_old + PLANE_LEAD_MS`. Work that out in ONE domain
-/// and the load duration D cancels: the ceiling was `D + PLANE_LEAD_MS` and the old clock itself
-/// started D late, so the stamps sat `2 * PLANE_LEAD_MS` ahead of the load call on every unit —
-/// NOT `PLANE_LEAD_MS + D`. (Reading it as `+ D` is what the old `plane_lead` reported, because
-/// that figure was taken against the same lagging clock.) So this is exactly the depth the 4K120
-/// 5.1 smoothness was confirmed on, now explicit and identical on every unit and mode instead of
-/// falling out of how long a TV took to load.
+/// **A preserved measurement, not a derivation.** It is exactly the depth the 4K120 5.1 smoothness
+/// was confirmed on — the old metronome's stamps worked out to `2 * PLANE_LEAD_MS` ahead of the
+/// load call once the arithmetic is done in ONE domain, NOT `PLANE_LEAD_MS + load_duration`. Do
+/// that arithmetic before touching this; docs/NOTES.md § "NDL's audio plane" has it written out,
+/// along with the lagging-clock reading that made `plane_lead` report the wrong figure.
 ///
 /// Kept at parity deliberately, in both directions. Under it is the known stutter risk. Over it is
 /// cheap — a silent plane costs nothing to hold, the real audio being on SDL, so unlike
@@ -106,6 +103,19 @@ const PRIME_RETRY: Duration = Duration::from_millis(20);
 /// The test is "no packets at all", never amplitude: a silent game still streams, since the host
 /// encodes silence into the same continuous 5 ms datagrams. Only a dead host capture gaps this wide.
 const REAL_FEED_GRACE_MS: i64 = 300;
+
+/// How long past the FIRST ACCEPTED FRAME an audio-enabled load has to report `LOADCOMPLETED`
+/// before its plane is declared refused and [`NdlVideo::begin_reload`] gives it up.
+///
+/// This is where the verdict has to be taken, not in the load wait: on a 2025 QNED the callback
+/// does not come until a frame has been fed (see [`AUDIO_PRIME_BUDGET`]), so a load judged before
+/// then is judged on a question the set cannot answer yet. Past the first frame both kinds of set
+/// can: the QNED answered 26 ms after it, and a CX has answered long before it.
+///
+/// Generous against that 26 ms, because the two outcomes are not symmetric. Early costs a working
+/// plane — the pacing reference the whole session depends on, and the bug this is. Late costs a
+/// few hundred ms of black on a set that really did refuse the config, which then reloads.
+const PLANE_VERDICT: Duration = Duration::from_millis(750);
 
 /// The audio plane every V2 load asks for: Opus, stereo, 48 kHz.
 ///
@@ -127,6 +137,23 @@ fn plane_config() -> ffi::AudioUnion {
     .to_union()
 }
 
+/// Arm the load counters and issue one `NDL_DirectMediaLoad`, returning the instant it was called
+/// — which is the origin of NDL's PTS domain (see [`NdlVideo::load_instant`]).
+///
+/// The only place that knows how a V2 load is issued: [`NdlVideo::try_load`] builds a handle
+/// around it, [`NdlVideo::advance_reload`] re-issues one under a handle that already exists,
+/// and neither should own a second copy of the `DataInfo`/callback/arming order.
+fn issue_load(fns: &'static ffi::V2, video: ffi::VideoInfo, audio: bool) -> Result<Instant> {
+    let mut info = ffi::DataInfo {
+        video,
+        audio: if audio { plane_config() } else { ffi::AudioUnion::SILENT },
+    };
+    arm_load();
+    let load_instant = Instant::now();
+    fns.load(&mut info, Some(super::on_load_state))?;
+    Ok(load_instant)
+}
+
 /// One loaded NDL v2 video decode session. Dropping unloads it (not `NDL_DirectMediaQuit`).
 pub struct NdlVideo {
     fns: &'static ffi::V2,
@@ -142,9 +169,15 @@ pub struct NdlVideo {
     /// player clock is already at the load duration when the session starts, which is what
     /// `last_real_feed_ms` is seeded against.
     load_instant: Instant,
-    /// Whether this load got an audio plane. False on a video-only load, i.e. one whose
-    /// audio-enabled attempt was rejected — and with it goes the picture's pacing reference.
-    audio: bool,
+    /// What the load asked the video plane for, kept so [`Self::begin_reload`] can re-issue
+    /// the same load without its audio arm.
+    video: ffi::VideoInfo,
+    /// Whether this load has an audio plane. Cleared by [`Self::begin_reload`] when the plane
+    /// turns out to be refused — and with it goes the picture's pacing reference.
+    ///
+    /// Atomic because the verdict is taken mid-session, on the video thread, while the audio
+    /// feeders read it.
+    audio: AtomicBool,
     /// Highest audio stamp fed so far (ms), shared by [`Self::play_audio`] and the clock plane so
     /// neither can hand NDL a timestamp going backwards — NDL reads a rewind as a seek and mutes
     /// the rest of the session.
@@ -163,12 +196,43 @@ pub struct NdlVideo {
     /// with a spurious "host capture is likely dead". Seeded, the grace runs from session start,
     /// so an offloaded session whose audio arrives normally never feeds a silent packet.
     last_real_feed_ms: AtomicI64,
-    /// `false` while `LOADCOMPLETED` still hasn't been seen for this load. Latched once, so the
-    /// steady-state feed path costs one relaxed load.
+    /// The VIDEO feed's gate: `false` while frames are still being held for the load. Latched
+    /// once, so the steady-state feed path costs one relaxed load.
     ///
-    /// It is also what [`Self::flush`] refuses on, which is the guard that matters most: flushing
-    /// a pipeline NDL has not finished loading kills the session's audio permanently.
-    load_confirmed: AtomicBool,
+    /// Not a synonym for "NDL confirmed the load" — [`Self::ensure_loaded`] also latches it when
+    /// the frames have to flow regardless, which on a set that reports `LOADCOMPLETED` only
+    /// against ingest is the very thing that produces the confirmation. Anything asking about the
+    /// PIPELINE, rather than about this gate, wants [`Self::plane_ready`] instead: feeding the
+    /// audio plane early costs the session its audio permanently.
+    feed_unblocked: AtomicBool,
+    /// Player-clock ms the video feed's hold is measured FROM — 0 for the original load, restamped
+    /// by [`Self::begin_reload`]. `load_instant` cannot serve: it stays anchored to the first
+    /// load (it is the session's media clock), so after a reload it already reads well past
+    /// [`FEED_ANYWAY_AFTER`] and the reissued load would get no hold at all.
+    feed_hold_from_ms: AtomicI64,
+    /// Player-clock ms at which an unconfirmed load's plane is declared refused, stamped on the
+    /// first accepted frame — see [`PLANE_VERDICT`]. Meaningless until then, and read only while
+    /// [`Self::verdict_settled`] is false.
+    verdict_deadline_ms: AtomicI64,
+    /// Latches once the plane question has an answer, either way, so the per-frame path costs one
+    /// relaxed load for the rest of the session.
+    verdict_settled: AtomicBool,
+    /// The re-load a refused plane triggers, `Some` while one is in flight.
+    ///
+    /// **The teardown a refused plane needs is an unload, a settle and a load — none of which may
+    /// happen inline on the feed thread.** Blocking it for the settle (400-800 ms) stops the pump
+    /// pulling frames, and a receive queue that fills is the `receive backlog stopped draining`
+    /// flush the load-time wait used to cause, moved mid-session. A thread of its own would be
+    /// worse: a second thread inside NDL is the one thing this module refuses (`LEAKED_THREADS`).
+    /// So the sequence is stepped by the video feed itself — each frame advances it, is answered
+    /// with [`NotReady`], and goes back to draining the queue. A `Mutex` rather than atomics
+    /// because nothing reads it off the hot path: [`Self::ensure_loaded`] returns before it.
+    reload: Mutex<Option<RetrySettle>>,
+    /// Whether the load itself confirmed the plane, which is what makes it safe to put the
+    /// session's only audio on — see [`AudioPlane::accepts_stream`]. A plane still awaiting its
+    /// verdict is worth keeping fed (that is the pacing) but must not be the audio path: if it is
+    /// refused, [`Self::begin_reload`] takes it away and the route has already been picked.
+    plane_proven: bool,
     /// HDR mastering metadata that arrived before the video plane had taken a frame.
     /// `NDL_DirectVideoSetHDRInfo` returns success against a pipeline that isn't ingesting yet
     /// but does nothing — the panel never enters HDR mode, and since the host only sends the
@@ -202,28 +266,30 @@ impl NdlVideo {
             unknown1: 0,
         };
         if audio {
-            // An audio-enabled load must PROVE itself with `LOADCOMPLETED`; a video-only one may
-            // proceed unconfirmed (below). `NDL_DirectMediaLoad` returning 0 is only "request
-            // accepted" — an Opus config the pipeline rejects fails asynchronously, then accepts
-            // every fed frame into a pipeline that is not running, which is a whole session of
-            // black picture with no error anywhere. Falling back needs an unload first (a failed
-            // load may hold decoder resources, docs/NOTES.md); it covers the `Err` arm, where no
-            // handle exists to unload on drop, and is harmless as a repeat.
-            // Snapshotted BEFORE the attempt, because the unconfirmed handle's own `Drop` unloads
-            // at the end of the match: a snapshot taken after it would miss that
-            // `UNLOADCOMPLETED` and wait out the settle for a callback already spent.
+            // The plane is asked for here, but NOT judged here. `NDL_DirectMediaLoad` returning 0
+            // is only "request accepted" — an Opus config the pipeline rejects fails
+            // asynchronously and then accepts every fed frame into a pipeline that is not running,
+            // which is a whole session of black picture with no error anywhere. That is a real
+            // failure and it still has to be caught, but `LOADCOMPLETED` before the first frame is
+            // not the test for it: a 2025 QNED does not report the callback until a frame has been
+            // fed, and nothing can feed one until this returns and the pumps spawn. Judging here
+            // gave that set a video-only fallback on every session, i.e. no pacing reference at
+            // all, which is issue #188. So an accepted load is taken unconfirmed and the verdict
+            // moves past the first frame — see [`PLANE_VERDICT`] and [`Self::begin_reload`].
+            //
+            // A hard `Err` is still answered here: there is no handle to defer with. The unload
+            // first is what a failed load needs before a retry (a failed load may hold decoder
+            // resources, docs/NOTES.md), and the snapshot precedes the attempt so a settle cannot
+            // wait out an `UNLOADCOMPLETED` already spent.
             let unloads_before = super::unload_count();
-            let why = match Self::try_load(fns, video, true) {
-                Ok(loaded) if loaded.load_confirmed.load(Ordering::Relaxed) => return Ok(loaded),
-                Ok(_) => "no LOADCOMPLETED".to_string(),
-                Err(e) => format!("{e:#}"),
-            };
-            // Loud, because a video-only load streams unpaced for the rest of the session
-            // (issue #188) and every later symptom reads as something else.
-            tracing::warn!(
-                "NDL audio-enabled load failed ({why}) — retrying video-only, the picture will not be paced"
-            );
-            // Best-effort cleanup of the rejected load.
+            match Self::try_load(fns, video, true) {
+                Ok(loaded) => return Ok(loaded),
+                // Loud, because a video-only load streams unpaced for the rest of the session
+                // (issue #188) and every later symptom reads as something else.
+                Err(e) => tracing::warn!(
+                    "NDL audio-enabled load failed ({e:#}) — retrying video-only, the picture will not be paced"
+                ),
+            }
             fns.unload();
             // The rejected load's callbacks are indistinguishable from the retry's, so let them
             // land BEFORE arming below rather than racing them.
@@ -232,57 +298,61 @@ impl NdlVideo {
         Self::try_load(fns, video, false)
     }
 
-    /// One `NDL_DirectMediaLoad` attempt, waited out to `LOADCOMPLETED` — priming the audio plane
-    /// through the wait when the load asked for one (see [`Self::prime_audio`]).
+    /// One `NDL_DirectMediaLoad` attempt, given its budget to report `LOADCOMPLETED` — priming
+    /// the audio plane through the wait when the load asked for one (see [`Self::prime_audio`]).
+    ///
+    /// An audio-enabled attempt that does not confirm is still returned: unconfirmed is a normal
+    /// state for one, not a failure (see [`Self::load`]).
     fn try_load(fns: &'static ffi::V2, video: ffi::VideoInfo, audio: bool) -> Result<Self> {
-        let mut info = ffi::DataInfo {
-            video,
-            audio: if audio { plane_config() } else { ffi::AudioUnion::SILENT },
-        };
-        arm_load();
-        let load_instant = Instant::now();
-        fns.load(&mut info, Some(super::on_load_state))?;
+        let load_instant = issue_load(fns, video, audio)?;
         // `ret == 0` is "request accepted", not "pipeline ready" — the first feed still needs
         // LOADCOMPLETED, and an audio-enabled load will not report it until its audio plane has
-        // seen a packet, which is what the prime supplies.
-        // Budget and waiter are picked at the same branch: what a load can afford to wait is a
-        // property of the load, not of whichever waiter it happens to reach. The two budgets are
-        // equal today (see `AUDIO_LOAD_TIMEOUT` for the measurement that made them equal) and are
-        // still named apart, because giving up on the plane and giving up on the picture are not
-        // the same failure.
+        // seen a packet, which is what the prime supplies. The two waits are different questions,
+        // not one budget twice: the audio one buys a fast confirmation and gives up cheaply, the
+        // video one is the picture's own bound.
         let (primed_pts_ms, confirmed) = if audio {
-            Self::prime_audio(fns, load_instant, AUDIO_LOAD_TIMEOUT)
+            Self::prime_audio(fns, load_instant)
         } else {
-            (0, wait_load_completed(LOAD_COMPLETE_TIMEOUT))
+            (0, wait_load_completed())
         };
         Ok(Self {
             fns,
             load_instant,
-            audio,
+            video,
+            audio: AtomicBool::new(audio),
             last_audio_pts_ms: AtomicI64::new(primed_pts_ms),
             last_real_feed_ms: AtomicI64::new(load_instant.elapsed().as_millis() as i64),
-            load_confirmed: AtomicBool::new(confirmed),
+            feed_unblocked: AtomicBool::new(confirmed),
+            feed_hold_from_ms: AtomicI64::new(0),
+            verdict_deadline_ms: AtomicI64::new(i64::MAX),
+            // A video-only load has no plane to judge, and a confirmed one has already answered.
+            verdict_settled: AtomicBool::new(!audio || confirmed),
+            reload: Mutex::new(None),
+            plane_proven: audio && confirmed,
             pending_hdr: Mutex::new(None),
             applied_hdr: Mutex::new(None),
         })
     }
 
     /// Feed silent Opus packets until the audio-enabled load reports `LOADCOMPLETED`, bounded by
-    /// `budget` — longer than the video-only wait, because the fallback this wait gives up to is
-    /// an unpaced session rather than a few held frames. Returns the highest stamp fed and whether
-    /// the load confirmed.
+    /// [`AUDIO_PRIME_BUDGET`]. Returns the highest stamp fed and whether the load confirmed.
+    ///
+    /// Not confirming is not a verdict. Sets differ in what they report the callback against, and
+    /// one that reports it against video ingest cannot answer inside this wait at all — see
+    /// [`AUDIO_PRIME_BUDGET`] and [`PLANE_VERDICT`].
     ///
     /// `load_instant` is the caller's, not re-derived here: these stamps ARE the player clock's
     /// domain, and handing the origin down is what makes that a value rather than a coincidence of
-    /// two adjacent `Instant::now()` calls (see the field). `budget` is measured from it too, so it
-    /// bounds the whole load — the `NDL_DirectMediaLoad` call included — rather than just the
+    /// two adjacent `Instant::now()` calls (see the field). The budget is measured from it too, so
+    /// it bounds the whole load — the `NDL_DirectMediaLoad` call included — rather than just the
     /// priming after it. That is the figure `LOADCOMPLETED` is relative to, and it means a set
     /// that blocks inside the load call cannot spend the budget twice.
     ///
     /// An audio-enabled load will not report until its audio plane has received data, but the
     /// pumps that would supply it don't spawn until `session::connect` returns — i.e. until this
     /// wait is over. That deadlock is the whole black-picture-with-sound bug, so the load window
-    /// feeds itself.
+    /// feeds itself. (The VIDEO half of the same deadlock is why the wait is no longer the
+    /// verdict: nothing here can feed a frame, and some sets report only once one has been.)
     ///
     /// A burst at a time, because a packet fed before the plane exists may be dropped silently
     /// (`NDL_DirectAudioPlay` reports success either way).
@@ -293,7 +363,7 @@ impl NdlVideo {
     /// the player-clock domain: the ceiling sits exactly [`PRIME_LEAD`] packets above the clock,
     /// the same lead every later feeder targets, so the clock overtakes it within one lead however
     /// long the load took.
-    fn prime_audio(fns: &'static ffi::V2, load_instant: Instant, budget: Duration) -> (i64, bool) {
+    fn prime_audio(fns: &'static ffi::V2, load_instant: Instant) -> (i64, bool) {
         let silence = &OPUS_SILENCE[..];
         let mut pts_ms = 0;
         while !LOAD_COMPLETED.fired() {
@@ -303,8 +373,13 @@ impl NdlVideo {
                 tracing::warn!("NDL load reported a fatal state after {pts_ms}ms of silence");
                 return (pts_ms, false);
             }
-            if load_instant.elapsed() >= budget {
-                tracing::warn!("NDL load: no LOADCOMPLETED within {budget:?} of priming {pts_ms}ms of silence");
+            if load_instant.elapsed() >= AUDIO_PRIME_BUDGET {
+                // INFO, not WARN: on a set that reports the callback against video ingest this is
+                // every session's normal path, and the plane is judged later (`PLANE_VERDICT`).
+                tracing::info!(
+                    "NDL load: no LOADCOMPLETED within {AUDIO_PRIME_BUDGET:?} of priming {pts_ms}ms of silence \
+                     — starting the stream and judging the plane after the first frame"
+                );
                 return (pts_ms, false);
             }
             // Stamps track wall-clock, topped up to PRIME_LEAD packets ahead of it — so the burst
@@ -330,11 +405,14 @@ impl NdlVideo {
         (pts_ms, true)
     }
 
-    /// Whether this load has an audio plane. It always does when the load confirmed, since NDL
-    /// only paces the picture against a fed audio plane — see [`Self::run_clock_plane`]. False means
-    /// the audio-enabled load was rejected and `load()` fell back to video-only.
+    /// Whether this load has an audio plane — the picture's only pacing reference, see
+    /// [`Self::run_clock_plane`]. False means the plane was refused, either at the load itself or
+    /// at the verdict past the first frame ([`Self::begin_reload`]).
+    ///
+    /// The session reads this once, to pick its audio route, and a later reload cannot un-pick it:
+    /// what it loses then is the pacing, which is the same thing a refusal at load costs.
     pub fn has_audio_plane(&self) -> bool {
-        self.audio
+        self.audio.load(Ordering::Relaxed)
     }
 
     /// Feed one Opus packet to the audio plane, stamped on the PLAYER clock.
@@ -365,7 +443,12 @@ impl NdlVideo {
         // The plane's start gate. Feeding a pipeline NDL has not finished loading costs the
         // session its audio outright, and unlike the video feed this path has no `ensure_loaded`
         // of its own — the prime is what carries the plane through the load window.
-        if !self.load_confirmed.load(Ordering::Relaxed) {
+        //
+        // The CALLBACK, not `feed_unblocked`: that flag is the video feed's gate and latches
+        // optimistically once the frames have to flow regardless (see [`Self::ensure_loaded`]).
+        // Audio has no such deadline — a plane fed early is a plane lost — so it waits for the
+        // real thing.
+        if !self.plane_ready() {
             return Ok(());
         }
         let now_ms = (self.elapsed_ns() / 1_000_000) as i64;
@@ -433,10 +516,27 @@ impl NdlVideo {
         } else {
             METRONOME_LEAD_MS
         };
-        let mut pts_ms = self.last_audio_pts_ms.load(Ordering::Relaxed);
         let mut filling = false;
         while !stop.load(Ordering::Relaxed) {
+            // Same gate as [`Self::play_audio`], for the same reason: the plane exists once NDL
+            // says so. The prime holds it through the load window, and on a set that confirms
+            // only after the first video frame this is the wait for that frame — bounded, because
+            // a load that never confirms loses the plane at [`PLANE_VERDICT`], which clears the
+            // other half of the gate for good.
+            if !self.plane_ready() {
+                if !self.audio.load(Ordering::Relaxed) {
+                    tracing::info!("NDL clock plane: the load has no audio plane — nothing to pace against");
+                    return;
+                }
+                super::poll_until(PRIME_RETRY, || self.plane_ready());
+                continue;
+            }
             let now_ms = (self.elapsed_ns() / 1_000_000) as i64;
+            // Any stretch the plane went unfed — the wait above, or a yielded run whose real
+            // stream stopped — is time the ceiling did not advance through. Carry it forward
+            // rather than letting the burst below pay it back a 5 ms packet at a time under the
+            // FFI lock the picture also needs. Forwards only, so it is never a rewind.
+            self.last_audio_pts_ms.fetch_max(now_ms, Ordering::Relaxed);
             if yields_to_real && now_ms - self.last_real_feed_ms.load(Ordering::Relaxed) < REAL_FEED_GRACE_MS {
                 if filling {
                     tracing::info!("NDL clock plane: host audio resumed at {now_ms}ms — yielding");
@@ -452,18 +552,26 @@ impl NdlVideo {
                 );
                 filling = true;
             }
-            match self.burst_silence(pts_ms, now_ms + lead_ms) {
-                Ok(fed_to) => pts_ms = fed_to,
+            // No running `pts_ms` of its own: `burst_silence` floors on the shared ceiling and
+            // publishes back to it, so a local could only ever restate what the atomic says.
+            match self.burst_silence(now_ms, now_ms + lead_ms) {
+                Ok(_) => {}
                 Err(e) => {
                     // Dead for the session; the picture keeps running unpaced, as it did before
                     // the clock plane existed.
-                    tracing::warn!("NDL clock plane stopping at {pts_ms}ms: {e:#}");
+                    tracing::warn!(
+                        "NDL clock plane stopping at {}ms: {e:#}",
+                        self.last_audio_pts_ms.load(Ordering::Relaxed)
+                    );
                     return;
                 }
             }
             std::thread::sleep(PRIME_RETRY);
         }
-        tracing::info!("NDL clock plane ending at {pts_ms}ms");
+        tracing::info!(
+            "NDL clock plane ending at {}ms",
+            self.last_audio_pts_ms.load(Ordering::Relaxed)
+        );
     }
 
     /// How far the audio plane's stamps currently run ahead of the player clock, in ms — the queue
@@ -485,15 +593,128 @@ impl NdlVideo {
         self.load_instant.elapsed().as_nanos() as u64
     }
 
+    /// Whether there is an audio plane to feed: this load asked for one AND NDL has confirmed it.
+    ///
+    /// Both halves matter. The callback latch alone is not enough — [`Self::begin_reload`]
+    /// leaves a pipeline that confirms normally and has no audio arm, and feeding that is a silent
+    /// session. [`Self::feed_unblocked`] is not the latch: that one is the video feed's gate and
+    /// latches optimistically (see [`Self::play_audio`]).
+    fn plane_ready(&self) -> bool {
+        self.audio.load(Ordering::Relaxed) && LOAD_COMPLETED.fired()
+    }
+
+    /// The audio plane's verdict, taken past the first accepted frame — see [`PLANE_VERDICT`].
+    ///
+    /// Runs at the tail of every [`Self::play`], so it settles into one relaxed load: both answers
+    /// are terminal (a confirmed plane stays confirmed for the load, a refused one is already
+    /// gone), and the deadline is an integer on the handle's own clock rather than the global
+    /// first-frame mutex the callback thread also takes.
+    ///
+    /// `Err(NotReady)` is the reload's own signal, not a failure: the sink answers it with a
+    /// keyframe request and no flush, which is exactly what the pipeline underneath just became.
+    fn check_plane_verdict(&self) -> Result<()> {
+        if self.verdict_settled.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        if self.plane_ready() {
+            self.verdict_settled.store(true, Ordering::Relaxed);
+            return Ok(());
+        }
+        // Frames are flowing (this runs after one was accepted) and NDL still has not confirmed
+        // the load. On every set measured, that is now conclusive.
+        if (self.elapsed_ns() / 1_000_000) as i64 <= self.verdict_deadline_ms.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        tracing::warn!(
+            "NDL: no LOADCOMPLETED {PLANE_VERDICT:?} after the first frame — the audio plane was \
+             refused, reloading video-only, the picture will not be paced"
+        );
+        self.verdict_settled.store(true, Ordering::Relaxed);
+        self.begin_reload();
+        Err(NotReady.into())
+    }
+
+    /// Give up the audio plane: unload now, and let the frames that follow carry the rest.
+    ///
+    /// The alternative to re-loading is a black session: a load whose audio config the pipeline
+    /// rejected keeps ACCEPTING frames and never runs, with no error on any call (see
+    /// [`Self::load`]). Only the timing of that fallback changed when the verdict moved past the
+    /// first frame — not the need for it.
+    ///
+    /// Clearing `audio` FIRST is what parks the audio feeders: it is half of [`Self::plane_ready`],
+    /// so neither the clock plane nor [`Self::play_audio`] can burst into a pipeline that is being
+    /// torn down — and it stays cleared across the re-load, which the callback latch does not.
+    fn begin_reload(&self) {
+        self.audio.store(false, Ordering::Relaxed);
+        self.feed_unblocked.store(false, Ordering::Relaxed);
+        let mut slot = self.reload();
+        let unloads_before = super::unload_count();
+        {
+            let _ffi = lock_ffi();
+            self.fns.unload();
+        }
+        *slot = Some(RetrySettle::after_unload(unloads_before));
+    }
+
+    /// Step a re-load in flight; `true` while this frame must still be held.
+    ///
+    /// `load_instant` is deliberately NOT restamped by any of this. It is the session's media
+    /// clock, which everything upstream has already anchored the host PTS onto, so moving it would
+    /// jump that clock backwards mid-stream. The new pipeline's own PTS domain starts at zero
+    /// under stamps that are already seconds in, which is inert here precisely because of what is
+    /// being given up: with no audio plane NDL presents at feed cadence and pays no attention to
+    /// the stamps.
+    fn advance_reload(&self) -> bool {
+        {
+            let mut slot = self.reload();
+            let Some(settle) = slot.as_mut() else { return false };
+            if !settle.ready() {
+                return true;
+            }
+            *slot = None;
+        }
+        // Whatever the panel was put in for the old pipeline has to be re-applied to the new one,
+        // and only once it is ingesting (see [`Self::pending_hdr`]). `issue_load` re-arms
+        // `presenting()`, so the replay lands on the reloaded pipeline's first frame. Locks in
+        // `replay_pending_hdr`'s order — pending, then applied — so the two cannot deadlock.
+        {
+            let mut pending = self.pending_hdr();
+            let mut applied = self.applied_hdr.lock().unwrap_or_else(PoisonError::into_inner);
+            if let Some(info) = applied.take() {
+                *pending = Some(info);
+            }
+        }
+        // The new load's own hold starts here, not at `load_instant` — which by now reads seconds,
+        // and would let the very next frame feed a pipeline that has not reported anything.
+        self.feed_hold_from_ms
+            .store((self.elapsed_ns() / 1_000_000) as i64, Ordering::Relaxed);
+        let _ffi = lock_ffi();
+        if let Err(e) = issue_load(self.fns, self.video, false) {
+            tracing::error!("NDL video-only re-load failed ({e:#}) — the session has no decoder left");
+        }
+        // Held one more frame either way: the load has only just been issued.
+        true
+    }
+
+    /// Guard on the re-load slot (see [`Self::reload`]).
+    fn reload(&self) -> MutexGuard<'_, Option<RetrySettle>> {
+        self.reload.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
     /// `Err` while this load hasn't reported `LOADCOMPLETED`: the sink then flushes, holds and
     /// requests a keyframe — exactly what a late load needs, instead of frames into a decoder that
     /// isn't there. Bounded by [`FEED_ANYWAY_AFTER`], since a model that never delivers the
     /// callback must still stream.
     fn ensure_loaded(&self) -> Result<()> {
-        if self.load_confirmed.load(Ordering::Relaxed) {
+        if self.feed_unblocked.load(Ordering::Relaxed) {
             return Ok(());
         }
-        let elapsed = self.load_instant.elapsed();
+        if self.advance_reload() {
+            return Err(NotReady.into());
+        }
+        let elapsed = self.load_instant.elapsed().saturating_sub(Duration::from_millis(
+            self.feed_hold_from_ms.load(Ordering::Relaxed) as u64,
+        ));
         if LOAD_COMPLETED.fired() {
             tracing::info!("NDL LOADCOMPLETED landed {elapsed:?} after load");
         } else if elapsed >= FEED_ANYWAY_AFTER {
@@ -503,7 +724,7 @@ impl NdlVideo {
         } else {
             return Err(NotReady.into());
         }
-        self.load_confirmed.store(true, Ordering::Relaxed);
+        self.feed_unblocked.store(true, Ordering::Relaxed);
         Ok(())
     }
 
@@ -560,8 +781,13 @@ impl NdlVideo {
         // Outside the FFI guard — `replay_pending_hdr` takes it again, and it isn't reentrant.
         if first_frame {
             self.replay_pending_hdr();
+            let now_ms = (self.elapsed_ns() / 1_000_000) as i64;
+            self.verdict_deadline_ms
+                .store(now_ms + PLANE_VERDICT.as_millis() as i64, Ordering::Relaxed);
         }
-        Ok(())
+        // Also outside it, and after the feed: the verdict is about what feeding produced, and the
+        // reload it may trigger takes the guard itself.
+        self.check_plane_verdict()
     }
 
     /// Apply HDR mastering metadata. `meta` and `color` use the same SEI-standard
@@ -629,7 +855,9 @@ impl NdlVideo {
         // the session's audio plane for the rest of the load (see [`NotReady`]), and nothing
         // has been fed yet, so there is no render buffer to discard either. The sink's loss path
         // flushes before it ever calls `play`, so the guard has to live here.
-        if !self.load_confirmed.load(Ordering::Relaxed) && !LOAD_COMPLETED.fired() {
+        // The callback latch, not [`Self::plane_ready`]: this is a question about the PIPELINE,
+        // and a video-only load has no plane but still has a render buffer to discard.
+        if !self.feed_unblocked.load(Ordering::Relaxed) && !LOAD_COMPLETED.fired() {
             return Ok(());
         }
         let _ffi = lock_ffi();
@@ -684,6 +912,10 @@ impl AudioPlane for NdlVideo {
 
     fn run_keepalive(&self, stop: &std::sync::atomic::AtomicBool, yields_to_real: bool) {
         self.run_clock_plane(stop, yields_to_real);
+    }
+
+    fn accepts_stream(&self) -> bool {
+        self.plane_proven
     }
 }
 

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -170,9 +170,10 @@ pub(super) fn run_inner() -> Result<()> {
             }
         };
         tracing::info!("session connected, entering event loop");
-        // `connect` returns past LOADCOMPLETED with the pump feeding; the reveal then waits for a
-        // frame to actually reach NDL, so the menu is swapped straight for live video. NDL's own
-        // `PLAYING` is NOT that signal — it lands during `load()`, before anything is fed.
+        // `connect` returns with the load issued and the pump feeding; the reveal then waits for
+        // a frame to actually reach NDL, so the menu is swapped straight for live video. NDL's own
+        // `PLAYING` is NOT that signal — it lands during `load()`, before anything is fed, and
+        // `LOADCOMPLETED` is not one either: some sets report it only once a frame has been fed.
         // Bounded — a host that never sends must not leave a stale menu frame up.
         let reveal_wait = Instant::now();
         let deadline = reveal_deadline(first_frame_deadline);

--- a/src/session/pipeline.rs
+++ b/src/session/pipeline.rs
@@ -9,7 +9,6 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use punktfunk_core::client::NativeClient;
-use punktfunk_core::quic;
 
 use crate::core::media::{AudioPlane, AudioSink, VideoSink};
 use crate::platform::webos::device::{self, NdlGeneration};
@@ -49,21 +48,17 @@ impl MediaPipeline {
         stop: &Arc<AtomicBool>,
         stats: &Arc<StreamStats>,
     ) -> Result<(Self, AudioRoutePref, bool)> {
-        let (player, is_hdr) = load_player(client, params.display_hdr)?;
-        // Re-checked against the plane the load actually produced: a rejected audio-enabled load
-        // leaves no plane to ride.
+        let (player, is_hdr) = load_player(client, params)?;
+        // Re-checked against the plane the load actually produced: rejected audio-enabled loads
+        // leave no plane to ride. Metronome rides any plane and paces unconfirmed fine; real stream
+        // rides only proven ones because the route can't be re-picked once running — a non-working
+        // plane means silent audio.
         let plane = player.audio_plane();
-        // Two different questions: the metronome rides any plane the load produced, the real
-        // stream only one the load PROVED (`AudioPlane::accepts_stream`) — an unproven one can
-        // still be taken away mid-session, and the route cannot be re-picked by then.
-        let route = resolve_route(
-            params.audio_route,
-            client.audio_channels,
-            plane.as_ref().is_some_and(|p| p.accepts_stream()),
-        );
+        let proven = plane.as_ref().is_some_and(|p| p.accepts_stream());
+        let route = resolve_route(params.audio_route, client.audio_channels, proven);
         tracing::info!(
             "audio path: {} on {} (host resolved {} channel(s))",
-            audio_path_label(route, plane.is_some()),
+            audio_path_label(params.audio_route, route, plane.is_some(), proven),
             player.name(),
             client.audio_channels,
         );
@@ -109,18 +104,10 @@ impl MediaPipeline {
     }
 }
 
-/// Picks the route a session WANTS, then downgrades it to what the load actually produced.
-///
-/// **Software is the default** ([`AudioRoutePref`]'s own default). It is the only shape whose
-/// pacing is known good: NDL paces the picture against a FED audio plane, and a plane fed from the
-/// network inherits the stream's arrival jitter — which is the stutter the silent clock plane was
-/// introduced to cure. The two plane routes are shorter and are kept selectable for exactly that
-/// comparison; until one of them is measured better on real hardware, the metronome keeps the plane
-/// and the audio takes the longer path.
-///
-/// A refused audio plane (`NdlVideo` gives it up, at the load or at its verdict past the first
-/// frame) and V1 leave no plane to ride, and software is what is left. `has_plane` is the PROVEN
-/// plane, not merely one that was asked for — see the call site.
+/// Downgrades the requested route to what the load proved. Software is the default and only
+/// route with known-good pacing: NDL paces against a fed plane, which inherits network jitter
+/// (silence plane cures this). Plane routes are kept selectable for comparison but unproven.
+/// `has_plane` is the proven plane, not the requested one — see the call site.
 fn resolve_route(pref: AudioRoutePref, channels: u8, has_plane: bool) -> AudioRoutePref {
     // Stereo or nothing: `Settings::clamp` already holds the document to it, and a session the
     // host resolved wider must not silently land on a plane whose decoder has no mode for it.
@@ -130,11 +117,26 @@ fn resolve_route(pref: AudioRoutePref, channels: u8, has_plane: bool) -> AudioRo
     }
 }
 
+/// How long the V2 load waits for LOADCOMPLETED before starting unconfirmed. Only offload needs
+/// proof — metronome paces unconfirmed planes fine, but wrong audio route is silent forever. Issue
+/// #188: some sets report the callback only after the first video frame; extra waiting during load
+/// just adds black screen.
+fn plane_budget(pref: AudioRoutePref, channels: u8) -> std::time::Duration {
+    // Same test as `resolve_route`, deliberately: only a session that will actually END UP on the
+    // plane is worth waiting for one. A wider layout takes the software route whatever the load
+    // says, so paying the long budget there is black screen bought for an answer nobody reads.
+    match pref {
+        AudioRoutePref::NdlOpus if channels == 2 => crate::platform::webos::ndl::AUDIO_PROVE_BUDGET,
+        AudioRoutePref::NdlOpus | AudioRoutePref::Software => crate::platform::webos::ndl::AUDIO_PRIME_BUDGET,
+    }
+}
+
 /// Opens the decoder for the negotiated stream and hands it the colorimetry.
 ///
 /// Returns the player and whether HDR mastering metadata is being applied — the answer the
 /// video pump needs to know whether to forward per-content metadata at all.
-fn load_player(client: &NativeClient, panel: quic::HdrMeta) -> Result<(Box<dyn VideoSink>, bool)> {
+fn load_player(client: &NativeClient, params: &ConnectParams) -> Result<(Box<dyn VideoSink>, bool)> {
+    let panel = params.display_hdr;
     let resolved_mode = client.mode();
     let fps = resolved_mode.refresh_hz.max(1);
     let codec =
@@ -143,12 +145,17 @@ fn load_player(client: &NativeClient, panel: quic::HdrMeta) -> Result<(Box<dyn V
     let (width, height) = (resolved_mode.width as i32, resolved_mode.height as i32);
     let player: Box<dyn VideoSink> = match device::ndl_generation() {
         NdlGeneration::V2 => Box::new(Arc::new(
-            // Every V2 load asks for a plane: a fed one is what makes NDL pace the picture at
-            // all (docs/NOTES.md § "NDL's audio plane"). What rides it — the real stream or
-            // `run_clock_plane`'s metronome — is the route's business. A set that refuses the
-            // plane reloads video-only and gives up pacing with it; the route is picked here
-            // before that verdict can be taken, and software is what both outcomes land on.
-            NdlVideo::load(&app_id, width, height, codec, true).context("NDL load")?,
+            // V2 loads ask for a plane to enable NDL pacing (docs/NOTES.md). Metronome is happy
+            // unconfirmed, but real audio needs proof or silence results. Only offload route pays
+            // the longer budget; wrong plane proof costs the route before any frame is fed.
+            NdlVideo::load(
+                &app_id,
+                width,
+                height,
+                codec,
+                Some(plane_budget(params.audio_route, client.audio_channels)),
+            )
+            .context("NDL load")?,
         )),
         NdlGeneration::V1 => Box::new(NdlV1Video::load(&app_id, width, height, codec).context("NDL v1 load")?),
     };
@@ -184,20 +191,24 @@ fn load_player(client: &NativeClient, panel: quic::HdrMeta) -> Result<(Box<dyn V
     Ok((player, is_hdr))
 }
 
-/// Why this session's audio ended up on the path it did.
-///
-/// Naming the REASON matters: "software Opus" is the correct outcome on the software route, on a
-/// route that asked for a plane and didn't get one, and on a backend that has no plane at all —
-/// and a silent session looks identical on all of them. Without this the first debugging question
-/// has no answer in the log.
-fn audio_path_label(route: AudioRoutePref, has_plane: bool) -> &'static str {
+/// Why this session's audio ended up on the route it did. "Software Opus" is correct on three
+/// different failure modes, all looking identical — logging the reason is essential for debugging.
+/// `pref` distinguishes a downgrade (which narrowed channels per `max_channels` clamp before plane
+/// proof) from a never-wanted route; downgrade merits explicit mention.
+fn audio_path_label(pref: AudioRoutePref, route: AudioRoutePref, has_plane: bool, proven: bool) -> &'static str {
     match (route, has_plane) {
         (AudioRoutePref::NdlOpus, _) => "NDL hardware Opus decode (+ clock plane standing by)",
+        // The user asked for the plane and the load never confirmed it in its budget. Stereo was
+        // already negotiated on the strength of that request and cannot be widened now. Gated on
+        // `proven` because a >2ch session takes the same downgrade for an unrelated reason.
+        (AudioRoutePref::Software, true) if pref == AudioRoutePref::NdlOpus && !proven => {
+            "software Opus decode -> SDL2 + NDL clock plane (offload asked for, plane unconfirmed)"
+        }
         // A plane the real stream is not using is the pacing metronome — see
         // `NdlVideo::run_clock_plane`.
         (AudioRoutePref::Software, true) => "software Opus decode -> SDL2 + NDL clock plane",
-        // No plane means no pacing reference either: NDL v1 has none, or the audio-enabled
-        // load's plane was refused and the video sink reloaded without it.
+        // No plane means no pacing reference either: NDL v1 has none, or the audio-enabled load
+        // was refused outright and fell back to video-only.
         (AudioRoutePref::Software, false) => "software Opus decode -> SDL2, no clock plane",
     }
 }
@@ -228,16 +239,10 @@ fn spawn_video_thread(
 /// `(audio pump, clock plane)`.
 type PlaneThreads = (Option<std::thread::JoinHandle<()>>, Option<std::thread::JoinHandle<()>>);
 
-/// The threads on NDL's audio plane, if this load got one: the loop that holds the plane at depth,
-/// plus the real stream's pump on the routes that ride it.
-///
-/// **Something feeds the plane on EVERY session that has one** — NDL paces the picture against a
-/// fed plane regardless of where the audio goes. Which loop does it is the route's one structural
-/// difference:
-///
-/// - `Software`: the metronome (`AudioPlane::run_keepalive`), silence only, and the audio goes to
-///   the SDL device the runtime owns.
-/// - `NdlOpus`: the metronome yielding to the real stream, which the TV's own decoder stamps.
+/// Threads feeding and riding NDL's audio plane: the keep-alive loop and real stream's pump
+/// (if the route rides it). NDL paces the picture against any fed plane regardless of audio routing;
+/// the route determines which thread feeds it: Software uses the metronome (silence only),
+/// `NdlOpus` yields to the real stream (hardware-stamped).
 fn spawn_plane_threads(
     client: &Arc<NativeClient>,
     ndl_audio: Option<Arc<dyn AudioPlane>>,

--- a/src/session/pipeline.rs
+++ b/src/session/pipeline.rs
@@ -53,7 +53,14 @@ impl MediaPipeline {
         // Re-checked against the plane the load actually produced: a rejected audio-enabled load
         // leaves no plane to ride.
         let plane = player.audio_plane();
-        let route = resolve_route(params.audio_route, client.audio_channels, plane.is_some());
+        // Two different questions: the metronome rides any plane the load produced, the real
+        // stream only one the load PROVED (`AudioPlane::accepts_stream`) — an unproven one can
+        // still be taken away mid-session, and the route cannot be re-picked by then.
+        let route = resolve_route(
+            params.audio_route,
+            client.audio_channels,
+            plane.as_ref().is_some_and(|p| p.accepts_stream()),
+        );
         tracing::info!(
             "audio path: {} on {} (host resolved {} channel(s))",
             audio_path_label(route, plane.is_some()),
@@ -111,8 +118,9 @@ impl MediaPipeline {
 /// comparison; until one of them is measured better on real hardware, the metronome keeps the plane
 /// and the audio takes the longer path.
 ///
-/// A rejected audio-enabled load (`NdlVideo::load` falls back to video-only) and V1 leave no
-/// plane to ride, and software is what is left.
+/// A refused audio plane (`NdlVideo` gives it up, at the load or at its verdict past the first
+/// frame) and V1 leave no plane to ride, and software is what is left. `has_plane` is the PROVEN
+/// plane, not merely one that was asked for — see the call site.
 fn resolve_route(pref: AudioRoutePref, channels: u8, has_plane: bool) -> AudioRoutePref {
     // Stereo or nothing: `Settings::clamp` already holds the document to it, and a session the
     // host resolved wider must not silently land on a plane whose decoder has no mode for it.
@@ -138,7 +146,8 @@ fn load_player(client: &NativeClient, panel: quic::HdrMeta) -> Result<(Box<dyn V
             // Every V2 load asks for a plane: a fed one is what makes NDL pace the picture at
             // all (docs/NOTES.md § "NDL's audio plane"). What rides it — the real stream or
             // `run_clock_plane`'s metronome — is the route's business. A set that refuses the
-            // load falls back to video-only in `NdlVideo::load`, and gives up pacing with it.
+            // plane reloads video-only and gives up pacing with it; the route is picked here
+            // before that verdict can be taken, and software is what both outcomes land on.
             NdlVideo::load(&app_id, width, height, codec, true).context("NDL load")?,
         )),
         NdlGeneration::V1 => Box::new(NdlV1Video::load(&app_id, width, height, codec).context("NDL v1 load")?),
@@ -187,8 +196,8 @@ fn audio_path_label(route: AudioRoutePref, has_plane: bool) -> &'static str {
         // A plane the real stream is not using is the pacing metronome — see
         // `NdlVideo::run_clock_plane`.
         (AudioRoutePref::Software, true) => "software Opus decode -> SDL2 + NDL clock plane",
-        // No plane means no pacing reference either: NDL v1 has none, or the
-        // audio-enabled load did not confirm and `load()` fell back to video-only.
+        // No plane means no pacing reference either: NDL v1 has none, or the audio-enabled
+        // load's plane was refused and the video sink reloaded without it.
         (AudioRoutePref::Software, false) => "software Opus decode -> SDL2, no clock plane",
     }
 }


### PR DESCRIPTION
Hardening around the NDL v2 load path and the audio plane that paces it.

**This no longer claims to fix #188.** It started as an attempt at it, the reporter confirmed it
didn't help, and the theory behind it doesn't hold up: `ffi::VideoInfo` carries no framerate and
`LOADCOMPLETED` is a pipeline callback, so a plane verdict is resolution-independent and can't
explain a fault that spares 4K60 and 1440p120 on the same TV. The same rejected-load sequence was
also measured on the HDR pattern screen, which loads at 960x540. And an unpaced picture presents at
feed cadence — judder, bounded — whereas #188 is a monotonic delay ramp with RAM climb, which is a
producer outrunning a consumer.

So #188 stays open. Everything below is justified on its own.

### Reverted

The mid-session plane verdict and its video-only re-load (`PLANE_VERDICT`, `check_plane_verdict`,
`begin_reload`/`advance_reload`, `RetrySettle`, and the verdict fields). Beyond resting on the dead
theory, it carried five defects — a failed re-load left the session permanently black with no
recovery, `begin_reload` unloaded without re-arming so `presenting()` lied through the settle, and
the reload was stepped by `play()`, which `VideoStage::gate` can skip on a loss burst. It also
re-applied HDR metadata to the new pipeline mid-session, which is documented as dropping a CX out
of its high-rate mode, so the fallback could cause the failure it was written to fix.

`NdlVideo` goes from 14 fields to 9.

### Kept

- **`load_instant` at the `NDL_DirectMediaLoad` call.** The prime stamped from the load call while
  the player clock started after the load wait, so the offload route's real lead was
  `PLANE_LEAD_MS - D`, about 0 ms on a CX — the exact underrun the constant exists to prevent.
- **`METRONOME_LEAD_MS = 80 ms`**, pinning the software route's cushion. Exact parity with what
  shipped: `(D - L + 40) + (t - D) + 40 = t + 80 - L`, so the load duration cancels.
- **`run_clock_plane` no longer gates on `LOADCOMPLETED`.** It's `prime_audio`'s continuation
  through the same call, and the prime isn't gated either. Gating it left the plane unfed from the
  end of the prime until the first video frame, covering the ~100 ms of ingest that sets NDL's
  standing present cushion. Only the real stream waits for the callback — silence on an unconfirmed
  plane is free, misrouted audio isn't.
- **Split load budgets.** `AUDIO_PRIME_BUDGET` (500 ms) for every session, `AUDIO_PROVE_BUDGET`
  (2 s) only where the session will actually end up on the plane, gated on the same test as
  `resolve_route`. On a set that reports the callback only after a frame has been fed, the longer
  wait is pure black screen for an answer nobody reads.
- **A FATAL audio-enabled load falls back video-only again**, so the audio request stays a probe.
- **`AudioPlane::accepts_stream()`** splits "a plane to keep fed" from "a plane the real audio may
  ride", and `audio_path_label` names an offload downgrade explicitly — `max_channels` has already
  clamped the handshake to stereo by then, so it's worse than either route on its own.
- `PRESENT_DEADLINE` 3s to 5s: worst-case load is ~3.3 s, so 3 s could fire mid-load and report a
  rejection that hadn't happened.
- The earlier render-queue watchdog is reverted entirely.

### Known regression

`PLANE_CONFIRM_GRACE` logs an unconfirmed plane past the first frame and recovers nothing. Before
this branch, an async Opus rejection was caught by treating an unconfirmed load as refused — at the
cost of misreading every healthy ingest-gated set, which is what sent #188 down the wrong path
three times. No set has been measured doing the async rejection. If that WARN shows up in a report,
that's the one to build a real fallback for.

`task -s docker:lint` clean. Not yet run on the reporter's TV.
