### PR TITLE
fix(library): stop reporting every fetch failure as an offline host

### DIFF
--- a/src/app/state/home.rs
+++ b/src/app/state/home.rs
@@ -528,7 +528,7 @@ impl App {
                 self.regroup_games();
             }
             Err(e) => {
-                tracing::warn!("library fetch failed ({host}:{mgmt_port}): {e}");
+                tracing::warn!("library fetch failed ({host}:{mgmt_port}): {e:?}");
                 self.handle_library_error(host, port, &e);
             }
         }
@@ -539,8 +539,8 @@ impl App {
     /// Shared handling for a failed library fetch/reachability check, used by both
     /// `drain_games` and `drain_launch_check`. `Unreachable` opens the Wake dialog
     /// (even with no MAC on record — `start_wake`/`render_wake` just hide the send
-    /// controls then); `NotPaired`/`PinMismatch`/`Http` mean the host answered, so
-    /// Wake-on-LAN wouldn't help — those stay a plain status line.
+    /// controls then); every other variant means the host answered (or that the fault is
+    /// this device's), so Wake-on-LAN wouldn't help — those stay a plain status line.
     pub(crate) fn handle_library_error(&mut self, host: String, port: u16, e: &crate::services::library::LibraryError) {
         let reason = e.to_string();
         // A live problem with the host beats the previous launch's reason for bouncing.

--- a/src/app/state/hostpower.rs
+++ b/src/app/state/hostpower.rs
@@ -124,9 +124,9 @@ impl App {
         let rx = &job.rx;
         let result = match rx.try_recv() {
             Ok(result) => result,
-            Err(std::sync::mpsc::TryRecvError::Disconnected) => Err(
-                crate::services::library::LibraryError::Unreachable("power action thread died".into()),
-            ),
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => Err(crate::services::library::LibraryError::BadReply(
+                "power action thread died".into(),
+            )),
             Err(std::sync::mpsc::TryRecvError::Empty) => return false,
         };
         self.jobs.power_action = None;

--- a/src/app/state/reach.rs
+++ b/src/app/state/reach.rs
@@ -15,9 +15,10 @@ pub(crate) struct Reachability {
     pub(crate) online: bool,
 }
 
-/// Whether a management-API failure means the host never answered. Every other error is a
-/// reply — `NotPaired` is a 401/403, `Http` carries a status, and `PinMismatch` is a
-/// certificate the host presented — so only the transport ones count as the host being down.
+/// Whether a management-API failure means the host never answered. Every other error proves
+/// it did: `NotPaired` is a 401/403, `Http` carries a status, `PinMismatch` and `Tls` are a
+/// handshake on an open socket, `Timeout` and `BadReply` are a connection the host accepted,
+/// and `Identity` never left this device. Only `Unreachable` is the host being down.
 /// Same split `handle_library_error` makes when it decides whether Wake-on-LAN would help.
 pub(crate) fn api_error_is_offline(e: &crate::services::library::LibraryError) -> bool {
     use crate::services::library::LibraryError;
@@ -134,5 +135,52 @@ impl App {
 
     pub(crate) fn new_reachability() -> HashMap<(String, u16), bool> {
         HashMap::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::api_error_is_offline;
+    use crate::services::library::LibraryError;
+
+    /// The wake dialog and the sidebar dot both hang off this one answer, so a host that
+    /// answered — however badly — must never be reported as down.
+    #[test]
+    fn only_an_unanswered_host_is_offline() {
+        assert!(api_error_is_offline(&LibraryError::Unreachable("refused".into())));
+        for answered in [
+            LibraryError::Timeout("timeout: Global".into()),
+            LibraryError::BadReply("bad JSON: eof".into()),
+            LibraryError::Tls("handshake".into()),
+            LibraryError::Identity("client key pem".into()),
+            LibraryError::NotPaired,
+            LibraryError::PinMismatch,
+            LibraryError::Http(500),
+        ] {
+            assert!(
+                !api_error_is_offline(&answered),
+                "{answered:?} is not the host being down"
+            );
+        }
+    }
+
+    /// Every line here is read off a status bar or a modal body, so each stays one sentence.
+    #[test]
+    fn each_reason_is_one_short_sentence() {
+        for e in [
+            LibraryError::Unreachable("refused".into()),
+            LibraryError::Timeout("timeout: Global".into()),
+            LibraryError::BadReply("bad JSON: eof".into()),
+            LibraryError::Tls("handshake".into()),
+            LibraryError::Identity("client key pem".into()),
+        ] {
+            let line = e.to_string();
+            assert!(line.len() <= 60, "too long for a status line: {line}");
+            assert_eq!(line.matches('.').count(), 1, "one sentence: {line}");
+            assert!(
+                !line.contains("refused") && !line.contains("pem"),
+                "cause leaked: {line}"
+            );
+        }
     }
 }

--- a/src/app/view/hostpower.rs
+++ b/src/app/view/hostpower.rs
@@ -82,6 +82,8 @@ pub fn refusal_message(e: &crate::services::library::LibraryError) -> String {
         LibraryError::NotPaired => "This device isn't allowed to control the host's power.".into(),
         LibraryError::Http(409) => "The host is refusing — another device is still streaming.".into(),
         LibraryError::Http(501) => "This host can't do that.".into(),
-        other => format!("Couldn't reach the host: {other}"),
+        // Already a whole sentence naming what did not happen; a "couldn't reach" prefix
+        // would both double it up and claim the host is down when it answered.
+        other => other.to_string(),
     }
 }

--- a/src/console/model.rs
+++ b/src/console/model.rs
@@ -458,10 +458,14 @@ impl Service {
         let games = match loaded.result {
             Ok(games) => games,
             Err(e) => {
-                tracing::warn!("console: library fetch failed: {e}");
-                // A transport failure is the one worth retrying; a rejected certificate does
-                // not become acceptable by asking again.
-                let can_retry = matches!(e, LibraryError::Unreachable(_));
+                tracing::warn!("console: library fetch failed: {e:?}");
+                // Retry only what asking again could answer differently. A rejected certificate
+                // does not become acceptable by repeating the question, and neither does an
+                // identity this device can't load.
+                let can_retry = matches!(
+                    e,
+                    LibraryError::Unreachable(_) | LibraryError::Timeout(_) | LibraryError::BadReply(_)
+                );
                 self.handles.library.set_phase(LibraryPhase::Error {
                     title: "Couldn't load the library".into(),
                     body: e.to_string(),

--- a/src/services/library.rs
+++ b/src/services/library.rs
@@ -20,14 +20,39 @@ pub use crate::core::model::GameEntry;
 pub const DEFAULT_MGMT_PORT: u16 = 47990;
 
 /// Errors surfaced to the UI so it can explain what to do next.
+///
+/// [`Unreachable`](Self::Unreachable) is the only variant that means the host never answered,
+/// so it is the only one Wake-on-LAN can help with — everything below it is a host that is
+/// demonstrably up. Keeping them apart is what stops a cut reply or an unreadable identity
+/// telling the user their PC is asleep.
+///
+/// Each carries the operator-side cause for the log (`{e:?}`); `Display` is the user register
+/// and stays one short sentence, because these land on a status line and a modal body.
 #[derive(Debug)]
+#[expect(
+    dead_code,
+    reason = "the causes are read as `{e:?}` in the log lines, never on screen"
+)]
 pub enum LibraryError {
     /// The host rejected our certificate — this device isn't on its paired list.
     NotPaired,
     /// The host's certificate didn't hash to the pinned fingerprint.
     PinMismatch,
     Http(u16),
+    /// Nothing answered: a refused connection, no route, or the connect budget spent.
     Unreachable(String),
+    /// Connected, then the whole-request budget ran out. The host is up and too slow, or
+    /// busy building the answer.
+    Timeout(String),
+    /// The host answered and the answer didn't survive: a cut body, malformed HTTP, or JSON
+    /// this build can't read.
+    BadReply(String),
+    /// The socket opened and TLS failed. Not [`PinMismatch`](Self::PinMismatch), which is the
+    /// pin check specifically.
+    Tls(String),
+    /// This device's own certificate, key or TLS setup wouldn't load. Says nothing about the
+    /// host at all.
+    Identity(String),
 }
 
 impl std::fmt::Display for LibraryError {
@@ -36,7 +61,11 @@ impl std::fmt::Display for LibraryError {
             Self::NotPaired => f.write_str("Not paired — pair with the host first."),
             Self::PinMismatch => f.write_str("Host certificate changed — re-pair with a PIN."),
             Self::Http(code) => write!(f, "Management API returned HTTP {code}."),
-            Self::Unreachable(why) => write!(f, "Couldn't reach the host's management API: {why}."),
+            Self::Unreachable(_) => f.write_str("The host isn't answering."),
+            Self::Timeout(_) => f.write_str("The host is answering too slowly."),
+            Self::BadReply(_) => f.write_str("Couldn't read the host's reply."),
+            Self::Tls(_) => f.write_str("Couldn't secure the connection to the host."),
+            Self::Identity(_) => f.write_str("Couldn't load this device's pairing identity."),
         }
     }
 }
@@ -64,7 +93,9 @@ pub fn agent_within(
     budget: std::time::Duration,
 ) -> Result<ureq::Agent, LibraryError> {
     use rustls::pki_types::pem::PemObject;
-    let bad = |what: &str, e: &dyn std::fmt::Display| LibraryError::Unreachable(format!("{what}: {e}"));
+    // Every failure below is this device's own PEMs or crypto setup, not the host's — the
+    // agent is built before anything is dialled.
+    let bad = |what: &str, e: &dyn std::fmt::Display| LibraryError::Identity(format!("{what}: {e}"));
     // aws-lc-rs, matching punktfunk-core's QUIC for consistent crypto — the invariant this
     // comment always claimed, now that core has moved off ring too. Naming a provider here
     // (rather than letting rustls infer one) is also what keeps this path working if a second
@@ -114,10 +145,10 @@ pub(crate) fn get_json<T: serde::de::DeserializeOwned>(
         Ok(mut resp) => resp
             .body_mut()
             .read_to_string()
-            .map_err(|e| LibraryError::Unreachable(format!("read body: {e}")))?,
+            .map_err(|e| LibraryError::BadReply(format!("read body: {e}")))?,
         Err(e) => return Err(classify(e)),
     };
-    serde_json::from_str(&body).map_err(|e| LibraryError::Unreachable(format!("bad JSON: {e}")))
+    serde_json::from_str(&body).map_err(|e| LibraryError::BadReply(format!("bad JSON: {e}")))
 }
 
 /// Fetch the host's library.
@@ -181,7 +212,7 @@ pub fn fetch_art(agent: &ureq::Agent, addr: &str, mgmt_port: u16, art_path: &str
         Ok(mut resp) => resp
             .body_mut()
             .read_to_vec()
-            .map_err(|e| LibraryError::Unreachable(format!("read art body: {e}"))),
+            .map_err(|e| LibraryError::BadReply(format!("read art body: {e}"))),
         Err(e) => Err(classify(e)),
     }
 }
@@ -194,11 +225,14 @@ fn fetch_external_art(url: &str) -> Result<Vec<u8>, LibraryError> {
         Ok(mut resp) => resp
             .body_mut()
             .read_to_vec()
-            .map_err(|e| LibraryError::Unreachable(format!("read external art body: {e}"))),
+            .map_err(|e| LibraryError::BadReply(format!("read external art body: {e}"))),
         Err(e) => Err(classify(e)),
     }
 }
 
+/// Sorts one transport failure into "the host never answered" and the several ways a host that
+/// *did* answer can still fail us. The split is what the Wake dialog and the reachability dot
+/// key off, so a wrong bucket here tells the user to go and switch their PC on.
 pub(crate) fn classify(e: ureq::Error) -> LibraryError {
     match e {
         ureq::Error::StatusCode(401 | 403) => LibraryError::NotPaired,
@@ -209,6 +243,17 @@ pub(crate) fn classify(e: ureq::Error) -> LibraryError {
         ureq::Error::Rustls(rustls::Error::InvalidCertificate(
             rustls::CertificateError::ApplicationVerificationFailure,
         )) => LibraryError::PinMismatch,
+        // TLS runs on an open socket, so the host is up whatever the handshake decided.
+        ureq::Error::Rustls(e) => LibraryError::Tls(e.to_string()),
+        ureq::Error::Tls(what) => LibraryError::Tls(what.to_string()),
+        // Connect carries its own (shorter) budget, so it is what expires when nothing is
+        // listening; any later timeout means the connection came up and the host went quiet.
+        ureq::Error::Timeout(t @ (ureq::Timeout::Connect | ureq::Timeout::Resolve)) => {
+            LibraryError::Unreachable(format!("timeout: {t:?}"))
+        }
+        ureq::Error::Timeout(t) => LibraryError::Timeout(format!("timeout: {t:?}")),
+        // Malformed HTTP is still a reply.
+        ureq::Error::Protocol(e) => LibraryError::BadReply(e.to_string()),
         other => LibraryError::Unreachable(other.to_string()),
     }
 }


### PR DESCRIPTION
A tester on the new client reported *"can't connect — it starts loading the apps, then it says
the host is offline"*, with the Mac client fine against the same host. That wording is
`app/view/wake.rs::status_text` — "…isn't responding. It may be powered off or asleep." — and
it has one producer: a failed `GET /api/v1/library`. It told us nothing, because
`LibraryError::Unreachable` carried four unrelated failures at once:

| what happened | what the user was told |
| --- | --- |
| nothing answered at the address | may be powered off or asleep |
| the reply timed out or was cut | may be powered off or asleep |
| JSON this build can't read | may be powered off or asleep |
| a TLS handshake on an open socket | may be powered off or asleep |
| **this device's own PEMs wouldn't load** | may be powered off or asleep |

All five opened the Wake dialog and put the sidebar dot out, so a user with a perfectly healthy
PC was told to go and switch it on.

## What each one says now

| class | on screen |
| --- | --- |
| `Unreachable` | The host isn't answering. |
| `Timeout` | The host is answering too slowly. |
| `BadReply` | Couldn't read the host's reply. |
| `Tls` | Couldn't secure the connection to the host. |
| `Identity` | Couldn't load this device's pairing identity. |

Only `Unreachable` still means the host is down, so it is the only one that opens the Wake
dialog or clears the reachability dot. The cause no longer reaches the screen at all — the
status bar and the console's error card have room for one sentence — and goes to the log as
`{e:?}` instead: `Timeout("timeout: Global")`, `BadReply("bad JSON: …")`.

`classify` leans on one fact worth stating: connect carries its own, tighter budget (3 s inside
a 9 s request), so `Timeout::Connect`/`Resolve` is what expires when nothing is listening, and
any later timeout means the connection came up and the host then went quiet.

Also here: the console shell retries only what asking again could answer differently (not a
rejected certificate, not an identity this device can't load), and `refusal_message` stopped
prefixing "Couldn't reach the host: " onto sentences that already say the host answered.

## Rejected

- **Showing the cause on the wake card.** It is the one screen where the generic wording is
  now accurate, and a raw `ureq` string is not something to put in front of a user.
- **An accessor for the cause instead of `#[expect(dead_code)]`.** Every caller wanted the
  `Debug` form anyway, so the accessor would have existed only to satisfy the lint.

## Checked

`task docker:lint` (rustfmt + `clippy --target armv7-unknown-linux-gnueabi --all-targets
-- -D warnings`) clean, and `task docker:test` 51 passed. Two new tests: no class except
`Unreachable` may read as offline, and every line stays one sentence under 60 characters with
the cause kept out of it.

## Still open

This does not fix the tester's connection — it makes the next report name the cause. Their
build can already tell us directly: Settings → Send logs offers the developer upload when the
host is unreachable, and the log carries `library fetch failed (<host>:<port>): …`.
