### PR TITLE
Unify confirmation card rendering

### DIFF
--- a/src/app/render/compose.rs
+++ b/src/app/render/compose.rs
@@ -121,7 +121,7 @@ impl App {
             // The snapshot is a copy of `tile::MODAL`, which no longer carries a shadow of its
             // own — so the leaving card needs the same nine draws the entering one gets.
             let region = prev.region.offset(0, dy);
-            Self::push_shadow(cmds, tile::MODAL_SHADOW, ui::widgets::MODAL_RADIUS, region, a);
+            ui::painter::push_shadow(cmds, tile::MODAL_SHADOW, ui::widgets::MODAL_RADIUS, region, a);
             cmds.push(DrawCmd::Tex {
                 tile: tile::MODAL_PREV,
                 dst: region,
@@ -186,19 +186,6 @@ impl App {
         });
     }
 
-    /// Panel drop shadow: nine stretched atlas draws instead of panel-sized CPU blit.
-    /// Nine-sliceable (corners carry alpha variance, centre is flat). GPU not CPU.
-    fn push_shadow(cmds: &mut Vec<DrawCmd>, tile: ui::render::TileId, radius: i32, panel: Rect, alpha: u8) {
-        ui::render::push_nine_slice(
-            cmds,
-            tile,
-            ui::painter::shadow_atlas_side(radius),
-            ui::painter::shadow_slice(radius),
-            ui::painter::shadow_rect(panel),
-            alpha,
-        );
-    }
-
     /// Open modal card, content, dropdown, focus widget. m is modal fade/rise (rides everything).
     fn compose_modal_card(
         &self,
@@ -213,7 +200,7 @@ impl App {
         let dy = ui::animation::modal_rise(m);
         // Tile covers card region only; opening plays fade+rise (reverse of closing snapshot).
         let modal_base = self.render.modal.tile_region.offset(0, dy);
-        Self::push_shadow(
+        ui::painter::push_shadow(
             cmds,
             tile::MODAL_SHADOW,
             ui::widgets::MODAL_RADIUS,
@@ -283,7 +270,7 @@ impl App {
                 options_len as u32 * ui::widgets::DROPDOWN_OPTION_H,
             );
             // The popup lifts off the row behind it, same as the card lifts off the screen.
-            Self::push_shadow(cmds, tile::PANEL_SHADOW, ui::widgets::CARD_RADIUS, panel, dd_alpha);
+            ui::painter::push_shadow(cmds, tile::PANEL_SHADOW, ui::widgets::CARD_RADIUS, panel, dd_alpha);
             cmds.push(DrawCmd::Tex {
                 tile: tile::DROPDOWN_OVERLAY,
                 dst: panel,

--- a/src/app/screens/confirm.rs
+++ b/src/app/screens/confirm.rs
@@ -1,9 +1,9 @@
-//! The two-button confirm dialogs: Wake, Forget host, Send logs, and a finished speed test.
+//! The app's two-button confirmation dialogs.
 //!
-//! All four are one card whose height its subtitle decides, one button row under it, and a
+//! Each is one card whose height its subtitle decides, one button row under it, and a
 //! cursor picking between the two buttons. That used to be six `match self.screen` tables —
 //! the subtitle, the focus, the focus setter, the button rect, and two inside `prepare_modal`
-//! — each of which had to list the same four screens. Here the screen answers once, with a
+//! — each of which had to list every confirmation screen. Here the screen answers once, with a
 //! value, and everything else reads that value.
 use crate::app::nav::ScreenKey;
 use crate::app::view;

--- a/src/app/view/confirm.rs
+++ b/src/app/view/confirm.rs
@@ -26,16 +26,13 @@ impl ModalMetrics for Modal<'_> {
 
 impl ModalScreen for Modal<'_> {
     fn render(&self, c: &mut Canvas, hover_close: bool) -> Result<()> {
-        let (card, content) = ui::tiles::confirm_dialog_layout(c.screen_w, c.screen_h, c.fonts, &self.confirm.subtitle);
-        c.modal_shell(card, hover_close)?;
-        c.modal_header(
-            card,
+        c.confirm_dialog(
             self.title,
-            ui::theme::palette().text,
             &self.confirm.subtitle,
             ui::theme::palette().muted,
-        )?;
-        // Every button drawn unfocused: the focused one is composited from its own tile.
-        c.render(ui::widgets::ConfirmButtons::new(&self.confirm.widgets()), content)
+            &self.confirm.widgets(),
+            hover_close,
+            ui::tiles::ConfirmSurface::Glass,
+        )
     }
 }

--- a/src/app/view/speedtest.rs
+++ b/src/app/view/speedtest.rs
@@ -81,37 +81,6 @@ pub(crate) fn status(state: Option<&SpeedTestState>, host_name: &str) -> String 
     }
 }
 
-pub(crate) fn card_rect(
-    screen_w: u32,
-    screen_h: u32,
-    fonts: &Fonts,
-    state: Option<&SpeedTestState>,
-    host_name: &str,
-) -> Rect {
-    let status = status(state, host_name);
-    // Finished, it is the same two-button confirm dialog as Forget/SendLogs/Wake; while the
-    // test is still running there is nothing to press, so it is a plain message card.
-    if finished(state) {
-        ui::tiles::confirm_dialog_card(screen_w, screen_h, fonts, &status)
-    } else {
-        ui::widgets::simple_modal_card(screen_w, screen_h, |probe| {
-            (ui::text::modal_header_end_y(fonts, probe, &status) + 32) as u32
-        })
-    }
-}
-
-/// The button row's rect, below the status text. Only meaningful once the test has
-/// finished — see [`card_rect`].
-pub(crate) fn buttons_rect(
-    screen_w: u32,
-    screen_h: u32,
-    fonts: &Fonts,
-    state: Option<&SpeedTestState>,
-    host_name: &str,
-) -> Rect {
-    ui::tiles::confirm_dialog_layout(screen_w, screen_h, fonts, &status(state, host_name)).1
-}
-
 /// The recommendation this result's primary button would apply, if any.
 pub(crate) fn recommendation(state: Option<&SpeedTestState>) -> Option<u32> {
     match state {
@@ -130,16 +99,33 @@ pub(crate) struct Modal<'a> {
 
 impl ModalMetrics for Modal<'_> {
     fn card_rect(&self, screen_w: u32, screen_h: u32, fonts: &Fonts) -> Rect {
-        card_rect(screen_w, screen_h, fonts, self.state, self.host_name)
+        match self.confirm {
+            Some(confirm) => ui::tiles::confirm_dialog_card(screen_w, screen_h, fonts, &confirm.subtitle),
+            None => ui::widgets::message_modal_card(screen_w, screen_h, fonts, &status(self.state, self.host_name)),
+        }
     }
 }
 
 impl ModalScreen for Modal<'_> {
     fn render(&self, c: &mut Canvas, hover_close: bool) -> Result<()> {
         let (state, host_name) = (self.state, self.host_name);
+        let failed = matches!(state, Some(SpeedTestState::Failed(_)));
+        if let Some(confirm) = self.confirm {
+            return c.confirm_dialog(
+                TITLE,
+                &confirm.subtitle,
+                if failed {
+                    ui::theme::palette().error
+                } else {
+                    ui::theme::palette().muted
+                },
+                &confirm.widgets(),
+                hover_close,
+                ui::tiles::ConfirmSurface::Glass,
+            );
+        }
         let card = self.card_rect(c.screen_w, c.screen_h, c.fonts);
         c.modal_shell(card, hover_close)?;
-        let failed = matches!(state, Some(SpeedTestState::Failed(_)));
         c.modal_header(
             card,
             TITLE,
@@ -151,13 +137,6 @@ impl ModalScreen for Modal<'_> {
                 ui::theme::palette().muted
             },
         )?;
-        if let Some(confirm) = self.confirm {
-            // Every button drawn unfocused; the focused one is its own tile.
-            c.render(
-                ui::widgets::ConfirmButtons::new(&confirm.widgets()),
-                buttons_rect(c.screen_w, c.screen_h, c.fonts, state, host_name),
-            )?;
-        }
         Ok(())
     }
 }

--- a/src/app/view/wake.rs
+++ b/src/app/view/wake.rs
@@ -8,34 +8,6 @@ use crate::ui::ModalMetrics;
 use crate::ui::ModalScreen;
 use anyhow::Result;
 
-/// Card for the no-MAC modal: an informational "Host unreachable" message with no button
-/// row (nothing to send), so it's a plain message card, not a confirm dialog.
-pub(crate) fn message_card(screen_w: u32, screen_h: u32, fonts: &Fonts, status: &str) -> Rect {
-    ui::widgets::simple_modal_card(screen_w, screen_h, |probe| {
-        (ui::text::modal_header_end_y(fonts, probe, status) + 32) as u32
-    })
-}
-
-/// With a MAC it's the shared confirmation dialog; without one, the button-less card.
-pub(crate) fn card_rect(screen_w: u32, screen_h: u32, wake: &WakeState, fonts: &Fonts) -> Rect {
-    let status = status_text(wake);
-    if wake.mac.is_empty() {
-        message_card(screen_w, screen_h, fonts, &status)
-    } else {
-        ui::tiles::confirm_dialog_card(screen_w, screen_h, fonts, &status)
-    }
-}
-
-/// Title varies: with a MAC it's an action ("Wake this host?"), without it it's state. The
-/// prompt never turns into a progress line — pressing Wake closes the modal instead.
-pub(crate) fn title(wake: &WakeState) -> &'static str {
-    if wake.mac.is_empty() {
-        "Host unreachable"
-    } else {
-        "Wake this host?"
-    }
-}
-
 /// Status line; reconstructible from `wake` alone, so render and layout can't disagree.
 pub(crate) fn status_text(wake: &WakeState) -> String {
     if wake.mac.is_empty() {
@@ -60,36 +32,38 @@ pub(crate) struct Modal<'a> {
 
 impl ModalMetrics for Modal<'_> {
     fn card_rect(&self, screen_w: u32, screen_h: u32, fonts: &Fonts) -> Rect {
-        card_rect(screen_w, screen_h, self.wake, fonts)
+        match self.confirm {
+            Some(confirm) => ui::tiles::confirm_dialog_card(screen_w, screen_h, fonts, &confirm.subtitle),
+            None => ui::widgets::message_modal_card(screen_w, screen_h, fonts, &status_text(self.wake)),
+        }
     }
 }
 
 impl ModalScreen for Modal<'_> {
     fn render(&self, c: &mut Canvas, hover_close: bool) -> Result<()> {
         let wake = self.wake;
+        if let Some(confirm) = self.confirm {
+            return c.confirm_dialog(
+                "Wake this host?",
+                &confirm.subtitle,
+                ui::theme::palette().muted,
+                &confirm.widgets(),
+                hover_close,
+                ui::tiles::ConfirmSurface::Glass,
+            );
+        }
         let status = status_text(wake);
-        // With a MAC it's the shared confirmation dialog (card + Wake/Cancel row); without one
-        // it's a button-less informational card — `drain_discovery` reconnects automatically
-        // once the host reappears on mDNS, so there is nothing for the user to do.
-        let (card, button_row) = match self.confirm {
-            Some(confirm) => {
-                let (card, content) = ui::tiles::confirm_dialog_layout(c.screen_w, c.screen_h, c.fonts, &status);
-                (card, Some((content, confirm)))
-            }
-            None => (message_card(c.screen_w, c.screen_h, c.fonts, &status), None),
-        };
+        // Without a MAC this is a button-less informational card. Discovery reconnects
+        // automatically once the host reappears, so there is nothing for the user to do.
+        let card = ui::widgets::message_modal_card(c.screen_w, c.screen_h, c.fonts, &status);
         c.modal_shell(card, hover_close)?;
         c.modal_header(
             card,
-            title(wake),
+            "Host unreachable",
             ui::theme::palette().text,
             &status,
             ui::theme::palette().muted,
         )?;
-        if let Some((content, confirm)) = button_row {
-            // Every button drawn unfocused; the focused one is its own tile.
-            c.render(ui::widgets::ConfirmButtons::new(&confirm.widgets()), content)?;
-        }
         Ok(())
     }
 }

--- a/src/runtime/input.rs
+++ b/src/runtime/input.rs
@@ -308,7 +308,11 @@ impl ConfirmDialog {
                     title: self.title,
                     subtitle: self.subtitle,
                     buttons: &self.buttons,
-                    glass: glass.is_some(),
+                    surface: if glass.is_some() {
+                        crate::ui::tiles::ConfirmSurface::Glass
+                    } else {
+                        crate::ui::tiles::ConfirmSurface::Opaque
+                    },
                 },
                 &mut self.tc,
                 fonts,
@@ -515,9 +519,11 @@ struct NavRepeat {
 pub(super) fn is_menu_press(event: &sdl2::event::Event, want: MenuEvent, allow_repeat: bool) -> bool {
     use sdl2::event::Event;
     match *event {
-        Event::KeyDown { keycode: Some(k), repeat, .. } => {
-            (allow_repeat || !repeat) && crate::platform::webos::input::menu_event_for_key(k) == Some(want)
-        }
+        Event::KeyDown {
+            keycode: Some(k),
+            repeat,
+            ..
+        } => (allow_repeat || !repeat) && crate::platform::webos::input::menu_event_for_key(k) == Some(want),
         Event::ControllerButtonDown { button, .. } => {
             crate::platform::webos::input::menu_event_for_button(button) == Some(want)
         }
@@ -529,9 +535,7 @@ pub(super) fn is_menu_press(event: &sdl2::event::Event, want: MenuEvent, allow_r
 pub(super) fn is_menu_release(event: &sdl2::event::Event, want: MenuEvent) -> bool {
     use sdl2::event::Event;
     match *event {
-        Event::KeyUp { keycode: Some(k), .. } => {
-            crate::platform::webos::input::menu_event_for_key(k) == Some(want)
-        }
+        Event::KeyUp { keycode: Some(k), .. } => crate::platform::webos::input::menu_event_for_key(k) == Some(want),
         Event::ControllerButtonUp { button, .. } => {
             crate::platform::webos::input::menu_event_for_button(button) == Some(want)
         }
@@ -583,7 +587,11 @@ impl UiInput {
     fn press_nav(&mut self, source: NavSource, ev: Option<MenuEvent>) -> Option<MenuEvent> {
         // Same source *and* same direction is the OS repeating a held key. A different
         // direction from the same control (a stick flicked across centre) is a new press.
-        if self.nav_repeat.as_ref().is_some_and(|r| r.source == source && Some(r.ev) == ev) {
+        if self
+            .nav_repeat
+            .as_ref()
+            .is_some_and(|r| r.source == source && Some(r.ev) == ev)
+        {
             return None;
         }
         let ev = ev?;

--- a/src/runtime/input.rs
+++ b/src/runtime/input.rs
@@ -297,6 +297,7 @@ impl ConfirmDialog {
         let full = crate::ui::render::Rect::new(0, 0, w, h);
         // The theme's glass, but only where there is a framebuffer backdrop to blur.
         let glass = blurrable.then(crate::ui::theme::glass).flatten();
+        let frosted = glass.is_some();
         let styled_at = crate::ui::theme::epoch();
         self.shell_dirty |= std::mem::replace(&mut self.styled_at, styled_at) != styled_at;
         if self.shell_dirty {
@@ -359,6 +360,15 @@ impl ConfirmDialog {
             rect: full,
             color: crate::ui::render::Color::RGBA(0, 0, 0, (f32::from(crate::ui::theme::palette().scrim.a) * m) as u8),
         });
+        if frosted {
+            crate::ui::painter::push_shadow(
+                cmds,
+                tile::MODAL_SHADOW,
+                crate::ui::widgets::MODAL_RADIUS,
+                card.offset(0, dy),
+                (255.0 * m) as u8,
+            );
+        }
         cmds.push(DrawCmd::Tex {
             tile: tile::DISCONNECT_DIALOG,
             dst: shell_dst,

--- a/src/ui/painter.rs
+++ b/src/ui/painter.rs
@@ -1,5 +1,5 @@
 //! Anti-aliased software rendering backend (`tiny_skia` Pixmap framebuffer).
-use crate::ui::render::{Color, Rect};
+use crate::ui::render::{Color, DrawList, Rect, TileId};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use tiny_skia::{
@@ -512,6 +512,18 @@ pub fn shadow_rect(rect: Rect) -> Rect {
         rect.width() + 2 * pad as u32,
         rect.height() + 2 * pad as u32,
     )
+}
+
+/// Composites a panel shadow from the shared nine-slice atlas.
+pub fn push_shadow(cmds: &mut DrawList, tile: TileId, radius: i32, panel: Rect, alpha: u8) {
+    crate::ui::render::push_nine_slice(
+        cmds,
+        tile,
+        shadow_atlas_side(radius),
+        shadow_slice(radius),
+        shadow_rect(panel),
+        alpha,
+    );
 }
 
 /// How hard [`render_glow_shape`] drives the dense end of its blur ramp to full

--- a/src/ui/tiles/confirm.rs
+++ b/src/ui/tiles/confirm.rs
@@ -1,8 +1,7 @@
 //! The shared confirm-dialog shape: its geometry, its hit test, and its shell tile.
 //!
-//! Four modals wear it — forget host, send logs, wake, and the disconnect/quit prompts — and
-//! the last of those run in `runtime`, which has no `App`. So the geometry lives here, where
-//! both sides can reach it, and all four match by construction.
+//! Menu confirmations and the runtime's disconnect/quit prompts both use it. The runtime has
+//! no `App`, so the geometry lives here where both paths can match by construction.
 use crate::ui::prelude::*;
 use anyhow::Result;
 
@@ -49,36 +48,63 @@ pub fn confirm_button_at(content: Rect, x: i32, y: i32) -> Option<usize> {
     (0..2).find(|&i| confirm_button_rect(content, i).contains_point((x, y)))
 }
 
-/// Confirm dialog shell (full-screen tile): the same card + close (X) + header + unfocused
-/// buttons that `Canvas::modal_shell`/`Canvas::modal_header` paint for the forget-host and
-/// send-logs modals — replicated here because the streaming/quit loops have no `App`. The focused
-/// button composites on top as its own small tile (shell/focus-tile split).
+impl Canvas<'_, '_> {
+    /// Paints the shared confirmation card and its unfocused buttons.
+    pub fn confirm_dialog(
+        &mut self,
+        title: &str,
+        subtitle: &str,
+        subtitle_color: Color,
+        buttons: &[ConfirmButton<'_>; 2],
+        hover_close: bool,
+        surface: ConfirmSurface,
+    ) -> Result<()> {
+        let (card, content) = confirm_dialog_layout(self.screen_w, self.screen_h, self.fonts, subtitle);
+        match surface {
+            ConfirmSurface::Glass => self.modal_shell(card, hover_close)?,
+            ConfirmSurface::Opaque => {
+                self.painter.modal_card(card);
+                let color = if hover_close { palette().text } else { palette().muted };
+                self.icon(modal_close_rect(card), icons().close, color)?;
+            }
+        }
+        self.modal_header(card, title, palette().text, subtitle, subtitle_color)?;
+        self.render(ConfirmButtons::new(buttons), content)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum ConfirmSurface {
+    Glass,
+    Opaque,
+}
+
+/// Confirm dialog shell (full-screen tile), using the same card, header, and unfocused-button
+/// painter as the app's confirmation modals. The focused button composites on top separately.
 pub struct ConfirmDialogShellTile<'a> {
     pub screen_w: u32,
     pub screen_h: u32,
     pub title: &'a str,
     pub subtitle: &'a str,
     pub buttons: &'a [ConfirmButton<'a>; 2],
-    /// Draw the card as glass, for a caller that pushes a matching `DrawCmd::Frost` under it
-    /// (the menu's quit dialog). The in-stream prompts pass `false`: NDL video lives on a
+    /// Draw the card as glass when the caller pushes a matching `DrawCmd::Frost` under it.
+    /// In-stream prompts use [`ConfirmSurface::Opaque`]: NDL video lives on a
     /// hardware plane *below* the SDL surface, so it is not in the framebuffer and there is
     /// nothing there to blur.
-    pub glass: bool,
+    pub surface: ConfirmSurface,
 }
 
 impl Widget for ConfirmDialogShellTile<'_> {
     fn render(self, _area: Rect, c: &mut Canvas) -> Result<()> {
-        let (card, content) = confirm_dialog_layout(self.screen_w, self.screen_h, c.fonts, self.subtitle);
-        if self.glass {
-            c.painter.modal_card_glass(card);
-        } else {
-            c.painter.modal_card(card);
-        }
-        // These dialogs are remote/controller-driven (no local pointer over the overlay), so the
-        // X is a visual affordance only — always in the unhovered color.
-        c.icon(modal_close_rect(card), icons().close, palette().muted)?;
-        c.modal_header(card, self.title, palette().text, self.subtitle, palette().muted)?;
-        c.render(ConfirmButtons::new(self.buttons), content)
+        // These dialogs are remote/controller-driven, so the X is always unhovered.
+        c.confirm_dialog(
+            self.title,
+            self.subtitle,
+            palette().muted,
+            self.buttons,
+            false,
+            self.surface,
+        )
     }
 }
 

--- a/src/ui/tiles/mod.rs
+++ b/src/ui/tiles/mod.rs
@@ -22,7 +22,9 @@ pub use card::{
     FOCUS_RING_PAD,
 };
 pub use cardmenu::{CardMenuBandTile, CardMenuRowsTile, CardMenuTile, CardMenuTitleTile};
-pub use confirm::{confirm_button_at, confirm_dialog_card, confirm_dialog_layout, ConfirmDialogShellTile};
+pub use confirm::{
+    confirm_button_at, confirm_dialog_card, confirm_dialog_layout, ConfirmDialogShellTile, ConfirmSurface,
+};
 pub use overlay::{LogOverlayTile, StatsOverlayTile, LOG_OVERLAY_LINES};
 pub use text::{TextTile, WrappedTextTile};
 

--- a/src/ui/widgets/modal.rs
+++ b/src/ui/widgets/modal.rs
@@ -146,6 +146,13 @@ pub fn simple_modal_card(screen_w: u32, screen_h: u32, content_height: impl FnOn
     modal_card_rect(screen_w, screen_h, SIMPLE_MODAL_WIDTH_FRAC, height)
 }
 
+/// A button-less modal sized to its header and standard bottom padding.
+pub fn message_modal_card(screen_w: u32, screen_h: u32, fonts: &Fonts, subtitle: &str) -> Rect {
+    simple_modal_card(screen_w, screen_h, |probe| {
+        (modal_header_end_y(fonts, probe, subtitle) + 32) as u32
+    })
+}
+
 pub fn modal_close_rect(card_rect: Rect) -> Rect {
     const SIZE: u32 = 44;
     const MARGIN: i32 = 20;


### PR DESCRIPTION
Use one confirmation renderer across app and runtime cards. Menu confirmations keep frosted glass. In-stream prompts remain opaque because NDL video is unavailable to framebuffer blur.

Wake and SpeedTest now source layout from their confirmation descriptors. Button-less states and failed-test coloring remain unchanged.

Validated with:
- `cargo fmt --all`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`