### PR TITLE
Close the webOS UI reports: collections, profiles, toggles, wake, the exit freeze

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=a157fe582#a157fe5822684ce05909c52e3b27b9b3967eefef"
+source = "git+https://git.unom.io/unom/punktfunk?rev=9f2ab6789#9f2ab678953657ad3deb2301cdc31f43cb76f290"
 
 [[package]]
 name = "fiat-crypto"
@@ -1286,7 +1286,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "pf-client-core"
 version = "0.34.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=a157fe582#a157fe5822684ce05909c52e3b27b9b3967eefef"
+source = "git+https://git.unom.io/unom/punktfunk?rev=9f2ab6789#9f2ab678953657ad3deb2301cdc31f43cb76f290"
 dependencies = [
  "anyhow",
  "punktfunk-core",
@@ -1299,7 +1299,7 @@ dependencies = [
 [[package]]
 name = "pf-console-ui"
 version = "0.34.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=a157fe582#a157fe5822684ce05909c52e3b27b9b3967eefef"
+source = "git+https://git.unom.io/unom/punktfunk?rev=9f2ab6789#9f2ab678953657ad3deb2301cdc31f43cb76f290"
 dependencies = [
  "anyhow",
  "pf-client-core",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "punktfunk-core"
 version = "0.34.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=a157fe582#a157fe5822684ce05909c52e3b27b9b3967eefef"
+source = "git+https://git.unom.io/unom/punktfunk?rev=9f2ab6789#9f2ab678953657ad3deb2301cdc31f43cb76f290"
 dependencies = [
  "aes-gcm",
  "cbindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,14 +65,14 @@ tracing-appender = "0.2"
 # also be ONE source: pin punktfunk-core by tag while pf-client-core resolves it by rev and
 # cargo builds two copies whose types do not unify — the shell would then reject the
 # `GamepadPref` this crate hands it. Re-pin all three together, to v0.35.0 once it is cut.
-# a157fe582 is main (with unom/punktfunk#660, a noted row's value on the centre line, and #662,
-# the kit's brand mark the sidebar draws) plus #664, the mark's highlight as the icon draws it.
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "a157fe582", features = ["quic"] }
+# 9f2ab6789 is main with unom/punktfunk#729: the override dot beside the value it marks, no row
+# dip when a switch flips, and the connect/launch takeovers off their full-screen layer.
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "9f2ab6789", features = ["quic"] }
 # The portable half of the client stack: `trust::Settings` (the shared settings document this
 # client now persists), the menu vocabulary, the library model, deep links. Pure Rust with no
 # Skia and no SDL, so it builds on every host — `services::store::shared` and its tests need it
 # on the dev target too.
-pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "a157fe582", default-features = false }
+pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "9f2ab6789", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # mDNS LAN discovery; direct dep (not via pf-client-core — see session.rs docs).
@@ -114,7 +114,7 @@ libc = "0.2"
 # surface — and `gl` asks Skia for the GLES backend the panel exposes. skia-safe keeps its
 # DEFAULT features: they carry `binary-cache` (the prebuilt fetch) and the jpeg/pdf codecs, and
 # they are what make the key `gl-jpegd-jpege-pdf-textlayout` — the one both sources publish.
-pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "a157fe582", default-features = false, features = ["gl"] }
+pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "9f2ab6789", default-features = false, features = ["gl"] }
 # `Console::frame` draws into a `skia_safe::Canvas`, and the host owns the `DirectContext` plus
 # the surface wrapping framebuffer 0.
 skia-safe = { version = "0.99", features = ["gl", "textlayout"] }

