### PR TITLE
chore(repo): land the pointer UI stack's missing tail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=01d990cda#01d990cdaf710f17494db3a110a4ffff516955d8"
+source = "git+https://git.unom.io/unom/punktfunk?rev=5998aa42d#5998aa42dceb3fd78326083472805615490a627b"
 
 [[package]]
 name = "fiat-crypto"
@@ -1286,7 +1286,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "pf-client-core"
 version = "0.34.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=01d990cda#01d990cdaf710f17494db3a110a4ffff516955d8"
+source = "git+https://git.unom.io/unom/punktfunk?rev=5998aa42d#5998aa42dceb3fd78326083472805615490a627b"
 dependencies = [
  "anyhow",
  "punktfunk-core",
@@ -1299,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "pf-console-ui"
 version = "0.34.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=01d990cda#01d990cdaf710f17494db3a110a4ffff516955d8"
+source = "git+https://git.unom.io/unom/punktfunk?rev=5998aa42d#5998aa42dceb3fd78326083472805615490a627b"
 dependencies = [
  "anyhow",
  "pf-client-core",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "punktfunk-core"
 version = "0.34.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=01d990cda#01d990cdaf710f17494db3a110a4ffff516955d8"
+source = "git+https://git.unom.io/unom/punktfunk?rev=5998aa42d#5998aa42dceb3fd78326083472805615490a627b"
 dependencies = [
  "aes-gcm",
  "cbindgen",
@@ -2235,6 +2235,7 @@ version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=5998aa42d#5998aa42dceb3fd78326083472805615490a627b"
+source = "git+https://git.unom.io/unom/punktfunk?rev=7fa3b81d4#7fa3b81d43f87d84dc3e0a2babcf99207f5e554a"
 
 [[package]]
 name = "fiat-crypto"
@@ -1286,7 +1286,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "pf-client-core"
 version = "0.34.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=5998aa42d#5998aa42dceb3fd78326083472805615490a627b"
+source = "git+https://git.unom.io/unom/punktfunk?rev=7fa3b81d4#7fa3b81d43f87d84dc3e0a2babcf99207f5e554a"
 dependencies = [
  "anyhow",
  "punktfunk-core",
@@ -1299,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "pf-console-ui"
 version = "0.34.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=5998aa42d#5998aa42dceb3fd78326083472805615490a627b"
+source = "git+https://git.unom.io/unom/punktfunk?rev=7fa3b81d4#7fa3b81d43f87d84dc3e0a2babcf99207f5e554a"
 dependencies = [
  "anyhow",
  "pf-client-core",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "punktfunk-core"
 version = "0.34.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=5998aa42d#5998aa42dceb3fd78326083472805615490a627b"
+source = "git+https://git.unom.io/unom/punktfunk?rev=7fa3b81d4#7fa3b81d43f87d84dc3e0a2babcf99207f5e554a"
 dependencies = [
  "aes-gcm",
  "cbindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=7fa3b81d4#7fa3b81d43f87d84dc3e0a2babcf99207f5e554a"
+source = "git+https://git.unom.io/unom/punktfunk?rev=a157fe582#a157fe5822684ce05909c52e3b27b9b3967eefef"
 
 [[package]]
 name = "fiat-crypto"
@@ -1286,7 +1286,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "pf-client-core"
 version = "0.34.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=7fa3b81d4#7fa3b81d43f87d84dc3e0a2babcf99207f5e554a"
+source = "git+https://git.unom.io/unom/punktfunk?rev=a157fe582#a157fe5822684ce05909c52e3b27b9b3967eefef"
 dependencies = [
  "anyhow",
  "punktfunk-core",
@@ -1299,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "pf-console-ui"
 version = "0.34.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=7fa3b81d4#7fa3b81d43f87d84dc3e0a2babcf99207f5e554a"
+source = "git+https://git.unom.io/unom/punktfunk?rev=a157fe582#a157fe5822684ce05909c52e3b27b9b3967eefef"
 dependencies = [
  "anyhow",
  "pf-client-core",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "punktfunk-core"
 version = "0.34.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=7fa3b81d4#7fa3b81d43f87d84dc3e0a2babcf99207f5e554a"
+source = "git+https://git.unom.io/unom/punktfunk?rev=a157fe582#a157fe5822684ce05909c52e3b27b9b3967eefef"
 dependencies = [
  "aes-gcm",
  "cbindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,13 +65,14 @@ tracing-appender = "0.2"
 # also be ONE source: pin punktfunk-core by tag while pf-client-core resolves it by rev and
 # cargo builds two copies whose types do not unify — the shell would then reject the
 # `GamepadPref` this crate hands it. Re-pin all three together, to v0.35.0 once it is cut.
-# 5998aa42d is main plus unom/punktfunk#660 (a noted row's value back on the centre line).
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "5998aa42d", features = ["quic"] }
+# 7fa3b81d4 is main plus unom/punktfunk#660 (a noted row's value on the centre line) and the
+# kit's brand mark (`pf_console_ui::brand`), which the sidebar draws.
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "7fa3b81d4", features = ["quic"] }
 # The portable half of the client stack: `trust::Settings` (the shared settings document this
 # client now persists), the menu vocabulary, the library model, deep links. Pure Rust with no
 # Skia and no SDL, so it builds on every host — `services::store::shared` and its tests need it
 # on the dev target too.
-pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "5998aa42d", default-features = false }
+pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "7fa3b81d4", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # mDNS LAN discovery; direct dep (not via pf-client-core — see session.rs docs).
@@ -113,7 +114,7 @@ libc = "0.2"
 # surface — and `gl` asks Skia for the GLES backend the panel exposes. skia-safe keeps its
 # DEFAULT features: they carry `binary-cache` (the prebuilt fetch) and the jpeg/pdf codecs, and
 # they are what make the key `gl-jpegd-jpege-pdf-textlayout` — the one both sources publish.
-pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "5998aa42d", default-features = false, features = ["gl"] }
+pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "7fa3b81d4", default-features = false, features = ["gl"] }
 # `Console::frame` draws into a `skia_safe::Canvas`, and the host owns the `DirectContext` plus
 # the surface wrapping framebuffer 0.
 skia-safe = { version = "0.99", features = ["gl", "textlayout"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,14 +65,14 @@ tracing-appender = "0.2"
 # also be ONE source: pin punktfunk-core by tag while pf-client-core resolves it by rev and
 # cargo builds two copies whose types do not unify — the shell would then reject the
 # `GamepadPref` this crate hands it. Re-pin all three together, to v0.35.0 once it is cut.
-# 7fa3b81d4 is main plus unom/punktfunk#660 (a noted row's value on the centre line) and the
-# kit's brand mark (`pf_console_ui::brand`), which the sidebar draws.
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "7fa3b81d4", features = ["quic"] }
+# a157fe582 is main (with unom/punktfunk#660, a noted row's value on the centre line, and #662,
+# the kit's brand mark the sidebar draws) plus #664, the mark's highlight as the icon draws it.
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "a157fe582", features = ["quic"] }
 # The portable half of the client stack: `trust::Settings` (the shared settings document this
 # client now persists), the menu vocabulary, the library model, deep links. Pure Rust with no
 # Skia and no SDL, so it builds on every host — `services::store::shared` and its tests need it
 # on the dev target too.
-pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "7fa3b81d4", default-features = false }
+pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "a157fe582", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # mDNS LAN discovery; direct dep (not via pf-client-core — see session.rs docs).
@@ -114,7 +114,7 @@ libc = "0.2"
 # surface — and `gl` asks Skia for the GLES backend the panel exposes. skia-safe keeps its
 # DEFAULT features: they carry `binary-cache` (the prebuilt fetch) and the jpeg/pdf codecs, and
 # they are what make the key `gl-jpegd-jpege-pdf-textlayout` — the one both sources publish.
-pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "7fa3b81d4", default-features = false, features = ["gl"] }
+pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "a157fe582", default-features = false, features = ["gl"] }
 # `Console::frame` draws into a `skia_safe::Canvas`, and the host owns the `DirectContext` plus
 # the surface wrapping framebuffer 0.
 skia-safe = { version = "0.99", features = ["gl", "textlayout"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,12 +65,13 @@ tracing-appender = "0.2"
 # also be ONE source: pin punktfunk-core by tag while pf-client-core resolves it by rev and
 # cargo builds two copies whose types do not unify — the shell would then reject the
 # `GamepadPref` this crate hands it. Re-pin all three together, to v0.35.0 once it is cut.
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "01d990cda", features = ["quic"] }
+# 5998aa42d is main plus unom/punktfunk#660 (a noted row's value back on the centre line).
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "5998aa42d", features = ["quic"] }
 # The portable half of the client stack: `trust::Settings` (the shared settings document this
 # client now persists), the menu vocabulary, the library model, deep links. Pure Rust with no
 # Skia and no SDL, so it builds on every host — `services::store::shared` and its tests need it
 # on the dev target too.
-pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "01d990cda", default-features = false }
+pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "5998aa42d", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # mDNS LAN discovery; direct dep (not via pf-client-core — see session.rs docs).
@@ -112,7 +113,7 @@ libc = "0.2"
 # surface — and `gl` asks Skia for the GLES backend the panel exposes. skia-safe keeps its
 # DEFAULT features: they carry `binary-cache` (the prebuilt fetch) and the jpeg/pdf codecs, and
 # they are what make the key `gl-jpegd-jpege-pdf-textlayout` — the one both sources publish.
-pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "01d990cda", default-features = false, features = ["gl"] }
+pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "5998aa42d", default-features = false, features = ["gl"] }
 # `Console::frame` draws into a `skia_safe::Canvas`, and the host owns the `DirectContext` plus
 # the surface wrapping framebuffer 0.
 skia-safe = { version = "0.99", features = ["gl", "textlayout"] }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ This repo is only the webOS-specific client: an SDL2 UI, NDL DirectMedia hardwar
 - **Host power** — Wake-on-LAN starts a sleeping host from the TV, and a paired host can be put to
   sleep or shut down on exit when it grants those rights.
 - **Game mode (rooted TVs)** — optional setting that switches picture and sound to Game mode while
-  streaming and restores the previous settings on exit.
+  streaming and restores the previous settings on exit. On a TV that is not rooted, pick
+  *Game Optimizer* in the TV's own picture menu while a stream is up; webOS remembers it for
+  the app, and it is the largest input-latency win the panel has.
 
 > **Controller advanced features need newer webOS version.** Haptics, triggers, speakers, touchpad, and
 > lightbar all rely on the kernel's `hid-playstation` driver, which LG ships only on webOS versions 10+.

--- a/src/app/draw/dialog.rs
+++ b/src/app/draw/dialog.rs
@@ -132,8 +132,8 @@ pub(crate) fn draw(
     });
 }
 
