### PR TITLE
feat(home): give the Desktop card a mark of its own

### DIFF
--- a/src/app/draw/home.rs
+++ b/src/app/draw/home.rs
@@ -405,6 +405,12 @@ impl App {
             c.draw_path(&path, &theme::fill(theme::fg(0.92 * alpha)));
             return;
         }
+        // Neither an OS nor a brand: a UI mark, which is what the Desktop card falls back to.
+        // Stroked, not filled — Lucide's paths are outlines, and filling one gives a blob.
+        if let Some(icon) = game.icon.as_deref().and_then(by_name) {
+            draw_icon(c, icon, r.center_x(), r.center_y(), side * 0.8, theme::fg(0.92 * alpha));
+            return;
+        }
         let pad = 18.0;
         let max_w = (r.width() - 2.0 * pad).max(1.0);
         // The largest size the title fits at, down a short ladder.

--- a/src/app/library.rs
+++ b/src/app/library.rs
@@ -39,7 +39,9 @@ fn desktop_entry() -> GameEntry {
         id: DESKTOP_PIN_ID.to_string(),
         title: "Desktop".to_string(),
         art: crate::core::model::Artwork::default(),
-        icon: None,
+        // Its own mark from the start, so the card never draws as a title while the OS the
+        // [`Library::set_desktop_icon`] mark comes from is still unknown.
+        icon: Some(crate::app::view::icons::ICON_DESKTOP.to_string()),
     }
 }
 
@@ -61,10 +63,15 @@ impl Library {
     /// Desktop's icon is client-picked (every other entry carries the host's token), so it is
     /// chosen here rather than in the grid build loop. Idempotent: re-run on every regroup and
     /// whenever mDNS teaches a new OS.
+    ///
+    /// The host's OS mark says WHICH desktop, so it wins whenever the chain has one. A host
+    /// that has not advertised an OS — a hand-added one, or one not yet discovered — takes the
+    /// plain desktop mark rather than the card's title, which reads as art that failed to load.
     pub(crate) fn set_desktop_icon(&mut self, os: &str) {
-        let token = crate::app::assets::os_icon_token(os);
+        let token =
+            crate::app::assets::os_icon_token(os).unwrap_or_else(|| crate::app::view::icons::ICON_DESKTOP.to_string());
         if let Some(desktop) = self.games.iter_mut().find(|g| g.id == DESKTOP_PIN_ID) {
-            desktop.icon = token;
+            desktop.icon = Some(token);
         }
     }
 

--- a/src/app/view/icons.rs
+++ b/src/app/view/icons.rs
@@ -15,3 +15,7 @@ pub const ICON_CLOSE: &str = "x";
 pub const ICON_WRENCH: &str = "wrench";
 pub const ICON_PLAY: &str = "play";
 pub const ICON_PIN: &str = "pin";
+/// The Desktop card's own mark, for a host whose OS it cannot wear. Mirrors the kit's
+/// `library::DESKTOP_ICON`, which the pinned revision predates — read it from there once
+/// the pin moves.
+pub const ICON_DESKTOP: &str = "monitor";


### PR DESCRIPTION
The Desktop card's mark chain ended at the host's OS logo, so a host that never advertised an OS — a hand-added one, or one not yet discovered — drew its title instead. A card reading "Desktop" reads as art that failed to load, which is the one thing that card is not.

The kit's Lucide table is already imported in this painter for the sidebar and the settings rows, so the chain gains a rung rather than an asset:

    cover art -> OS mark -> brand mark -> UI mark -> wrapped title

- `src/app/draw/home.rs` — the new rung, stroked rather than filled (Lucide's paths are outlines; filling one gives a blob).
- `src/app/view/icons.rs` — `ICON_DESKTOP = "monitor"`, in the app's existing icon vocabulary.
- `src/app/library.rs` — the card carries that mark from construction, and `set_desktop_icon` falls back to it instead of `None`.

**The OS mark still wins wherever it exists.** It says WHICH desktop, which is more than a monitor outline says, so this only fills the hole underneath it. That is a deliberate divergence from the five clients in the monorepo ([unom/punktfunk#785](https://git.unom.io/unom/punktfunk/pulls/785)), which always draw `monitor` because they have no OS mark on that card. Easy to make uniform later — it is one line in `set_desktop_icon`.

### Verification

| Gate | Result |
| --- | --- |
| `task docker:check` (armv7 cross) | clean |
| `task docker:test` (host) | 47 pass |
| `cargo fmt --check` + armv7 `cargo clippy --all-targets -D warnings` | clean |

Only the repo's pre-existing `-Ctarget-feature` warnings (neon/vfp3/soft-float) appear.

`task docker:lint` cannot run as-is: it runs `cargo fmt --check` first and the image has no `cargo-fmt` for its toolchain (`'cargo-fmt' is not installed for the toolchain '1.98.0-…'`). I ran the same container with `rustup component add rustfmt` added, which is how both halves above were checked. Worth fixing separately.
