### PR TITLE
fix(wake): reach the wake card's buttons with a d-pad

### DIFF
--- a/src/app/pointer.rs
+++ b/src/app/pointer.rs
@@ -245,8 +245,8 @@ impl App {
             // Two-button confirm modals (Forget/SendLogs/Wake/finished SpeedTest — the same
             // modal type as the in-stream Disconnect dialog): hovering a button focuses it,
             // so the pointer can pick action-vs-Cancel, not just confirm whatever the D-pad
-            // last focused. `confirm_subtitle` is `None` for the variants with no buttons up
-            // (a Wake with no MAC, a test still running), which reads as nothing to hover.
+            // last focused. `confirm_subtitle` is `None` while a test is still measuring,
+            // which reads as nothing to hover.
             Screen::ForgetHost
             | Screen::SendLogs
             | Screen::Wake

--- a/src/app/render/geometry.rs
+++ b/src/app/render/geometry.rs
@@ -478,9 +478,9 @@ impl App {
             }),
             // Every one-field text form, described once by `text_form`.
             Screen::AddHost | Screen::EditHost | Screen::RenameCollection => f(&self.text_form()?),
-            Screen::Wake => f(&view::wake::Modal {
-                wake: self.screens.wake.as_ref()?,
-                confirm: confirm.as_ref(),
+            Screen::Wake => f(&view::confirm::Modal {
+                title: view::wake::TITLE,
+                confirm: confirm.as_ref()?,
             }),
             Screen::ForgetHost => f(&view::confirm::Modal {
                 title: view::forget::TITLE,

--- a/src/app/render/prepare.rs
+++ b/src/app/render/prepare.rs
@@ -344,12 +344,7 @@ impl App {
                     self.screens.collections.dragging.is_some(),
                 ))
             }
-            Screen::Wake => self
-                .screens
-                .wake
-                .as_ref()
-                .filter(|w| !w.mac.is_empty())
-                .map(|w| ModalFocusKey::WakeButton(w.focused)),
+            Screen::Wake => self.screens.wake.as_ref().map(|w| ModalFocusKey::WakeButton(w.focused)),
             Screen::Pairing => Some(match self.screens.pairing_focus {
                 PairingFocus::Pin => ModalFocusKey::PairingDigit(
                     self.screens.pin_digit_index,
@@ -522,8 +517,7 @@ impl App {
         }
         // Whichever modal is open has at most one focused, zoom-animated widget
         // (`ModalFocusKey`'s docs) — `None` for screens with no such widget
-        // (Home, AddHost) or when Wake has nothing to focus (no MAC on record,
-        // see `handle_wake_event`'s matching guard).
+        // (Home, AddHost) or while a speed test is still measuring.
         if let Some(version) = self.modal_focus_version(&host_menu_actions, host_menu_power) {
             // Also stale on every tick of an in-flight `switch_anim`: the knob's
             // position depends on elapsed time, not on the key, which doesn't
@@ -683,7 +677,9 @@ impl App {
             let options = self.dropdown_options(dd.row);
             // The overlay hangs inside whichever viewport its list is drawn in.
             let content_w = match self.nav.screen {
-                s if crate::app::screens::is_list_modal(s) => self.modal_list_content(screen_w, screen_h, fonts).width(),
+                s if crate::app::screens::is_list_modal(s) => {
+                    self.modal_list_content(screen_w, screen_h, fonts).width()
+                }
                 _ => view::settings::layout(self.settings_scope(), screen_w, screen_h)
                     .1
                     .width(),

--- a/src/app/screens/confirm.rs
+++ b/src/app/screens/confirm.rs
@@ -81,9 +81,8 @@ impl Confirm {
 }
 
 impl App {
-    /// The open confirm dialog, or `None` — on a screen that isn't one, and on the two whose
-    /// buttons aren't up yet: a Wake with no MAC on record is a button-less message, and a
-    /// speed test still running has nothing to apply.
+    /// The open confirm dialog, or `None` — on a screen that isn't one, and on the one whose
+    /// buttons aren't up yet: a speed test still running has nothing to apply.
     ///
     /// That `None` is load-bearing beyond the geometry: it is what says the dialog is not
     /// showing buttons, so a caller holding a `Some` has already proved the arm it is in is
@@ -135,7 +134,7 @@ impl App {
                 "Wake host",
                 palette().accent_bright,
                 "Cancel",
-                view::wake::status_text(self.screens.wake.as_ref().filter(|w| !w.mac.is_empty())?),
+                view::wake::status_text(self.screens.wake.as_ref()?),
             ),
             Screen::SpeedTest => {
                 let state = self.screens.speed_test.as_ref();

--- a/src/app/state/wake.rs
+++ b/src/app/state/wake.rs
@@ -1,6 +1,7 @@
 //! The "host unreachable — wake it?" flow's logic: the Wake-on-LAN prompt, its retry/probe
 //! timers, and its send-side plumbing. The per-host auto-send setting the prompt obeys
 //! lives in `app::state::hostpower`. Rendering lives in `app::view::wake`.
+use crate::app::view;
 use crate::app::{App, Screen, WakeState};
 use crate::core::event::MenuEvent;
 use crate::services::store::KnownHost;
@@ -9,6 +10,7 @@ use std::time::Instant;
 impl App {
     /// Enters the WOL flow. With `wol_auto` off, shows prompt immediately.
     /// With it on, fires packet silently, shows prompt only after `WAKE_RETRY_INTERVAL`.
+    /// A host with no MAC on record never prompts at all (see [`wake_prompts`]).
     pub(crate) fn start_wake(&mut self, host: String, port: u16, mac: Vec<String>, reason: String) {
         let known = self.hosts.known.iter().find(|h| h.host == host && h.port == port);
         let name = known.map_or_else(|| host.clone(), |h| h.name.clone());
@@ -18,6 +20,7 @@ impl App {
         let auto = known.is_some_and(|h| h.wol_auto)
             && !mac.is_empty()
             && self.hosts.powered_down.as_ref() != Some(&(host.clone(), port));
+        let prompts = wake_prompts(auto, &mac);
         let mut wake = WakeState {
             host,
             port,
@@ -30,7 +33,7 @@ impl App {
             attempts: 0,
             since: None,
             last_attempt: None,
-            silent: auto,
+            silent: !prompts,
             // Baseline for `WAKE_PROBE_INTERVAL` — the first active probe fires
             // `WAKE_PROBE_INTERVAL` from now, not immediately.
             last_probe: Some(Instant::now()),
@@ -38,12 +41,19 @@ impl App {
         };
         if auto {
             Self::send_wake(&mut wake);
+        }
+        if prompts {
+            self.nav.screen = Screen::Wake;
+        } else {
             // No modal is up in this branch, so the Home bar is the only place the
             // wait is visible at all — without this it would sit on `select_host`'s
             // stale "Loading library…" until the host came back (or didn't).
-            self.set_home_status(Some(Self::wake_home_status(&wake)), false);
-        } else {
-            self.nav.screen = Screen::Wake;
+            let line = if wake.mac.is_empty() {
+                view::wake::status_text(&wake)
+            } else {
+                Self::wake_home_status(&wake)
+            };
+            self.set_home_status(Some(line), false);
         }
         self.screens.wake = Some(wake);
     }
@@ -165,12 +175,9 @@ impl App {
 
     /// Handles Wake modal events: direction moves between "Wake"/"Cancel" buttons.
     /// Confirm sends and closes the modal, or cancels. Back dismisses it (wake runs on in bg).
+    /// The card only ever opens with both buttons on it, so every event has a target.
     pub fn handle_wake_event(&mut self, ev: MenuEvent) {
         let Some(wake) = self.screens.wake.as_mut() else { return };
-        // WHY: no MAC = no send/automate possible. Every event but Back is no-op.
-        if wake.mac.is_empty() && ev != MenuEvent::Back {
-            return;
-        }
         if ev == MenuEvent::Back {
             self.close_wake(false);
             return;
@@ -226,5 +233,27 @@ impl App {
                 wake.name
             ),
         }
+    }
+}
+
+/// Whether a wake puts its prompt up rather than waiting on the Home status line.
+///
+/// Neither silent case has anything on the card to press: `auto` has already sent the packet,
+/// and with no MAC there is none to send. The ✕ answers the pointer alone, so a card without
+/// buttons is a dead end for a d-pad.
+fn wake_prompts(auto: bool, mac: &[String]) -> bool {
+    !auto && !mac.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wake_prompts;
+
+    #[test]
+    fn only_a_sendable_wake_prompts() {
+        let mac = ["aa:bb:cc:dd:ee:ff".to_string()];
+        assert!(wake_prompts(false, &mac));
+        assert!(!wake_prompts(true, &mac));
+        assert!(!wake_prompts(false, &[]));
     }
 }

--- a/src/app/view/confirm.rs
+++ b/src/app/view/confirm.rs
@@ -1,9 +1,9 @@
 //! The two-button confirm dialog, as a screen — the shell every one of them draws.
 //!
 //! What differs between Forget host, Send logs, a Wake prompt and a finished speed test is a
-//! title and a [`Confirm`]; the card, the header and the button row are this. The screens with
-//! a button-less state of their own (Wake without a MAC, a test still running) keep their own
-//! `Modal` and take their buttons from the same descriptor.
+//! title and a [`Confirm`]; the card, the header and the button row are this. A speed test
+//! still running has no buttons yet, so it keeps its own `Modal` and takes them from the same
+//! descriptor once it does.
 use crate::app::screens::confirm::Confirm;
 use crate::ui;
 use crate::ui::render::Rect;

--- a/src/app/view/wake.rs
+++ b/src/app/view/wake.rs
@@ -1,12 +1,11 @@
-//! The "host unreachable — wake it?" modal — presentation. Logic lives in `app::state::wake`.
+//! "Wake this host?" confirmation. Logic lives in `app::state::wake`.
+//!
+//! The dialog itself is `app::view::confirm` — this is only its copy. A host with no MAC on
+//! record never opens it (`state::wake::wake_prompts`): [`status_text`] goes on the Home
+//! status line instead, since there would be nothing on the card to press.
 use crate::app::WakeState;
-use crate::ui;
-use crate::ui::render::Rect;
-use crate::ui::text::Fonts;
-use crate::ui::Canvas;
-use crate::ui::ModalMetrics;
-use crate::ui::ModalScreen;
-use anyhow::Result;
+
+pub const TITLE: &str = "Wake this host?";
 
 /// Status line; reconstructible from `wake` alone, so render and layout can't disagree.
 pub(crate) fn status_text(wake: &WakeState) -> String {
@@ -18,52 +17,5 @@ pub(crate) fn status_text(wake: &WakeState) -> String {
         )
     } else {
         format!("{} isn't responding. It may be powered off or asleep.", wake.name)
-    }
-}
-
-/// The wake-on-LAN modal as a [`ModalScreen`].
-pub(crate) struct Modal<'a> {
-    pub wake: &'a WakeState,
-    /// `None` while there is nothing to press — a wake with no MAC on record is an
-    /// informational card, since `drain_discovery` reconnects on its own once the host
-    /// reappears on mDNS.
-    pub confirm: Option<&'a crate::app::screens::confirm::Confirm>,
-}
-
-impl ModalMetrics for Modal<'_> {
-    fn card_rect(&self, screen_w: u32, screen_h: u32, fonts: &Fonts) -> Rect {
-        match self.confirm {
-            Some(confirm) => ui::tiles::confirm_dialog_card(screen_w, screen_h, fonts, &confirm.subtitle),
-            None => ui::widgets::message_modal_card(screen_w, screen_h, fonts, &status_text(self.wake)),
-        }
-    }
-}
-
-impl ModalScreen for Modal<'_> {
-    fn render(&self, c: &mut Canvas, hover_close: bool) -> Result<()> {
-        let wake = self.wake;
-        if let Some(confirm) = self.confirm {
-            return c.confirm_dialog(
-                "Wake this host?",
-                &confirm.subtitle,
-                ui::theme::palette().muted,
-                &confirm.widgets(),
-                hover_close,
-                ui::tiles::ConfirmSurface::Glass,
-            );
-        }
-        let status = status_text(wake);
-        // Without a MAC this is a button-less informational card. Discovery reconnects
-        // automatically once the host reappears, so there is nothing for the user to do.
-        let card = ui::widgets::message_modal_card(c.screen_w, c.screen_h, c.fonts, &status);
-        c.modal_shell(card, hover_close)?;
-        c.modal_header(
-            card,
-            "Host unreachable",
-            ui::theme::palette().text,
-            &status,
-            ui::theme::palette().muted,
-        )?;
-        Ok(())
     }
 }


### PR DESCRIPTION
Reported from a TV test: "the stream works and everything looks great apart from
the wake on lan modal: I cannot navigate to cancel button with d-pad or
controller, only cursor works."

## What was wrong

`start_wake` opened `Screen::Wake` for every unreachable host, including one with
no MAC on record. That card is informational — `confirm_of` returns `None` for
it, so it draws no buttons — and `handle_wake_event` swallowed every event but
Back. The only control left on it is the ✕, and `hover_close` is set by pointer
motion alone, so the Magic Remote's cursor could close the card and neither its
d-pad nor a gamepad could touch anything on it.

A host gets its MAC from mDNS or from the entry it was paired through; one added
by IP, or never seen on mDNS while it was up, has none — and the wake card is by
definition shown when the host is down and off mDNS.

## What changed

- A wake with nothing to send no longer opens a card. The explanation goes on the
  Home status line, which is where the silent auto-send path already puts its
  wait, and `tick_wake`'s probe loop still brings the host back on its own.
- Every wake card that does open now carries "Wake host" / "Cancel". That deletes
  the no-MAC branches in the handler, the view and the focus tile, and leaves
  `app::view::wake` as copy over the shared `app::view::confirm` — same shape as
  `view::forget`.

## Other modals

Audited every `Screen` on `main`. Each confirm dialog goes through
`confirm_nav_event`, each list through `list_nav_event`, and every handler takes
Back and Confirm. The one remaining button-less state is a speed test still
measuring: a progress card that grows its two buttons a few seconds later, with
Back to cancel meanwhile. Left as is.

Note the shared console shell (`pf-console-ui`, which fronts the menus whenever a
pad is connected) shows its own full-screen wake takeover with a `Ⓑ Cancel`
*hint*, not a focusable button. If the report came from that UI rather than these
menus, this is not the fix — worth confirming which was on screen.

## Verified

`task docker:check`, `task docker:lint`, `task docker:test` (29 passed, including
a new `only_a_sendable_wake_prompts`). Not yet run on a TV.
