### PR TITLE
fix(wake): reach the wake card's buttons with a d-pad

### DIFF
--- a/src/app/draw/dialog.rs
+++ b/src/app/draw/dialog.rs
@@ -132,8 +132,8 @@ pub(crate) fn draw(
     });
 }
 
-/// A card with no buttons: what a wake with no address on record, or a speed test still
-/// running, shows.
+/// A card with no buttons: what a speed test still measuring shows, until it has a result to
+/// apply.
 pub(crate) fn draw_message(
     f: &Frame<'_>,
     title: &str,
@@ -338,13 +338,11 @@ impl App {
     }
 
     /// The buttonless card a screen shows while it has nothing to confirm: title, body and
-    /// the body's tone. Wake without an address on record; a speed test still running.
+    /// the body's tone. Only a speed test still measuring — a wake with nothing to send never
+    /// opens a card at all (`state::wake::wake_prompts`), since it would have nothing on it a
+    /// d-pad could reach.
     pub(crate) fn message_card(&self, screen: Screen) -> Option<(&'static str, String, Color4f)> {
         match screen {
-            Screen::Wake => {
-                let wake = self.screens.wake.as_ref()?;
-                Some(("Host unreachable", view::wake::status_text(wake), theme::fg(0.72)))
-            }
             Screen::SpeedTest => {
                 let state = self.screens.speed_test.as_ref();
                 let failed = matches!(state, Some(crate::app::state::speedtest::SpeedTestState::Failed(_)));

--- a/src/app/screens/confirm.rs
+++ b/src/app/screens/confirm.rs
@@ -132,7 +132,7 @@ impl App {
                 "Wake host",
                 Tone::Primary,
                 "Cancel",
-                view::wake::status_text(self.screens.wake.as_ref().filter(|w| !w.mac.is_empty())?),
+                view::wake::status_text(self.screens.wake.as_ref()?),
             ),
             Screen::SpeedTest => {
                 let state = self.screens.speed_test.as_ref();

--- a/src/app/state/wake.rs
+++ b/src/app/state/wake.rs
@@ -1,6 +1,7 @@
 //! The "host unreachable — wake it?" flow's logic: the Wake-on-LAN prompt, its retry/probe
 //! timers, and its send-side plumbing. The per-host auto-send setting the prompt obeys
 //! lives in `app::state::hostpower`. Rendering lives in `app::view::wake`.
+use crate::app::view;
 use crate::app::{App, Screen, WakeState};
 use crate::core::event::MenuEvent;
 use crate::services::store::KnownHost;
@@ -9,6 +10,7 @@ use std::time::Instant;
 impl App {
     /// Enters the WOL flow. With `wol_auto` off, shows prompt immediately.
     /// With it on, fires packet silently, shows prompt only after `WAKE_RETRY_INTERVAL`.
+    /// A host with no MAC on record never prompts at all (see [`wake_prompts`]).
     pub(crate) fn start_wake(&mut self, host: String, port: u16, mac: Vec<String>, reason: String) {
         let known = self.hosts.known.iter().find(|h| h.addr == host && h.port == port);
         let name = known.map_or_else(|| host.clone(), |h| h.name.clone());
@@ -18,6 +20,7 @@ impl App {
         let auto = known.is_some_and(|h| h.wol_auto)
             && !mac.is_empty()
             && self.hosts.powered_down.as_ref() != Some(&(host.clone(), port));
+        let prompts = wake_prompts(auto, &mac);
         let mut wake = WakeState {
             host,
             port,
@@ -30,7 +33,7 @@ impl App {
             attempts: 0,
             since: None,
             last_attempt: None,
-            silent: auto,
+            silent: !prompts,
             // Baseline for `WAKE_PROBE_INTERVAL` — the first active probe fires
             // `WAKE_PROBE_INTERVAL` from now, not immediately.
             last_probe: Some(Instant::now()),
@@ -38,12 +41,19 @@ impl App {
         };
         if auto {
             Self::send_wake(&mut wake);
+        }
+        if prompts {
+            self.nav.screen = Screen::Wake;
+        } else {
             // No modal is up in this branch, so the Home bar is the only place the
             // wait is visible at all — without this it would sit on `select_host`'s
             // stale "Loading library…" until the host came back (or didn't).
-            self.set_home_status(Some(Self::wake_home_status(&wake)), false);
-        } else {
-            self.nav.screen = Screen::Wake;
+            let line = if wake.mac.is_empty() {
+                view::wake::status_text(&wake)
+            } else {
+                Self::wake_home_status(&wake)
+            };
+            self.set_home_status(Some(line), false);
         }
         self.screens.wake = Some(wake);
     }
@@ -165,12 +175,9 @@ impl App {
 
     /// Handles Wake modal events: direction moves between "Wake"/"Cancel" buttons.
     /// Confirm sends and closes the modal, or cancels. Back dismisses it (wake runs on in bg).
+    /// The card only ever opens with both buttons on it, so every event has a target.
     pub fn handle_wake_event(&mut self, ev: MenuEvent) {
         let Some(wake) = self.screens.wake.as_mut() else { return };
-        // WHY: no MAC = no send/automate possible. Every event but Back is no-op.
-        if wake.mac.is_empty() && ev != MenuEvent::Back {
-            return;
-        }
         if ev == MenuEvent::Back {
             self.close_wake(false);
             return;
@@ -226,5 +233,27 @@ impl App {
                 wake.name
             ),
         }
+    }
+}
+
+/// Whether a wake puts its prompt up rather than waiting on the Home status line.
+///
+/// Neither silent case has anything on the card to press: `auto` has already sent the packet,
+/// and with no MAC there is none to send. The close mark answers the pointer alone, so a card
+/// without buttons is a dead end for a d-pad.
+fn wake_prompts(auto: bool, mac: &[String]) -> bool {
+    !auto && !mac.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wake_prompts;
+
+    #[test]
+    fn only_a_sendable_wake_prompts() {
+        let mac = ["aa:bb:cc:dd:ee:ff".to_string()];
+        assert!(wake_prompts(false, &mac));
+        assert!(!wake_prompts(true, &mac));
+        assert!(!wake_prompts(false, &[]));
     }
 }

--- a/src/app/view/wake.rs
+++ b/src/app/view/wake.rs
@@ -1,4 +1,7 @@
-//! The "host unreachable — wake it?" modal — presentation. Logic lives in `app::state::wake`.
+//! "Wake this host?" copy. Logic lives in `app::state::wake`, the card in `app::draw::dialog`.
+//!
+//! A host with no MAC on record never opens that card — [`status_text`] goes on the Home
+//! status line instead, since there would be nothing on it to press.
 use crate::app::WakeState;
 
 /// Status line; reconstructible from `wake` alone, so render and layout can't disagree.


### PR DESCRIPTION
Stacked on #204 (`fix/stream-sweep-on-pointer-ui`), which is where the report came
from. My first attempt at this (#205) was cut against `main` and so against the
`ui/` layer #202 deletes — closed in favour of this.

Reported from a TV test: "the stream works and everything looks great apart from
the wake on lan modal: I cannot navigate to cancel button with d-pad or
controller, only cursor works."

## What was wrong

`start_wake` opened `Screen::Wake` for every unreachable host, including one with
no MAC on record. That card has no buttons — `confirm_for` returns `None` for it
and it falls through to `dialog::draw_message` — and `handle_wake_event` swallowed
every event but Back. The only control left on it is the close mark, and
`hover_close` is set by pointer motion alone, so the Magic Remote's cursor could
close the card and neither its d-pad nor a gamepad could touch anything on it.

A host gets its MAC from mDNS or from the entry it was paired through; one added
by IP, or never seen on mDNS while it was up, has none — and the wake card is by
definition shown when the host is down and off mDNS.

## What changed

- A wake with nothing to send no longer opens a card. The explanation goes on the
  Home status line, which is where the silent auto-send path already puts its
  wait, and `tick_wake`'s probe loop still brings the host back on its own.
- Every wake card that does open now carries "Wake host" / "Cancel". That drops
  the no-MAC branches in the handler, in `confirm_for` and in `message_card`.

## Other modals

Audited every `Screen` on this branch. Each confirm dialog goes through
`confirm_nav_event`, each list through `list_nav_event`, and every handler takes
Back and Confirm. The one remaining button-less state is a speed test still
measuring: a progress card that grows its two buttons a few seconds later, with
Back to cancel meanwhile. Left as is — `draw_message` now serves only that.

Note the shared console shell (`pf-console-ui`, which fronts the menus whenever a
pad is connected) shows its own full-screen wake takeover with a `Ⓑ Cancel`
*hint*, not a focusable button. If the report came from that UI rather than these
menus, this is not the fix — worth confirming which was on screen.

## Verified

`task docker:check`, `task docker:lint`, `task docker:test` (43 passed, including
a new `only_a_sendable_wake_prompts`). Not yet run on a TV.
