### PR TITLE
fix(packaging): link libstdc++ statically instead of bundling it

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -21,7 +21,7 @@ BUNDLED / EMBEDDED NON-RUST COMPONENTS
       Bundled as lib/libfreetype.so.6 in the .ipk (Skia calls entry points the on-device copy lacks below webOS 9 — see taskfiles/toolchain.yml). FreeType License (BSD-style with credit clause).
       https://freetype.org
   GNU libstdc++
-      Bundled as lib/libstdc++.so.6 in the .ipk (the SDK builds against a newer GLIBCXX than the TV ships). GPL-3.0 with the GCC Runtime Library Exception.
+      Linked statically into the binary (a bundled .so would shadow the TV's own through DT_RPATH — see scripts/cc-shim.sh). GPL-3.0 with the GCC Runtime Library Exception.
       https://gcc.gnu.org/onlinedocs/libstdc++/
   Geist (Geist Sans)
       punktfunk's brand typeface, embedded into the binary by the console kit (pf-console-ui). SIL Open Font License 1.1.

--- a/build.rs
+++ b/build.rs
@@ -48,7 +48,7 @@ fn generate_third_party_notices(manifest_dir: &str) {
          None,
          "https://freetype.org"),
         ("GNU libstdc++",
-         "Bundled as lib/libstdc++.so.6 in the .ipk (the SDK builds against a newer GLIBCXX than the TV ships). GPL-3.0 with the GCC Runtime Library Exception.",
+         "Linked statically into the binary (a bundled .so would shadow the TV's own through DT_RPATH — see scripts/cc-shim.sh). GPL-3.0 with the GCC Runtime Library Exception.",
          None,
          "https://gcc.gnu.org/onlinedocs/libstdc++/"),
         ("Geist (Geist Sans)",

--- a/scripts/cc-shim.sh
+++ b/scripts/cc-shim.sh
@@ -13,5 +13,22 @@ set -eu
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 NDK_DIR="${PUNKTFUNK_WEBOS_NDK:-$REPO_ROOT/.toolchains/arm-webos-linux-gnueabi_sdk-buildroot}"
 
-exec "$NDK_DIR/bin/arm-webos-linux-gnueabi-gcc" \
-    --sysroot="$NDK_DIR/arm-webos-linux-gnueabi/sysroot" "$@"
+SYSROOT="$NDK_DIR/arm-webos-linux-gnueabi/sysroot"
+
+# Link libstdc++ statically: `-lstdc++` becomes the archive, so no libstdc++.so.6
+# rides in the .ipk. A bundled one is loaded by the binary's DT_RPATH, which outranks
+# the jail's `LD_LIBRARY_PATH=/usr/lib:$APPDIR/lib` — the TV's own libraries then get
+# our copy too, and webOS 11's /usr/lib/libhelpers.so.2 wants GLIBCXX_3.4.32 that the
+# SDK's 6.0.30 has never had. SDL reports that as "Failed to load webOS libraries".
+# Static keeps one binary correct on every firmware: our C++ runtime is ours, the TV's
+# stays the TV's. Nothing C++ crosses the boundary — SDL, NDL and Luna are all C.
+n=$#
+for arg in "$@"; do
+    case "$arg" in
+    -lstdc++) set -- "$@" "$SYSROOT/usr/lib/libstdc++.a" ;;
+    *) set -- "$@" "$arg" ;;
+    esac
+done
+shift "$n"
+
+exec "$NDK_DIR/bin/arm-webos-linux-gnueabi-gcc" --sysroot="$SYSROOT" "$@"

--- a/taskfiles/toolchain.yml
+++ b/taskfiles/toolchain.yml
@@ -108,11 +108,9 @@ tasks:
         mkdir -p "$STAGE_DIR/bin" "$STAGE_DIR/lib"
         cp target/{{.TARGET}}/release/punktfunk-webos "$STAGE_DIR/bin/"
         cp -L {{.SYSROOT}}/usr/lib/libSDL2-2.0.so.0 "$STAGE_DIR/lib/libSDL2-2.0.so.0"
