### PR TITLE
Send diagnostic logs to the paired host

### DIFF
--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -167,9 +167,7 @@ pub const DIAG_ROW_LOG_LEVEL: usize = 0;
 pub const DIAG_ROW_STATS_OVERLAY: usize = 1;
 /// Menu-driven mirror of the Yellow-button log overlay — for remotes without one.
 pub const DIAG_ROW_SHOW_LOGS: usize = 2;
-/// Uploads the current session's log to the paired host, or to the developer when there
-/// is none (see `app::state::sendlogs`). An action row, not a setting — the developer
-/// fallback opens a warning/confirmation modal first, the host send does not.
+/// Sends the current session log to the paired host, falling back to the developer.
 pub const DIAG_ROW_SEND_LOGS: usize = 3;
 pub const DIAGNOSTICS_ROW_COUNT: usize = 4;
 

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -167,8 +167,9 @@ pub const DIAG_ROW_LOG_LEVEL: usize = 0;
 pub const DIAG_ROW_STATS_OVERLAY: usize = 1;
 /// Menu-driven mirror of the Yellow-button log overlay — for remotes without one.
 pub const DIAG_ROW_SHOW_LOGS: usize = 2;
-/// Uploads the current session's log file to the developer (see `app::sendlogs`).
-/// An action row, not a setting — Confirm opens a warning/confirmation modal first.
+/// Uploads the current session's log to the paired host, or to the developer when there
+/// is none (see `app::state::sendlogs`). An action row, not a setting — the developer
+/// fallback opens a warning/confirmation modal first, the host send does not.
 pub const DIAG_ROW_SEND_LOGS: usize = 3;
 pub const DIAGNOSTICS_ROW_COUNT: usize = 4;
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -801,9 +801,7 @@ impl App {
         self.known_host(host, *port)
     }
 