--- a/src/app/draw/home.rs
+++ b/src/app/draw/home.rs
@@ -135,7 +135,10 @@ impl App {
     /// Everything under the modals: the grid or what stands in for it, the status band, the
     /// sidebar. Skipped over live video, where all of it would cover the picture.
     pub(crate) fn draw_home(&mut self, f: &Frame<'_>, dt: f64) {
-        if self.over_video_layers() {
+        // Past its fade the launch covers the screen with an opaque rect, so rasterizing the
+        // grid (a blurred shadow per card) under it only costs the hero pan its frame rate.
+        let covered = self.launch_anim.is_some_and(|t| t.elapsed() >= hero::LAUNCH_FADE);
+        if self.over_video_layers() || covered {
             return;
         }
         let grid_x = SIDEBAR_W as f32;

--- a/src/app/draw/mod.rs
+++ b/src/app/draw/mod.rs
@@ -492,6 +492,10 @@ impl App {
                         view::collections::trailing_marks(c.dynamic),
                         on_row.then(|| lit?.trailing()).flatten(),
                     );
+                    // A collection is a labelled row even with nothing to count: the kit reads
+                    // a valueless row as a centred action button, which is what Library and
+                    // every empty collection turned into.
+                    spec.value.get_or_insert_with(String::new);
                     spec.icon = None;
                 }
                 ListCard {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -78,7 +78,6 @@ pub struct WakeState {
     pub(crate) mac: Vec<String>,
     /// Original library error, restored on back-out.
     pub(crate) reason: String,
-    pub(crate) focused: usize,
     pub(crate) sent: bool,
     /// Packet count; shown so silent wait visibly progresses.
     pub(crate) attempts: u32,

--- a/src/app/render/geometry.rs
+++ b/src/app/render/geometry.rs
@@ -70,7 +70,6 @@ impl App {
     /// actually moved — the hover/click contract every focus setter here follows.
     pub(crate) fn set_confirm_focused(&mut self, index: usize) -> bool {
         let Some(focused) = (match self.nav.screen {
-            Screen::Wake => self.screens.wake.as_mut().map(|w| &mut w.focused),
             screen if is_confirm(screen) => Some(self.nav.cursor_mut(ScreenKey::of(screen))),
             _ => None,
         }) else {

--- a/src/app/screens/slots.rs
+++ b/src/app/screens/slots.rs
@@ -48,6 +48,9 @@ pub(crate) struct ScreenSlots {
     pub(crate) settings_page: SettingsPage,
     /// The name being typed for the profile in scope (`Screen::RenameProfile`).
     pub(crate) profile_name: TextField,
+    /// That profile exists only in memory until the name is confirmed — backing out of the
+    /// form drops it again, so a mis-press leaves nothing on disk.
+    pub(crate) profile_name_new: bool,
     /// What `Screen::PickProfile` is picking for.
     pub(crate) profile_pick: Option<crate::app::state::profilepick::ProfilePick>,
     /// The About document's first visible line.

--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -209,7 +209,7 @@ impl App {
                     self.screens.add_host = TextField::ipv4();
                     self.nav.screen = Screen::AddHost;
                 }
-                HomeFocus::Sidebar(_) => self.open_settings_page(),
+                HomeFocus::Sidebar(_) => self.open_settings_page(crate::app::state::settingspage::Scope::Global),
                 HomeFocus::SidebarMenu(i) => self.open_host_menu(i),
                 HomeFocus::Grid(i) => self.confirm_grid_card(i, columns),
             },

--- a/src/app/state/profiles.rs
+++ b/src/app/state/profiles.rs
@@ -45,6 +45,9 @@ impl App {
             self.profiles.retain(|p| p.id != id);
         }
         self.screens.settings_page.scope = Scope::Global;
+        // A discovery announce persists the document from under the open form, so the drop has
+        // to reach disk too rather than only the catalog in memory.
+        self.persist();
     }
 
     /// The card menu's "Game settings": the title's bound profile in profile scope, created

--- a/src/app/state/profiles.rs
+++ b/src/app/state/profiles.rs
@@ -25,14 +25,26 @@ fn unique_name(catalog: &[StreamProfile], wanted: &str) -> String {
 }
 
 impl App {
-    /// Editing ▸ New profile…: an empty overlay under a placeholder name, opened for editing.
+    /// Editing ▸ New profile…: an empty overlay under a placeholder name, opened for naming.
+    /// Nothing is written until that name is confirmed.
     pub(crate) fn new_profile(&mut self) {
         let profile = StreamProfile::new(unique_name(&self.profiles, "New profile"));
         let id = profile.id.clone();
         self.profiles.push(profile);
-        self.persist();
         self.screens.settings_page.scope = Scope::Profile(id);
         self.open_rename_profile();
+        self.screens.profile_name_new = true;
+    }
+
+    /// Drops the profile the name form was naming, if it was never committed.
+    fn discard_new_profile(&mut self) {
+        if !std::mem::take(&mut self.screens.profile_name_new) {
+            return;
+        }
+        if let Scope::Profile(id) = self.screens.settings_page.scope.clone() {
+            self.profiles.retain(|p| p.id != id);
+        }
+        self.screens.settings_page.scope = Scope::Global;
     }
 
     /// The card menu's "Game settings": the title's bound profile in profile scope, created
@@ -73,6 +85,7 @@ impl App {
             .find(|p| &p.id == id)
             .map_or(String::new(), |p| p.name.clone());
         self.screens.profile_name = TextField::name(MAX_COLLECTION_NAME, &name);
+        self.screens.profile_name_new = false;
         self.nav.screen = Screen::RenameProfile;
     }
 
@@ -80,7 +93,10 @@ impl App {
         match ev {
             MenuEvent::Left => self.screens.profile_name.backspace(),
             MenuEvent::Confirm => self.confirm_rename_profile(),
-            MenuEvent::Back | MenuEvent::Secondary => self.nav.resume(Screen::SettingsPage),
+            MenuEvent::Back | MenuEvent::Secondary => {
+                self.discard_new_profile();
+                self.nav.resume(Screen::SettingsPage);
+            }
             MenuEvent::Right | MenuEvent::Up | MenuEvent::Down => {}
         }
     }
@@ -109,6 +125,7 @@ impl App {
             return;
         }
         let name = self.screens.profile_name.text().trim().to_string();
+        self.screens.profile_name_new = false;
         if let Scope::Profile(id) = self.screens.settings_page.scope.clone() {
             if let Some(p) = self.profiles.iter_mut().find(|p| p.id == id) {
                 p.name = name;

--- a/src/app/state/profiles.rs
+++ b/src/app/state/profiles.rs
@@ -59,9 +59,8 @@ impl App {
                 id
             }
         };
-        self.screens.settings_page.scope = Scope::Profile(id);
         self.screens.settings_page.page = Page::Display;
-        self.open_settings_page();
+        self.open_settings_page(Scope::Profile(id));
     }
 
     pub(crate) fn open_rename_profile(&mut self) {

--- a/src/app/state/settingspage.rs
+++ b/src/app/state/settingspage.rs
@@ -285,7 +285,10 @@ pub(crate) fn settings_nav(column: bool, ev: MenuEvent) -> NavStep {
 }
 
 impl App {
-    pub(crate) fn open_settings_page(&mut self) {
+    /// `scope` is the caller's, not the last visit's: the sidebar edits the document, the
+    /// card menu edits a title's profile, and a stale scope silently edits the wrong one.
+    pub(crate) fn open_settings_page(&mut self, scope: Scope) {
+        self.screens.settings_page.scope = scope;
         // The page column takes focus first; OK or Right on a page moves into its rows.
         self.screens.settings_page.column = true;
         self.nav.enter(Screen::SettingsPage, 0);

--- a/src/app/state/settingspage.rs
+++ b/src/app/state/settingspage.rs
@@ -13,7 +13,7 @@
 use pf_client_core::profiles::{SettingsOverlay, StreamProfile};
 use pf_client_core::trust;
 use pf_console_ui::settings_rows::{self as engine, Ctx, RowId};
-use pf_console_ui::widgets::RowSpec;
+use pf_console_ui::widgets::{Control, RowSpec};
 
 use crate::app::nav::ScreenKey;
 use crate::app::{menu, App};
@@ -454,6 +454,19 @@ impl App {
                         Row::Delete => RowSpec::action("Delete…", true),
                     };
                     spec.header = header;
+                    // The engine draws every boolean as text with chevrons, while this app's
+                    // own rows are switches — one page, two controls for one kind of setting.
+                    // ponytail: matched on the drawn value, so a future three-state row whose
+                    // value reads "On" would need its own test.
+                    if let Some(on) = match spec.value.as_deref() {
+                        Some("On") => Some(true),
+                        Some("Off") => Some(false),
+                        _ => None,
+                    } {
+                        spec.control = Control::Toggle(on);
+                        // The switch is the affordance: no chevrons, and no value to slide.
+                        spec.adjustable = false;
+                    }
                     spec
                 })
                 .collect()

--- a/src/app/state/settingspage.rs
+++ b/src/app/state/settingspage.rs
@@ -86,6 +86,8 @@ pub(crate) enum Row {
     Kit(RowId),
     /// The scope switcher at the top of General.
     Editing,
+    /// Creates a profile — its own row, because a cycle slot creates one on a stray step.
+    NewProfile,
     /// `webos.game_mode`, rooted TVs only.
     GameMode,
     /// The three-step calibration screen.
@@ -126,6 +128,7 @@ fn page_rows(page: Page, scope: &Scope) -> Rows {
     match page {
         Page::General => {
             push(Row::Editing, Some("Editing"));
+            push(Row::NewProfile, None);
             if profile {
                 push(Row::Rename, Some("Profile"));
                 push(Row::Duplicate, None);
@@ -445,6 +448,7 @@ impl App {
                             true,
                         ),
                         Row::Licences => RowSpec::action("Open-source licences", true),
+                        Row::NewProfile => RowSpec::action("New profile…", true),
                         Row::Rename => RowSpec::action("Rename…", true),
                         Row::Duplicate => RowSpec::action("Duplicate", true),
                         Row::Delete => RowSpec::action("Delete…", true),
@@ -552,6 +556,7 @@ impl App {
             Row::SendLogs => self.send_logs_action(),
             Row::ResetHdr => self.open_reset_hdr_calibration(),
             Row::Licences => self.open_about(),
+            Row::NewProfile => self.new_profile(),
             Row::Rename => self.open_rename_profile(),
             Row::Duplicate => self.duplicate_profile(),
             Row::Delete => self.open_delete_profile(),
@@ -621,9 +626,11 @@ impl App {
         }
     }
 
-    /// Editing: Default settings → each profile → New profile… → back around.
+    /// Editing: Default settings → each profile → back around. Creating one is its own row:
+    /// as a slot here, a single step off the last profile (or Left off the first) made and
+    /// saved a profile the user never asked for.
     fn step_scope(&mut self, delta: i32) {
-        let n = self.profiles.len() + 2;
+        let n = self.profiles.len() + 1;
         let cur = match &self.screens.settings_page.scope {
             Scope::Global => 0,
             Scope::Profile(id) => self.profiles.iter().position(|p| &p.id == id).map_or(0, |i| i + 1),
@@ -631,8 +638,6 @@ impl App {
         let next = menu::cycle_index(cur, n, delta >= 0);
         if next == 0 {
             self.screens.settings_page.scope = Scope::Global;
-        } else if next == n - 1 {
-            self.new_profile();
         } else {
             self.screens.settings_page.scope = Scope::Profile(self.profiles[next - 1].id.clone());
         }
@@ -734,5 +739,22 @@ mod nav_tests {
         assert_eq!(settings_nav(false, MenuEvent::Left), NavStep::Row(RowStep::Step(-1)));
         assert_eq!(settings_nav(false, MenuEvent::Right), NavStep::Row(RowStep::Step(1)));
         assert_eq!(settings_nav(false, MenuEvent::Confirm), NavStep::Row(RowStep::Activate));
+    }
+
+    /// Creating a profile is a row the user picks, never a slot the Editing row's value cycle
+    /// steps into — as a slot, one press made and saved a profile nobody asked for.
+    #[test]
+    fn new_profile_is_a_row_of_its_own_in_both_scopes() {
+        for scope in [Scope::Global, Scope::Profile("p1".into())] {
+            let rows = page_rows(Page::General, &scope);
+            assert_eq!(rows.iter().filter(|(r, _)| *r == Row::NewProfile).count(), 1);
+        }
+        for page in Page::ALL {
+            if page == Page::General {
+                continue;
+            }
+            let rows = page_rows(page, &Scope::Global);
+            assert!(!rows.iter().any(|(r, _)| *r == Row::NewProfile));
+        }
     }
 }

--- a/src/app/state/wake.rs
+++ b/src/app/state/wake.rs
@@ -27,8 +27,6 @@ impl App {
             name,
             mac,
             reason,
-            // Lands on the "Wake host" button — the reason the user is here.
-            focused: 0,
             sent: false,
             attempts: 0,
             since: None,
@@ -43,7 +41,8 @@ impl App {
             Self::send_wake(&mut wake);
         }
         if prompts {
-            self.nav.screen = Screen::Wake;
+            // Cursor 0 is "Wake host" — the reason the user is here.
+            self.nav.enter(Screen::Wake, 0);
         } else {
             // No modal is up in this branch, so the Home bar is the only place the
             // wait is visible at all — without this it would sit on `select_host`'s
@@ -142,7 +141,7 @@ impl App {
             wake.last_probe = Some(now);
         }
         if reveal {
-            self.nav.screen = Screen::Wake;
+            self.nav.enter(Screen::Wake, 0);
         }
         if let Some(status) = new_status {
             self.set_home_status(Some(status), false);
@@ -177,17 +176,25 @@ impl App {
     /// Confirm sends and closes the modal, or cancels. Back dismisses it (wake runs on in bg).
     /// The card only ever opens with both buttons on it, so every event has a target.
     pub fn handle_wake_event(&mut self, ev: MenuEvent) {
-        let Some(wake) = self.screens.wake.as_mut() else { return };
+        if self.screens.wake.is_none() {
+            return;
+        }
         if ev == MenuEvent::Back {
             self.close_wake(false);
             return;
         }
+        if self.confirm_nav_event(ev) {
+            return;
+        }
         match ev {
-            MenuEvent::Up | MenuEvent::Down | MenuEvent::Left | MenuEvent::Right => {
-                wake.focused = usize::from(wake.focused == 0);
+            // The buttons sit side by side, so Up and Down move between them too.
+            MenuEvent::Up | MenuEvent::Down => {
+                let key = crate::app::nav::ScreenKey::Wake;
+                self.nav.set_cursor(key, 1 - self.nav.cursor(key));
                 self.render.modal.focus_anim = Some(Instant::now());
             }
-            MenuEvent::Confirm if wake.focused == 0 => {
+            MenuEvent::Confirm if self.nav.cursor(crate::app::nav::ScreenKey::Wake) == 0 => {
+                let Some(wake) = self.screens.wake.as_mut() else { return };
                 Self::send_wake(wake);
                 // Hand the wait to the grid's spinner; `tick_wake` re-pops the modal if the
                 // host is still down after `WAKE_RETRY_INTERVAL`. A packet that never went
@@ -198,7 +205,7 @@ impl App {
                 }
             }
             MenuEvent::Confirm => self.close_wake(false),
-            MenuEvent::Back | MenuEvent::Secondary => {}
+            MenuEvent::Back | MenuEvent::Secondary | MenuEvent::Left | MenuEvent::Right => {}
         }
     }
 

--- a/src/console/model.rs
+++ b/src/console/model.rs
@@ -208,6 +208,8 @@ impl Service {
             .filter(|d| !state.known_hosts.iter().any(|h| same_host(h, d)))
             .map(|d| HostRow {
                 key: shared::host_key("", &d.addr, d.port),
+                // Nothing saved to point at, so the shell hides "Make default host".
+                id: None,
                 name: d.name.clone(),
                 addr: d.addr.clone(),
                 port: d.port,
@@ -253,6 +255,8 @@ impl Service {
         let advert = self.discovered.iter().find(|d| same_host(h, d));
         let online = advert.is_some() || self.reachable.get(&key).copied().unwrap_or(false);
         HostRow {
+            // The store record's own id, which is what the shell's default host names.
+            id: h.id.clone(),
             name: if h.name.is_empty() {
                 h.addr.clone()
             } else {

--- a/src/runtime/console_flow.rs
+++ b/src/runtime/console_flow.rs
@@ -188,11 +188,16 @@ pub(super) fn run(
                         }
                     }
                 }
-                Event::ControllerDeviceRemoved { .. } => {
-                    *controller = None;
-                    // An unplugged pad sends no releases: drop what the synthesizer holds.
-                    nav.reset();
-                    sample = MenuSample::default();
+                Event::ControllerDeviceRemoved { which, .. } => {
+                    // Only the pad we hold: webOS enumerates the Magic Remote as a controller
+                    // and it drops constantly, and clearing on its removal took the real pad's
+                    // input away with it.
+                    if controller.as_ref().is_some_and(|c| c.instance_id() == which) {
+                        *controller = None;
+                        // An unplugged pad sends no releases: drop what the synthesizer holds.
+                        nav.reset();
+                        sample = MenuSample::default();
+                    }
                 }
                 Event::KeyDown {
                     keycode: Some(k),
@@ -400,7 +405,11 @@ pub(super) fn run(
         // pad withdraws it without writing anything. Plain `Reenter` — `leave_for_classic`
         // would turn the switch off, and a pad going flat is not the user saying "off".
         let state = store.snapshot();
-        if !state.settings.gamepad_ui_active(pad.is_some()) {
+        // 🛑 The SAME expression `stream`'s menu loop enters on, not the open handle: a handle
+        // that went stale while a pad is still attached made the loop enter here, leave, and
+        // enter again forever, drawing no frame — a freeze on the way out of a stream.
+        let pad_connected = crate::platform::webos::gamepad::any_pad_connected(game_controller);
+        if !state.settings.gamepad_ui_active(pad_connected) {
             tracing::info!("console: the controller UI no longer applies — back to the cursor menus");
             break 'ui UiOutcome::Reenter;
         }


### PR DESCRIPTION
Closes the reported webOS issues. Each commit is one fix, so they can be dropped independently.

### What was wrong

- **Library drew as a button in the collections list.** A collection with nothing to count carried an empty value, and the kit reads a valueless row as a centred action button. Library never has a count, so it always hit it — and so did every empty collection, whose "Hidden until you add a game" note then sat under a centred label.
- **Settings opened on the last-edited game profile.** The card menu's Game settings set the scope before opening the page and nothing put it back, so the next visit from the sidebar was still editing that title's profile.
- **A d-pad press saved a new profile.** The Editing row's value cycle had a last slot that created a profile and persisted it. It was never drawn before it fired, so one step past the last profile — or a single Left from the default scope, which wraps — saved a profile nobody asked for. OK on the row did it too.
- **Boolean settings drew two different ways.** Rows the shared settings engine builds are text with chevrons; the two rows this client builds itself are switches. Display showed "10-bit HDR  On" three rows above a "Game mode" switch.
- **A toggle animated its whole row.** Half of that was the value slide, which goes away with the switch, since a switch row is not adjustable. The other half was the kit's confirm dip, fixed upstream.
- **The Wake-on-LAN card's highlight never moved.** The card drew from the confirm family's cursor, which nothing wrote for this screen, while the handler read a field on the wake state. The highlight sat on "Wake host", the real target moved unseen, and the first OK after a d-pad step cancelled.
- **The app froze on the way out of a stream with the controller UI on.** The menu loop entered the shell when SDL listed a pad; the shell left when the handle it had opened was gone. webOS enumerates the Magic Remote as a controller and it drops often, and its removal cleared the handle for the pad still attached — so the loop entered, left and entered again, rebuilding fonts, the mDNS daemon and the state writer each lap without ever drawing a frame. The same clearing also took the real pad's input away from the shell.
- **The launch animation was heavy.** Past its fade the launch covers the screen with an opaque rect, and the home screen kept rasterizing the grid — a blurred shadow per card — underneath it for the whole hero pan.

### The kit half

The override dot's placement, the row squash when a switch flips and the launch takeover's full-screen layer were in `pf-console-ui`. That is unom/punktfunk#729, merged as `9f2ab6789`, and the last commit here re-pins all three punktfunk crates onto it.

That bump brings the rest of upstream main with it, which is worth knowing when reviewing: the shell leads every shelf with a Desktop tile and opens on the default host, so `HostRow` now carries the store record's id (filled from `KnownHost`, `None` on a discovered row); core side it is the adaptive FEC floor, bounded Welcome audio fields, recovery asks that match the losses, and a lost AV1 inter frame read through `ref_order_hint`.

### Verified

`task docker:lint`, `task docker:test` (46 pass, one new), `cargo fmt --check`, all green on the re-pinned tree. Not on glass: the G5 was off. The dot's new gutter and the switch rows are what to look at first on a panel.