-        # Skia is C++, and this SDK builds against libstdc++ 6.0.30 while the TV ships 6.0.29 —
-        # whose newest symbol set is GLIBCXX_3.4.29. The binary asks for GLIBCXX_3.4.30, so
-        # without the SDK's copy here the app dies before `main` with nothing on screen and
-        # nothing in its own log. The `$ORIGIN/../lib` rpath that already finds libSDL2 covers it.
-        cp -L {{.SYSROOT}}/usr/lib/libstdc++.so.6 "$STAGE_DIR/lib/libstdc++.so.6"
+        # No libstdc++ here: it is linked statically (scripts/cc-shim.sh). A bundled one wins
+        # over the TV's through DT_RPATH and is then used by the TV's own libraries too, which
+        # breaks the moment a firmware wants a newer GLIBCXX than this SDK ever had.
         # Skia calls FreeType 2.13's COLRv1 and variable-font entry points (FT_Get_Paint,
         # FT_Palette_Select, FT_Set_Default_Properties); webOS ships a FreeType that has them
         # only from 9.0, and below that the app dies before `main` the same way. Ships on every
@@ -120,7 +118,7 @@ tasks:
         cp -L {{.SYSROOT}}/usr/lib/libfreetype.so.6 "$STAGE_DIR/lib/libfreetype.so.6"
         {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-strip \
           "$STAGE_DIR/bin/punktfunk-webos" "$STAGE_DIR/lib/libSDL2-2.0.so.0" \
-          "$STAGE_DIR/lib/libstdc++.so.6" "$STAGE_DIR/lib/libfreetype.so.6"
+          "$STAGE_DIR/lib/libfreetype.so.6"
         # PROBES=1 ships the headless diagnostic CLI (`pfprobe`) alongside the app, for running
         # over SSH against a host. Off by default: it is a quarter megabyte the store package has
         # no use for, and nothing in the app launches it.


### PR DESCRIPTION
The bundled `lib/libstdc++.so.6` is found through the binary's `DT_RPATH`, which outranks the
jail's `LD_LIBRARY_PATH=/usr/lib:$APPDIR/lib`. Every library the process loads then gets the
SDK's 6.0.30 — the TV's own included. webOS 11 ships libstdc++ 6.0.32 and its libraries use it:
`/usr/lib/libNDL_media_impl.so.1` and `libhelpers.so.2`'s dependency chain want
`GLIBCXX_3.4.32`, which our copy has never had. SDL's dlopen of the webOS libraries fails its
version lookup and the app exits at the splash with "Failed to load webOS libraries".

Reported on a 55QNED82BXA (`k26`, webOS 11) against both 0.21.0 and 0.21.1; the reporter's
`LD_DEBUG=libs` named the missing version, and deleting the bundled library cleared it.

## Why static rather than the two obvious fixes

**Ship a newer libstdc++** only moves the cliff: we would still shadow the system runtime with a
fixed version, and the next firmware that wants `GLIBCXX_3.4.34` breaks the same way. The
buildroot SDK also has nothing newer than 6.0.30.

**Drop the bundle** breaks older sets. The binary itself requires `GLIBCXX_3.4.30` and webOS 10.3
ships 6.0.29 — verified, that package fails to resolve at all.

Static keeps one artifact correct on every firmware: our C++ runtime is ours, the TV's stays the
TV's. Nothing C++ crosses the boundary — SDL, NDL and Luna are all C. The rewrite lives in
`scripts/cc-shim.sh` because that is the seam every compile and link for this target already goes
through; a rustflag would have to fight skia-bindings' emitted `dylib=stdc++`.

## Verification

Checked against real TV userlands extracted from LG firmware (`epk2extract`, rootfs squashfs),
resolving and starting the packaged binary under `qemu-arm`:

| package | webOS 10.3.0 (`k25lp`, firmware 33.31.24) | webOS 11.2.0 (`o26`, firmware 43.21.62) |
| --- | --- | --- |
| released 0.21.1 | passes | **fails** — `GLIBCXX_3.4.32 not found (required by /usr/lib/libNDL_media_impl.so.1)` |
| this branch | passes | passes |

Binary 23.9 MB → 24.8 MB; the .ipk shrinks 12.81 MB → 12.54 MB, since the 1.45 MB shared object
is gone. No `libstdc++.so.6` in `NEEDED`, and no `GLIBCXX_` reference left in the binary at all,
so there is nothing for a version lookup to fail on.

`libNDL_media_impl.so.1` is the media stack, loaded when playback starts — worth knowing for the
separate report of a crash just after the stream starts, which may share this cause.
