### PR TITLE
fix(session): keep the resume keyframe whole, quiet blip toasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ This repo is only the webOS-specific client: an SDL2 UI, NDL DirectMedia hardwar
 - **Host power** — Wake-on-LAN starts a sleeping host from the TV, and a paired host can be put to
   sleep or shut down on exit when it grants those rights.
 - **Game mode (rooted TVs)** — optional setting that switches picture and sound to Game mode while
-  streaming and restores the previous settings on exit.
+  streaming and restores the previous settings on exit. On a TV that is not rooted, pick
+  *Game Optimizer* in the TV's own picture menu while a stream is up; webOS remembers it for
+  the app, and it is the largest input-latency win the panel has.
 
 > **Controller advanced features need newer webOS version.** Haptics, triggers, speakers, touchpad, and
 > lightbar all rely on the kernel's `hid-playstation` driver, which LG ships only on webOS versions 10+.

--- a/src/platform/webos/device.rs
+++ b/src/platform/webos/device.rs
@@ -249,11 +249,45 @@ pub const HOT_THREAD_NICE: libc::c_int = -10;
 
 /// Renices `tid` (0 = calling thread) to [`HOT_THREAD_NICE`]; `false` if the kernel refused.
 ///
-/// Always best-effort: it needs `CAP_SYS_NICE` or a nonzero `RLIMIT_NICE`, present on a rooted
-/// install and absent under a plain Dev-Mode SAM jail.
+/// Always best-effort: it needs `CAP_SYS_NICE` or a large enough `RLIMIT_NICE`, present on a
+/// rooted install and absent under a plain Dev-Mode SAM jail — see [`unlock_nice_limit`].
 pub fn renice(tid: i32) -> bool {
+    unlock_nice_limit();
     // SAFETY: plain syscall — tid and priority value only, no pointers.
     unsafe { libc::setpriority(libc::PRIO_PROCESS, tid as libc::id_t, HOT_THREAD_NICE) == 0 }
+}
+
+/// Raises `RLIMIT_NICE`'s soft limit to its hard limit, once. Raising the soft limit needs no
+/// privilege, so a jail that grants the hard limit alone would otherwise refuse every renice
+/// for nothing. Logged either way: the limit is what a session log needs to say why the boost
+/// did or did not apply. The kernel reads the limit as `20 - rlim_cur`, so nice -10 needs 30.
+fn unlock_nice_limit() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        let mut lim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        // SAFETY: `lim` is a valid, writable rlimit for the duration of the call.
+        if unsafe { libc::getrlimit(libc::RLIMIT_NICE, &mut lim) } != 0 {
+            return;
+        }
+        if lim.rlim_cur < lim.rlim_max {
+            lim.rlim_cur = lim.rlim_max;
+            // SAFETY: `lim` is a valid rlimit this function owns for the duration of the call.
+            if unsafe { libc::setrlimit(libc::RLIMIT_NICE, &lim) } != 0 {
+                tracing::warn!(
+                    "RLIMIT_NICE: raising the soft limit failed: {}",
+                    std::io::Error::last_os_error()
+                );
+            }
+        }
+        tracing::info!(
+            "RLIMIT_NICE soft={} hard={} (nice floor is 20 - soft; the boost asks {HOT_THREAD_NICE})",
+            lim.rlim_cur,
+            lim.rlim_max,
+        );
+    });
 }
 
 /// Boosts the calling thread. See [`renice`].

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -17,6 +17,11 @@ fn reveal_deadline(started: Option<Instant>) -> Instant {
 /// How many copies of a mid-stream `GamepadArrival` to send — see its one caller.
 const ARRIVAL_SENDS: usize = 3;
 
+/// How long a freeze-until-reanchor hold must last before the toast names it. An RFI recovery
+/// lifts a hold within a round trip and the startup capacity probe's own loss clears at the
+/// burst's end; a toast for those flashed on every blip and said nothing the picture did not.
+const HOLD_TOAST_AFTER: Duration = Duration::from_millis(300);
+
 /// `DualSense` HID feedback (adaptive triggers, lightbar), opened only for a pad kind that emits
 /// it — anything else never sends these events. Not found (USB pad, no `luna-send-pub`) isn't an
 /// error: logged once, the feature just stays off.
@@ -372,10 +377,10 @@ pub(super) fn run_inner() -> Result<()> {
         // wiped once; `stats_dst`/`log_dst` recomposite each frame at their own slower cadence.
         let mut notif = crate::ui::widgets::Notification::new();
         let mut toast = super::toast::Toast::default();
-        // Edge-detects `stats.holding` (freeze-until-reanchor — see `session::pump`'s video pump) so a
-        // packet-loss stall surfaces as a toast even with the stats overlay off, same signal the
-        // overlay's "Beat" line already reads.
-        let mut was_holding = false;
+        // When the current freeze-until-reanchor hold began (`stats.holding`, see `session::pump`),
+        // and whether it has been announced — see `HOLD_TOAST_AFTER`.
+        let mut hold_since: Option<Instant> = None;
+        let mut hold_toasted = false;
         let mut overlay_was_active = false;
         // The two overlays' own rasterized-text cache, long-lived and separate from anything
         // the menu owns: their content is dynamic (a log tail, per-frame figures), so it must
@@ -724,18 +729,21 @@ pub(super) fn run_inner() -> Result<()> {
                     log_fade.close(());
                 }
             }
-            // Connection-issue toast: fires on the rising edge of a freeze-until-reanchor hold
-            // (dropped/gapped frames — see `session::pump`), which is the same "network
-            // trouble" signal the stats overlay's "Beat" line reads, just edge-triggered here so
-            // it's visible without the overlay open. No matching "recovered" toast — the video
-            // itself resuming is the recovery signal.
-            let holding_now = connected.stats().holding.load(Ordering::Relaxed);
-            if holding_now && !was_holding {
-                tracing::warn!("connection issues detected (freeze-until-reanchor)");
-                notif.show("Connection issues — recovering...");
-                overlay_last = None;
+            // Connection-issue toast, once per hold that outlasts `HOLD_TOAST_AFTER` — the same
+            // "network trouble" signal the stats overlay's "Beat" line reads, visible without the
+            // overlay open. No matching "recovered" toast: the picture resuming is that signal.
+            if connected.stats().holding.load(Ordering::Relaxed) {
+                let since = *hold_since.get_or_insert_with(Instant::now);
+                if !hold_toasted && since.elapsed() >= HOLD_TOAST_AFTER {
+                    hold_toasted = true;
+                    tracing::warn!("connection issues detected (freeze-until-reanchor)");
+                    notif.show("Connection issues — recovering...");
+                    overlay_last = None;
+                }
+            } else {
+                hold_since = None;
+                hold_toasted = false;
             }
-            was_holding = holding_now;
             // The dialog is navigated with the Magic Remote's pointer, so a captured stream
             // must hand the pointer back while it's up — hidden/relative there'd be nothing
             // to aim with. Recaptured on dismiss. The evdev reader releases its grabs for the

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -293,10 +293,9 @@ impl VideoStage {
             partial,
         };
         let result = self.feed(frame.data, frame.pts_ns, flags);
-        // Either the piece never reached the decoder (a hold swallows it, an error refused it) or
-        // it did and a keyframe has just been asked for regardless — on both paths the AU cannot
-        // be completed. Forgetting it costs the rest of one AU; keeping it would eventually feed a
-        // frame with a hole in it.
+        // The piece never reached the decoder (a hold swallowed it, an error refused it, the
+        // decoder is gone), so the AU cannot be completed. Forgetting it costs the rest of one AU;
+        // keeping it would eventually feed a frame with a hole in it.
         if !matches!(result, SinkResult::Presented { .. }) {
             self.parts.drop_open();
             // The AU this was accumulating for will never complete, so it must not be added to
@@ -313,10 +312,9 @@ impl VideoStage {
         if self.sink.is_dead() {
             return SinkResult::Dead;
         }
-        let request_keyframe = match self.gate(&flags) {
-            HoldGate::Skip(result) => return result,
-            HoldGate::Feed { request_keyframe } => request_keyframe,
-        };
+        if let HoldGate::Skip(result) = self.gate(&flags) {
+            return result;
+        }
 
         let base_ns = self.au_stamp_ns(pts_ns, flags.partial);
         // The feed is timed only where something reads the figure: the host's ABR controller, or
@@ -362,7 +360,7 @@ impl VideoStage {
             Err(e) => (None, self.on_play_error(&e, &flags, base_ns)),
         };
 
-        if request_keyframe || failed_keyframe {
+        if failed_keyframe {
             SinkResult::NeedKeyframe
         } else {
             SinkResult::Presented { decode_us }
@@ -390,17 +388,18 @@ impl VideoStage {
             // queue holds good frames that the hold is about to present anyway.
         }
         let Some(started) = self.hold_started else {
-            return HoldGate::Feed {
-                request_keyframe: false,
-            };
+            return HoldGate::Feed;
         };
         if flags.recovery_mark {
             self.recovery_marks = self.recovery_marks.saturating_add(1);
         }
-        let request_keyframe = self.take_keyframe_slot();
         let recovered = flags.reanchor || self.recovery_marks >= punktfunk_core::reanchor::REANCHOR_MARKS_TO_LIFT;
         if !recovered {
-            return HoldGate::Skip(if request_keyframe {
+            // The slot is taken only while frames are still skipped. The frame that lifts the hold
+            // restarts decoding by itself, and reporting a request on it made `submit` read the
+            // feed as refused — abandoning the open AU, i.e. truncating the very keyframe that
+            // resumed the picture on a slice-progressive session, and re-arming the hold.
+            return HoldGate::Skip(if self.take_keyframe_slot() {
                 SinkResult::NeedKeyframe
             } else {
                 SinkResult::Held
@@ -419,7 +418,7 @@ impl VideoStage {
         self.stats.holding.store(false, Ordering::Relaxed);
         self.hold_started = None;
         self.recovery_marks = 0;
-        HoldGate::Feed { request_keyframe }
+        HoldGate::Feed
     }
 
     /// Handles a refused feed; returns whether to ask the host for a keyframe.
@@ -457,9 +456,85 @@ impl VideoStage {
 
 /// What [`VideoStage::gate`] decided about this frame.
 enum HoldGate {
-    /// Feed it. `request_keyframe` is set when a hold released on this frame and the throttle
-    /// allowed asking for one — the frame is still fed, but the request is what gets reported.
-    Feed { request_keyframe: bool },
+    /// Feed it — not holding, or this is the frame that lifts the hold.
+    Feed,
     /// Still frozen — skip it, and report this instead.
     Skip(SinkResult),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A decoder that takes pieces and accepts everything.
+    struct FakeSink;
+
+    impl VideoSink for FakeSink {
+        fn name(&self) -> &'static str {
+            "fake"
+        }
+        fn caps(&self) -> VideoSinkCaps {
+            VideoSinkCaps {
+                pts: true,
+                partial_au: true,
+                flush: false,
+            }
+        }
+        fn feed(&self, _au: &[u8], _pts_ns: u64) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn stage() -> VideoStage {
+        VideoStage::new(
+            Box::new(FakeSink),
+            Arc::new(StreamStats::default()),
+            SinkConfig {
+                stream_hz: 60,
+                report_decode_latency: false,
+            },
+        )
+    }
+
+    fn frame(index: u32, part: Option<(bool, bool, u32)>, reanchor: bool, loss: bool) -> WireFrame<'static> {
+        WireFrame {
+            data: &[0u8; 4],
+            pts_ns: u64::from(index) * 16_666_667,
+            index,
+            part: part.map(|(first, last, offset)| punktfunk_core::session::FramePart { offset, first, last }),
+            reanchor,
+            recovery_mark: false,
+            loss,
+        }
+    }
+
+    /// A keyframe lifting a hold is fed whole, however long since the last request — reporting a
+    /// request on its first piece made `submit` abandon the AU and re-arm the hold on the next.
+    #[test]
+    fn the_resume_keyframe_keeps_its_au_open() {
+        let mut s = stage();
+        assert!(matches!(
+            s.submit(&frame(1, None, false, true)),
+            SinkResult::NeedKeyframe
+        ));
+        assert!(s.holding());
+        // The throttle has long expired by the time the host's keyframe lands.
+        s.last_keyframe_request = None;
+        let before = s.frames();
+        assert!(matches!(
+            s.submit(&frame(2, Some((true, false, 0)), true, false)),
+            SinkResult::Presented { .. }
+        ));
+        assert!(!s.holding());
+        assert!(matches!(
+            s.submit(&frame(2, Some((false, true, 4)), true, false)),
+            SinkResult::Presented { .. }
+        ));
+        assert_eq!(s.frames(), before + 1, "two pieces, one picture");
+        assert!(matches!(
+            s.submit(&frame(3, None, false, false)),
+            SinkResult::Presented { .. }
+        ));
+        assert!(!s.holding(), "the next AU must not read the resumed one as lost");
+    }
 }

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -63,7 +63,8 @@ pub enum SinkResult {
     /// Fed to the decoder. `decode_us` is the latency figure for the host's ABR
     /// controller, present only when the sink was built with `report_decode_latency`.
     Presented { decode_us: Option<u32> },
-    /// Skipped — still frozen, waiting for a re-anchor.
+    /// Nothing reached the decoder — frozen, or the play was refused — and no keyframe request
+    /// is due yet.
     Held,
     /// Skipped or failed, and the throttle allows asking the host for a keyframe now.
     NeedKeyframe,
@@ -278,13 +279,6 @@ impl VideoStage {
             self.au_base_ns = None;
             return SinkResult::Held;
         };
-        // Only a completed AU is a frame — a session feeding pieces would otherwise count one
-        // picture several times, and the overlay reads this figure as pictures per second.
-        if partial {
-            self.parts_fed += 1;
-        } else {
-            self.frames += 1;
-        }
         let flags = FrameFlags {
             reanchor: frame.reanchor,
             recovery_mark: frame.recovery_mark,
@@ -293,10 +287,19 @@ impl VideoStage {
             partial,
         };
         let result = self.feed(frame.data, frame.pts_ns, flags);
-        // The piece never reached the decoder (a hold swallowed it, an error refused it, the
-        // decoder is gone), so the AU cannot be completed. Forgetting it costs the rest of one AU;
-        // keeping it would eventually feed a frame with a hole in it.
-        if !matches!(result, SinkResult::Presented { .. }) {
+        if matches!(result, SinkResult::Presented { .. }) {
+            // Counted once the decoder took it, never on arrival: the overlay reads `frames` as
+            // pictures per second, and a held delivery is not one. Only a completed AU is a
+            // picture — pieces would count one several times.
+            if partial {
+                self.parts_fed += 1;
+            } else {
+                self.frames += 1;
+            }
+        } else {
+            // The piece never reached the decoder (a hold swallowed it, an error refused it, the
+            // decoder is gone), so the AU cannot be completed. Forgetting it costs the rest of
+            // one AU; keeping it would eventually feed a frame with a hole in it.
             self.parts.drop_open();
             // The AU this was accumulating for will never complete, so it must not be added to
             // whatever AU comes next — nor may its stamp be repeated onto one.
@@ -347,23 +350,26 @@ impl VideoStage {
             self.au_feed_us = 0;
         }
 
-        let (decode_us, failed_keyframe) = match play_result {
-            Ok(()) if flags.partial => (None, false),
+        match play_result {
+            Ok(()) if flags.partial => SinkResult::Presented { decode_us: None },
             Ok(()) => {
                 // NDL exposes no decoded-output callback. Its render-buffer depth is presentation
                 // lead, not decoder latency, and feeding it into ABR created false learned caps at
                 // 4K120. `play` duration is the only measured decoder-pressure signal available:
                 // when input backpressures, it rises naturally.
-                let decode_us = self.cfg.report_decode_latency.then_some(au_feed_us);
-                (decode_us, false)
+                SinkResult::Presented {
+                    decode_us: self.cfg.report_decode_latency.then_some(au_feed_us),
+                }
             }
-            Err(e) => (None, self.on_play_error(&e, &flags, base_ns)),
-        };
-
-        if failed_keyframe {
-            SinkResult::NeedKeyframe
-        } else {
-            SinkResult::Presented { decode_us }
+            // A refused piece was not presented whatever the throttle says; `Held` keeps the
+            // caller's AU bookkeeping honest where a request is not due yet.
+            Err(e) => {
+                if self.on_play_error(&e, &flags, base_ns) {
+                    SinkResult::NeedKeyframe
+                } else {
+                    SinkResult::Held
+                }
+            }
         }
     }
 
@@ -466,8 +472,10 @@ enum HoldGate {
 mod tests {
     use super::*;
 
-    /// A decoder that takes pieces and accepts everything.
-    struct FakeSink;
+    /// A decoder that takes pieces and accepts everything — or refuses everything as not loaded.
+    struct FakeSink {
+        refuse: bool,
+    }
 
     impl VideoSink for FakeSink {
         fn name(&self) -> &'static str {
@@ -481,13 +489,20 @@ mod tests {
             }
         }
         fn feed(&self, _au: &[u8], _pts_ns: u64) -> anyhow::Result<()> {
+            if self.refuse {
+                return Err(NotReady.into());
+            }
             Ok(())
         }
     }
 
     fn stage() -> VideoStage {
+        stage_on(FakeSink { refuse: false })
+    }
+
+    fn stage_on(sink: FakeSink) -> VideoStage {
         VideoStage::new(
-            Box::new(FakeSink),
+            Box::new(sink),
             Arc::new(StreamStats::default()),
             SinkConfig {
                 stream_hz: 60,
@@ -536,5 +551,30 @@ mod tests {
             SinkResult::Presented { .. }
         ));
         assert!(!s.holding(), "the next AU must not read the resumed one as lost");
+    }
+
+    /// `frames` is pictures the decoder took: a held delivery is not one, and neither is a
+    /// refused play — which reports `Held`, not `Presented`, while its request is throttled.
+    #[test]
+    fn only_a_fed_picture_counts() {
+        let mut s = stage();
+        assert!(matches!(
+            s.submit(&frame(1, None, false, true)),
+            SinkResult::NeedKeyframe
+        ));
+        assert_eq!(s.frames(), 0, "held on arrival");
+        assert!(matches!(
+            s.submit(&frame(2, None, true, false)),
+            SinkResult::Presented { .. }
+        ));
+        assert_eq!(s.frames(), 1);
+
+        let mut r = stage_on(FakeSink { refuse: true });
+        assert!(matches!(
+            r.submit(&frame(1, None, false, false)),
+            SinkResult::NeedKeyframe
+        ));
+        assert!(matches!(r.submit(&frame(2, None, false, false)), SinkResult::Held));
+        assert_eq!(r.frames(), 0, "refused twice");
     }
 }


### PR DESCRIPTION
Sweep of the streaming path (ABR, pacing, hold/resume, audio routes, priorities). Five commits, one theme: a stable low-latency stream.

## 1. `fix(session): feed the hold-lifting keyframe whole` — the real bug

`VideoStage::gate` took the keyframe-request slot **before** checking whether the frame lifts the hold. A reanchor arriving ≥100 ms after the previous request returned `NeedKeyframe` even though it was fed; `submit` treats every non-`Presented` result as "this AU can't complete" and drops the open AU.

Every NDL v2 stream is slice-progressive (`Negotiated::clamp` turns `frame_parts` on), so a multi-piece 4K keyframe that resumed the picture got truncated, its tail discarded, and the next AU flagged `lost_parts` → a second freeze right after recovery, waiting out the host's 750 ms IDR cooldown. Trigger: the resume frame being the first arrival after a ≥100 ms gap — the Wi-Fi bunching/black-hole shape `docs/NOTES.md` describes.

## 2. `fix(session): count a picture once the decoder took it`

`frames` incremented on arrival, so the overlay's fps kept ticking through a hold, and a play refused inside the request throttle came back `Presented` (AU kept open, counted). Both now report honestly.

## 3. `fix(stream): name a hold only once it outlasts a blip`

The "Connection issues — recovering…" toast fired on every hold's rising edge — including RFI recoveries that lift within a round trip and the startup capacity probe's own loss (320 Mbps burst on a ~245 Mbps airlink). Now it waits 300 ms into a hold, once per hold. Core PR `feat/core-input-coalesce` adds `NativeClient::probe_active()`; once this client re-pins past it, the toast can also skip the probe window outright.

## 4. `feat(device): raise RLIMIT_NICE before the first boost`

Raising the soft limit to the hard limit needs no privilege; a jail granting only the hard limit refused every renice for nothing. Both limits now go to the log, so a session log says why the boost did or did not apply.

## 5. `docs(readme): point non-rooted TVs at Game Optimizer by hand`

`settingsservice` is private; the manual picture-menu route is the lever every other user has.

## Verified

- `task docker:test`: 30 pass (28 before + 2 new). The resume test fails on `origin/main`'s `gate` at the first piece of the resume keyframe.
- `task docker:lint` (armv7 clippy, `-D warnings`): clean.
- Not run on glass. Things worth a look there: the `RLIMIT_NICE soft=… hard=…` line on a Dev-Mode G5, and whether the toast still shows ~2 s into a Wi-Fi session.

## Note

Touches `session/stage/mod.rs`, which #202 also extends (backpressure sampling + its own `FakeSink` test module). Code hunks don't overlap; whichever lands second merges the two test modules.