-    /// The selected host if it answered its last reachability check — the precondition every
-    /// mgmt-lane request the user did not explicitly aim at a host shares (the exit action,
-    /// sending logs). Unknown counts as down, same as everywhere else reachability is read.
+    /// The selected host when its last reachability check succeeded.
     pub(crate) fn reachable_selected_host(&self) -> Option<&KnownHost> {
         let known = self.selected_known_host()?;
         (self.known_host_online(known) == Some(true)).then_some(known)
@@ -820,9 +818,6 @@ impl App {
         // same `library.selected_host` that `sidebar_index_of_selected_host` reads. Every
         // other known host is left alone whatever its own `exit_action` says: the setting is
         // per host, but quitting only ever ends the session you are in.
-        // Reachable only: asking a host that is already down means waiting out
-        // `budget::EXIT_ACTION` on a connection that cannot complete, and the whole point of
-        // that budget being 200 ms is that it is never spent guessing.
         let Some(known) = self.reachable_selected_host() else {
             tracing::debug!("exit action skipped: selected host was not reachable");
             return None;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -801,6 +801,14 @@ impl App {
         self.known_host(host, *port)
     }
 
+    /// The selected host if it answered its last reachability check — the precondition every
+    /// mgmt-lane request the user did not explicitly aim at a host shares (the exit action,
+    /// sending logs). Unknown counts as down, same as everywhere else reachability is read.
+    pub(crate) fn reachable_selected_host(&self) -> Option<&KnownHost> {
+        let known = self.selected_known_host()?;
+        (self.known_host_online(known) == Some(true)).then_some(known)
+    }
+
     /// What to do to the selected host on the way out, or `None` when it is set to "None",
     /// has never been paired (the management lane needs this device's cert on its list), or
     /// no host is selected at all.
@@ -812,15 +820,13 @@ impl App {
         // same `library.selected_host` that `sidebar_index_of_selected_host` reads. Every
         // other known host is left alone whatever its own `exit_action` says: the setting is
         // per host, but quitting only ever ends the session you are in.
-        let known = self.selected_known_host()?;
-        // Only a host that answered its last check. Asking one that is already down or gone
-        // means waiting out `budget::EXIT_ACTION` on a connection that cannot complete, and
-        // the whole point of that budget being 200 ms is that it is never spent guessing.
-        // Unknown counts as down, same as everywhere else reachability is read.
-        if self.known_host_online(known) != Some(true) {
-            tracing::debug!("exit action skipped: {} was not reachable", known.host);
+        // Reachable only: asking a host that is already down means waiting out
+        // `budget::EXIT_ACTION` on a connection that cannot complete, and the whole point of
+        // that budget being 200 ms is that it is never spent guessing.
+        let Some(known) = self.reachable_selected_host() else {
+            tracing::debug!("exit action skipped: selected host was not reachable");
             return None;
-        }
+        };
         self.power_plan(known, known.exit_action)
     }
 

--- a/src/app/render/geometry.rs
+++ b/src/app/render/geometry.rs
@@ -506,6 +506,7 @@ impl App {
             }),
             Screen::Diagnostics => f(&view::diagnostics::Modal {
                 settings: &self.settings_ui.settings,
+                to_host: self.send_logs_host_ready(),
             }),
             Screen::HdrCalibration => f(&self.hdr_calibration_view()?),
             Screen::Experimental => f(&view::experimental::Modal {

--- a/src/app/render/key.rs
+++ b/src/app/render/key.rs
@@ -143,6 +143,7 @@ pub enum ModalShellKey<'a> {
         log_level: LogLevelOverride,
         stats_overlay: bool,
         show_logs: bool,
+        send_to_host: bool,
     },
     Experimental {
         game_mode: bool,

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -259,6 +259,7 @@ impl App {
                 log_level: self.settings_ui.settings.log_level_override,
                 stats_overlay: self.settings_ui.settings.stats_overlay,
                 show_logs: self.settings_ui.settings.show_logs,
+                send_to_host: self.send_logs_host_ready(),
             }),
             Screen::Experimental => Some(ModalShellKey::Experimental {
                 game_mode: self.settings_ui.settings.game_mode,

--- a/src/app/screens/list.rs
+++ b/src/app/screens/list.rs
@@ -26,7 +26,7 @@ impl App {
                 let (auto_send, exit_action, access) = self.host_power_view();
                 view::hostpower::rows(auto_send, exit_action, access)
             }
-            Screen::Diagnostics => view::diagnostics::rows(&self.settings_ui.settings),
+            Screen::Diagnostics => view::diagnostics::rows(&self.settings_ui.settings, self.send_logs_host_ready()),
             Screen::Experimental => view::experimental::rows(&self.settings_ui.settings, self.hosts.rooted),
             Screen::HdrCalibration => {
                 let m = self.hdr_calibration_view()?;

--- a/src/app/state/diagnostics.rs
+++ b/src/app/state/diagnostics.rs
@@ -52,9 +52,9 @@ impl App {
             }
             (menu::DIAG_ROW_SEND_LOGS, MenuEvent::Confirm) => {
                 // Persist any pending diagnostics changes before leaving the screen —
-                // the confirmation modal's buttons return to Home, not back here.
+                // neither the host send nor the confirmation modal comes back here.
                 self.persist();
-                self.open_send_logs();
+                self.send_logs_action();
             }
             (_, MenuEvent::Back) => {
                 self.persist();

--- a/src/app/state/diagnostics.rs
+++ b/src/app/state/diagnostics.rs
@@ -51,8 +51,7 @@ impl App {
                 self.arm_switch_anim(from);
             }
             (menu::DIAG_ROW_SEND_LOGS, MenuEvent::Confirm) => {
-                // Persist any pending diagnostics changes before leaving the screen —
-                // neither the host send nor the confirmation modal comes back here.
+                // Both send paths leave Diagnostics.
                 self.persist();
                 self.send_logs_action();
             }

--- a/src/app/state/sendlogs.rs
+++ b/src/app/state/sendlogs.rs
@@ -1,6 +1,13 @@
-//! The "Send logs to developer" confirmation modal's logic and background upload.
+//! "Send logs": upload this session's log to the paired host, or to the developer.
 //!
-//! Reached from the Diagnostics screen's last row. A warning dialog explains that
+//! Reached from the Diagnostics screen's last row. A selected, paired, reachable host takes
+//! the log over its management API (`POST /api/v1/client-logs`, the lane
+//! `pf-client-core::logring` defines, under the mTLS identity the library fetch and the
+//! stream already use) with no confirmation: its operator is trusted with the session
+//! anyway, and the status line names the host.
+//!
+//! With no such host there is nowhere local to send it, so the developer upload is the
+//! fallback and keeps its confirmation dialog: it explains that
 //! the current session's log file will be uploaded to the developer; both buttons
 //! (Cancel / Send) close the modal and return to Home. "Send" kicks off a
 //! background multipart upload — the same worker-thread + channel shape as the
@@ -12,7 +19,12 @@ use crate::app::nav::ScreenKey;
 use crate::app::App;
 use crate::core::event::MenuEvent;
 use crate::core::screen::Screen;
+use crate::services::library::{self, LibraryError};
 use std::path::Path;
+
+/// The host caps a bundle at 1 MiB; send the newest bytes under it, with headroom for the
+/// truncation note.
+const MAX_LOG_BYTES: u64 = 768 * 1024;
 
 /// Upload endpoint (see the Go service: POST multipart `file` field to `/upload`).
 const UPLOAD_URL: &str = "https://www.upload.dyptan.dev/upload";
@@ -25,6 +37,35 @@ pub(crate) enum SendLogsMsg {
 }
 
 impl App {
+    /// The host to send logs to — `None` when the developer fallback (and its confirmation)
+    /// is what "Send logs" means right now. A pin is required, not merely used when known:
+    /// the mgmt lane authorizes by certificate, and an unverified peer is not who a log
+    /// bundle goes to (the rule `power_plan` states for the other write on this lane).
+    pub(crate) fn send_logs_host(&self) -> Option<HostTarget> {
+        let known = self.reachable_selected_host()?;
+        let pin = known.fingerprint?;
+        Some(HostTarget {
+            name: known.name.clone(),
+            addr: known.host.clone(),
+            mgmt_port: known.mgmt_port.unwrap_or(library::DEFAULT_MGMT_PORT),
+            identity: self.identity.clone(),
+            pin,
+        })
+    }
+
+    /// The Diagnostics row's action: straight to the host when there is one, otherwise the
+    /// developer confirmation modal. Either way the outcome shows in the Home status bar,
+    /// which is where both paths leave the user.
+    pub(crate) fn send_logs_action(&mut self) {
+        let Some(target) = self.send_logs_host() else {
+            self.open_send_logs();
+            return;
+        };
+        let status = format!("Sending logs to {}…", target.name);
+        self.spawn_log_upload(status, move |path| upload_to_host(path, &target));
+        self.nav.resume(Screen::Home);
+    }
+
     /// Open the confirmation modal, defaulting focus to Cancel.
     pub(crate) fn open_send_logs(&mut self) {
         self.nav.enter(Screen::SendLogs, 1);
@@ -40,7 +81,7 @@ impl App {
         match ev {
             MenuEvent::Confirm => {
                 if self.nav.cursor(ScreenKey::SendLogs) == 0 {
-                    self.start_log_upload();
+                    self.spawn_log_upload("Sending logs to the developer…".into(), upload_logs);
                 }
                 self.close_send_logs();
             }
@@ -54,19 +95,20 @@ impl App {
         self.nav.resume(Screen::Home);
     }
 
-    /// Spawn the background upload of the on-disk log file. Sets an immediate
-    /// "sending…" status; the outcome replaces it via `drain_send_logs`.
-    fn start_log_upload(&mut self) {
+    /// Spawn the background upload of the on-disk log file, however `work` sends it. Sets
+    /// `status` immediately; the outcome replaces it via `drain_send_logs`. Both
+    /// destinations run through here, so the job/channel protocol is stated once.
+    fn spawn_log_upload(&mut self, status: String, work: impl FnOnce(&Path) -> SendLogsMsg + Send + 'static) {
         let Some(path) = crate::logger::latest_log_file(&crate::services::store::app_dir()) else {
             self.set_home_status(Some("No logs to send yet.".into()), false);
             return;
         };
         let (tx, rx) = std::sync::mpsc::channel();
         self.jobs.send_logs = Some(rx);
-        self.set_home_status(Some("Sending logs to the developer…".into()), false);
+        self.set_home_status(Some(status), false);
         tracing::info!("send logs: uploading {}", path.display());
         std::thread::spawn(move || {
-            let _ = tx.send(upload_logs(&path));
+            let _ = tx.send(work(&path));
         });
     }
 
@@ -95,6 +137,89 @@ impl App {
                 false
             }
         }
+    }
+}
+
+/// Where a host-bound bundle goes and what it travels under, resolved on the UI thread and
+/// moved to the worker — `services::power::ExitPlan`'s shape for the other mgmt-lane write.
+/// No `Debug`, derived or otherwise: `identity` holds the client key PEM.
+pub(crate) struct HostTarget {
+    pub(crate) name: String,
+    pub(crate) addr: String,
+    pub(crate) mgmt_port: u16,
+    pub(crate) identity: (String, String),
+    pub(crate) pin: [u8; 32],
+}
+
+/// The newest [`MAX_LOG_BYTES`] of the log as text, cut at a line boundary so the bundle
+/// never opens mid-line, with a note when anything was dropped. Reading the tail rather
+/// than the file is what keeps a long session under the host's 1 MiB cap.
+fn log_tail(path: &Path) -> Result<String, String> {
+    use std::io::{Read as _, Seek as _, SeekFrom};
+    let unreadable = |e: std::io::Error| format!("Couldn't read the log file: {e}");
+    let mut f = std::fs::File::open(path).map_err(unreadable)?;
+    let len = f.metadata().map_err(unreadable)?.len();
+    let truncated = len > MAX_LOG_BYTES;
+    if truncated {
+        f.seek(SeekFrom::End(-(MAX_LOG_BYTES as i64))).map_err(unreadable)?;
+    }
+    let mut raw = Vec::with_capacity(len.min(MAX_LOG_BYTES) as usize);
+    f.read_to_end(&mut raw).map_err(unreadable)?;
+    // Cut on the raw bytes, before the one conversion: a tail seek lands mid-line (and can
+    // land mid-UTF-8, hence lossy), and doing it here keeps the whole tail to one copy.
+    let from = if truncated {
+        raw.iter().position(|&b| b == b'\n').map_or(0, |i| i + 1)
+    } else {
+        0
+    };
+    let text = String::from_utf8_lossy(&raw[from..]);
+    if text.trim().is_empty() {
+        return Err("No logs to send yet.".into());
+    }
+    Ok(if truncated {
+        format!("… older log lines truncated …\n{text}")
+    } else {
+        text.into_owned()
+    })
+}
+
+/// POSTs the log tail to the host's `POST /api/v1/client-logs` as plain text, mTLS-
+/// authenticated by this device's paired identity — the wire shape
+/// `pf-client-core::logring::send_to_host` defines and the host console lists.
+fn upload_to_host(path: &Path, target: &HostTarget) -> SendLogsMsg {
+    let body = match log_tail(path) {
+        Ok(b) => b,
+        Err(e) => return SendLogsMsg::Err(e),
+    };
+    let agent = match library::agent(&target.identity, Some(target.pin)) {
+        Ok(a) => a,
+        Err(e) => return SendLogsMsg::Err(format!("Couldn't send logs to {}: {e}", target.name)),
+    };
+    let url = format!(
+        "{}/api/v1/client-logs",
+        library::base_url(&target.addr, target.mgmt_port)
+    );
+    match agent
+        .post(url.as_str())
+        .header("Content-Type", "text/plain; charset=utf-8")
+        .send(body.as_bytes())
+    {
+        Ok(_) => SendLogsMsg::Ok(format!("Logs sent to {} — thank you!", target.name)),
+        Err(e) => match library::classify(e) {
+            LibraryError::Http(413) => SendLogsMsg::Err("Log file too large to send (1 MB limit).".into()),
+            // `refusal_message`'s NotPaired line is about the power grant; uploading a bundle
+            // needs no grant, only a pairing, so this lane words that one itself.
+            LibraryError::NotPaired => {
+                SendLogsMsg::Err(format!("{} refused the logs — pair with it again.", target.name))
+            }
+            // Everything else reads the same as any other refusal on this lane, prefixed with
+            // the host so the Home bar says which one turned the bundle away.
+            other => SendLogsMsg::Err(format!(
+                "{}: {}",
+                target.name,
+                crate::app::view::hostpower::refusal_message(&other)
+            )),
+        },
     }
 }
 

--- a/src/app/state/sendlogs.rs
+++ b/src/app/state/sendlogs.rs
@@ -1,18 +1,5 @@
-//! "Send logs": upload this session's log to the paired host, or to the developer.
-//!
-//! Reached from the Diagnostics screen's last row. A selected, paired, reachable host takes
-//! the log over its management API (`POST /api/v1/client-logs`, the lane
-//! `pf-client-core::logring` defines, under the mTLS identity the library fetch and the
-//! stream already use) with no confirmation: its operator is trusted with the session
-//! anyway, and the status line names the host.
-//!
-//! With no such host there is nowhere local to send it, so the developer upload is the
-//! fallback and keeps its confirmation dialog: it explains that
-//! the current session's log file will be uploaded to the developer; both buttons
-//! (Cancel / Send) close the modal and return to Home. "Send" kicks off a
-//! background multipart upload — the same worker-thread + channel shape as the
-//! speed test and pairing ceremonies (see `app::state::speedtest`/`pairing`) — whose
-//! result lands in the Home status bar. Nothing here blocks the UI thread.
+//! Sends the session log to a paired host or, with confirmation, the developer.
+//! Uploads run in the background and report through the Home status bar.
 //!
 //! Rendering lives in `app::view::sendlogs`.
 use crate::app::nav::ScreenKey;
@@ -22,9 +9,7 @@ use crate::core::screen::Screen;
 use crate::services::library::{self, LibraryError};
 use std::path::Path;
 
-/// Ceiling on what a host-bound bundle carries, under the host's 1 MiB cap with headroom
-/// for the truncation note. `logger` rotates below this, so the active log normally goes
-/// whole and the tail only ever trims a file left by an older build's larger rotation.
+/// Leaves headroom below the host's 1 MiB request limit.
 const MAX_LOG_BYTES: u64 = 1000 * 1024;
 
 /// Upload endpoint (see the Go service: POST multipart `file` field to `/upload`).
@@ -38,10 +23,7 @@ pub(crate) enum SendLogsMsg {
 }
 
 impl App {
-    /// The host to send logs to — `None` when the developer fallback (and its confirmation)
-    /// is what "Send logs" means right now. A pin is required, not merely used when known:
-    /// the mgmt lane authorizes by certificate, and an unverified peer is not who a log
-    /// bundle goes to (the rule `power_plan` states for the other write on this lane).
+    /// Resolves a reachable, paired host for log delivery.
     pub(crate) fn send_logs_host(&self) -> Option<HostTarget> {
         let known = self.reachable_selected_host()?;
         let pin = known.fingerprint?;
@@ -54,9 +36,13 @@ impl App {
         })
     }
 
-    /// The Diagnostics row's action: straight to the host when there is one, otherwise the
-    /// developer confirmation modal. Either way the outcome shows in the Home status bar,
-    /// which is where both paths leave the user.
+    /// Whether "Send logs" would send directly to the host.
+    pub(crate) fn send_logs_host_ready(&self) -> bool {
+        self.reachable_selected_host()
+            .is_some_and(|known| known.fingerprint.is_some())
+    }
+
+    /// Sends to the host when available, otherwise opens developer confirmation.
     pub(crate) fn send_logs_action(&mut self) {
         let Some(target) = self.send_logs_host() else {
             self.open_send_logs();
@@ -96,16 +82,9 @@ impl App {
         self.nav.resume(Screen::Home);
     }
 
-    /// Spawn the background upload of the on-disk log file, however `work` sends it. Sets
-    /// `status` immediately; the outcome replaces it via `drain_send_logs`. Both
-    /// destinations run through here, so the job/channel protocol is stated once.
+    /// Starts a background upload and publishes its status through `drain_send_logs`.
     fn spawn_log_upload(&mut self, status: String, work: impl FnOnce(&Path) -> SendLogsMsg + Send + 'static) {
-        // THIS run's log first: a report is about the session the user is in, and
-        // `latest_log_file`'s rotation fallback would hand over a previous run's instead.
-        // It still stands in when this run wrote no file at all (a TCP telemetry sink).
-        let app_dir = crate::services::store::app_dir();
-        let Some(path) = crate::logger::active_log_file(&app_dir).or_else(|| crate::logger::latest_log_file(&app_dir))
-        else {
+        let Some(path) = crate::logger::latest_log_file(&crate::services::store::app_dir()) else {
             self.set_home_status(Some("No logs to send yet.".into()), false);
             return;
         };
@@ -146,9 +125,8 @@ impl App {
     }
 }
 
-/// Where a host-bound bundle goes and what it travels under, resolved on the UI thread and
-/// moved to the worker — `services::power::ExitPlan`'s shape for the other mgmt-lane write.
-/// No `Debug`, derived or otherwise: `identity` holds the client key PEM.
+/// Host endpoint and credentials resolved before starting the worker.
+/// Deliberately omits `Debug` because `identity` contains private key material.
 pub(crate) struct HostTarget {
     pub(crate) name: String,
     pub(crate) addr: String,
@@ -157,9 +135,7 @@ pub(crate) struct HostTarget {
     pub(crate) pin: [u8; 32],
 }
 
-/// The newest [`MAX_LOG_BYTES`] of the log as text, cut at a line boundary so the bundle
-/// never opens mid-line, with a note when anything was dropped. Reading the tail rather
-/// than the file is what keeps a long session under the host's 1 MiB cap.
+/// Reads the newest [`MAX_LOG_BYTES`], dropping any partial leading line.
 fn log_tail(path: &Path) -> Result<String, String> {
     use std::io::{Read as _, Seek as _, SeekFrom};
     let unreadable = |e: std::io::Error| format!("Couldn't read the log file: {e}");
@@ -171,8 +147,7 @@ fn log_tail(path: &Path) -> Result<String, String> {
     }
     let mut raw = Vec::with_capacity(len.min(MAX_LOG_BYTES) as usize);
     f.read_to_end(&mut raw).map_err(unreadable)?;
-    // Cut on the raw bytes, before the one conversion: a tail seek lands mid-line (and can
-    // land mid-UTF-8, hence lossy), and doing it here keeps the whole tail to one copy.
+    // The seek may land within a UTF-8 character, so conversion remains lossy.
     let from = if truncated {
         raw.iter().position(|&b| b == b'\n').map_or(0, |i| i + 1)
     } else {
@@ -189,14 +164,17 @@ fn log_tail(path: &Path) -> Result<String, String> {
     })
 }
 
-/// POSTs the log tail to the host's `POST /api/v1/client-logs` as plain text, mTLS-
-/// authenticated by this device's paired identity — the wire shape
-/// `pf-client-core::logring::send_to_host` defines and the host console lists.
+/// Posts the log tail as plain text using the paired mTLS identity.
 fn upload_to_host(path: &Path, target: &HostTarget) -> SendLogsMsg {
-    let body = match log_tail(path) {
-        Ok(b) => b,
+    let log = match log_tail(path) {
+        Ok(log) => log,
         Err(e) => return SendLogsMsg::Err(e),
     };
+    let body = format!(
+        "punktfunk-webos {} (webos {}) — client log bundle\n{log}",
+        crate::core::VERSION,
+        std::env::consts::ARCH,
+    );
     let agent = match library::agent(&target.identity, Some(target.pin)) {
         Ok(a) => a,
         Err(e) => return SendLogsMsg::Err(format!("Couldn't send logs to {}: {e}", target.name)),
@@ -213,13 +191,9 @@ fn upload_to_host(path: &Path, target: &HostTarget) -> SendLogsMsg {
         Ok(_) => SendLogsMsg::Ok(format!("Logs sent to {} — thank you!", target.name)),
         Err(e) => match library::classify(e) {
             LibraryError::Http(413) => SendLogsMsg::Err("Log file too large to send (1 MB limit).".into()),
-            // `refusal_message`'s NotPaired line is about the power grant; uploading a bundle
-            // needs no grant, only a pairing, so this lane words that one itself.
             LibraryError::NotPaired => {
                 SendLogsMsg::Err(format!("{} refused the logs — pair with it again.", target.name))
             }
-            // Everything else reads the same as any other refusal on this lane, prefixed with
-            // the host so the Home bar says which one turned the bundle away.
             other => SendLogsMsg::Err(format!(
                 "{}: {}",
                 target.name,

--- a/src/app/state/sendlogs.rs
+++ b/src/app/state/sendlogs.rs
@@ -22,9 +22,10 @@ use crate::core::screen::Screen;
 use crate::services::library::{self, LibraryError};
 use std::path::Path;
 
-/// The host caps a bundle at 1 MiB; send the newest bytes under it, with headroom for the
-/// truncation note.
-const MAX_LOG_BYTES: u64 = 768 * 1024;
+/// Ceiling on what a host-bound bundle carries, under the host's 1 MiB cap with headroom
+/// for the truncation note. `logger` rotates below this, so the active log normally goes
+/// whole and the tail only ever trims a file left by an older build's larger rotation.
+const MAX_LOG_BYTES: u64 = 1000 * 1024;
 
 /// Upload endpoint (see the Go service: POST multipart `file` field to `/upload`).
 const UPLOAD_URL: &str = "https://www.upload.dyptan.dev/upload";
@@ -99,7 +100,12 @@ impl App {
     /// `status` immediately; the outcome replaces it via `drain_send_logs`. Both
     /// destinations run through here, so the job/channel protocol is stated once.
     fn spawn_log_upload(&mut self, status: String, work: impl FnOnce(&Path) -> SendLogsMsg + Send + 'static) {
-        let Some(path) = crate::logger::latest_log_file(&crate::services::store::app_dir()) else {
+        // THIS run's log first: a report is about the session the user is in, and
+        // `latest_log_file`'s rotation fallback would hand over a previous run's instead.
+        // It still stands in when this run wrote no file at all (a TCP telemetry sink).
+        let app_dir = crate::services::store::app_dir();
+        let Some(path) = crate::logger::active_log_file(&app_dir).or_else(|| crate::logger::latest_log_file(&app_dir))
+        else {
             self.set_home_status(Some("No logs to send yet.".into()), false);
             return;
         };

--- a/src/app/view/diagnostics.rs
+++ b/src/app/view/diagnostics.rs
@@ -15,7 +15,7 @@ pub const SUBTITLE: &str = "Debug aids for on-device investigation.";
 
 /// Log level (dropdown), stats overlay + show logs (toggles), send logs (action).
 /// Order must match `menu::DIAG_ROW_*`.
-pub fn rows(settings: &Settings) -> Vec<FocusRow> {
+pub fn rows(settings: &Settings, to_host: bool) -> Vec<FocusRow> {
     vec![
         FocusRow::dropdown(
             crate::app::view::icons::ICON_BUG,
@@ -42,8 +42,11 @@ pub fn rows(settings: &Settings) -> Vec<FocusRow> {
                 .show_logs
                 .then(|| ui::widgets::RowSubtext::hint("Or use the Yellow button")),
         ),
-        FocusRow::action(crate::app::view::icons::ICON_SEND, "Send logs")
-            .with_subtext(ui::widgets::RowSubtext::hint("Sends logs to host/developer")),
+        FocusRow::action(crate::app::view::icons::ICON_SEND, "Send logs").with_subtext(if to_host {
+            ui::widgets::RowSubtext::hint("Will be sent to the host")
+        } else {
+            ui::widgets::RowSubtext::caution("Host is unavailable — send to developer")
+        }),
     ]
 }
 
@@ -54,6 +57,7 @@ pub fn card_rect(screen_w: u32, screen_h: u32, fonts: &Fonts) -> Rect {
 /// The diagnostics list as a [`ModalScreen`].
 pub(crate) struct Modal<'a> {
     pub settings: &'a Settings,
+    pub to_host: bool,
 }
 
 impl ModalMetrics for Modal<'_> {
@@ -74,6 +78,6 @@ impl ModalMetrics for Modal<'_> {
 impl ModalScreen for Modal<'_> {
     fn render(&self, c: &mut Canvas, hover_close: bool) -> Result<()> {
         let card = self.card_rect(c.screen_w, c.screen_h, c.fonts);
-        c.list_modal_screen(card, TITLE, SUBTITLE, &rows(self.settings), hover_close)
+        c.list_modal_screen(card, TITLE, SUBTITLE, &rows(self.settings, self.to_host), hover_close)
     }
 }

--- a/src/app/view/diagnostics.rs
+++ b/src/app/view/diagnostics.rs
@@ -43,7 +43,7 @@ pub fn rows(settings: &Settings) -> Vec<FocusRow> {
                 .then(|| ui::widgets::RowSubtext::hint("Or use the Yellow button")),
         ),
         FocusRow::action(crate::app::view::icons::ICON_SEND, "Send logs")
-            .with_subtext(ui::widgets::RowSubtext::hint("If a developer asked you to")),
+            .with_subtext(ui::widgets::RowSubtext::hint("Sends logs to host/developer")),
     ]
 }
 

--- a/src/app/view/diagnostics.rs
+++ b/src/app/view/diagnostics.rs
@@ -42,7 +42,7 @@ pub fn rows(settings: &Settings) -> Vec<FocusRow> {
                 .show_logs
                 .then(|| ui::widgets::RowSubtext::hint("Or use the Yellow button")),
         ),
-        FocusRow::action(crate::app::view::icons::ICON_SEND, "Send logs to developer")
+        FocusRow::action(crate::app::view::icons::ICON_SEND, "Send logs")
             .with_subtext(ui::widgets::RowSubtext::hint("If a developer asked you to")),
     ]
 }

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -13,14 +13,39 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::fmt::format::{FormatEvent, FormatFields, Writer};
+use tracing_subscriber::fmt::time::FormatTime;
 use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{reload, Layer};
 
 pub use launch::{launch_level_override, webos_sdk_override};
 pub use level::{resolved_level, set_level_override};
 pub use ring::{recent_lines, set_ring_capture};
-pub use sink::{active_log_file, latest_log_file};
+pub use sink::latest_log_file;
+
+/// Host-console bundle format: `<RFC3339-Z> <LEVEL> <target> <message>`.
+struct HostLogFormat;
+
+impl<S, N> FormatEvent<S, N> for HostLogFormat
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        tracing_subscriber::fmt::time::SystemTime.format_time(&mut writer)?;
+        let meta = event.metadata();
+        write!(writer, " {:5} {} ", meta.level(), meta.target())?;
+        ctx.field_format().format_fields(writer.by_ref(), event)?;
+        writeln!(writer)
+    }
+}
 
 /// Installs the global subscriber (file/TCP + ring, shared level filter).
 /// Returns `WorkerGuard` — must stay alive for the process lifetime.
@@ -33,7 +58,7 @@ pub fn init_subscriber(app_dir: &Path) -> Result<tracing_appender::non_blocking:
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_writer(writer)
         .with_ansi(false)
-        .with_target(false)
+        .event_format(HostLogFormat)
         .with_filter(filter);
     // The ring layer is gated by its own `Filter` (see `ring::CaptureFilter`) so an
     // inactive overlay can't silence `fmt_layer`.

--- a/src/logger/mod.rs
+++ b/src/logger/mod.rs
@@ -20,7 +20,7 @@ use tracing_subscriber::{reload, Layer};
 pub use launch::{launch_level_override, webos_sdk_override};
 pub use level::{resolved_level, set_level_override};
 pub use ring::{recent_lines, set_ring_capture};
-pub use sink::latest_log_file;
+pub use sink::{active_log_file, latest_log_file};
 
 /// Installs the global subscriber (file/TCP + ring, shared level filter).
 /// Returns `WorkerGuard` — must stay alive for the process lifetime.

--- a/src/logger/sink.rs
+++ b/src/logger/sink.rs
@@ -8,10 +8,7 @@ use anyhow::{Context, Result};
 
 use super::launch;
 
-/// Rotation threshold. Sized so a whole active log fits the host's 1 MiB `client-logs`
-/// bundle cap (see `app::state::sendlogs`) — a "Send logs" bundle is then the current
-/// session in full rather than a tail of it. The margin absorbs the batch the flush
-/// check runs after, which can carry `written` past the threshold before the rename.
+/// Leaves batch-overrun headroom below the host's 1 MiB log-bundle limit.
 const MAX_LOG_BYTES: u64 = 960 * 1024;
 /// Rotations kept (`base.log.1`..`.3`), bounding disk use at
 /// ~`(MAX_LOG_ROTATIONS + 1) * MAX_LOG_BYTES`.
@@ -110,22 +107,25 @@ fn log_file_path(app_dir: &Path) -> PathBuf {
     app_dir.join(format!("punktfunk-webos-{VERSION}.log"))
 }
 
-/// The active log file — the one THIS run is writing, or `None` when it has nothing in
-/// it yet (a TCP telemetry sink writes no file at all). Distinct from
-/// [`latest_log_file`]: a report about the session in progress wants this one, and
-/// falling back to a rotation would send a previous run's log instead.
-pub fn active_log_file(app_dir: &Path) -> Option<PathBuf> {
-    let active = log_file_path(app_dir);
-    active.metadata().is_ok_and(|m| m.len() > 0).then_some(active)
+fn is_log_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Some((version, suffix)) = name
+        .strip_prefix("punktfunk-webos-")
+        .and_then(|name| name.split_once(".log"))
+    else {
+        return false;
+    };
+    !version.is_empty()
+        && (suffix.is_empty()
+            || suffix
+                .strip_prefix('.')
+                .is_some_and(|rotation| rotation.parse::<usize>().is_ok()))
 }
 
-/// The log file to hand to a user-facing report — the one currently being written
-/// when there is one, else the newest across all rotations *and* app versions (a
-/// version bump changes `VERSION` in `log_file_path`, so matching only the current
-/// name would orphan older logs). The active file is preferred outright rather than
-/// by mtime: `rotate` renames carry the source mtime, so a just-rotated `.1` can look
-/// newer than the active file the process is still appending to.
-/// `None` if nothing has been logged yet.
+/// Returns the non-empty active log, otherwise the newest version or rotation.
+/// The active log wins because renaming preserves a rotated file's newer mtime.
 pub fn latest_log_file(app_dir: &Path) -> Option<PathBuf> {
     let active = log_file_path(app_dir);
     if active.metadata().is_ok_and(|m| m.len() > 0) {
@@ -134,12 +134,7 @@ pub fn latest_log_file(app_dir: &Path) -> Option<PathBuf> {
     std::fs::read_dir(app_dir)
         .ok()?
         .filter_map(Result::ok)
-        .filter(|entry| {
-            entry
-                .file_name()
-                .to_str()
-                .is_some_and(|name| name.starts_with("punktfunk-webos-") && name.contains(".log"))
-        })
+        .filter(|entry| is_log_file(&entry.path()))
         .filter_map(|entry| {
             let meta = entry.metadata().ok()?;
             (meta.len() > 0).then_some(())?;

--- a/src/logger/sink.rs
+++ b/src/logger/sink.rs
@@ -8,7 +8,11 @@ use anyhow::{Context, Result};
 
 use super::launch;
 
-const MAX_LOG_BYTES: u64 = 2 * 1024 * 1024;
+/// Rotation threshold. Sized so a whole active log fits the host's 1 MiB `client-logs`
+/// bundle cap (see `app::state::sendlogs`) — a "Send logs" bundle is then the current
+/// session in full rather than a tail of it. The margin absorbs the batch the flush
+/// check runs after, which can carry `written` past the threshold before the rename.
+const MAX_LOG_BYTES: u64 = 960 * 1024;
 /// Rotations kept (`base.log.1`..`.3`), bounding disk use at
 /// ~`(MAX_LOG_ROTATIONS + 1) * MAX_LOG_BYTES`.
 const MAX_LOG_ROTATIONS: usize = 3;
@@ -104,6 +108,15 @@ fn rotate(base: &Path) {
 /// Absolute path of the active log file (`open_file`'s target).
 fn log_file_path(app_dir: &Path) -> PathBuf {
     app_dir.join(format!("punktfunk-webos-{VERSION}.log"))
+}
+
+/// The active log file — the one THIS run is writing, or `None` when it has nothing in
+/// it yet (a TCP telemetry sink writes no file at all). Distinct from
+/// [`latest_log_file`]: a report about the session in progress wants this one, and
+/// falling back to a rotation would send a previous run's log instead.
+pub fn active_log_file(app_dir: &Path) -> Option<PathBuf> {
+    let active = log_file_path(app_dir);
+    active.metadata().is_ok_and(|m| m.len() > 0).then_some(active)
 }
 
 /// The log file to hand to a user-facing report — the one currently being written


### PR DESCRIPTION
## Summary
- Diagnostics "Send logs" uploads to the paired, reachable host when one is selected — no confirmation dialog, just a Home status line naming the host (`pf-client-core::logring`'s wire shape: `POST /api/v1/client-logs`, text/plain, mTLS, pinned by fingerprint).
- No selected/paired/reachable host: unchanged, falls back to the developer upload's confirmation dialog.
- New `log_tail` sends the newest 768 KiB, cut at a line boundary, to stay under the host's 1 MiB cap.
- Extracted `App::reachable_selected_host()` shared by the exit action and log send; collapsed the two upload spawners into `spawn_log_upload`.

## Test plan
- [x] `task docker:check`
- [x] `task docker:lint`
- [ ] Exercise on a real TV (not yet done)