-/// A card with no buttons: what a wake with no address on record, or a speed test still
-/// running, shows.
+/// A card with no buttons: what a speed test still measuring shows, until it has a result to
+/// apply.
 pub(crate) fn draw_message(
     f: &Frame<'_>,
     title: &str,
@@ -338,13 +338,11 @@ impl App {
     }
 
     /// The buttonless card a screen shows while it has nothing to confirm: title, body and
-    /// the body's tone. Wake without an address on record; a speed test still running.
+    /// the body's tone. Only a speed test still measuring — a wake with nothing to send never
+    /// opens a card at all (`state::wake::wake_prompts`), since it would have nothing on it a
+    /// d-pad could reach.
     pub(crate) fn message_card(&self, screen: Screen) -> Option<(&'static str, String, Color4f)> {
         match screen {
-            Screen::Wake => {
-                let wake = self.screens.wake.as_ref()?;
-                Some(("Host unreachable", view::wake::status_text(wake), theme::fg(0.72)))
-            }
             Screen::SpeedTest => {
                 let state = self.screens.speed_test.as_ref();
                 let failed = matches!(state, Some(crate::app::state::speedtest::SpeedTestState::Failed(_)));

--- a/src/app/draw/home.rs
+++ b/src/app/draw/home.rs
@@ -30,9 +30,9 @@ const VALUE: f32 = 20.0;
 const TITLE: f32 = 40.0;
 const CAPTION: f32 = 14.0;
 pub(crate) const CARD_RADIUS: f32 = 10.0;
-/// The app mark top left at the panel's padding, on its own — the host rows say what the
-/// column is. `MARK_SIDE` is the discs' box, not an icon tile; [`view::sidebar::TOP_Y`]
-/// follows it.
+/// The app mark top left, on its own — the host rows say what the column is. Its left edge
+/// lines up with the row icons, not the panel padding, or it reads as hanging off the edge.
+/// `MARK_SIDE` is the discs' box, not an icon tile; [`view::sidebar::TOP_Y`] follows it.
 const MARK_SIDE: f32 = 64.0;
 const SIDEBAR_ICON: f32 = 30.0;
 const SIDEBAR_ICON_PAD: f32 = 20.0;
@@ -229,7 +229,7 @@ impl App {
         // Opaque on every look, glass included: a lit edge against the grid reads as a seam.
         c.draw_rect(panel_rect, &theme::fill(panel()));
         let x = SIDEBAR_PAD as f32;
-        app_mark(c, x, x, MARK_SIDE);
+        app_mark(c, x + SIDEBAR_ICON_PAD, x, MARK_SIDE);
 
         let entries = &self.hosts.entries;
         let add_row = entries.len();

--- a/src/app/draw/home.rs
+++ b/src/app/draw/home.rs
@@ -30,11 +30,10 @@ const VALUE: f32 = 20.0;
 const TITLE: f32 = 40.0;
 const CAPTION: f32 = 14.0;
 pub(crate) const CARD_RADIUS: f32 = 10.0;
-/// Plan D7: the app mark top left at the panel's padding, the "Hosts" title under it.
-/// `MARK_SIDE` is the discs' box, not an icon tile; [`view::sidebar::TOP_Y`] follows these.
-const MARK_SIDE: f32 = 48.0;
-const HEADER_GAP: f32 = 36.0;
-const HEADER_SIZE: f32 = 26.0;
+/// The app mark top left at the panel's padding, on its own — the host rows say what the
+/// column is. `MARK_SIDE` is the discs' box, not an icon tile; [`view::sidebar::TOP_Y`]
+/// follows it.
+const MARK_SIDE: f32 = 64.0;
 const SIDEBAR_ICON: f32 = 30.0;
 const SIDEBAR_ICON_PAD: f32 = 20.0;
 const MENU_GLYPH: f32 = 26.0;
@@ -231,16 +230,6 @@ impl App {
         c.draw_rect(panel_rect, &theme::fill(panel()));
         let x = SIDEBAR_PAD as f32;
         app_mark(c, x, x, MARK_SIDE);
-        let size = px(f, HEADER_SIZE);
-        f.fonts.draw(
-            c,
-            "Hosts",
-            f64::from(x),
-            f64::from(x + MARK_SIDE + HEADER_GAP) + size * 0.8,
-            W::SemiBold,
-            size,
-            theme::fg(1.0),
-        );
 
         let entries = &self.hosts.entries;
         let add_row = entries.len();

--- a/src/app/draw/home.rs
+++ b/src/app/draw/home.rs
@@ -8,10 +8,10 @@ use std::time::Instant;
 
 use pf_console_ui::icons::{by_name, draw_icon};
 use pf_console_ui::theme::{self, W};
-use pf_console_ui::{launcher_icons, os_marks};
+use pf_console_ui::{brand, launcher_icons, os_marks};
 use skia_safe::{
-    images, BlendMode, BlurStyle, Canvas, ClipOp, Color4f, Data, FilterMode, Image, ImageInfo, MaskFilter, MipmapMode,
-    Paint, Path, RRect, Rect, SamplingOptions,
+    images, BlendMode, BlurStyle, ClipOp, Color4f, Data, FilterMode, Image, ImageInfo, MaskFilter, MipmapMode, Paint,
+    RRect, Rect, SamplingOptions,
 };
 
 use super::{focus_face, line_h, panel, sk, with_pop, Frame};
@@ -110,31 +110,6 @@ pub(crate) fn cover_image(art: &crate::services::art::CardArt) -> Option<Image> 
     raw_image(art.width, art.height, RawFormat::Rgba8888, &art.pixels)
 }
 
-/// The brand mark: two discs of radius `side / 3` at (r, 2r) and (2r, r) with their lens,
-/// the favicon's geometry. Deep disc on the accent, the light disc and lens toward `fg`,
-/// so the mark follows the palette instead of shipping the launcher tile's background.
-pub(crate) fn app_mark(c: &Canvas, x: f32, y: f32, side: f32) {
-    let r = side / 3.0;
-    let light = (x + r, y + 2.0 * r);
-    let deep = (x + 2.0 * r, y + r);
-    let toward_fg = |t: f32| {
-        let (a, g) = (theme::accent(1.0), theme::fg(1.0));
-        let mix = |a: f32, b: f32| a + (b - a) * t;
-        Color4f::new(mix(a.r, g.r), mix(a.g, g.g), mix(a.b, g.b), 1.0)
-    };
-    let mut paint = theme::fill(toward_fg(0.4));
-    paint.set_anti_alias(true);
-    c.draw_circle(light, r, &paint);
-    paint.set_color4f(theme::accent(1.0), None);
-    c.draw_circle(deep, r, &paint);
-    let lens = Path::circle(light, r, None);
-    c.save();
-    c.clip_path(&lens, ClipOp::Intersect, true);
-    paint.set_color4f(toward_fg(0.68), None);
-    c.draw_circle(deep, r, &paint);
-    c.restore();
-}
-
 /// Card tint for a coverless poster: hashed per title so a library reads as varied, on the
 /// kit's face colour so it follows the palette.
 fn face_for(title: &str) -> Color4f {
@@ -229,7 +204,10 @@ impl App {
         // Opaque on every look, glass included: a lit edge against the grid reads as a seam.
         c.draw_rect(panel_rect, &theme::fill(panel()));
         let x = SIDEBAR_PAD as f32;
-        app_mark(c, x + SIDEBAR_ICON_PAD, x, MARK_SIDE);
+        // The entrance plays once, from the first frame the sidebar shows.
+        let shown = *self.render.mark_shown_at.get_or_insert_with(Instant::now);
+        let intro = brand::intro_progress(shown.elapsed().as_secs_f32());
+        brand::draw(c, x + SIDEBAR_ICON_PAD, x, MARK_SIDE, intro);
 
         let entries = &self.hosts.entries;
         let add_row = entries.len();
@@ -678,7 +656,7 @@ mod tests {
         theme::set_ink(pf_console_ui::theme::Ink::of(pf_console_ui::library::palette("violet")));
         let mut surface = skia_safe::surfaces::raster_n32_premul((60, 60)).unwrap();
         surface.canvas().clear(Color4f::new(0.0, 0.0, 0.0, 1.0));
-        app_mark(surface.canvas(), 6.0, 6.0, 48.0);
+        brand::draw(surface.canvas(), 6.0, 6.0, 48.0, 1.0);
         let img = surface.image_snapshot();
         if let Ok(dir) = std::env::var("PF_WEBOS_DUMP") {
             let png = img.encode(None, skia_safe::EncodedImageFormat::PNG, 100).unwrap();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -678,6 +678,14 @@ impl App {
         {
             animating = true;
         }
+        // The mark's entrance, from the sidebar's first frame.
+        if self
+            .render
+            .mark_shown_at
+            .is_some_and(|t| t.elapsed().as_secs_f32() < pf_console_ui::brand::INTRO_SECS)
+        {
+            animating = true;
+        }
         animating
     }
 

--- a/src/app/render/state.rs
+++ b/src/app/render/state.rs
@@ -38,4 +38,7 @@ pub(crate) struct RenderState {
     /// The sidebar rows' and the settings tabs' eased focus (`app::draw::FocusEase`).
     pub(crate) sidebar_focus: crate::app::draw::FocusEase,
     pub(crate) tab_focus: crate::app::draw::FocusEase,
+    /// When the sidebar first drew the brand mark — the start of its one-shot entrance
+    /// (`pf_console_ui::brand`). `None` until then.
+    pub(crate) mark_shown_at: Option<std::time::Instant>,
 }

--- a/src/app/screens/confirm.rs
+++ b/src/app/screens/confirm.rs
@@ -132,7 +132,7 @@ impl App {
                 "Wake host",
                 Tone::Primary,
                 "Cancel",
-                view::wake::status_text(self.screens.wake.as_ref().filter(|w| !w.mac.is_empty())?),
+                view::wake::status_text(self.screens.wake.as_ref()?),
             ),
             Screen::SpeedTest => {
                 let state = self.screens.speed_test.as_ref();

--- a/src/app/state/wake.rs
+++ b/src/app/state/wake.rs
@@ -1,6 +1,7 @@
 //! The "host unreachable — wake it?" flow's logic: the Wake-on-LAN prompt, its retry/probe
 //! timers, and its send-side plumbing. The per-host auto-send setting the prompt obeys
 //! lives in `app::state::hostpower`. Rendering lives in `app::view::wake`.
+use crate::app::view;
 use crate::app::{App, Screen, WakeState};
 use crate::core::event::MenuEvent;
 use crate::services::store::KnownHost;
@@ -9,6 +10,7 @@ use std::time::Instant;
 impl App {
     /// Enters the WOL flow. With `wol_auto` off, shows prompt immediately.
     /// With it on, fires packet silently, shows prompt only after `WAKE_RETRY_INTERVAL`.
+    /// A host with no MAC on record never prompts at all (see [`wake_prompts`]).
     pub(crate) fn start_wake(&mut self, host: String, port: u16, mac: Vec<String>, reason: String) {
         let known = self.hosts.known.iter().find(|h| h.addr == host && h.port == port);
         let name = known.map_or_else(|| host.clone(), |h| h.name.clone());
@@ -18,6 +20,7 @@ impl App {
         let auto = known.is_some_and(|h| h.wol_auto)
             && !mac.is_empty()
             && self.hosts.powered_down.as_ref() != Some(&(host.clone(), port));
+        let prompts = wake_prompts(auto, &mac);
         let mut wake = WakeState {
             host,
             port,
@@ -30,7 +33,7 @@ impl App {
             attempts: 0,
             since: None,
             last_attempt: None,
-            silent: auto,
+            silent: !prompts,
             // Baseline for `WAKE_PROBE_INTERVAL` — the first active probe fires
             // `WAKE_PROBE_INTERVAL` from now, not immediately.
             last_probe: Some(Instant::now()),
@@ -38,12 +41,19 @@ impl App {
         };
         if auto {
             Self::send_wake(&mut wake);
+        }
+        if prompts {
+            self.nav.screen = Screen::Wake;
+        } else {
             // No modal is up in this branch, so the Home bar is the only place the
             // wait is visible at all — without this it would sit on `select_host`'s
             // stale "Loading library…" until the host came back (or didn't).
-            self.set_home_status(Some(Self::wake_home_status(&wake)), false);
-        } else {
-            self.nav.screen = Screen::Wake;
+            let line = if wake.mac.is_empty() {
+                view::wake::status_text(&wake)
+            } else {
+                Self::wake_home_status(&wake)
+            };
+            self.set_home_status(Some(line), false);
         }
         self.screens.wake = Some(wake);
     }
@@ -165,12 +175,9 @@ impl App {
 
     /// Handles Wake modal events: direction moves between "Wake"/"Cancel" buttons.
     /// Confirm sends and closes the modal, or cancels. Back dismisses it (wake runs on in bg).
+    /// The card only ever opens with both buttons on it, so every event has a target.
     pub fn handle_wake_event(&mut self, ev: MenuEvent) {
         let Some(wake) = self.screens.wake.as_mut() else { return };
-        // WHY: no MAC = no send/automate possible. Every event but Back is no-op.
-        if wake.mac.is_empty() && ev != MenuEvent::Back {
-            return;
-        }
         if ev == MenuEvent::Back {
             self.close_wake(false);
             return;
@@ -226,5 +233,27 @@ impl App {
                 wake.name
             ),
         }
+    }
+}
+
+/// Whether a wake puts its prompt up rather than waiting on the Home status line.
+///
+/// Neither silent case has anything on the card to press: `auto` has already sent the packet,
+/// and with no MAC there is none to send. The close mark answers the pointer alone, so a card
+/// without buttons is a dead end for a d-pad.
+fn wake_prompts(auto: bool, mac: &[String]) -> bool {
+    !auto && !mac.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::wake_prompts;
+
+    #[test]
+    fn only_a_sendable_wake_prompts() {
+        let mac = ["aa:bb:cc:dd:ee:ff".to_string()];
+        assert!(wake_prompts(false, &mac));
+        assert!(!wake_prompts(true, &mac));
+        assert!(!wake_prompts(false, &[]));
     }
 }

--- a/src/app/view/sidebar.rs
+++ b/src/app/view/sidebar.rs
@@ -4,9 +4,8 @@
 use crate::ui;
 use crate::ui::render::Rect;
 
-/// Where the host rows start: under the mark and its title (plan D7) — pad 24, mark 48,
-/// gap 36, title line 44.
-pub const TOP_Y: i32 = 152;
+/// Where the host rows start: under the mark — pad 24, mark 64, gap 36.
+pub const TOP_Y: i32 = 124;
 
 /// Every nav position's rect, in order: the host rows and "+ Add host" stacked from
 /// [`TOP_Y`], then "Settings" pinned to the bottom of the panel — a spacer slot between

--- a/src/app/view/wake.rs
+++ b/src/app/view/wake.rs
@@ -1,4 +1,7 @@
-//! The "host unreachable — wake it?" modal — presentation. Logic lives in `app::state::wake`.
+//! "Wake this host?" copy. Logic lives in `app::state::wake`, the card in `app::draw::dialog`.
+//!
+//! A host with no MAC on record never opens that card — [`status_text`] goes on the Home
+//! status line instead, since there would be nothing on it to press.
 use crate::app::WakeState;
 
 /// Status line; reconstructible from `wake` alone, so render and layout can't disagree.

--- a/src/platform/webos/device.rs
+++ b/src/platform/webos/device.rs
@@ -249,11 +249,45 @@ pub const HOT_THREAD_NICE: libc::c_int = -10;
 
 /// Renices `tid` (0 = calling thread) to [`HOT_THREAD_NICE`]; `false` if the kernel refused.
 ///
-/// Always best-effort: it needs `CAP_SYS_NICE` or a nonzero `RLIMIT_NICE`, present on a rooted
-/// install and absent under a plain Dev-Mode SAM jail.
+/// Always best-effort: it needs `CAP_SYS_NICE` or a large enough `RLIMIT_NICE`, present on a
+/// rooted install and absent under a plain Dev-Mode SAM jail — see [`unlock_nice_limit`].
 pub fn renice(tid: i32) -> bool {
+    unlock_nice_limit();
     // SAFETY: plain syscall — tid and priority value only, no pointers.
     unsafe { libc::setpriority(libc::PRIO_PROCESS, tid as libc::id_t, HOT_THREAD_NICE) == 0 }
+}
+
+/// Raises `RLIMIT_NICE`'s soft limit to its hard limit, once. Raising the soft limit needs no
+/// privilege, so a jail that grants the hard limit alone would otherwise refuse every renice
+/// for nothing. Logged either way: the limit is what a session log needs to say why the boost
+/// did or did not apply. The kernel reads the limit as `20 - rlim_cur`, so nice -10 needs 30.
+fn unlock_nice_limit() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        let mut lim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        // SAFETY: `lim` is a valid, writable rlimit for the duration of the call.
+        if unsafe { libc::getrlimit(libc::RLIMIT_NICE, &mut lim) } != 0 {
+            return;
+        }
+        if lim.rlim_cur < lim.rlim_max {
+            lim.rlim_cur = lim.rlim_max;
+            // SAFETY: `lim` is a valid rlimit this function owns for the duration of the call.
+            if unsafe { libc::setrlimit(libc::RLIMIT_NICE, &lim) } != 0 {
+                tracing::warn!(
+                    "RLIMIT_NICE: raising the soft limit failed: {}",
+                    std::io::Error::last_os_error()
+                );
+            }
+        }
+        tracing::info!(
+            "RLIMIT_NICE soft={} hard={} (nice floor is 20 - soft; the boost asks {HOT_THREAD_NICE})",
+            lim.rlim_cur,
+            lim.rlim_max,
+        );
+    });
 }
 
 /// Boosts the calling thread. See [`renice`].

--- a/src/platform/webos/device.rs
+++ b/src/platform/webos/device.rs
@@ -88,7 +88,7 @@ fn system_info() -> &'static str {
         }
         super::luna::call_capture(
             "luna://com.webos.service.tv.systemproperty/getSystemInfo",
-            r#"{"keys":["sdkVersion","otaId"]}"#,
+            r#"{"keys":["sdkVersion","otaId","UHD"]}"#,
             super::luna::CALL_TIMEOUT,
         )
         .unwrap_or_default()
@@ -124,6 +124,31 @@ pub fn sdk_version() -> Option<(u32, u32)> {
 /// `otaId` from Luna's `getSystemInfo`, e.g. `HE_DTV_W19H_...`. Display-only.
 fn ota_id() -> Option<String> {
     json_str_field(system_info(), "otaId")
+}
+
+/// The panel's own stream mode — what the shared settings document's `0` ("Native") and
+/// `match_window` resolve to at connect, as the desktop clients resolve them to the monitor.
+///
+/// SDL cannot answer this: it reports the app plane as 1080p@60 on a 4K panel. The resolution
+/// comes from `getSystemInfo`'s `UHD` flag; an unanswered query reads as 1080p, which streams
+/// rather than failing the handshake with a 0×0 request. The rate is 60: the plane rate the
+/// compositor reports, and the shipped default before the document moved. 120 stays a pick.
+pub fn native_mode() -> punktfunk_core::config::Mode {
+    let uhd = json_str_field(system_info(), "UHD");
+    let (width, height) = if uhd.as_deref() == Some("true") {
+        (3840, 2160)
+    } else {
+        (1920, 1080)
+    };
+    tracing::info!(
+        "panel: UHD={} — native mode {width}x{height}@60",
+        uhd.as_deref().unwrap_or("unknown")
+    );
+    punktfunk_core::config::Mode {
+        width,
+        height,
+        refresh_hz: 60,
+    }
 }
 
 /// SoC/board codename (`/etc/prefs/properties/machineName`, e.g. `m16p`, `k5lp`), read only for

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -66,6 +66,22 @@ fn resolve_gamepad_type(
     settings
 }
 
+/// The mode to dial with: the document's explicit pick, or the panel where it says "Native"
+/// (`0`) or "Match window" — the two the desktop clients resolve to the monitor, and which the
+/// host refuses as a 0×0 request if passed through.
+fn stream_mode(settings: &store::Settings, native: Mode) -> Mode {
+    let explicit = !settings.match_window && settings.width != 0 && settings.height != 0;
+    Mode {
+        width: if explicit { settings.width } else { native.width },
+        height: if explicit { settings.height } else { native.height },
+        refresh_hz: if settings.refresh_hz == 0 {
+            native.refresh_hz
+        } else {
+            settings.refresh_hz
+        },
+    }
+}
+
 /// Set when a connect attempt returns an error, cleared as the next one is spawned. The
 /// loading screen otherwise has only `is_finished`, which success and failure reach alike —
 /// and a failure never presents a frame, so it sat out the whole
@@ -83,18 +99,8 @@ fn spawn_connect(
     std::thread::Builder::new()
         .name("punktfunk-webos-connect".into())
         .spawn(move || {
-            // SDL2/Wayland reports refresh_rate=0; use settings' nominal rate instead
-            let mode = Mode {
-                width: settings.width,
-                height: settings.height,
-                refresh_hz: settings.refresh_hz,
-            };
-            tracing::info!(
-                "requesting {}x{}@{}",
-                settings.width,
-                settings.height,
-                settings.refresh_hz
-            );
+            let mode = stream_mode(&settings, crate::platform::webos::device::native_mode());
+            tracing::info!("requesting {}x{}@{}", mode.width, mode.height, mode.refresh_hz);
             session::connect(&session::ConnectParams {
                 host,
                 port,
@@ -303,3 +309,34 @@ use ui_flow::run_ui_flow;
 
 /// The shared gamepad shell's flow. `runtime` is Linux-only, and so is the shell.
 mod console_flow;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// "Native" (0) and "Match window" dial the panel; an explicit pick dials itself.
+    #[test]
+    fn a_native_mode_dials_the_panel() {
+        let panel = Mode {
+            width: 3840,
+            height: 2160,
+            refresh_hz: 60,
+        };
+        let mut s = store::Settings::default();
+        assert_eq!(stream_mode(&s, panel), panel, "the document's default is Native");
+        s.match_window = true;
+        s.width = 1280;
+        assert_eq!(stream_mode(&s, panel), panel);
+        s.match_window = false;
+        s.height = 720;
+        s.refresh_hz = 120;
+        assert_eq!(
+            stream_mode(&s, panel),
+            Mode {
+                width: 1280,
+                height: 720,
+                refresh_hz: 120
+            }
+        );
+    }
+}

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -74,6 +74,11 @@ fn wait_for_dial(handle: &std::thread::JoinHandle<Result<session::Connected>>, e
 /// How many copies of a mid-stream `GamepadArrival` to send — see its one caller.
 const ARRIVAL_SENDS: usize = 3;
 
+/// How long a freeze-until-reanchor hold must last before the toast names it. An RFI recovery
+/// lifts a hold within a round trip and the startup capacity probe's own loss clears at the
+/// burst's end; a toast for those flashed on every blip and said nothing the picture did not.
+const HOLD_TOAST_AFTER: Duration = Duration::from_millis(300);
+
 /// `DualSense` HID feedback (adaptive triggers, lightbar), opened only for a pad kind that emits
 /// it — anything else never sends these events. Not found (USB pad, no `luna-send-pub`) isn't an
 /// error: logged once, the feature just stays off.
@@ -438,10 +443,10 @@ pub(super) fn run_inner() -> Result<()> {
             // Transient toasts. `overlay_was_active` catches the fade-out edge so the canvas gets
             // wiped once; `stats_dst`/`log_dst` recomposite each frame at their own slower cadence.
             let mut notif = overlay::Notification::new();
-            // Edge-detects `stats.holding` (freeze-until-reanchor — see `session::pump`'s video pump) so a
-            // packet-loss stall surfaces as a toast even with the stats overlay off, same signal the
-            // overlay's "Beat" line already reads.
-            let mut was_holding = false;
+            // When the current freeze-until-reanchor hold began (`stats.holding`, see `session::pump`),
+            // and whether it has been announced — see `HOLD_TOAST_AFTER`.
+            let mut hold_since: Option<Instant> = None;
+            let mut hold_toasted = false;
             let mut overlay_was_active = false;
             // The stats card's lines and the log tail, rebuilt on their 500 ms cadence and drawn
             // as they stand on every overlay frame between.
@@ -789,18 +794,21 @@ pub(super) fn run_inner() -> Result<()> {
                         log_fade.close(());
                     }
                 }
-                // Connection-issue toast: fires on the rising edge of a freeze-until-reanchor hold
-                // (dropped/gapped frames — see `session::pump`), which is the same "network
-                // trouble" signal the stats overlay's "Beat" line reads, just edge-triggered here so
-                // it's visible without the overlay open. No matching "recovered" toast — the video
-                // itself resuming is the recovery signal.
-                let holding_now = connected.stats().holding.load(Ordering::Relaxed);
-                if holding_now && !was_holding {
-                    tracing::warn!("connection issues detected (freeze-until-reanchor)");
-                    notif.show("Connection issues — recovering...");
-                    overlay_last = None;
+                // Connection-issue toast, once per hold that outlasts `HOLD_TOAST_AFTER` — the same
+                // "network trouble" signal the stats overlay's "Beat" line reads, visible without the
+                // overlay open. No matching "recovered" toast: the picture resuming is that signal.
+                if connected.stats().holding.load(Ordering::Relaxed) {
+                    let since = *hold_since.get_or_insert_with(Instant::now);
+                    if !hold_toasted && since.elapsed() >= HOLD_TOAST_AFTER {
+                        hold_toasted = true;
+                        tracing::warn!("connection issues detected (freeze-until-reanchor)");
+                        notif.show("Connection issues — recovering...");
+                        overlay_last = None;
+                    }
+                } else {
+                    hold_since = None;
+                    hold_toasted = false;
                 }
-                was_holding = holding_now;
                 // The dialog is navigated with the Magic Remote's pointer, so a captured stream
                 // must hand the pointer back while it's up — hidden/relative there'd be nothing
                 // to aim with. Recaptured on dismiss. The evdev reader releases its grabs for the

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -632,7 +632,7 @@ mod tests {
     /// refused play — which reports `Held`, not `Presented`, while its request is throttled.
     #[test]
     fn only_a_fed_picture_counts() {
-        let mut s = stage();
+        let mut s = stage(None);
         assert!(matches!(
             s.submit(&frame(1, None, false, true)),
             SinkResult::NeedKeyframe

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -334,10 +334,9 @@ impl VideoStage {
             partial,
         };
         let result = self.feed(frame.data, frame.pts_ns, flags);
-        // Either the piece never reached the decoder (a hold swallows it, an error refused it) or
-        // it did and a keyframe has just been asked for regardless — on both paths the AU cannot
-        // be completed. Forgetting it costs the rest of one AU; keeping it would eventually feed a
-        // frame with a hole in it.
+        // The piece never reached the decoder (a hold swallowed it, an error refused it, the
+        // decoder is gone), so the AU cannot be completed. Forgetting it costs the rest of one AU;
+        // keeping it would eventually feed a frame with a hole in it.
         if !matches!(result, SinkResult::Presented { .. }) {
             self.parts.drop_open();
             // The AU this was accumulating for will never complete, so it must not be added to
@@ -354,10 +353,9 @@ impl VideoStage {
         if self.sink.is_dead() {
             return SinkResult::Dead;
         }
-        let request_keyframe = match self.gate(&flags) {
-            HoldGate::Skip(result) => return result,
-            HoldGate::Feed { request_keyframe } => request_keyframe,
-        };
+        if let HoldGate::Skip(result) = self.gate(&flags) {
+            return result;
+        }
 
         let base_ns = self.au_stamp_ns(pts_ns, flags.partial);
         // The feed is timed only where something reads the figure: the host's ABR controller, or
@@ -403,7 +401,7 @@ impl VideoStage {
             Err(e) => (None, self.on_play_error(&e, &flags, base_ns)),
         };
 
-        if request_keyframe || failed_keyframe {
+        if failed_keyframe {
             SinkResult::NeedKeyframe
         } else {
             SinkResult::Presented { decode_us }
@@ -431,17 +429,18 @@ impl VideoStage {
             // queue holds good frames that the hold is about to present anyway.
         }
         let Some(started) = self.hold_started else {
-            return HoldGate::Feed {
-                request_keyframe: false,
-            };
+            return HoldGate::Feed;
         };
         if flags.recovery_mark {
             self.recovery_marks = self.recovery_marks.saturating_add(1);
         }
-        let request_keyframe = self.take_keyframe_slot();
         let recovered = flags.reanchor || self.recovery_marks >= punktfunk_core::reanchor::REANCHOR_MARKS_TO_LIFT;
         if !recovered {
-            return HoldGate::Skip(if request_keyframe {
+            // The slot is taken only while frames are still skipped. The frame that lifts the hold
+            // restarts decoding by itself, and reporting a request on it made `submit` read the
+            // feed as refused — abandoning the open AU, i.e. truncating the very keyframe that
+            // resumed the picture on a slice-progressive session, and re-arming the hold.
+            return HoldGate::Skip(if self.take_keyframe_slot() {
                 SinkResult::NeedKeyframe
             } else {
                 SinkResult::Held
@@ -460,7 +459,7 @@ impl VideoStage {
         self.stats.holding.store(false, Ordering::Relaxed);
         self.hold_started = None;
         self.recovery_marks = 0;
-        HoldGate::Feed { request_keyframe }
+        HoldGate::Feed
     }
 
     /// Handles a refused feed; returns whether to ask the host for a keyframe.
@@ -498,9 +497,8 @@ impl VideoStage {
 
 /// What [`VideoStage::gate`] decided about this frame.
 enum HoldGate {
-    /// Feed it. `request_keyframe` is set when a hold released on this frame and the throttle
-    /// allowed asking for one — the frame is still fed, but the request is what gets reported.
-    Feed { request_keyframe: bool },
+    /// Feed it — not holding, or this is the frame that lifts the hold.
+    Feed,
     /// Still frozen — skip it, and report this instead.
     Skip(SinkResult),
 }
@@ -510,7 +508,7 @@ mod tests {
     use super::*;
     use std::cell::Cell;
 
-    /// A decoder that accepts everything and reports whatever depth the test sets.
+    /// A decoder that takes pieces, accepts everything, and reports whatever depth the test sets.
     struct FakeSink {
         depth: Cell<Option<u32>>,
     }
@@ -521,7 +519,11 @@ mod tests {
             "fake"
         }
         fn caps(&self) -> VideoSinkCaps {
-            VideoSinkCaps::FEED_ONLY
+            VideoSinkCaps {
+                pts: true,
+                partial_au: true,
+                flush: false,
+            }
         }
         fn feed(&self, _au: &[u8], _pts_ns: u64) -> anyhow::Result<()> {
             Ok(())
@@ -544,15 +546,15 @@ mod tests {
         )
     }
 
-    fn frame(index: u32, reanchor: bool) -> WireFrame<'static> {
+    fn frame(index: u32, part: Option<(bool, bool, u32)>, reanchor: bool, loss: bool) -> WireFrame<'static> {
         WireFrame {
             data: &[0u8; 4],
             pts_ns: u64::from(index) * 16_666_667,
             index,
-            part: None,
+            part: part.map(|(first, last, offset)| punktfunk_core::session::FramePart { offset, first, last }),
             reanchor,
             recovery_mark: false,
-            loss: false,
+            loss,
         }
     }
 
@@ -565,8 +567,11 @@ mod tests {
         s.backlog_sampled = None;
         assert!(s.backpressure(), "the second asks for a keyframe");
         assert!(s.holding());
-        assert!(matches!(s.submit(&frame(1, false)), SinkResult::Held));
-        assert!(matches!(s.submit(&frame(2, true)), SinkResult::Presented { .. }));
+        assert!(matches!(s.submit(&frame(1, None, false, false)), SinkResult::Held));
+        assert!(matches!(
+            s.submit(&frame(2, None, true, false)),
+            SinkResult::Presented { .. }
+        ));
         assert!(!s.holding());
 
         let mut shallow = stage(Some(1));
@@ -575,5 +580,35 @@ mod tests {
         shallow.backlog_sampled = None;
         assert!(!shallow.backpressure());
         assert!(!stage(None).backpressure(), "no queue to read, nothing to steer on");
+    }
+
+    /// A keyframe lifting a hold is fed whole, however long since the last request — reporting a
+    /// request on its first piece made `submit` abandon the AU and re-arm the hold on the next.
+    #[test]
+    fn the_resume_keyframe_keeps_its_au_open() {
+        let mut s = stage(None);
+        assert!(matches!(
+            s.submit(&frame(1, None, false, true)),
+            SinkResult::NeedKeyframe
+        ));
+        assert!(s.holding());
+        // The throttle has long expired by the time the host's keyframe lands.
+        s.last_keyframe_request = None;
+        let before = s.frames();
+        assert!(matches!(
+            s.submit(&frame(2, Some((true, false, 0)), true, false)),
+            SinkResult::Presented { .. }
+        ));
+        assert!(!s.holding());
+        assert!(matches!(
+            s.submit(&frame(2, Some((false, true, 4)), true, false)),
+            SinkResult::Presented { .. }
+        ));
+        assert_eq!(s.frames(), before + 1, "two pieces, one picture");
+        assert!(matches!(
+            s.submit(&frame(3, None, false, false)),
+            SinkResult::Presented { .. }
+        ));
+        assert!(!s.holding(), "the next AU must not read the resumed one as lost");
     }
 }

--- a/src/session/stage/mod.rs
+++ b/src/session/stage/mod.rs
@@ -63,7 +63,8 @@ pub enum SinkResult {
     /// Fed to the decoder. `decode_us` is the latency figure for the host's ABR
     /// controller, present only when the sink was built with `report_decode_latency`.
     Presented { decode_us: Option<u32> },
-    /// Skipped — still frozen, waiting for a re-anchor.
+    /// Nothing reached the decoder — frozen, or the play was refused — and no keyframe request
+    /// is due yet.
     Held,
     /// Skipped or failed, and the throttle allows asking the host for a keyframe now.
     NeedKeyframe,
@@ -319,13 +320,6 @@ impl VideoStage {
             self.au_base_ns = None;
             return SinkResult::Held;
         };
-        // Only a completed AU is a frame — a session feeding pieces would otherwise count one
-        // picture several times, and the overlay reads this figure as pictures per second.
-        if partial {
-            self.parts_fed += 1;
-        } else {
-            self.frames += 1;
-        }
         let flags = FrameFlags {
             reanchor: frame.reanchor,
             recovery_mark: frame.recovery_mark,
@@ -334,10 +328,19 @@ impl VideoStage {
             partial,
         };
         let result = self.feed(frame.data, frame.pts_ns, flags);
-        // The piece never reached the decoder (a hold swallowed it, an error refused it, the
-        // decoder is gone), so the AU cannot be completed. Forgetting it costs the rest of one AU;
-        // keeping it would eventually feed a frame with a hole in it.
-        if !matches!(result, SinkResult::Presented { .. }) {
+        if matches!(result, SinkResult::Presented { .. }) {
+            // Counted once the decoder took it, never on arrival: the overlay reads `frames` as
+            // pictures per second, and a held delivery is not one. Only a completed AU is a
+            // picture — pieces would count one several times.
+            if partial {
+                self.parts_fed += 1;
+            } else {
+                self.frames += 1;
+            }
+        } else {
+            // The piece never reached the decoder (a hold swallowed it, an error refused it, the
+            // decoder is gone), so the AU cannot be completed. Forgetting it costs the rest of
+            // one AU; keeping it would eventually feed a frame with a hole in it.
             self.parts.drop_open();
             // The AU this was accumulating for will never complete, so it must not be added to
             // whatever AU comes next — nor may its stamp be repeated onto one.
@@ -388,23 +391,26 @@ impl VideoStage {
             self.au_feed_us = 0;
         }
 
-        let (decode_us, failed_keyframe) = match play_result {
-            Ok(()) if flags.partial => (None, false),
+        match play_result {
+            Ok(()) if flags.partial => SinkResult::Presented { decode_us: None },
             Ok(()) => {
                 // NDL exposes no decoded-output callback. Its render-buffer depth is presentation
                 // lead, not decoder latency, and feeding it into ABR created false learned caps at
                 // 4K120. `play` duration is the only measured decoder-pressure signal available:
                 // when input backpressures, it rises naturally.
-                let decode_us = self.cfg.report_decode_latency.then_some(au_feed_us);
-                (decode_us, false)
+                SinkResult::Presented {
+                    decode_us: self.cfg.report_decode_latency.then_some(au_feed_us),
+                }
             }
-            Err(e) => (None, self.on_play_error(&e, &flags, base_ns)),
-        };
-
-        if failed_keyframe {
-            SinkResult::NeedKeyframe
-        } else {
-            SinkResult::Presented { decode_us }
+            // A refused piece was not presented whatever the throttle says; `Held` keeps the
+            // caller's AU bookkeeping honest where a request is not due yet.
+            Err(e) => {
+                if self.on_play_error(&e, &flags, base_ns) {
+                    SinkResult::NeedKeyframe
+                } else {
+                    SinkResult::Held
+                }
+            }
         }
     }
 
@@ -508,9 +514,11 @@ mod tests {
     use super::*;
     use std::cell::Cell;
 
-    /// A decoder that takes pieces, accepts everything, and reports whatever depth the test sets.
+    /// A decoder that takes pieces, accepts everything (or refuses everything as not loaded), and
+    /// reports whatever depth the test sets.
     struct FakeSink {
         depth: Cell<Option<u32>>,
+        refuse: bool,
     }
 
     // `Cell` is `!Sync`; the trait wants `Send` only and the test never shares it.
@@ -526,6 +534,9 @@ mod tests {
             }
         }
         fn feed(&self, _au: &[u8], _pts_ns: u64) -> anyhow::Result<()> {
+            if self.refuse {
+                return Err(NotReady.into());
+            }
             Ok(())
         }
         fn queue_depth(&self) -> Option<u32> {
@@ -534,10 +545,15 @@ mod tests {
     }
 
     fn stage(depth: Option<u32>) -> VideoStage {
+        stage_on(FakeSink {
+            depth: Cell::new(depth),
+            refuse: false,
+        })
+    }
+
+    fn stage_on(sink: FakeSink) -> VideoStage {
         VideoStage::new(
-            Box::new(FakeSink {
-                depth: Cell::new(depth),
-            }),
+            Box::new(sink),
             Arc::new(StreamStats::default()),
             SinkConfig {
                 stream_hz: 60,
@@ -610,5 +626,33 @@ mod tests {
             SinkResult::Presented { .. }
         ));
         assert!(!s.holding(), "the next AU must not read the resumed one as lost");
+    }
+
+    /// `frames` is pictures the decoder took: a held delivery is not one, and neither is a
+    /// refused play — which reports `Held`, not `Presented`, while its request is throttled.
+    #[test]
+    fn only_a_fed_picture_counts() {
+        let mut s = stage();
+        assert!(matches!(
+            s.submit(&frame(1, None, false, true)),
+            SinkResult::NeedKeyframe
+        ));
+        assert_eq!(s.frames(), 0, "held on arrival");
+        assert!(matches!(
+            s.submit(&frame(2, None, true, false)),
+            SinkResult::Presented { .. }
+        ));
+        assert_eq!(s.frames(), 1);
+
+        let mut r = stage_on(FakeSink {
+            depth: Cell::new(None),
+            refuse: true,
+        });
+        assert!(matches!(
+            r.submit(&frame(1, None, false, false)),
+            SinkResult::NeedKeyframe
+        ));
+        assert!(matches!(r.submit(&frame(2, None, false, false)), SinkResult::Held));
+        assert_eq!(r.frames(), 0, "refused twice");
     }
 }


### PR DESCRIPTION
Main is missing the tail of the pointer UI stack. #202 merged into main at
17:50:27; #204 merged into #202's branch eleven seconds later, and #206 into
#204's branch that morning. Both landed on branches that had already been
merged down, so main never picked them up.

This merges the branch forward. It carries the wake card's d-pad navigation,
the Home brand mark, the Native panel dial, the hold and keyframe session
fixes, RLIMIT_NICE before the first boost, the README note for non-rooted TVs,
and three kit re-pins.

No new work, and the merge is conflict-free.
