### PR TITLE
Frosted glass modals, with the grid shadow fixed to stay fast

### DIFF
--- a/src/app/draw/about.rs
+++ b/src/app/draw/about.rs
@@ -10,7 +10,6 @@ use super::{glass_card, line_h, wrap, Frame};
 
 const WIDTH_FRAC: f32 = 0.78;
 const HEIGHT_FRAC: f32 = 0.84;
-/// Design units.
 const PAD: f32 = 26.0;
 const CORNER: f32 = 18.0;
 const TITLE_SIZE: f64 = 22.0;
@@ -28,7 +27,6 @@ pub(crate) struct Layout {
     pub sub_baseline: f32,
     /// Pixel stride between visual lines.
     pub stride: f32,
-    /// How many visual lines the body shows.
     pub visible: usize,
 }
 
@@ -111,7 +109,7 @@ pub(crate) fn draw(
     c.save();
     c.translate((0.0, dy));
     c.save_layer_alpha_f(Some(l.card), alpha);
-    glass_card(c, l.card, CORNER, k);
+    glass_card(f, l.card, CORNER);
     let x = f64::from(l.card.left + PAD * k);
     f.fonts.draw(
         c,
@@ -159,7 +157,6 @@ pub(crate) fn draw(
         );
     }
     c.restore();
-    // A thin track on the right says how far along the document the window is.
     if lines.len() > l.visible {
         let track = Rect::from_xywh(l.card.right - 12.0 * k, l.body.top, 4.0 * k, l.body.height());
         c.draw_rrect(

--- a/src/app/draw/card_rim.rs
+++ b/src/app/draw/card_rim.rs
@@ -1,0 +1,116 @@
+//! The rim of the frosted card: the `SkSL` and the one function that builds its shader.
+//!
+//! Split out of [`super::glass`] because it is the only part of the material written in
+//! another language — the shader source stays whole and adjacent to the uniforms it declares.
+
+use pf_console_ui::theme;
+use skia_safe::{Canvas, RRect, Rect};
+
+/// How far in from the edge the rim ramp reaches, design units. Past ~40 it covers enough of
+/// the card to read as shading rather than as an edge; kept narrow so it reads as a chamfer.
+const CARD_BEVEL: f32 = 14.0;
+/// The RIM of the liquid-glass material, ported from plx-native's `shaders/fs_glass.frag`.
+///
+/// THE SDF THE ROUNDED RECT ALREADY NEEDS IS THE WHOLE EFFECT. The distance that rounds the
+/// corners is exactly the "how deep into the bevel am I" term, and the analytic gradient of
+/// the same field is the surface normal to light along.
+///
+/// Two of plx's three parts are here:
+///  - A DIRECTIONAL EDGE LIGHT, not a uniform ring. A slab lit from above has a bright top
+///    chamfer and a dark bottom one, and that asymmetry is most of what says "solid object at
+///    an angle" rather than "rectangle with a glow". The lit side mixes toward white, the
+///    shaded side toward black — a LERP, not an addition, because an added near-black rim
+///    adds near-nothing and a dark edge could then never exist.
+///  - A HAIRLINE SPECULAR, measured in pixels off the edge rather than as a fraction of the
+///    bevel. Its thinness is most of why it reads as an edge rather than as lighting.
+///
+/// NOT here: the lens, plx's part 1 — the refraction that displaces the backdrop sample
+/// outward along the normal. That one needs the blurred backdrop as a shader INPUT, and the
+/// only way to get it (`SkImageFilters::RuntimeShader` as the layer's backdrop) sampled to
+/// transparent in this app's coordinate space, which `mix(0, frost, .72)` turned into a solid
+/// frost-coloured card — the "not transparent" regression. This draws OVER the frost instead
+/// and samples nothing, so it cannot reintroduce that.
+const CARD_RIM_SKSL: &str = r#"
+uniform float2 u_c;      // card centre, canvas px
+uniform float2 u_ch;     // card half-size
+uniform float  u_r;      // corner radius
+uniform float  u_bevel;  // how far in from the edge the rim ramp reaches
+
+// Deliberately faint: the rim states the card's edge, the frost states the material.
+const float2 LIGHT = float2(-0.35, -0.94);
+const float EDGE = 0.03;
+const float DARK = 0.02;
+const float SPEC = 0.04;
+
+// Rounded-box SDF. The same `q` also gives the analytic gradient, so the normal is derived
+// from it at the one place that needs it rather than returned from here.
+float sdBox(float2 q, float r) {
+  return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - r;
+}
+
+half4 main(float2 coord) {
+  float2 p = coord - u_c;
+  float2 q = abs(p) - u_ch + float2(u_r);
+  float d = sdBox(q, u_r);
+  // One range test covers both dead zones: the flat middle past the bevel, and everything
+  // outside the antialiased edge. The branch is coherent across a tile, which is what pays.
+  if (d < -u_bevel || d >= 1.0) { return half4(0.0); }
+
+  float white = smoothstep(-2.2, -0.9, d) * (1.0 - smoothstep(-0.6, 0.4, d)) * SPEC;
+  float dark = 0.0;
+
+  // The chamfer band peaks just INSIDE the rim: on it, coverage eats most of it and the line
+  // reads as aliasing instead of as a highlight. Outside the band no normal is needed, which
+  // is what keeps the normalize off the hairline-only and antialiasing pixels.
+  float t = 1.0 + d / u_bevel;
+  float band = smoothstep(0.55, 1.0, t) * (1.0 - smoothstep(0.94, 1.0, t));
+  if (band > 0.0) {
+    float2 m = max(q, 0.0);
+    float2 n = (q.x > 0.0 || q.y > 0.0)
+        ? normalize(m + float2(1e-5))
+        : (q.x > q.y ? float2(1.0, 0.0) : float2(0.0, 1.0));
+    float ndl = dot(sign(p) * n, LIGHT);
+    white += band * max(ndl, 0.0) * EDGE;
+    dark = band * max(-ndl, 0.0) * DARK;
+  }
+
+  white = min(white, 1.0);
+  float a = min(white + dark, 1.0);
+  // Premultiplied, so the lit/shaded split IS the colour: rgb = (white / a) * a = white.
+  float cov = 1.0 - smoothstep(-1.0, 1.0, d);
+  return half4(half3(white * cov), half(a * cov));
+}
+"#;
+
+/// Compiled once per thread — `RuntimeEffect` is refcounted but not `Send`, so this cannot be
+/// a `OnceLock`. Each draw clones a handle rather than recompiling `SkSL`.
+fn shader(rect: Rect, corner: f32, k: f32) -> Option<skia_safe::Shader> {
+    thread_local! {
+        static EFFECT: std::cell::OnceCell<Option<skia_safe::RuntimeEffect>> =
+            const { std::cell::OnceCell::new() };
+    }
+    let effect = EFFECT.with(|c| {
+        c.get_or_init(|| {
+            skia_safe::RuntimeEffect::make_for_shader(CARD_RIM_SKSL, None)
+                .inspect_err(|e| tracing::warn!("card rim shader failed to compile: {e}"))
+                .ok()
+        })
+        .clone()
+    })?;
+    let mut b = skia_safe::runtime_effect::RuntimeShaderBuilder::new(effect);
+    b.set_uniform_float("u_c", &[rect.center_x(), rect.center_y()])
+        .and(b.set_uniform_float("u_ch", &[rect.width() / 2.0, rect.height() / 2.0]))
+        .and(b.set_uniform_float("u_r", &[corner * k]))
+        .and(b.set_uniform_float("u_bevel", &[CARD_BEVEL * k]))
+        .ok()?;
+    b.make_shader(&skia_safe::Matrix::default())
+}
+
+/// A no-op if the shader fails to compile: graceful degradation to a chamferless card.
+pub(super) fn draw(canvas: &Canvas, rr: RRect, rect: Rect, corner: f32, k: f32) {
+    if let Some(shader) = shader(rect, corner, k) {
+        let mut p = theme::shaded();
+        p.set_shader(shader);
+        canvas.draw_rrect(rr, &p);
+    }
+}

--- a/src/app/draw/dialog.rs
+++ b/src/app/draw/dialog.rs
@@ -46,13 +46,11 @@ pub(crate) struct Layout {
 }
 
 impl Layout {
-    /// Button under `(x, y)`, or `None` off both.
     pub fn button_at(&self, x: i32, y: i32) -> Option<usize> {
         let p = Point::new(x as f32, y as f32);
         self.buttons.iter().position(|b| b.contains(p))
     }
 
-    /// Whether `(x, y)` is on the close mark.
     pub fn on_close(&self, x: i32, y: i32) -> bool {
         self.close.contains(Point::new(x as f32, y as f32))
     }
@@ -170,8 +168,7 @@ fn draw_on(
     c.save();
     c.translate((0.0, dy));
     c.save_layer_alpha_f(Some(l.card), alpha);
-    glass_card(c, l.card, CORNER, k);
-    // Title, then the body's lines.
+    glass_card(f, l.card, CORNER);
     f.fonts.draw_clipped(
         c,
         title,
@@ -194,7 +191,6 @@ fn draw_on(
             body_tone,
         );
     }
-    // Close mark, lit under the pointer.
     let hover_close = motion.is_some_and(|m| m.hover_close);
     if let Some(x) = by_name("x") {
         draw_icon(

--- a/src/app/draw/form.rs
+++ b/src/app/draw/form.rs
@@ -14,7 +14,6 @@ use crate::core::screen::PairingFocus;
 use crate::ui;
 
 const WIDTH_FRAC: f32 = 0.40;
-/// The system keyboard takes roughly the bottom half of the panel (`KEYBOARD_PANEL_FRAC`).
 const KEYBOARD_FRAC: f32 = 0.5;
 /// Design units.
 const PAD: f32 = 26.0;
@@ -41,7 +40,6 @@ pub(crate) struct Layout {
     pub title_baseline: f32,
     pub body_top: f32,
     pub body: Vec<String>,
-    /// Where a caution line goes, under the field.
     pub hint_baseline: f32,
 }
 
@@ -56,8 +54,6 @@ impl Layout {
     }
 }
 
-/// The card for a form with `subtitle`, with room for a hint when `hint`, lifted when the
-/// system keyboard is shown.
 pub(crate) fn layout(fonts: &Fonts, fw: f32, fh: f32, k: f32, subtitle: &str, hint: bool, keyboard: bool) -> Layout {
     let w = (fw * WIDTH_FRAC).round();
     let inner_w = w - 2.0 * PAD * k;
@@ -158,7 +154,6 @@ fn header(
     }
 }
 
-/// Draw the form: `typed` in the field with a caret after it, `hint` under it in the error tone.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn draw(
     f: &Frame<'_>,
@@ -175,7 +170,7 @@ pub(crate) fn draw(
     c.save();
     c.translate((0.0, dy));
     c.save_layer_alpha_f(Some(l.card), alpha);
-    glass_card(c, l.card, CORNER, k);
+    glass_card(f, l.card, CORNER);
     header(f, l.card, title, l.title_baseline, &l.body, l.body_top, hover_close);
     theme::panel(
         c,
@@ -336,7 +331,7 @@ pub(crate) fn draw_pair(f: &Frame<'_>, l: &PairLayout, s: &PairState<'_>, hover_
     c.save();
     c.translate((0.0, dy));
     c.save_layer_alpha_f(Some(l.card), alpha);
-    glass_card(c, l.card, CORNER, k);
+    glass_card(f, l.card, CORNER);
     header(
         f,
         l.card,
@@ -373,7 +368,6 @@ pub(crate) fn draw_pair(f: &Frame<'_>, l: &PairLayout, s: &PairState<'_>, hover_
         PAIR_BUTTON_CAPTION,
         theme::fg(0.6),
     );
-    // "or" between two hairlines.
     let or_w = f.fonts.measure("or", W::Medium, size);
     let cx = l.card.center_x();
     let inner_left = l.card.left + PAD * k;

--- a/src/app/draw/glass.rs
+++ b/src/app/draw/glass.rs
@@ -59,7 +59,19 @@ fn draw_card_backdrop(f: &Frame<'_>, bd: Backdrop<'_>, rr: RRect) -> bool {
     // taking the size from the frame rather than from the image keeps the two in step on both
     // axes, which a single device-pixels-per-unit ratio cannot when the drawable's aspect is
     // not the display mode's. The clip is what bounds the work to the card.
-    canvas.draw_image_rect(bd.page, None, Rect::from_wh(f.w, f.h), &p);
+    //
+    // Placed against the surface, not against the card: every painter translates by the modal
+    // rise before it gets here, so drawing at the frame's origin would slide the backdrop down
+    // with the card and show the page off-register for the whole open animation. The CTM's own
+    // translation, back in layout units, is exactly what has to come off again.
+    let m = canvas.local_to_device_as_3x3();
+    let (sx, sy) = (m.scale_x(), m.scale_y());
+    let origin = if sx == 0.0 || sy == 0.0 {
+        (0.0, 0.0)
+    } else {
+        (-m.translate_x() / sx, -m.translate_y() / sy)
+    };
+    canvas.draw_image_rect(bd.page, None, Rect::from_xywh(origin.0, origin.1, f.w, f.h), &p);
     canvas.restore();
     true
 }

--- a/src/app/draw/glass.rs
+++ b/src/app/draw/glass.rs
@@ -106,3 +106,21 @@ pub(crate) fn glass_card(f: &Frame<'_>, rect: Rect, corner: f32) {
     card_rim::draw(canvas, rr, rect, corner, k);
     card_hairline(canvas, rect, rr, k);
 }
+
+/// Frost `window` over the cover already drawn at `art`, same blur and face as [`glass_card`].
+///
+/// The card menu grows out of one card, so the only thing behind it is that card's cover:
+/// blurring the image straight into the rect it was drawn at needs no surface grab and stays
+/// registered through the card's zoom. `false` when there is no blur filter.
+pub(crate) fn frost_over_art(canvas: &Canvas, img: &skia_safe::Image, art: Rect, window: Rect, k: f32) -> bool {
+    let Some(blur) = card_blur(k) else {
+        return false;
+    };
+    let mut p = theme::layer();
+    p.set_image_filter(blur);
+    canvas.draw_image_rect(img, None, art, &p);
+    let mut face = surface();
+    face.a = CARD_FROST;
+    canvas.draw_rect(window, &theme::fill(face));
+    true
+}

--- a/src/app/draw/glass.rs
+++ b/src/app/draw/glass.rs
@@ -12,12 +12,17 @@ use skia_safe::{Canvas, RRect, Rect};
 use super::card_rim;
 use super::{surface, Frame};
 
-/// The page as it stood before any modal drew, for [`glass_card`].
+/// The page as it stood before any modal drew, already blurred by [`blur_page`], for
+/// [`glass_card`].
 ///
 /// A snapshot rather than `save_layer`'s `backdrop` filter, which is the obvious answer and did
 /// nothing here: the layer was composited but came back unfiltered, so the card read as
 /// transparent-but-sharp. An explicit image is also the only form the lens could ever use,
 /// since a refraction has to SAMPLE the backdrop at a displaced coordinate.
+///
+/// Blurred once by whoever takes the snapshot rather than per draw: the page behind a settled
+/// modal does not change, and re-running a 14-unit blur over the whole card every frame was
+/// most of what the card cost.
 #[derive(Clone, Copy)]
 pub(crate) struct Backdrop<'a> {
     pub page: &'a skia_safe::Image,
@@ -29,30 +34,54 @@ const CARD_BLUR: f32 = 14.0;
 /// transparent shows more backdrop and costs the contrast a couch reader needs, and the
 /// binding constraint is the text on the card, not the material. Tuned denser than that.
 const CARD_FROST: f32 = 0.9;
-/// The card blur, cached per `k` to avoid allocating and busting Skia's filter cache every frame.
-fn card_blur(k: f32) -> Option<skia_safe::ImageFilter> {
-    thread_local! {
-        static BLUR: std::cell::RefCell<Option<(f32, skia_safe::ImageFilter)>> =
-            const { std::cell::RefCell::new(None) };
-    }
-    BLUR.with(|c| {
-        let mut c = c.borrow_mut();
-        if !matches!(&*c, Some((cached, _)) if *cached == k) {
-            let sigma = CARD_BLUR * k;
-            *c = skia_safe::image_filters::blur((sigma, sigma), skia_safe::TileMode::Clamp, None, None).map(|f| (k, f));
-        }
-        c.as_ref().map(|(_, f)| f.clone())
-    })
+/// How much smaller everything is blurred than it is drawn. A `CARD_BLUR` gaussian destroys
+/// detail far finer than a quarter-resolution downscale does, so the two are indistinguishable
+/// while the blur covers a sixteenth of the pixels — and it is the difference between a modal
+/// appearing at once and visibly arriving, since a full 1080p blur cost hundreds of
+/// milliseconds on this chip. Both callers draw the result stretched back over the source rect.
+const DOWNSCALE: i32 = 4;
+
+/// `img` blurred into a quarter-size copy of itself on `target`, which is what decides whether
+/// the work lands on the GPU or the CPU: a GPU offscreen for the page, a raster one for a cover
+/// small enough that the deferred GPU filter would cost more than the blur.
+fn downscaled_blur(
+    target: impl FnOnce(i32, i32) -> Option<skia_safe::Surface>,
+    img: &skia_safe::Image,
+    sigma: f32,
+) -> Option<skia_safe::Image> {
+    let (w, h) = ((img.width() / DOWNSCALE).max(1), (img.height() / DOWNSCALE).max(1));
+    let mut surface = target(w, h)?;
+    let mut p = theme::layer();
+    // Sigma comes down with the image, so the blur covers the same fraction of it.
+    let sigma = sigma / DOWNSCALE as f32;
+    p.set_image_filter(skia_safe::image_filters::blur(
+        (sigma, sigma),
+        skia_safe::TileMode::Clamp,
+        None,
+        None,
+    )?);
+    surface
+        .canvas()
+        .draw_image_rect_with_sampling_options(img, None, Rect::from_iwh(w, h), super::linear(), &p);
+    Some(surface.image_snapshot())
 }
 
-/// Blur the page under the card if a blur filter exists; return `false` to signal the caller to draw opaque.
-fn draw_card_backdrop(f: &Frame<'_>, bd: Backdrop<'_>, rr: RRect) -> bool {
+/// The page, downscaled and blurred once, ready to be a [`Backdrop`].
+///
+/// `surface` is the live one, only to spawn a compatible offscreen to downscale into: a surface
+/// made from it shares the GPU context, so this never leaves the device.
+pub(crate) fn blur_page(surface: &mut skia_safe::Surface, page: &skia_safe::Image, k: f32) -> Option<skia_safe::Image> {
+    let info = surface.image_info();
+    downscaled_blur(
+        |w, h| surface.new_surface(&info.with_dimensions((w, h))),
+        page,
+        CARD_BLUR * k,
+    )
+}
+
+fn draw_card_backdrop(f: &Frame<'_>, bd: Backdrop<'_>, rr: RRect) {
     let canvas = f.canvas;
-    let Some(blur) = card_blur(f.k) else {
-        return false;
-    };
-    let mut p = theme::layer();
-    p.set_image_filter(blur);
+    let p = theme::layer();
     canvas.save();
     canvas.clip_rrect(rr, None, Some(true));
     // The page covers the whole surface, and the whole surface in layout units is the frame:
@@ -71,9 +100,16 @@ fn draw_card_backdrop(f: &Frame<'_>, bd: Backdrop<'_>, rr: RRect) -> bool {
     } else {
         (-m.translate_x() / sx, -m.translate_y() / sy)
     };
-    canvas.draw_image_rect(bd.page, None, Rect::from_xywh(origin.0, origin.1, f.w, f.h), &p);
+    // Linear: the page is a quarter-size blur, so it comes back up 4x and default sampling
+    // would stair-step it.
+    canvas.draw_image_rect_with_sampling_options(
+        bd.page,
+        None,
+        Rect::from_xywh(origin.0, origin.1, f.w, f.h),
+        super::linear(),
+        &p,
+    );
     canvas.restore();
-    true
 }
 
 /// The card's top-to-bottom hairline: the flat panel's stroke, kept over the glass because the
@@ -104,13 +140,12 @@ fn card_hairline(canvas: &Canvas, rect: Rect, rr: RRect, k: f32) {
 pub(crate) fn glass_card(f: &Frame<'_>, rect: Rect, corner: f32) {
     let (canvas, k) = (f.canvas, f.k);
     let rr = RRect::new_rect_xy(rect, corner * k, corner * k);
-    let frosted = f.backdrop.is_some_and(|bd| draw_card_backdrop(f, bd, rr));
-    if !frosted {
+    let Some(bd) = f.backdrop else {
         canvas.draw_rrect(rr, &theme::fill(surface()));
         theme::panel(canvas, rect, corner, None, PanelStroke::Gradient, k);
         return;
-    }
-    // Face must be translucent so the blurred backdrop shows through.
+    };
+    draw_card_backdrop(f, bd, rr);
     let mut face = surface();
     face.a = CARD_FROST;
     canvas.draw_rrect(rr, &theme::fill(face));
@@ -123,16 +158,56 @@ pub(crate) fn glass_card(f: &Frame<'_>, rect: Rect, corner: f32) {
 ///
 /// The card menu grows out of one card, so the only thing behind it is that card's cover:
 /// blurring the image straight into the rect it was drawn at needs no surface grab and stays
-/// registered through the card's zoom. `false` when there is no blur filter.
-pub(crate) fn frost_over_art(canvas: &Canvas, img: &skia_safe::Image, art: Rect, window: Rect, k: f32) -> bool {
-    let Some(blur) = card_blur(k) else {
+/// registered through the card's zoom. `false` when the blur could not be baked, and the caller
+/// draws the strip opaque.
+///
+/// The blurred cover is cached under `id`: the menu holds still once it is up, and re-blurring
+/// the same cover every frame is what made it lag on the way in.
+pub(crate) fn frost_over_art(
+    canvas: &Canvas,
+    id: &str,
+    img: &skia_safe::Image,
+    art: Rect,
+    window: Rect,
+    k: f32,
+) -> bool {
+    let Some(blurred) = blurred_cover(id, img, art, k) else {
         return false;
     };
-    let mut p = theme::layer();
-    p.set_image_filter(blur);
-    canvas.draw_image_rect(img, None, art, &p);
+    canvas.draw_image_rect_with_sampling_options(&blurred, None, art, super::linear(), &theme::layer());
     let mut face = surface();
     face.a = CARD_FROST;
     canvas.draw_rect(window, &theme::fill(face));
     true
+}
+
+/// The one cover the open card menu sits on, blurred. One entry, because one card menu is open
+/// at a time.
+///
+/// The blur is baked at the SOURCE image's scale so it looks the same once drawn into `art`, and
+/// the sigma is quantized because `art` is the focus-zoomed, pop-animated card rect: keyed on the
+/// exact float, every sub-pixel of that animation would re-bake, which is the cost this cache
+/// exists to avoid. A blur drawn stretched cannot show the rounding.
+fn blurred_cover(id: &str, img: &skia_safe::Image, art: Rect, k: f32) -> Option<skia_safe::Image> {
+    thread_local! {
+        static COVER: std::cell::RefCell<Option<(String, i32, skia_safe::Image)>> =
+            const { std::cell::RefCell::new(None) };
+    }
+    if art.width() <= 0.0 {
+        return None;
+    }
+    // Sigma in the source image's pixels: the canvas blur is CARD_BLUR * k across a card of
+    // `art.width()`, and the image is squeezed into that, so it scales by the same ratio.
+    let sigma = (CARD_BLUR * k * img.width() as f32 / art.width()).round() as i32;
+    COVER.with(|c| {
+        let mut c = c.borrow_mut();
+        if !matches!(&*c, Some((cached, s, _)) if cached == id && *s == sigma) {
+            // Raster rather than a GPU offscreen: the source is already a raster image and a
+            // quarter-size cover is microseconds on the CPU, where a GPU filter would instead
+            // land, deferred, on the flush of the frame the menu opened.
+            *c = downscaled_blur(|w, h| skia_safe::surfaces::raster_n32_premul((w, h)), img, sigma as f32)
+                .map(|blurred| (id.to_owned(), sigma, blurred));
+        }
+        c.as_ref().map(|(_, _, img)| img.clone())
+    })
 }

--- a/src/app/draw/glass.rs
+++ b/src/app/draw/glass.rs
@@ -1,0 +1,108 @@
+//! The frosted-glass material every modal card is made of, ported from plx-native's
+//! `shaders/fs_glass.frag`.
+//!
+//! One seam: all five modal painters call [`glass_card`], so the material lives in one
+//! function rather than in each of them. A card frosts only when its [`Frame`] carries a
+//! [`Backdrop`] — the page as it stood before any modal drew. Without one it is the flat
+//! opaque card it has always been, which is what a frame over live video must stay.
+
+use pf_console_ui::theme::{self, PanelStroke};
+use skia_safe::{Canvas, RRect, Rect};
+
+use super::card_rim;
+use super::{surface, Frame};
+
+/// The page as it stood before any modal drew, for [`glass_card`].
+///
+/// A snapshot rather than `save_layer`'s `backdrop` filter, which is the obvious answer and did
+/// nothing here: the layer was composited but came back unfiltered, so the card read as
+/// transparent-but-sharp. An explicit image is also the only form the lens could ever use,
+/// since a refraction has to SAMPLE the backdrop at a displaced coordinate.
+#[derive(Clone, Copy)]
+pub(crate) struct Backdrop<'a> {
+    pub page: &'a skia_safe::Image,
+}
+
+/// How far the backdrop is smeared under a frosted card, in design units (scaled by `k`).
+const CARD_BLUR: f32 = 14.0;
+/// Frost opacity. plx-native measured 0.72 as the legibility floor on a television: more
+/// transparent shows more backdrop and costs the contrast a couch reader needs, and the
+/// binding constraint is the text on the card, not the material. Tuned denser than that.
+const CARD_FROST: f32 = 0.9;
+/// The card blur, cached per `k` to avoid allocating and busting Skia's filter cache every frame.
+fn card_blur(k: f32) -> Option<skia_safe::ImageFilter> {
+    thread_local! {
+        static BLUR: std::cell::RefCell<Option<(f32, skia_safe::ImageFilter)>> =
+            const { std::cell::RefCell::new(None) };
+    }
+    BLUR.with(|c| {
+        let mut c = c.borrow_mut();
+        if !matches!(&*c, Some((cached, _)) if *cached == k) {
+            let sigma = CARD_BLUR * k;
+            *c = skia_safe::image_filters::blur((sigma, sigma), skia_safe::TileMode::Clamp, None, None).map(|f| (k, f));
+        }
+        c.as_ref().map(|(_, f)| f.clone())
+    })
+}
+
+/// Blur the page under the card if a blur filter exists; return `false` to signal the caller to draw opaque.
+fn draw_card_backdrop(f: &Frame<'_>, bd: Backdrop<'_>, rr: RRect) -> bool {
+    let canvas = f.canvas;
+    let Some(blur) = card_blur(f.k) else {
+        return false;
+    };
+    let mut p = theme::layer();
+    p.set_image_filter(blur);
+    canvas.save();
+    canvas.clip_rrect(rr, None, Some(true));
+    // The page covers the whole surface, and the whole surface in layout units is the frame:
+    // taking the size from the frame rather than from the image keeps the two in step on both
+    // axes, which a single device-pixels-per-unit ratio cannot when the drawable's aspect is
+    // not the display mode's. The clip is what bounds the work to the card.
+    canvas.draw_image_rect(bd.page, None, Rect::from_wh(f.w, f.h), &p);
+    canvas.restore();
+    true
+}
+
+/// The card's top-to-bottom hairline: the flat panel's stroke, kept over the glass because the
+/// rim shader lights the chamfer but does not draw the edge itself.
+fn card_hairline(canvas: &Canvas, rect: Rect, rr: RRect, k: f32) {
+    let mut p = theme::shaded_stroke(k);
+    p.set_shader(skia_safe::gradient::shaders::linear_gradient(
+        (
+            skia_safe::Point::new(rect.left, rect.top),
+            skia_safe::Point::new(rect.left, rect.bottom),
+        ),
+        &skia_safe::gradient::Gradient::new(
+            skia_safe::gradient::Colors::new_evenly_spaced(
+                &[theme::fg(0.22), theme::fg(0.04)],
+                skia_safe::TileMode::Clamp,
+                None,
+            ),
+            skia_safe::gradient::Interpolation::default(),
+        ),
+        None,
+    ));
+    canvas.draw_rrect(rr, &p);
+}
+
+/// A raised card. Over the menu it is a pane of frosted glass: the page behind it blurred,
+/// under a translucent face, with [`CARD_RIM_SKSL`]'s chamfer light and hairline over that.
+/// Without a backdrop on the frame it stays the opaque face it has always been.
+pub(crate) fn glass_card(f: &Frame<'_>, rect: Rect, corner: f32) {
+    let (canvas, k) = (f.canvas, f.k);
+    let rr = RRect::new_rect_xy(rect, corner * k, corner * k);
+    let frosted = f.backdrop.is_some_and(|bd| draw_card_backdrop(f, bd, rr));
+    if !frosted {
+        canvas.draw_rrect(rr, &theme::fill(surface()));
+        theme::panel(canvas, rect, corner, None, PanelStroke::Gradient, k);
+        return;
+    }
+    // Face must be translucent so the blurred backdrop shows through.
+    let mut face = surface();
+    face.a = CARD_FROST;
+    canvas.draw_rrect(rr, &theme::fill(face));
+    // Skip theme::panel on frosted path: its glass fill would re-opacify the translucent face.
+    card_rim::draw(canvas, rr, rect, corner, k);
+    card_hairline(canvas, rect, rr, k);
+}

--- a/src/app/draw/home.rs
+++ b/src/app/draw/home.rs
@@ -15,6 +15,7 @@ use skia_safe::{
 };
 
 use super::{focus_face, line_h, panel, sk, with_pop, Frame};
+use crate::app::draw::glass;
 use crate::app::grid::{Entrance, GridLayout};
 use crate::app::hosts::HostEntry;
 use crate::app::state::cardmenu::CardMenuRow;
@@ -482,8 +483,13 @@ impl App {
         c.save();
         c.clip_rrect(rr(r), ClipOp::Intersect, true);
         c.clip_rect(window, ClipOp::Intersect, true);
-        // An opaque strip over the art, the same face every card wears.
-        c.draw_rect(window, &theme::fill(super::surface()));
+        // Frosted over the cover it sits on, opaque where there is no cover to blur.
+        let frosted = (self.render.covers)
+            .get(&game.id)
+            .is_some_and(|img| glass::frost_over_art(c, img, r, window, f.k));
+        if !frosted {
+            c.draw_rect(window, &theme::fill(super::surface()));
+        }
         let size = px(f, VALUE);
         let title_top = window.top;
         f.fonts.draw_clipped(

--- a/src/app/draw/home.rs
+++ b/src/app/draw/home.rs
@@ -10,11 +10,11 @@ use pf_console_ui::icons::{by_name, draw_icon};
 use pf_console_ui::theme::{self, W};
 use pf_console_ui::{brand, launcher_icons, os_marks};
 use skia_safe::{
-    images, BlendMode, BlurStyle, ClipOp, Color4f, Data, FilterMode, Image, ImageInfo, MaskFilter, MipmapMode, Paint,
-    RRect, Rect, SamplingOptions,
+    images, BlendMode, BlurStyle, ClipOp, Color4f, Data, FilterMode, IRect, Image, ImageInfo, MaskFilter, Paint, RRect,
+    Rect,
 };
 
-use super::{focus_face, line_h, panel, sk, with_pop, Frame};
+use super::{focus_face, line_h, linear, panel, sk, with_pop, Frame};
 use crate::app::draw::glass;
 use crate::app::grid::{Entrance, GridLayout};
 use crate::app::hosts::HostEntry;
@@ -48,12 +48,70 @@ const MENU_ICON_INSET: f32 = 14.0;
 const GLOW_BLUR: f32 = 18.0;
 const SPINNER_R: f64 = 24.0;
 
-fn px(f: &Frame<'_>, size: f32) -> f64 {
-    f64::from(super::px_1080(f.h, size))
+/// The drop shadow every grid card wears: one small raster, stretched as a nine-patch.
+///
+/// `theme::drop_shadow` runs a `MaskFilter` blur per draw, and on this chip that is not the
+/// analytic rounded-rect path it is on a desktop GPU — one per visible card cost about 6ms of
+/// the grid's ~14ms of GPU time per frame, which is most of what made scrolling drop frames.
+///
+/// A nine-patch rather than one raster per card size, because there is never just one size: the
+/// focused card is zoomed and entering cards are mid-pop, so a cache keyed on size would re-bake
+/// several times a frame — worse than what it replaced. Only the corners carry the shape, so a
+/// single bake stretches to every card, and the alpha rides the paint so cards still fade in.
+fn card_shadow() -> Option<Image> {
+    thread_local! {
+        static SHADOW: std::cell::RefCell<Option<Option<Image>>> = const { std::cell::RefCell::new(None) };
+    }
+    SHADOW.with(|c| c.borrow_mut().get_or_insert_with(bake_card_shadow).clone())
 }
 
-fn linear() -> SamplingOptions {
-    SamplingOptions::new(FilterMode::Linear, MipmapMode::None)
+/// The shadow's own bed: a rounded rect blurred with [`SHADOW_MARGIN`] of room to spread into on
+/// every side. The body is wide enough that the middle of each edge reaches full opacity before
+/// the opposite corner's blur reaches it — a narrower one stretches out lighter than the shadow
+/// it is standing in for, since the nine-patch repeats that midpoint across the whole card.
+fn bake_card_shadow() -> Option<Image> {
+    let bed = 2 * SHADOW_MARGIN + SHADOW_BODY;
+    let mut surface = skia_safe::surfaces::raster_n32_premul((bed, bed))?;
+    let canvas = surface.canvas();
+    canvas.clear(Color4f::new(0.0, 0.0, 0.0, 0.0));
+    let mut p = Paint::new(Color4f::new(0.0, 0.0, 0.0, 1.0), None);
+    p.set_anti_alias(true);
+    p.set_mask_filter(MaskFilter::blur(BlurStyle::Normal, SHADOW_SIGMA, None));
+    let (m, side) = (SHADOW_MARGIN as f32, SHADOW_BODY as f32);
+    canvas.draw_rrect(
+        RRect::new_rect_xy(Rect::from_xywh(m, m, side, side), CARD_RADIUS, CARD_RADIUS),
+        &p,
+    );
+    Some(surface.image_snapshot())
+}
+
+/// The blur's reach, its room to spread, and its drop — the kit's own values at `k = 1`
+/// (`theme::drop_shadow`), transcribed because it exports none, so the picture is the one it
+/// drew. A kit bump that retunes them leaves these stale.
+const SHADOW_SIGMA: f32 = 10.0;
+const SHADOW_MARGIN: i32 = 30;
+const SHADOW_DROP: f32 = 10.0;
+/// The baked body, at 8x the sigma so its edge midpoints are saturated. Only the corners carry
+/// shape, so the rest is what the nine-patch stretches.
+const SHADOW_BODY: i32 = 80;
+/// The corner the nine-patch must not stretch: the radius plus what the blur carries past it.
+const SHADOW_EDGE: i32 = CARD_RADIUS as i32;
+
+/// Draw the cached shadow under `r`. A no-op if the bed could not be rasterized — a card with no
+/// shadow beats no card.
+fn draw_card_shadow(c: &skia_safe::Canvas, r: Rect, alpha: f32) {
+    let Some(shadow) = card_shadow() else {
+        return;
+    };
+    let edge = SHADOW_MARGIN + SHADOW_EDGE;
+    let centre = IRect::new(edge, edge, shadow.width() - edge, shadow.height() - edge);
+    let m = SHADOW_MARGIN as f32;
+    let bed = r.with_outset((m, m)).with_offset((0.0, SHADOW_DROP));
+    c.draw_image_nine(&shadow, centre, bed, FilterMode::Linear, Some(&alpha_paint(alpha)));
+}
+
+fn px(f: &Frame<'_>, size: f32) -> f64 {
+    f64::from(super::px_1080(f.h, size))
 }
 
 fn fade(c: Color4f, alpha: f32) -> Color4f {
@@ -314,7 +372,6 @@ impl App {
         let visible = view::home::visible_cards(available_wi, layout, scroll, f.h as i32, pad);
         // A held card's collection dims to the scrim's level while its order is unwritten.
         let unfixed = self.reordering_slots(layout);
-        // The modal scrim's strength: half.
         let dimmed = 0.5;
         let now = Instant::now();
         for idx in visible {
@@ -335,7 +392,7 @@ impl App {
                 continue;
             }
             let r = sk(pop_in_rect(card_rect(idx), pop, shrink));
-            theme::drop_shadow(c, r, CARD_RADIUS, 1.0, 0.45 * alpha);
+            draw_card_shadow(c, r, 0.45 * alpha);
             self.poster(f, r, game, alpha);
         }
         // One heading per section, scrolled with the cards it names.
@@ -450,7 +507,7 @@ impl App {
         let mut glow = theme::stroke(theme::accent(0.85 * focus * pop), 6.0);
         glow.set_mask_filter(MaskFilter::blur(BlurStyle::Normal, GLOW_BLUR / 2.0, None));
         c.draw_rrect(rr(r), &glow);
-        theme::drop_shadow(c, r, CARD_RADIUS, 1.0, 0.5 * pop);
+        draw_card_shadow(c, r, 0.5 * pop);
         self.poster(f, r, game, pop);
         self.draw_card_strip(f, game, r, pop);
         // The lit edge last, over the art and the strip, so the halo has a boundary to end on.
@@ -483,10 +540,13 @@ impl App {
         c.save();
         c.clip_rrect(rr(r), ClipOp::Intersect, true);
         c.clip_rect(window, ClipOp::Intersect, true);
-        // Frosted over the cover it sits on, opaque where there is no cover to blur.
-        let frosted = (self.render.covers)
-            .get(&game.id)
-            .is_some_and(|img| glass::frost_over_art(c, img, r, window, f.k));
+        // Frosted over the cover it sits on, opaque where there is no cover to blur. Only the
+        // menu panel earns it: the bare title strip is drawn for the focused card on every
+        // frame, and a per-frame blur of a full cover is what made scrolling the grid lag.
+        let frosted = menu.is_some()
+            && (self.render.covers)
+                .get(&game.id)
+                .is_some_and(|img| glass::frost_over_art(c, pin_id, img, r, window, f.k));
         if !frosted {
             c.draw_rect(window, &theme::fill(super::surface()));
         }

--- a/src/app/draw/list.rs
+++ b/src/app/draw/list.rs
@@ -35,7 +35,6 @@ const MARGIN: f32 = 40.0;
 pub(crate) struct Layout {
     pub card: Rect,
     pub close: Rect,
-    /// Where the `MenuList` draws.
     pub rows: Rect,
     pub title_baseline: f32,
     pub sub_top: f32,
@@ -130,7 +129,7 @@ pub(crate) fn draw(
     c.save();
     c.translate((0.0, dy));
     c.save_layer_alpha_f(Some(l.card), alpha);
-    glass_card(c, l.card, CORNER, k);
+    glass_card(f, l.card, CORNER);
     f.fonts.draw_clipped(
         c,
         title,

--- a/src/app/draw/mod.rs
+++ b/src/app/draw/mod.rs
@@ -9,8 +9,10 @@
 //! (`height / 800`) the shell applies, so a row here is a row there.
 
 pub(crate) mod about;
+mod card_rim;
 pub(crate) mod dialog;
 pub(crate) mod form;
+pub(crate) mod glass;
 pub(crate) mod home;
 pub(crate) mod list;
 pub(crate) mod settings;
@@ -19,13 +21,14 @@ use std::sync::OnceLock;
 
 use pf_console_ui::anim::approach;
 use pf_console_ui::theme::{self, Fonts, PanelStroke, W};
-use skia_safe::{Canvas, RRect, Rect};
+use skia_safe::{Canvas, Rect};
 
 use crate::app::screens::rowbuttons::RowButton;
 use crate::app::App;
 use crate::core::screen::Screen;
 use crate::platform::webos::device;
 use crate::ui;
+pub(crate) use glass::{glass_card, Backdrop};
 
 /// Which screens draw here rather than as tiles. Every prepare, compose and hit-test path
 /// asks this, so a screen moves over by being added to this list and nowhere else.
@@ -69,6 +72,7 @@ pub(crate) const fn draws_kit_rows(screen: Screen) -> bool {
 }
 
 /// What every draw fn takes.
+#[derive(Clone, Copy)]
 pub(crate) struct Frame<'a> {
     pub canvas: &'a Canvas,
     pub fonts: &'a Fonts,
@@ -77,6 +81,12 @@ pub(crate) struct Frame<'a> {
     pub h: f32,
     /// Pixels per design unit.
     pub k: f32,
+    /// The page a frosted card blurs, when this frame has one. `None` is the opaque card, and
+    /// it is what a frame over live video must stay: the decoded picture sits on the TV's
+    /// hardware plane, composited outside our GL context, so a grab of our own framebuffer
+    /// reads punch-through alpha and the card would frost a smear of the graphics plane.
+    /// Frosting over video is unrepresentable rather than merely discouraged.
+    pub backdrop: Option<Backdrop<'a>>,
 }
 
 impl<'a> Frame<'a> {
@@ -87,6 +97,16 @@ impl<'a> Frame<'a> {
             w: w as f32,
             h: h as f32,
             k: scale(h),
+            backdrop: None,
+        }
+    }
+
+    /// The same frame with a page for its cards to frost. The borrow is what keeps a snapshot
+    /// from outliving the frame it was taken in.
+    pub fn with_backdrop(self, page: Option<&'a skia_safe::Image>) -> Self {
+        Self {
+            backdrop: page.map(|page| Backdrop { page }),
+            ..self
         }
     }
 }
@@ -180,22 +200,10 @@ pub(crate) fn wrap(fonts: &Fonts, text: &str, w: W, size: f64, max_w: f64) -> Ve
     lines
 }
 
-/// A raised card: an opaque face lifted off the ground toward the accent, the kit's panel
-/// tint and hairline over it. Opaque on purpose: the TV's GL has no backdrop blur to make a
-/// translucent card read as glass, and a plain translucent card over a grid of covers read
-/// as a mistake.
-pub(crate) fn glass_card(canvas: &Canvas, rect: Rect, corner: f32, k: f32) {
-    let rr = RRect::new_rect_xy(rect, corner * k, corner * k);
-    canvas.draw_rrect(rr, &theme::fill(surface()));
-    theme::panel(canvas, rect, corner, None, PanelStroke::Gradient, k);
-}
-
-/// The face of a raised card.
 pub(crate) fn surface() -> skia_safe::Color4f {
     theme::card_face(0.16)
 }
 
-/// The dim over whatever a modal covers, at the modal's alpha.
 pub(crate) fn scrim(canvas: &Canvas, w: f32, h: f32, alpha: f32) {
     canvas.draw_rect(
         Rect::from_xywh(0.0, 0.0, w, h),
@@ -203,7 +211,6 @@ pub(crate) fn scrim(canvas: &Canvas, w: f32, h: f32, alpha: f32) {
     );
 }
 
-/// An `ui::render::Rect` as Skia's.
 pub(crate) fn sk(r: ui::render::Rect) -> Rect {
     Rect::from_xywh(r.x() as f32, r.y() as f32, r.width() as f32, r.height() as f32)
 }
@@ -238,7 +245,6 @@ fn current_palette() -> String {
     PALETTE.with(|p| p.borrow().clone())
 }
 
-/// A Skia rect as the app's integer one, for the hit tests.
 pub(crate) fn ui_rect(r: Rect) -> ui::render::Rect {
     ui::render::Rect::new(
         r.left.round() as i32,
@@ -328,22 +334,46 @@ pub(crate) fn with_pop(c: &Canvas, r: Rect, f: f32, paint: impl FnOnce(&Canvas))
 }
 
 impl App {
+    /// The modal cards this frame: the open one's alpha, and the one being left, already
+    /// filtered to the ported screens. Both `draw_modals` and [`App::modal_visible`] read it,
+    /// so the snapshot can never disagree with what actually draws.
+    fn modal_frames(&self) -> (f32, Option<(f32, Screen)>) {
+        let m = if matches!(self.nav.screen, Screen::Home) {
+            0.0
+        } else {
+            self.render.modal.fade.open_alpha()
+        };
+        let leaving = self
+            .render
+            .modal
+            .fade
+            .closing_frame_against(m)
+            .filter(|(_, left)| ported(*left));
+        (m, leaving)
+    }
+
+    /// Whether a modal card will be drawn this frame — i.e. whether the page behind it is
+    /// worth snapshotting. Asked by the runtime BEFORE `draw_modals`, because the snapshot has
+    /// to be taken while the page is all that is on the surface.
+    pub(crate) fn modal_visible(&self) -> bool {
+        // A card over the video plane draws opaque (`draw_modal_screen` drops the backdrop), so
+        // it is not worth a snapshot — and on that screen the surface holds punch-through alpha
+        // rather than a page.
+        let frosts = |screen| !crate::app::screens::over_video(screen);
+        let (m, leaving) = self.modal_frames();
+        leaving.is_some_and(|(_, left)| frosts(left)) || (ported(self.nav.screen) && m > 0.0 && frosts(self.nav.screen))
+    }
+
     /// The ported modal layer, drawn after the tiles: the open card at its open alpha and
     /// rise, and the card being left at its closing alpha — the same cross-fade
     /// `render::compose` plays for tiles, from state instead of from a snapshot. `dt` is
     /// the frame's step, for the kit widgets' own motion.
     pub(crate) fn draw_modals(&mut self, f: &Frame<'_>, dt: f64) {
-        let screen = self.nav.screen;
-        let m = if matches!(screen, Screen::Home) {
-            0.0
-        } else {
-            self.render.modal.fade.open_alpha()
-        };
-        if let Some((alpha, left)) = self.render.modal.fade.closing_frame_against(m) {
-            if ported(left) {
-                self.draw_modal_screen(f, left, alpha, false, dt);
-            }
+        let (m, leaving) = self.modal_frames();
+        if let Some((alpha, left)) = leaving {
+            self.draw_modal_screen(f, left, alpha, false, dt);
         }
+        let screen = self.nav.screen;
         if ported(screen) && m > 0.0 {
             self.draw_modal_screen(f, screen, m, true, dt);
         }
@@ -352,10 +382,16 @@ impl App {
     /// One ported card. `live` is whether it is the screen the cursor is on: a card on its
     /// way out keeps its last focus but takes no pop and no press.
     fn draw_modal_screen(&mut self, f: &Frame<'_>, screen: Screen, alpha: f32, live: bool, dt: f64) {
-        // Over live video the card is all there is; over the menu it sits on a dim.
-        if !crate::app::screens::over_video(screen) {
+        // Over live video the card is all there is; over the menu it sits on a dim. The dim
+        // goes on after the page was snapshotted, so it darkens around the card, not through it.
+        let over_video = crate::app::screens::over_video(screen);
+        let mut solid = *f;
+        if over_video {
+            solid.backdrop = None;
+        } else {
             scrim(f.canvas, f.w, f.h, alpha);
         }
+        let f = &solid;
         let dy = ui::animation::modal_rise(alpha) as f32;
         let focus = self.nav.cursor(crate::app::nav::ScreenKey::of(screen));
         if matches!(
@@ -654,7 +690,6 @@ impl App {
         hit
     }
 
-    /// The pairing card's geometry on a frame of the given size.
     pub(crate) fn pair_layout(&self, w: u32, h: u32) -> form::PairLayout {
         form::pair_layout(
             &self.fonts,
@@ -665,7 +700,6 @@ impl App {
         )
     }
 
-    /// Where a ported screen's close mark is hit, if one is up.
     pub(crate) fn ported_close_hit(&self, x: i32, y: i32, w: u32, h: u32) -> Option<bool> {
         let screen = self.nav.screen;
         if screen == Screen::SettingsPage {
@@ -698,7 +732,6 @@ impl App {
     }
 }
 
-/// What a ported list screen shows.
 pub(crate) struct ListCard {
     pub title: String,
     pub subtitle: Option<String>,

--- a/src/app/draw/mod.rs
+++ b/src/app/draw/mod.rs
@@ -71,7 +71,6 @@ pub(crate) const fn draws_kit_rows(screen: Screen) -> bool {
     is_list(screen) || matches!(screen, Screen::SettingsPage)
 }
 
-/// What every draw fn takes.
 #[derive(Clone, Copy)]
 pub(crate) struct Frame<'a> {
     pub canvas: &'a Canvas,
@@ -81,7 +80,8 @@ pub(crate) struct Frame<'a> {
     pub h: f32,
     /// Pixels per design unit.
     pub k: f32,
-    /// The page a frosted card blurs, when this frame has one. `None` is the opaque card, and
+    /// The already-blurred page a frosted card sits on, when this frame has one. `None` is the
+    /// opaque card, and
     /// it is what a frame over live video must stay: the decoded picture sits on the TV's
     /// hardware plane, composited outside our GL context, so a grab of our own framebuffer
     /// reads punch-through alpha and the card would frost a smear of the graphics plane.
@@ -121,7 +121,6 @@ pub(crate) fn scale(h: u32) -> f32 {
     (h as f32 / 800.0 * panel_k()).clamp(0.75, 3.0)
 }
 
-/// The panel the design is tuned on.
 const REFERENCE_INCHES: f32 = 65.0;
 
 /// How much larger this client draws than the kit's design units say: a TV is read from a
@@ -209,6 +208,11 @@ pub(crate) fn scrim(canvas: &Canvas, w: f32, h: f32, alpha: f32) {
         Rect::from_xywh(0.0, 0.0, w, h),
         &theme::fill(theme::shade(0.45 * alpha)),
     );
+}
+
+/// Plain bilinear sampling, no mipmaps: what every image this app draws is scaled with.
+pub(crate) fn linear() -> skia_safe::SamplingOptions {
+    skia_safe::SamplingOptions::new(skia_safe::FilterMode::Linear, skia_safe::MipmapMode::None)
 }
 
 pub(crate) fn sk(r: ui::render::Rect) -> Rect {
@@ -504,8 +508,7 @@ impl App {
         &mut self.render.list.as_mut().expect("just set").1
     }
 
-    /// The card a ported list screen shows: its title, subtitle and rows in the kit's
-    /// vocabulary. `None` on any other screen.
+    /// `None` on any other screen.
     pub(crate) fn list_card(&self, screen: Screen) -> Option<ListCard> {
         use crate::app::view;
         Some(match screen {
@@ -602,7 +605,7 @@ impl App {
         })
     }
 
-    /// A ported list card's geometry. The HDR card sits at the bottom, under the pattern.
+    /// The HDR card sits at the bottom, under the pattern.
     fn list_layout(&self, screen: Screen, card: &ListCard, fw: f32, fh: f32, k: f32) -> list::Layout {
         let headers = card.rows.iter().filter(|r| r.header.is_some()).count();
         let l = list::layout(
@@ -621,7 +624,6 @@ impl App {
         }
     }
 
-    /// The trailing button of the kit's rows under `(x, y)`, as `(row, button)`.
     pub(crate) fn kit_list_button_at(&mut self, x: i32, y: i32) -> Option<(usize, usize)> {
         let screen = self.nav.screen;
         if !draws_kit_rows(screen) {
@@ -668,7 +670,6 @@ impl App {
         let _ = list.menu(kit, len);
     }
 
-    /// The row of the ported list under `(x, y)` — the kit's own last-drawn geometry.
     pub(crate) fn kit_list_row_at(&mut self, x: i32, y: i32) -> Option<usize> {
         let screen = self.nav.screen;
         if !draws_kit_rows(screen) {

--- a/src/app/draw/settings.rs
+++ b/src/app/draw/settings.rs
@@ -109,7 +109,7 @@ pub(crate) fn draw(
     c.save();
     c.translate((0.0, dy));
     c.save_layer_alpha_f(Some(l.card), alpha);
-    glass_card(c, l.card, CORNER, k);
+    glass_card(f, l.card, CORNER);
     f.fonts.draw(
         c,
         "Settings",

--- a/src/console/gl.rs
+++ b/src/console/gl.rs
@@ -10,8 +10,7 @@ use anyhow::{anyhow, Result};
 use skia_safe::gpu::{self, DirectContext, SurfaceOrigin};
 use skia_safe::{ColorType, Surface};
 
-/// Sized internal format of the RGBA8888 default framebuffer.
-const GL_RGBA8: u32 = 0x8058;
+const GL_RGBA8: u32 = 0x8058; // RGBA8888 framebuffer format
 
 /// Skia's resource budget. A quarter of the desktop's 160 MB: this `SoC` shares one memory pool
 /// with the NDL decoder, and covers are the only large thing the console caches.
@@ -24,7 +23,7 @@ pub(crate) struct ConsoleGl {
     /// once per menu entry is a stutter every time a stream ends.
     ctx: sdl2::video::GLContext,
     context: DirectContext,
-    /// Skia over framebuffer 0, with the drawable size it was wrapped at.
+    /// Skia over framebuffer 0; cached to avoid re-wrapping on every frame.
     surface: Option<(Surface, u32, u32)>,
     /// What the window's config actually granted, not what was asked for — Skia must be told
     /// the truth or it clips paths against a buffer that is not there.
@@ -32,7 +31,6 @@ pub(crate) struct ConsoleGl {
 }
 
 impl ConsoleGl {
-    /// Bring up the console's GL context and Skia over it. The context is left current.
     pub(crate) fn new(window: &sdl2::video::Window, video: &sdl2::VideoSubsystem) -> Result<Self> {
         let ctx = window
             .gl_create_context()
@@ -66,15 +64,15 @@ impl ConsoleGl {
         })
     }
 
-    /// Take the screen back from SDL's renderer. Called on every console entry, because the
-    /// old menus and the stream have both made their own context current in between.
+    /// Called on every console entry; old menus and the stream have both made their own
+    /// context current in between.
     pub(crate) fn make_current(&self, window: &sdl2::video::Window) -> Result<()> {
         window
             .gl_make_current(&self.ctx)
             .map_err(|e| anyhow!("console: gl_make_current: {e}"))
     }
 
-    /// The Skia surface over framebuffer 0 at `w`×`h`, re-wrapping when the drawable moves.
+    /// Re-wraps on drawable size change to keep Skia from clipping against a stale buffer.
     pub(crate) fn surface(&mut self, w: u32, h: u32) -> Result<&mut Surface> {
         if !matches!(self.surface, Some((_, sw, sh)) if sw == w && sh == h) {
             self.surface = None;
@@ -97,10 +95,17 @@ impl ConsoleGl {
             self.surface = Some((surface, w, h));
         }
         // The branch above either returned an error or filled it.
-        Ok(&mut self.surface.as_mut().expect("just wrapped").0)
+        let surface = &mut self.surface.as_mut().expect("just wrapped").0;
+        // Handed out at identity. The surface is cached by size and this context is shared by
+        // both menu flows and the stream overlays, so a canvas carries whatever matrix the last
+        // one left on it — the pointer UI scales by the panel correction, which silently cropped
+        // the gamepad shell until this reset existed. Resetting here rather than in each drawer
+        // is what keeps the next flow from having to know that.
+        surface.canvas().reset_matrix();
+        Ok(surface)
     }
 
-    /// Submit the frame's Skia work. SDL still owns the swap.
+    /// SDL still owns the swap.
     pub(crate) fn flush(&mut self) {
         self.context.flush_and_submit();
     }

--- a/src/runtime/overlay.rs
+++ b/src/runtime/overlay.rs
@@ -29,9 +29,7 @@ const TOAST_TOP: f32 = 18.0;
 const TOAST_PAD_X: f32 = 18.0;
 const TOAST_PAD_Y: f32 = 10.0;
 const TOAST_SIZE: f64 = 15.0;
-/// How many log lines the tail shows.
 pub(super) const LOG_LINES: usize = 9;
-/// How long a toast holds before its fade.
 const NOTIFICATION_HOLD: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// One frame on the GL context: the surface, cleared to `clear`, scaled from `display`
@@ -50,7 +48,6 @@ pub(super) fn frame(
         let surface = gl.surface(dw, dh)?;
         let c = surface.canvas();
         c.clear(clear);
-        c.reset_matrix();
         c.scale((dw as f32 / display.0.max(1) as f32, dh as f32 / display.1.max(1) as f32));
         fonts.begin_frame();
         draw(&Frame::new(c, fonts, display.0, display.1));
@@ -71,7 +68,6 @@ pub(super) fn wipe(gl: &mut Option<ConsoleGl>, canvas: &sdl2::render::WindowCanv
     Ok(())
 }
 
-/// The stats card, top right: the first line bright, the rest muted, the hint centred under.
 pub(super) fn stats(f: &Frame<'_>, lines: &[String], hint: &str, alpha: f32) {
     let k = f.k;
     let size = STATS_LINE * f64::from(k);
@@ -126,7 +122,6 @@ fn log_tone(line: &str) -> Color4f {
     }
 }
 
-/// The log tail, a full-width strip along the bottom edge, wrapped lines indented.
 pub(super) fn log(f: &Frame<'_>, lines: &[String], alpha: f32) {
     let k = f.k;
     let size = LOG_LINE * f64::from(k);
@@ -162,7 +157,6 @@ pub(super) fn log(f: &Frame<'_>, lines: &[String], alpha: f32) {
     c.restore();
 }
 
-/// A toast pill along the top edge.
 pub(super) fn toast(f: &Frame<'_>, text: &str, alpha: f32) {
     let k = f.k;
     let size = TOAST_SIZE * f64::from(k);

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -34,7 +34,6 @@ pub(super) fn run_ui_flow(
     // every 40ms spinner frame.
     const TICK_BUDGET: Duration = Duration::from_millis(16);
     canvas.window_mut().show();
-    // Both menus need it now; without a GL context there is nothing to draw with.
     let gl = console_flow::bring_up(gl, canvas).context("menu: GL host")?;
     let kit_fonts = std::rc::Rc::new(pf_console_ui::theme::build_fonts().context("menu: kit fonts")?);
     tracing::info!(
@@ -127,7 +126,7 @@ pub(super) fn run_ui_flow(
             crate::platform::webos::input::webos_scancode_down(crate::platform::webos::input::WEBOS_YELLOW_SCANCODE);
         if yellow_down && !yellow_held {
             cycle_log_overlay();
-            dirty = true; // force an immediate redraw with the new state
+            dirty = true;
             log_overlay_last = None;
         }
         yellow_held = yellow_down;
@@ -264,8 +263,6 @@ pub(super) fn run_ui_flow(
                 }
                 continue;
             }
-            // Device-level events, handled before anything screen-specific:
-            // shutdown and controller hotplug.
             match event {
                 Event::Quit { .. } => {
                     tracing::info!("quit during UI");
@@ -420,14 +417,24 @@ pub(super) fn run_ui_flow(
                 dw as f32 / display_mode.w.max(1) as f32,
                 dh as f32 / display_mode.h.max(1) as f32,
             ));
-            // Home, the modals, the launch transition, then the overlays (`app::draw`,
-            // `runtime::overlay`).
             app.apply_ink();
             kit_fonts.begin_frame();
             let dt = last_frame.elapsed().as_secs_f64().min(0.1);
             last_frame = Instant::now();
-            let frame = crate::app::draw::Frame::new(c, &kit_fonts, display_mode.w as u32, display_mode.h as u32);
-            app.draw_home(&frame, dt);
+            // Scoped so the frame's borrow of the canvas ends before the snapshot below.
+            {
+                let frame = crate::app::draw::Frame::new(c, &kit_fonts, display_mode.w as u32, display_mode.h as u32);
+                app.draw_home(&frame, dt);
+            }
+            // Snapshot the page for modal frost blur. Only taken when a modal is visible — a
+            // snapshot of a GPU surface forces a copy, so skip it when nothing needs it.
+            let page = app
+                .modal_visible()
+                .then(|| surface.image_snapshot_with_bounds(skia_safe::IRect::from_wh(dw as i32, dh as i32)))
+                .flatten();
+            let c = surface.canvas();
+            let frame = crate::app::draw::Frame::new(c, &kit_fonts, display_mode.w as u32, display_mode.h as u32)
+                .with_backdrop(page.as_ref());
             app.draw_modals(&frame, dt);
             app.draw_launch(&frame);
             if let Some(lines) = &log_lines {
@@ -436,7 +443,9 @@ pub(super) fn run_ui_flow(
             if let Some((text, alpha)) = &notif_frame {
                 overlay::toast(&frame, text, *alpha);
             }
-            quit_dialog.draw(&frame);
+            // Quit dialog draws over modal layer — page snapshot is already stale under it.
+            // Don't pass it; opaque is the one thing that always looks the same.
+            quit_dialog.draw(&frame.with_backdrop(None));
         }
         gl.flush();
         canvas.window().gl_swap_window();

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -55,7 +55,6 @@ pub(super) fn run_ui_flow(
     if initial_status.is_some() {
         app.set_home_status(initial_status, true);
     }
-    // Toast (same as the stream loop). Shown once as Home re-appears.
     let mut notif = Notification::new();
     if let Some(msg) = initial_toast {
         notif.show(msg);
@@ -111,9 +110,8 @@ pub(super) fn run_ui_flow(
     // dialog while streaming — see `DisconnectChord`.
     let mut chord = DisconnectChord::default();
     let mut quit_dialog_was_active = false;
-    // One-shot: warm the modal text/shadow/freetype caches on the first idle tick
-    // (Home already painted by then) so the first Settings/host-menu open doesn't
-    // hitch on cold rasterization. Reset per menu entry — `text_cache` is too.
+    // The blurred page a frosted modal card sits on, held across frames — see the frame block.
+    let mut page: Option<skia_safe::Image> = None;
     'ui: loop {
         // Start of this tick, for the loop's own pacing against `TICK_BUDGET`.
         let frame_start = Instant::now();
@@ -185,8 +183,6 @@ pub(super) fn run_ui_flow(
             hold.fired = true;
             let still_there = matches!(app.nav.screen, Screen::Home) && hold.focus == app.home_focus;
             if still_there {
-                // The hold's whole effect. It no longer pins — pinning is one of the two
-                // rows the menu it raises offers, and the only way to reach it.
                 app.open_card_menu(display_mode.w as u32);
             }
             dirty = true;
@@ -362,14 +358,12 @@ pub(super) fn run_ui_flow(
             dirty = true;
         }
         quit_dialog_was_active = quit_dialog_active;
-        // Anything the state machine queued this tick (`App::toast`) — a card move, so far.
         if let Some(msg) = app.take_toast() {
             notif.show(msg);
         }
         // Polled every tick like the streaming loop's toast, not gated behind
         // `content_dirty` — its own fade needs frames regardless of anything else.
         let notif_frame = notif.frame().map(|(t, a)| (t.to_string(), a));
-        // The dip has played out (see `App::press`) — the tile springs back.
         if app.poll_press() {
             dirty = true;
         }
@@ -393,7 +387,6 @@ pub(super) fn run_ui_flow(
             continue;
         }
         dirty = false;
-        // Advance per-tick app state (card size, modal fades) exactly once before drawing.
         app.advance_frame(display_mode.w as u32);
         app.prepare_frame(Size::new(display_mode.w as u32, display_mode.h as u32));
         // The log tail's text is read on the 500 ms cadence; between reads the last lines
@@ -408,30 +401,35 @@ pub(super) fn run_ui_flow(
         // documented to differ from the window on webOS (handoff trap 10), so it is scaled
         // rather than assumed equal.
         let (dw, dh) = canvas.window().drawable_size();
+        let dt = last_frame.elapsed().as_secs_f64().min(0.1);
+        last_frame = Instant::now();
         {
             let surface = gl.surface(dw, dh)?;
             let c = surface.canvas();
             c.clear(app.frame_clear_color());
-            c.reset_matrix();
             c.scale((
                 dw as f32 / display_mode.w.max(1) as f32,
                 dh as f32 / display_mode.h.max(1) as f32,
             ));
             app.apply_ink();
             kit_fonts.begin_frame();
-            let dt = last_frame.elapsed().as_secs_f64().min(0.1);
-            last_frame = Instant::now();
             // Scoped so the frame's borrow of the canvas ends before the snapshot below.
             {
                 let frame = crate::app::draw::Frame::new(c, &kit_fonts, display_mode.w as u32, display_mode.h as u32);
                 app.draw_home(&frame, dt);
             }
-            // Snapshot the page for modal frost blur. Only taken when a modal is visible — a
-            // snapshot of a GPU surface forces a copy, so skip it when nothing needs it.
-            let page = app
-                .modal_visible()
-                .then(|| surface.image_snapshot_with_bounds(skia_safe::IRect::from_wh(dw as i32, dh as i32)))
-                .flatten();
+            // The page a frosted card blurs: snapshotted and blurred ONCE, on the first frame
+            // that something frosts, and held until nothing does. Both cost GPU time on the frame
+            // a card opens, and neither result changes while the card is up, because the page it
+            // froze is exactly the page behind it. The quit dialog counts as a frosting card: it
+            // is the same glass, and it only ever opens over Home.
+            if !(app.modal_visible() || quit_dialog_active) {
+                page = None;
+            } else if page.is_none() {
+                let snap = surface.image_snapshot_with_bounds(skia_safe::IRect::from_wh(dw as i32, dh as i32));
+                let k = crate::app::draw::scale(display_mode.h as u32);
+                page = snap.and_then(|snap| crate::app::draw::glass::blur_page(surface, &snap, k));
+            }
             let c = surface.canvas();
             let frame = crate::app::draw::Frame::new(c, &kit_fonts, display_mode.w as u32, display_mode.h as u32)
                 .with_backdrop(page.as_ref());
@@ -443,9 +441,7 @@ pub(super) fn run_ui_flow(
             if let Some((text, alpha)) = &notif_frame {
                 overlay::toast(&frame, text, *alpha);
             }
-            // Quit dialog draws over modal layer — page snapshot is already stale under it.
-            // Don't pass it; opaque is the one thing that always looks the same.
-            quit_dialog.draw(&frame.with_backdrop(None));
+            quit_dialog.draw(&frame);
         }
         gl.flush();
         canvas.window().gl_swap_window();


### PR DESCRIPTION
## Summary

Modal cards, the card menu, and the quit dialog now draw as frosted glass over a blurred snapshot of the page/cover behind them, instead of a flat panel. Built across four commits, the last of which is a performance pass measured on the real TV plus a couple of correctness fixes it turned up:

- Home's grid shadow used `theme::drop_shadow`'s per-card `MaskFilter` blur every frame, costing ~6ms of the grid's ~14ms GPU time and dropping scroll to ~34fps on this SoC (not the analytic path desktop gets). Replaced with a shadow rasterized once and drawn as a nine-patch. GPU time per frame: 13.9-29.3ms -> 5.3-6.4ms while scrolling; loop holds a locked 601 frames/10s.
- A nine-patch rather than a per-size cache: the grid draws several card sizes a frame (focused zoom, entering pop), so a size-keyed cache would rebake several times a frame.
- The modal frost backdrop is taken once on open and held, instead of reblurred every frame; blurred at quarter resolution and drawn back stretched with linear sampling (a full 1080p blur cost hundreds of ms on the open frame).
- The card menu's cover frost is baked once per open at quarter size, cached per card, and gated to only run while the menu is open — it was also running for the plain title strip the focused card draws every frame.
- Cover blur cache key is the rounded sigma, not the exact float, since the card rect is focus-zoomed and pop-animated.
- `ConsoleGl::surface()` now hands out a canvas at identity. The cached surface is shared by the pointer UI, the gamepad shell and stream overlays, so a stale matrix from a previous flow was silently cropping the gamepad shell under the pointer UI's panel scale. Fixed at the producer; drops three consumer-side `reset_matrix()` calls.
- The quit dialog now frosts like every other modal — it already went through the shared dialog path, the runtime was just stripping its backdrop. Safe because it only ever opens over Home, where nothing else is frosting the page under it.
- Resolved a merge conflict in `app/draw/home.rs` between the card-menu frost work and an unrelated unused-binding cleanup.

Shadow constants (sigma 10, margin 30, drop 10) are transcribed from `theme::drop_shadow`, which exports none — will go stale if the kit retunes them; noted in place.

## Known, left as-is

- First open of a list modal (host submenu, card menu) still costs one ~150ms GPU frame, once per app launch. Bisected to the kit's `MenuList::render` row drawing, not this branch's glass/cover work; looks like a GPU resource cache purge at the 64MB budget. Likely fixed only by a `pf-console-ui` change.
- A WebP cover from the host fails to decode and falls back to a drawn poster — unrelated, noticed in the logs.
- The nine-patch shadow and linear-upscale fix landed after the last TV deploy, so they're unverified visually on device (lint/tests both clean).

## Test plan

- [x] `task docker:lint` clean
- [x] `task docker:test` — 47 passed
- [ ] Deploy to TV and visually confirm the nine-patch shadow and upscaled blurs