### PR TITLE
Row buttons for the actions a row already owns

### DIFF
--- a/src/app/draw/home.rs
+++ b/src/app/draw/home.rs
@@ -44,8 +44,6 @@ pub(crate) const MENU_ROW_H: f32 = 54.0;
 pub(crate) const MENU_ROWS_PAD: f32 = 10.0;
 const MENU_BAND_INSET: f32 = 10.0;
 const MENU_ICON_INSET: f32 = 14.0;
-const MARK_DOT_R: f32 = 4.0;
-const MARK_DOT_INSET: f32 = 16.0;
 const GLOW_BLUR: f32 = 18.0;
 const SPINNER_R: f64 = 24.0;
 
@@ -486,16 +484,8 @@ impl App {
         c.clip_rect(window, ClipOp::Intersect, true);
         // An opaque strip over the art, the same face every card wears.
         c.draw_rect(window, &theme::fill(super::surface()));
-        let overridden = self.game_is_bound(pin_id);
         let size = px(f, VALUE);
         let title_top = window.top;
-        let dot_x = r.right - MARK_DOT_INSET - MARK_DOT_R;
-        let marked_title = overridden && menu.is_none();
-        let right_pad = if marked_title {
-            MARK_DOT_INSET + 2.0 * MARK_DOT_R + 8.0
-        } else {
-            STRIP_INSET
-        };
         f.fonts.draw_clipped(
             c,
             &game.title,
@@ -504,15 +494,8 @@ impl App {
             W::Regular,
             size,
             theme::fg(pop),
-            f64::from(r.width() - STRIP_INSET - right_pad),
+            f64::from(r.width() - 2.0 * STRIP_INSET),
         );
-        if marked_title {
-            c.draw_circle(
-                (dot_x, title_top + title_h / 2.0),
-                MARK_DOT_R,
-                &theme::fill(theme::accent(pop)),
-            );
-        }
         if let Some(m) = menu {
             let rows_top = title_top + title_h;
             let band_x = r.left + MENU_BAND_INSET;
@@ -545,12 +528,6 @@ impl App {
                     draw_icon(c, mk, icon_x + 11.0, row.center_y(), 22.0, tone);
                 }
                 let text_x = icon_x + 22.0 + 10.0;
-                let marked = overridden && *kind == CardMenuRow::Settings;
-                let right_pad = if marked {
-                    MARK_DOT_INSET + 2.0 * MARK_DOT_R + 8.0
-                } else {
-                    STRIP_INSET
-                };
                 f.fonts.draw_clipped(
                     c,
                     label,
@@ -559,15 +536,8 @@ impl App {
                     W::Regular,
                     size,
                     tone,
-                    f64::from(row.right - right_pad - text_x),
+                    f64::from(row.right - STRIP_INSET - text_x),
                 );
-                if marked {
-                    c.draw_circle(
-                        (row.right - MARK_DOT_INSET - MARK_DOT_R, row.center_y()),
-                        MARK_DOT_R,
-                        &theme::fill(theme::accent(pop)),
-                    );
-                }
             }
         }
         c.restore();

--- a/src/app/draw/home.rs
+++ b/src/app/draw/home.rs
@@ -283,7 +283,7 @@ impl App {
                             &theme::fill(theme::accent(0.9)),
                         );
                     }
-                    if let Some(m) = by_name("ellipsis") {
+                    if let Some(m) = by_name(view::icons::ICON_MORE) {
                         let tone = if lit {
                             theme::on_accent()
                         } else {

--- a/src/app/draw/list.rs
+++ b/src/app/draw/list.rs
@@ -12,6 +12,7 @@ use pf_console_ui::widgets::{MenuList, RowSpec, ROW_H};
 use skia_safe::{Contains, Point, Rect};
 
 use super::{glass_card, line_h, wrap, Frame};
+use crate::app::screens::rowbuttons::RowButton;
 use crate::ui::widgets::{FocusRow, RowKind};
 
 /// Card width as a share of the screen; the rows centre inside it at the kit's own width.
@@ -190,6 +191,21 @@ pub(crate) fn row_spec(row: &FocusRow) -> RowSpec {
     spec.icon = Some(row.icon);
     spec.note = row.subtext.as_ref().map(|s| s.text.clone());
     spec
+}
+
+/// `spec` with the row's trailing buttons, lit when the cursor is on this row and on one of
+/// them. An action row keeps its centred label: a button is an extra the row wears at one end,
+/// not a value, and giving it one to reserve the gutter shunted every such label to the left.
+pub(crate) fn with_row_buttons(
+    spec: RowSpec,
+    marks: &'static [&'static str],
+    on_row: bool,
+    lit: Option<RowButton>,
+) -> RowSpec {
+    if marks.is_empty() {
+        return spec;
+    }
+    spec.with_buttons(marks, on_row.then(|| lit?.trailing()).flatten())
 }
 
 #[cfg(test)]

--- a/src/app/draw/mod.rs
+++ b/src/app/draw/mod.rs
@@ -21,6 +21,7 @@ use pf_console_ui::anim::approach;
 use pf_console_ui::theme::{self, Fonts, PanelStroke, W};
 use skia_safe::{Canvas, RRect, Rect};
 
+use crate::app::screens::rowbuttons::RowButton;
 use crate::app::App;
 use crate::core::screen::Screen;
 use crate::platform::webos::device;
@@ -61,6 +62,12 @@ pub(crate) const fn is_list(screen: Screen) -> bool {
     )
 }
 
+/// The screens whose rows are the kit's row widget — every list card, plus the settings page,
+/// which draws the same rows inside its own card. What the pointer hit tests are answerable on.
+pub(crate) const fn draws_kit_rows(screen: Screen) -> bool {
+    is_list(screen) || matches!(screen, Screen::SettingsPage)
+}
+
 /// What every draw fn takes.
 pub(crate) struct Frame<'a> {
     pub canvas: &'a Canvas,
@@ -97,6 +104,12 @@ pub(crate) fn scale(h: u32) -> f32 {
 /// The panel the design is tuned on.
 const REFERENCE_INCHES: f32 = 65.0;
 
+/// How much larger this client draws than the kit's design units say: a TV is read from a
+/// couch, and the kit is tuned for a handheld's arm's length. Rides [`panel_k`] rather than
+/// the type sizes, so boxes, gaps and the kit's own rows grow with the text. A launch
+/// `ui_scale` replaces it outright.
+const BASE_SCALE: f32 = 1.1;
+
 /// How far a smaller panel is compensated. A full correction (1.0) holds type the same
 /// physical size, which assumes everyone sits the same distance from whatever they bought; the
 /// square root splits it, because a smaller set is usually a closer set. The layouts agree: a
@@ -118,7 +131,7 @@ pub(crate) fn panel_k() -> f32 {
             tracing::info!("UI scale forced to {over} at launch");
             return over.clamp(0.5, 2.0);
         }
-        let k = device::panel_inches().map_or(1.0, panel_k_for);
+        let k = device::panel_inches().map_or(1.0, panel_k_for) * BASE_SCALE;
         tracing::info!("UI scale {k} from the panel size");
         k
     })
@@ -460,11 +473,29 @@ impl App {
     pub(crate) fn list_card(&self, screen: Screen) -> Option<ListCard> {
         use crate::app::view;
         Some(match screen {
-            Screen::HostMenu => ListCard {
-                title: self.host_menu_title(),
-                subtitle: Some(self.host_menu_subtitle()),
-                rows: self.host_menu_rows().iter().map(list::row_spec).collect(),
-            },
+            Screen::HostMenu => {
+                let cursor = self.nav.cursor(crate::app::nav::ScreenKey::HostMenu);
+                let lit = self.screens.row_button;
+                // The actions are derived once and carry both the row and its buttons: asking
+                // per row for the marks would re-derive the whole menu on every one of them.
+                let saved = self.host_menu_saved_entry();
+                let power = self.host_menu_power_row();
+                let rows = self
+                    .host_menu_actions_with(power)
+                    .iter()
+                    .zip(self.host_menu_rows().iter())
+                    .enumerate()
+                    .map(|(i, (&action, row))| {
+                        let marks = crate::app::state::hostmenu::marks_of(action, saved);
+                        list::with_row_buttons(list::row_spec(row), marks, i == cursor, lit)
+                    })
+                    .collect();
+                ListCard {
+                    title: self.host_menu_title(),
+                    subtitle: Some(self.host_menu_subtitle()),
+                    rows,
+                }
+            }
             Screen::HostPower => {
                 let (auto_send, exit_action, access) = self.host_power_view();
                 ListCard {
@@ -554,10 +585,10 @@ impl App {
         }
     }
 
-    /// The trailing button of the ported list under `(x, y)`, as `(row, button)`.
+    /// The trailing button of the kit's rows under `(x, y)`, as `(row, button)`.
     pub(crate) fn kit_list_button_at(&mut self, x: i32, y: i32) -> Option<(usize, usize)> {
         let screen = self.nav.screen;
-        if !is_list(screen) {
+        if !draws_kit_rows(screen) {
             return None;
         }
         let p = pf_console_ui::pointer::Pointer {
@@ -566,6 +597,14 @@ impl App {
             kind: pf_console_ui::pointer::PointerKind::Move,
         };
         self.kit_list(screen).button_at(p)
+    }
+
+    /// The trailing button of `row` under `(x, y)` — the pointer paths' question, since a hit
+    /// on some *other* row's button is a hit on no button at all.
+    pub(crate) fn kit_row_button_at(&mut self, x: i32, y: i32, row: usize) -> Option<RowButton> {
+        self.kit_list_button_at(x, y)
+            .filter(|(r, _)| *r == row)
+            .map(|(_, b)| RowButton::Trailing(b))
     }
 
     /// The kit widget's side of a menu event on a ported list screen: the recoil at an end,
@@ -596,7 +635,7 @@ impl App {
     /// The row of the ported list under `(x, y)` — the kit's own last-drawn geometry.
     pub(crate) fn kit_list_row_at(&mut self, x: i32, y: i32) -> Option<usize> {
         let screen = self.nav.screen;
-        if !is_list(screen) && screen != Screen::SettingsPage {
+        if !draws_kit_rows(screen) {
             return None;
         }
         let len = self.row_count();
@@ -672,8 +711,10 @@ mod tests {
 
     #[test]
     fn scale_follows_the_consoles_rule() {
-        assert!((scale(1080) - 1.35).abs() < 1e-6);
-        assert!((scale(2160) - 2.7).abs() < 1e-6);
+        // The kit's own rule, times this client's couch scale; the low clamp is untouched.
+        assert!((scale(1080) - 1.35 * BASE_SCALE).abs() < 1e-6);
+        // 4K rides the same rule up to the kit's ceiling. webOS hands this app 1080p anyway.
+        assert!((scale(2160) - (2.7 * BASE_SCALE).min(3.0)).abs() < 1e-6);
         assert!((scale(400) - 0.75).abs() < 1e-6);
     }
 
@@ -685,8 +726,8 @@ mod tests {
         assert!((panel_k_for(83) - 1.0).abs() < 1e-6);
         assert!((panel_k_for(48) - (65.0f32 / 48.0).sqrt()).abs() < 1e-6);
         assert!((panel_k_for(32) - 1.25).abs() < 1e-6);
-        // A 1080p-pixel metric is untouched at the reference panel.
-        assert!((px_1080(1080.0, 54.0) - 54.0).abs() < 1e-4);
+        // A 1080p-pixel metric takes the couch scale alone at the reference panel.
+        assert!((px_1080(1080.0, 54.0) - 54.0 * BASE_SCALE).abs() < 1e-4);
     }
 
     /// A focus move owes frames until every channel reaches its target, then none.

--- a/src/app/draw/settings.rs
+++ b/src/app/draw/settings.rs
@@ -143,7 +143,7 @@ pub(crate) fn draw(
                 c,
                 p.label(),
                 f64::from(r.left + 44.0 * k),
-                f64::from(r.center_y() + ENTRY_SIZE as f32 * k * 0.35),
+                f64::from(r.center_y()) + ENTRY_SIZE * f64::from(k) * 0.35,
                 if open { W::SemiBold } else { W::Medium },
                 ENTRY_SIZE * f64::from(k),
                 color,

--- a/src/app/pointer.rs
+++ b/src/app/pointer.rs
@@ -12,7 +12,6 @@
 use std::time::Instant;
 
 use crate::app::nav::ScreenKey;
-use crate::app::screens::rowbuttons::RowButton;
 use crate::app::{view, App, ConnectTarget, HomeFocus, PairingFocus, Screen};
 use crate::ui;
 use crate::ui::render::Rect;
@@ -141,10 +140,7 @@ impl App {
                 let Some(row) = self.kit_list_row_at(x, y) else {
                     return HoverChange::NONE;
                 };
-                let button = self
-                    .kit_list_button_at(x, y)
-                    .filter(|(r, _)| *r == row)
-                    .map(|(_, b)| RowButton::Trailing(b));
+                let button = self.kit_row_button_at(x, y, row);
                 let key = ScreenKey::Collections;
                 let row_changed = self.nav.cursor(key) != row;
                 let button_changed = self.screens.row_button != button;
@@ -167,31 +163,36 @@ impl App {
                 let Some(i) = self.kit_list_row_at(x, y) else {
                     return HoverChange::NONE;
                 };
+                // The calibrate row's bin, lit like any other row button under the pointer.
+                let button = self.kit_row_button_at(x, y, i);
                 let changed = self.nav.cursor(ScreenKey::SettingsPage) != i || self.screens.settings_page.column;
+                let button_changed = self.screens.row_button != button;
                 self.screens.settings_page.column = false;
                 self.nav.set_cursor(ScreenKey::SettingsPage, i);
-                HoverChange::row(changed)
+                self.screens.row_button = button;
+                HoverChange::split(changed, button_changed)
             }
-            // A list drawn on the kit: hover focuses the row under the pointer, through the
-            // list's own last-drawn rects (`app::draw::list`).
+            // A list drawn on the kit: hover focuses the row under the pointer, and whichever
+            // of its buttons the pointer is actually over, through the list's own last-drawn
+            // rects (`app::draw::list`). A screen whose rows carry none reads `None` here.
             screen @ (Screen::HostMenu | Screen::HostPower | Screen::PickProfile) => {
-                let Some(i) = self.kit_list_row_at(x, y) else {
+                let Some(row) = self.kit_list_row_at(x, y) else {
                     return HoverChange::NONE;
                 };
+                let button = self.kit_row_button_at(x, y, row);
                 let key = ScreenKey::of(screen);
-                let changed = self.nav.cursor(key) != i;
-                self.nav.set_cursor(key, i);
-                HoverChange::row(changed)
+                let row_changed = self.nav.cursor(key) != row;
+                let button_changed = self.screens.row_button != button;
+                self.nav.set_cursor(key, row);
+                self.screens.row_button = button;
+                HoverChange::split(row_changed, button_changed)
             }
             // Identical row-list geometry; only which focus field they carry differs.
             Screen::HdrCalibration => {
                 let Some(row) = self.kit_list_row_at(x, y) else {
                     return HoverChange::NONE;
                 };
-                let button = self
-                    .kit_list_button_at(x, y)
-                    .filter(|(r, _)| *r == row)
-                    .map(|(_, b)| RowButton::Trailing(b));
+                let button = self.kit_row_button_at(x, y, row);
                 // Same per-screen field table the keyboard path indexes, so hover and
                 // D-pad focus can never name different fields.
                 let Some(focused) = self.list_modal_focused_mut() else {
@@ -338,10 +339,7 @@ impl App {
                 }
                 if let Some(row) = self.kit_list_row_at(x, y) {
                     self.nav.set_cursor(ScreenKey::Collections, row);
-                    self.screens.row_button = self
-                        .kit_list_button_at(x, y)
-                        .filter(|(r, _)| *r == row)
-                        .map(|(_, b)| RowButton::Trailing(b));
+                    self.screens.row_button = self.kit_row_button_at(x, y, row);
                 } else {
                     // No row under the pointer, so no trailing button either: the press is on
                     // the focused row itself.
@@ -375,22 +373,22 @@ impl App {
                 let row = self.kit_list_row_at(x, y)?;
                 self.screens.settings_page.column = false;
                 self.nav.set_cursor(ScreenKey::SettingsPage, row);
+                self.screens.row_button = self.kit_row_button_at(x, y, row);
             }
-            // A click on a kit list picks the row under it; off the rows it confirms the
-            // focused one, as an OK press does.
+            // A click on a kit list picks the row under it, and any button of that row it
+            // landed on, which `press` then reads. Off the rows it confirms the focused one,
+            // as an OK press does.
             screen @ (Screen::HostMenu | Screen::HostPower | Screen::PickProfile) => {
                 if let Some(row) = self.kit_list_row_at(x, y) {
                     self.nav.set_cursor(ScreenKey::of(screen), row);
+                    self.screens.row_button = self.kit_row_button_at(x, y, row);
                 }
             }
             // The one row is a track and a button, so a press is one or the other. Only the
             // button falls through to `press` below, which is what advances the step.
             Screen::HdrCalibration => {
                 let row = self.kit_list_row_at(x, y)?;
-                let button = self
-                    .kit_list_button_at(x, y)
-                    .filter(|(r, _)| *r == row)
-                    .map(|(_, b)| RowButton::Trailing(b));
+                let button = self.kit_row_button_at(x, y, row);
                 // Focus follows the click, exactly as it does on a collection row's buttons.
                 self.screens.row_button = button;
                 if button.is_none() {

--- a/src/app/screens/rowbuttons.rs
+++ b/src/app/screens/rowbuttons.rs
@@ -71,6 +71,10 @@ impl App {
         match self.nav.screen {
             // One row, one button: the tick that finishes the measurement.
             Screen::HdrCalibration => RowButtons::trailing(view::hdrcalibration::ACTION_MARKS),
+            // The power row's ⋯ and Connect's pencil; every other row has no ends.
+            Screen::HostMenu => RowButtons::trailing(self.host_menu_row_marks(row)),
+            // The calibrate row's bin, once this TV has a calibration to throw away.
+            Screen::SettingsPage => RowButtons::trailing(self.settings_page_row_marks(row)),
             Screen::Collections => self
                 .selected_known_host()
                 .and_then(|host| host.collections().get(row))

--- a/src/app/state/collections.rs
+++ b/src/app/state/collections.rs
@@ -96,8 +96,8 @@ impl App {
     /// The modal's rows, `None` off the screen or with no host selected.
     pub(crate) fn collections_rows(&self) -> Option<Vec<FocusRow>> {
         let host = self.selected_known_host()?;
-        let target = self.screens.collections.target.as_deref()?;
-        Some(view::collections::rows(host, host.collection_of(target)))
+        self.screens.collections.target.as_ref()?;
+        Some(view::collections::rows(host))
     }
 
     pub(crate) fn collections_row_count(&self) -> usize {

--- a/src/app/state/hostmenu.rs
+++ b/src/app/state/hostmenu.rs
@@ -23,14 +23,13 @@ pub(crate) enum HostAction {
     /// it is right now is [`App::host_menu_power_row`].
     Power,
     /// This host's power settings (`Screen::HostPower`): wake automatically, exit behaviour.
+    /// A row of its own only where there is no power row to hang its ⋯ button off — an
+    /// unpaired host, which can be neither woken nor put down from here.
     PowerSettings,
     /// Stream the desktop once with a picked profile.
     ConnectWith,
-    /// The profile a title with no binding streams with.
-    DefaultProfile,
     /// Which profiles are cards under this host in the sidebar.
     Pin,
-    Edit,
     Forget,
 }
 
@@ -88,10 +87,28 @@ fn host_menu_row(action: HostAction, paired: bool, power: Option<ExitAction>) ->
         HostAction::Power => FocusRow::action(icons::ICON_POWER, power_row_label(power)),
         HostAction::PowerSettings => FocusRow::action(icons::ICON_SETTINGS, "Power settings"),
         HostAction::ConnectWith => FocusRow::action(icons::ICON_PLAY, "Connect with\u{2026}"),
-        HostAction::DefaultProfile => FocusRow::action(icons::ICON_WRENCH, "Default profile\u{2026}"),
         HostAction::Pin => FocusRow::action(icons::ICON_PIN, "Pin to sidebar\u{2026}"),
-        HostAction::Edit => FocusRow::action(icons::ICON_EDIT, "Edit address"),
         HostAction::Forget => FocusRow::action(icons::ICON_DELETE, "Forget host").danger(),
+    }
+}
+
+/// Connect's trailing button: the host's address, which is what a failed connect sends the
+/// user to change.
+const EDIT_MARKS: &[&str] = &[crate::app::view::icons::ICON_EDIT];
+
+/// The ⋯ a row wears when it does one thing now and holds the settings behind it: the power
+/// row's card, and the profile "Connect with…" streams a title with by default.
+const MORE_MARKS: &[&str] = &[crate::app::view::icons::ICON_MORE];
+
+/// The trailing buttons an action's row carries: the power row's ⋯ onto its settings,
+/// Connect's pencil onto the address behind it, and "Connect with…"'s ⋯ onto the profile it
+/// defaults to. Each is a modal that would otherwise need a row of its own. `saved` gates the
+/// address: a discovered host has none of ours to edit.
+pub(crate) fn marks_of(action: HostAction, saved: bool) -> &'static [&'static str] {
+    match action {
+        HostAction::Power | HostAction::ConnectWith => MORE_MARKS,
+        HostAction::Connect if saved => EDIT_MARKS,
+        _ => &[],
     }
 }
 
@@ -201,21 +218,31 @@ impl App {
         // a host with no MAC still gets the row once it is up.
         if paired && (!entry.mac().is_empty() || power.is_some()) {
             actions.push(HostAction::Power);
-        }
-        if saved {
+        } else if saved {
             actions.push(HostAction::PowerSettings);
         }
         // The profile rows need a paired, saved host and a catalog with something in it.
         if saved && paired && !self.profiles.is_empty() {
             actions.push(HostAction::ConnectWith);
-            actions.push(HostAction::DefaultProfile);
             actions.push(HostAction::Pin);
         }
         if saved {
-            actions.push(HostAction::Edit);
             actions.push(HostAction::Forget);
         }
         actions
+    }
+
+    /// Whether the menu's host is one this TV has saved — a discovered host has no address of
+    /// ours to edit. What [`marks_of`] gates Connect's pencil on.
+    pub(crate) fn host_menu_saved_entry(&self) -> bool {
+        matches!(self.host_menu_entry(), Some(HostEntry::Known(_)))
+    }
+
+    /// [`marks_of`] for row `row` — the index the pointer and the d-pad name a row by. The
+    /// painter has the action in hand already and calls [`marks_of`] directly.
+    pub(crate) fn host_menu_row_marks(&self, row: usize) -> &'static [&'static str] {
+        let saved = self.host_menu_saved_entry();
+        self.host_menu_actions().get(row).map_or(&[], |&a| marks_of(a, saved))
     }
 
     /// The host's name — the menu's title.
@@ -237,7 +264,11 @@ impl App {
             return;
         }
         match ev {
+            // On a row's button, Confirm means what that button opens rather than the row's
+            // own action.
+            MenuEvent::Confirm if self.screens.row_button.is_some() => self.confirm_host_menu_button(),
             MenuEvent::Confirm => self.confirm_host_menu_row(),
+            MenuEvent::Right | MenuEvent::Left if self.step_row_button(ev == MenuEvent::Right) => {}
             MenuEvent::Back => {
                 self.screens.host_menu_index = None;
                 self.nav.screen = Screen::Home;
@@ -267,6 +298,31 @@ impl App {
         self.start_power_action(&host, port, action, &name);
     }
 
+    /// The focused row's trailing button: the modal it stands for.
+    fn confirm_host_menu_button(&mut self) {
+        let actions = self.host_menu_actions();
+        let Some(action) = actions.get(self.nav.cursor(ScreenKey::HostMenu)) else {
+            return;
+        };
+        let Some(idx) = self.screens.host_menu_index else {
+            return;
+        };
+        match action {
+            HostAction::Power => self.open_host_power(),
+            HostAction::Connect => self.open_edit_host(idx),
+            // The row streams the desktop with a profile picked now; its ⋯ picks the one a
+            // title with no binding of its own streams with every time.
+            HostAction::ConnectWith => {
+                let Some(entry) = self.hosts.entries.get(idx) else {
+                    return;
+                };
+                let (host, port) = (entry.host().to_string(), entry.port());
+                self.open_pick_profile(ProfilePick::HostDefault { host, port });
+            }
+            _ => {}
+        }
+    }
+
     /// Runs focused row's action; every arm navigates away or closes menu.
     pub(crate) fn confirm_host_menu_row(&mut self) {
         let actions = self.host_menu_actions();
@@ -291,19 +347,17 @@ impl App {
             HostAction::SpeedTest => self.open_speed_test(idx),
             HostAction::Power => self.confirm_power_row(idx),
             HostAction::PowerSettings => self.open_host_power(),
-            HostAction::ConnectWith | HostAction::DefaultProfile | HostAction::Pin => {
+            HostAction::ConnectWith | HostAction::Pin => {
                 let Some(entry) = self.hosts.entries.get(idx) else {
                     return;
                 };
                 let (host, port) = (entry.host().to_string(), entry.port());
                 let pick = match action {
                     HostAction::ConnectWith => ProfilePick::ConnectWith { host, port },
-                    HostAction::DefaultProfile => ProfilePick::HostDefault { host, port },
                     _ => ProfilePick::Pin { host, port },
                 };
                 self.open_pick_profile(pick);
             }
-            HostAction::Edit => self.open_edit_host(idx),
             HostAction::Forget => self.open_forget_host(idx),
         }
     }

--- a/src/app/state/profiles.rs
+++ b/src/app/state/profiles.rs
@@ -212,14 +212,6 @@ impl App {
         self.persist();
     }
 
-    /// Whether `pin_id` on the selected host is bound to a profile that still exists — the
-    /// card's dot.
-    pub(crate) fn game_is_bound(&self, pin_id: &str) -> bool {
-        self.selected_known_host()
-            .and_then(|h| h.game_profile(pin_id))
-            .is_some_and(|id| self.profiles.iter().any(|p| p.id == id))
-    }
-
     /// The settings one launch runs with — `shared::launch_settings` over this App's document.
     pub(crate) fn launch_settings(
         &self,

--- a/src/app/state/settingspage.rs
+++ b/src/app/state/settingspage.rs
@@ -16,6 +16,8 @@ use pf_console_ui::settings_rows::{self as engine, Ctx, RowId};
 use pf_console_ui::widgets::{Control, RowSpec};
 
 use crate::app::nav::ScreenKey;
+use crate::app::screens::rowbuttons::RowButton;
+use crate::app::view::icons;
 use crate::app::{menu, App};
 use crate::core::event::MenuEvent;
 use crate::core::screen::Screen;
@@ -91,8 +93,6 @@ pub(crate) enum Row {
     GameMode,
     /// The three-step calibration screen.
     CalibrateHdr,
-    /// "Clear HDR calibration?", once one has been saved.
-    ResetHdr,
     /// One detected controller, or the "none" placeholder.
     Pad,
     Version,
@@ -148,7 +148,6 @@ fn page_rows(page: Page, scope: &Scope) -> Rows {
             push(Row::Kit(K::Hdr), None);
             if !profile {
                 push(Row::CalibrateHdr, None);
-                push(Row::ResetHdr, None);
                 push(Row::GameMode, Some("TV"));
             }
         }
@@ -265,6 +264,16 @@ pub(crate) enum RowStep {
     Clear,
 }
 
+/// The trailing buttons a row carries: the bin that throws away an HDR calibration, on the row
+/// that made it. Nothing wears one until there is something to clear, so the button's presence
+/// is the answer to "is this TV calibrated".
+fn marks_of(row: Row, calibrated: bool) -> &'static [&'static str] {
+    match row {
+        Row::CalibrateHdr if calibrated => &[icons::ICON_DELETE],
+        _ => &[],
+    }
+}
+
 pub(crate) fn settings_nav(column: bool, ev: MenuEvent) -> NavStep {
     if column {
         return match ev {
@@ -291,6 +300,9 @@ impl App {
     /// card menu edits a title's profile, and a stale scope silently edits the wrong one.
     pub(crate) fn open_settings_page(&mut self, scope: Scope) {
         self.screens.settings_page.scope = scope;
+        // One field serves every row list, so a button left focused on the screen that raised
+        // this one would arrive as this page's — and swallow Confirm on a row that draws none.
+        self.screens.row_button = None;
         // The page column takes focus first; OK or Right on a page moves into its rows.
         self.screens.settings_page.column = true;
         self.nav.enter(Screen::SettingsPage, 0);
@@ -359,6 +371,15 @@ impl App {
             .collect()
     }
 
+    /// [`marks_of`] for row `row` — the index the pointer and the d-pad name a row by. The
+    /// painter has the row in hand already and calls [`marks_of`] directly.
+    pub(crate) fn settings_page_row_marks(&self, row: usize) -> &'static [&'static str] {
+        let calibrated = self.settings_ui.settings.hdr_calibrated();
+        self.settings_page_rows()
+            .get(row)
+            .map_or(&[], |&(row, _)| marks_of(row, calibrated))
+    }
+
     /// The rows of the open page, gated: the plan's positive list, the console's platform
     /// gate, then its applicability filter.
     pub(crate) fn settings_page_rows(&self) -> Rows {
@@ -374,7 +395,6 @@ impl App {
                 }
                 let shown = match row {
                     Row::Kit(id) => engine::row_on(id, pf_console_ui::Platform::WebOS) && engine::row_applies(id, ctx),
-                    Row::ResetHdr => self.settings_ui.settings.hdr_calibrated(),
                     _ => true,
                 };
                 if shown {
@@ -387,6 +407,9 @@ impl App {
 
     /// The open page's rows as the kit draws them.
     pub(crate) fn settings_page_specs(&self) -> Vec<RowSpec> {
+        let cursor = self.nav.cursor(ScreenKey::SettingsPage);
+        let lit = self.screens.row_button;
+        let calibrated = self.settings_ui.settings.hdr_calibrated();
         let mut settings = self.scope_settings();
         let overlay = self.scope_profile().map(|p| p.overrides.clone());
         let rows = self.settings_page_rows();
@@ -394,7 +417,8 @@ impl App {
         let core = self.settings_ui.settings.clone();
         self.with_engine(&mut settings, |ctx| {
             rows.iter()
-                .map(|&(row, header)| {
+                .enumerate()
+                .map(|(i, &(row, header))| {
                     let mut spec = match row {
                         Row::Kit(id) => {
                             let mut spec = engine::row_spec(id, ctx, &profiles);
@@ -406,7 +430,7 @@ impl App {
                             spec.dot = overlay.as_ref().is_some_and(|o| overridden(o, id));
                             spec
                         }
-                        Row::Editing => RowSpec::choice("Editing", self.scope_label()),
+                        Row::Editing => RowSpec::choice("Profile", self.scope_label()),
                         Row::GameMode => {
                             let spec = RowSpec::toggle("Game mode", core.game_mode())
                                 .with_note("Asks the TV to switch its picture mode for the stream");
@@ -424,10 +448,6 @@ impl App {
                                 spec.locked("Turn HDR on to calibrate")
                             }
                         }
-                        Row::ResetHdr => RowSpec {
-                            danger: true,
-                            ..RowSpec::action("Clear HDR calibration…", true)
-                        },
                         Row::Pad => match self.detected_gamepad_type {
                             Some(kind) => RowSpec::field(format!("{kind:?}"), "Connected".into(), ""),
                             None => RowSpec::field("No controller detected", String::new(), "Connect one to your TV"),
@@ -450,7 +470,11 @@ impl App {
                         Row::NewProfile => RowSpec::action("New profile…", true),
                         Row::Rename => RowSpec::action("Rename…", true),
                         Row::Duplicate => RowSpec::action("Duplicate", true),
-                        Row::Delete => RowSpec::action("Delete…", true),
+                        // The one row here that destroys saved state, in the kit's loss colour.
+                        Row::Delete => RowSpec {
+                            danger: true,
+                            ..RowSpec::action("Delete…", true)
+                        },
                     };
                     spec.header = header;
                     // The engine draws every boolean as text with chevrons, while this app's
@@ -466,7 +490,7 @@ impl App {
                         // The switch is the affordance: no chevrons, and no value to slide.
                         spec.adjustable = false;
                     }
-                    spec
+                    crate::app::draw::list::with_row_buttons(spec, marks_of(row, calibrated), i == cursor, lit)
                 })
                 .collect()
         })
@@ -498,6 +522,14 @@ impl App {
     /// One menu event on the page. Left/Right on the column switch pages; on a row they step
     /// it. Confirm activates. Secondary clears an override in profile scope.
     pub(crate) fn handle_settings_page_event(&mut self, ev: MenuEvent) {
+        // The focused row's buttons come first, exactly as on a collections row: Right steps
+        // onto them, Left back off, and neither reaches the value stepper while one is lit.
+        if !self.screens.settings_page.column
+            && matches!(ev, MenuEvent::Left | MenuEvent::Right)
+            && self.step_row_button(ev == MenuEvent::Right)
+        {
+            return;
+        }
         let sp = &self.screens.settings_page;
         match settings_nav(sp.column, ev) {
             NavStep::Page(delta) => {
@@ -510,7 +542,12 @@ impl App {
                 self.show_page(Page::ALL[next]);
             }
             NavStep::EnterRows => self.screens.settings_page.column = false,
-            NavStep::ToColumn => self.screens.settings_page.column = true,
+            // A trailing button belongs to the row it is on, so leaving the rows leaves it —
+            // the same rule `list_nav_event` applies when the cursor moves between rows.
+            NavStep::ToColumn => {
+                self.screens.settings_page.column = true;
+                self.screens.row_button = None;
+            }
             NavStep::Leave => self.leave_settings_page(),
             NavStep::Row(step) => {
                 if self.list_nav_event(ev) {
@@ -526,7 +563,15 @@ impl App {
                 };
                 match step {
                     RowStep::Step(delta) => self.step_row(row, delta, false),
-                    RowStep::Activate => self.activate_row(row),
+                    // A row's button acts on the row it is on, read by icon rather than by
+                    // index, exactly as a collection row's is (`confirm_collections_row`).
+                    RowStep::Activate => match self.screens.row_button {
+                        Some(RowButton::Trailing(i)) => match self.row_trailing_button(cursor, i) {
+                            Some(icons::ICON_DELETE) => self.open_reset_hdr_calibration(),
+                            _ => self.activate_row(row),
+                        },
+                        _ => self.activate_row(row),
+                    },
                     RowStep::Clear => self.clear_override(row),
                 }
             }
@@ -537,6 +582,7 @@ impl App {
     pub(crate) fn show_page(&mut self, page: Page) {
         if self.screens.settings_page.page != page {
             self.screens.settings_page.page = page;
+            self.screens.row_button = None;
             self.nav.set_cursor(ScreenKey::SettingsPage, 0);
             self.render.modal.focus_anim = Some(std::time::Instant::now());
         }
@@ -566,7 +612,6 @@ impl App {
                 self.persist();
             }
             Row::SendLogs => self.send_logs_action(),
-            Row::ResetHdr => self.open_reset_hdr_calibration(),
             Row::Licences => self.open_about(),
             Row::NewProfile => self.new_profile(),
             Row::Rename => self.open_rename_profile(),

--- a/src/app/state/settingspage.rs
+++ b/src/app/state/settingspage.rs
@@ -595,7 +595,7 @@ impl App {
                 let mut after = before.clone();
                 let changed = self.with_engine(&mut after, |ctx| engine::adjust(id, delta, wrap, ctx));
                 if changed {
-                    self.write_scope(&before, &after);
+                    self.write_scope(&before, &after, overlay_field(id));
                 }
             }
             _ => {}
@@ -603,8 +603,9 @@ impl App {
     }
 
     /// Persist an edited document: the global one, clamped to the TV's caps and projected onto
-    /// this client's own struct; or the profile's overlay, absorbing what changed.
-    fn write_scope(&mut self, before: &trust::Settings, after: &trust::Settings) {
+    /// this client's own struct; or the profile's overlay, absorbing what changed. `field` is
+    /// the overlay key the edited row pins, if any.
+    fn write_scope(&mut self, before: &trust::Settings, after: &trust::Settings, field: Option<&'static str>) {
         match self.screens.settings_page.scope.clone() {
             Scope::Global => {
                 let mut document = after.clone();
@@ -613,8 +614,18 @@ impl App {
                 self.persist();
             }
             Scope::Profile(id) => {
+                let global = self.settings_ui.settings.clone();
                 if let Some(p) = self.profiles.iter_mut().find(|p| p.id == id) {
                     p.overrides.absorb(before, after);
+                    // `absorb` pins a value even when it equals the global one, but the dot
+                    // reads as "differs from Default settings" — so an edit that lands back on
+                    // the global value drops its pin instead of keeping a no-op override.
+                    if let Some(field) = field {
+                        let mut without = p.overrides.clone();
+                        if without.clear(field) && without.apply(&global) == p.overrides.apply(&global) {
+                            p.overrides = without;
+                        }
+                    }
                     self.persist();
                 }
             }

--- a/src/app/view/collections.rs
+++ b/src/app/view/collections.rs
@@ -90,17 +90,13 @@ pub(crate) fn name_hint(host: &KnownHost, at: Option<usize>, typed: &str) -> Opt
     (!typed.is_empty() && !host.can_name(at, typed)).then_some("Already used")
 }
 
-/// One row per entry in grid order, Library included. `holding` is the collection the card
-/// being moved is in right now (`None` for Library, its implicit home) — that row wears the
-/// mark dot, so the list opens saying where the card already is instead of leaving the user
-/// to work it out.
-pub(crate) fn rows(host: &KnownHost, holding: Option<usize>) -> Vec<FocusRow> {
-    let library = host.library_index();
+/// One row per entry in grid order, Library included. Where the card already sits is said by
+/// the cursor, which opens on that row (`App::open_collections`).
+pub(crate) fn rows(host: &KnownHost) -> Vec<FocusRow> {
     let mut rows: Vec<FocusRow> = host
         .collections()
         .iter()
-        .enumerate()
-        .map(|(i, collection)| {
+        .map(|collection| {
             let count = if collection.dynamic {
                 // Library's members are whatever no one else claims, so its count is not in
                 // the vector — and saying "0 games" of it would be a lie.
@@ -114,16 +110,11 @@ pub(crate) fn rows(host: &KnownHost, holding: Option<usize>) -> Vec<FocusRow> {
             let row = FocusRow::action_with_value(icons::ICON_REORDER, collection.name.clone(), count_label(count))
                 .with_trailing(trailing(collection.dynamic))
                 .with_leading_button();
-            let row = match count {
+            match count {
                 // An empty collection is hidden in the grid, which reads as a vanished one
                 // unless the row that still lists it says so.
                 Some(0) => row.with_subtext(ui::widgets::RowSubtext::hint("Hidden until you add a game")),
                 _ => row,
-            };
-            if holding == Some(i) || (holding.is_none() && library == Some(i)) {
-                row.marked()
-            } else {
-                row
             }
         })
         .collect();
@@ -132,8 +123,7 @@ pub(crate) fn rows(host: &KnownHost, holding: Option<usize>) -> Vec<FocusRow> {
     if host.can_add_collection() {
         rows.push(FocusRow::action(icons::ICON_ADD, ADD_ROW.to_string()));
     }
-    // Library has no Remove and one row wears the mark dot, both of which would otherwise
-    // shift that row's count.
+    // Library has no Remove, which would otherwise shift that row's count.
     ui::widgets::align_values(&mut rows);
     rows
 }

--- a/src/app/view/icons.rs
+++ b/src/app/view/icons.rs
@@ -9,6 +9,7 @@ pub const ICON_SIGNAL: &str = "activity";
 pub const ICON_POWER: &str = "power";
 pub const ICON_DELETE: &str = "trash-2";
 pub const ICON_EDIT: &str = "pencil";
+pub const ICON_MORE: &str = "ellipsis";
 pub const ICON_SEND: &str = "send";
 pub const ICON_REORDER: &str = "grip-vertical";
 pub const ICON_CLOSE: &str = "x";


### PR DESCRIPTION
Four screens had a row whose whole job was to act on the row above it. Those are buttons now, reached the way a collection row's rename and remove already are.

- Host menu: the power row carries the ⋯ onto its power settings, Connect the pencil onto the address behind it, and "Connect with…" the ⋯ onto the profile it defaults to. `Power settings`, `Edit address` and `Default profile…` are gone as rows.
- Settings: the calibrate row carries the bin that throws an HDR calibration away, and only once there is one to throw — its presence is the answer to "is this TV calibrated". `Clear HDR calibration…` is gone.
- Home cards drop the profile-bound dot, and the collections list drops its current-collection mark (the cursor already opens on that row).
- A profile row edited back to the global value clears its override instead of pinning an equal one, so the dot goes out.

One marks table per screen behind `row_buttons`, Left/Right to step onto them, Confirm keyed by icon. The pointer paths share one `kit_row_button_at` — the settings page's buttons were d-pad-only until `draws_kit_rows` replaced the two hand-copied list-membership guards. Type rides one `BASE_SCALE` rather than per-screen sizes.

`task docker:lint` and `task docker:test` pass.