### PR TITLE
fix(hosts): edit-address dialog returns to host menu, not Home

### DIFF
--- a/src/app/hosts.rs
+++ b/src/app/hosts.rs
@@ -94,3 +94,11 @@ pub(crate) struct HostsState {
     /// Whether this TV is webosbrew-rooted — `None` until `App::start_root_probe` answers.
     pub(crate) rooted: Option<bool>,
 }
+
+impl HostsState {
+    /// Which sidebar row a host sits on now. What every path that has just rebuilt `entries`
+    /// asks, since the rebuild may have moved the row it was acting on.
+    pub(crate) fn entry_index(&self, host: &str, port: u16) -> Option<usize> {
+        self.entries.iter().position(|e| e.host() == host && e.port() == port)
+    }
+}

--- a/src/app/render/geometry.rs
+++ b/src/app/render/geometry.rs
@@ -14,11 +14,7 @@ impl App {
     pub(crate) fn text_form(&self) -> Option<FormCopy<'_>> {
         let (title, subtitle, typed, hint) = match self.nav.screen {
             Screen::EditHost => {
-                let name = self
-                    .screens
-                    .edit_host_index
-                    .and_then(|i| self.hosts.entries.get(i))
-                    .map_or_else(String::new, |e| e.name().to_string());
+                let name = self.host_menu_title();
                 (
                     view::addhost::EDIT_TITLE,
                     view::addhost::edit_subtitle(&name),

--- a/src/app/screens/slots.rs
+++ b/src/app/screens/slots.rs
@@ -34,8 +34,6 @@ pub(crate) struct ScreenSlots {
     /// while the menu is open still offers Wake, and a magic packet to a running host is
     /// nothing.
     pub(crate) host_menu_power: Option<crate::services::store::ExitAction>,
-    /// The sidebar row `Screen::EditHost` is editing, `None` otherwise.
-    pub(crate) edit_host_index: Option<usize>,
     /// The HDR calibration in progress — its step, its scratch volume and the pattern feed on the
     /// video plane. `None` whenever that screen isn't open, which is also what stops the feed.
     pub(crate) hdr: Option<HdrCalibrationState>,

--- a/src/app/state/addhost.rs
+++ b/src/app/state/addhost.rs
@@ -52,13 +52,7 @@ impl App {
         );
         self.persist();
         self.rebuild_entries();
-        self.set_home_focus(HomeFocus::Sidebar(
-            self.hosts
-                .entries
-                .iter()
-                .position(|e| e.host() == host && e.port() == port)
-                .unwrap_or(0),
-        ));
+        self.set_home_focus(HomeFocus::Sidebar(self.hosts.entry_index(&host, port).unwrap_or(0)));
         self.nav.screen = Screen::Home;
     }
     /// Shared by `AddHost` and `EditHost`.

--- a/src/app/state/edithost.rs
+++ b/src/app/state/edithost.rs
@@ -15,21 +15,16 @@ impl App {
             return;
         };
         self.screens.add_host = TextField::from_host_port(&h.addr, h.port);
-        self.screens.edit_host_index = Some(idx);
-        self.screens.host_menu_index = None;
-        self.nav.screen = Screen::EditHost;
+        self.nav.enter(Screen::EditHost, 0);
     }
 
-    /// Handle menu event. Left/Right stand in for backspace; Confirm commits with 4 octets.
+    /// Left/Right stand in for backspace; Confirm commits with 4 octets.
     pub(crate) fn handle_edit_host_event(&mut self, ev: MenuEvent) {
         match ev {
             MenuEvent::Left => self.screens.add_host.backspace(),
             MenuEvent::Right => self.screens.add_host.advance_field(),
             MenuEvent::Confirm => self.confirm_edit_host(),
-            MenuEvent::Back => {
-                self.screens.edit_host_index = None;
-                self.nav.screen = Screen::Home;
-            }
+            MenuEvent::Back => self.close_edit_host(),
             MenuEvent::Up | MenuEvent::Down | MenuEvent::Secondary => {}
         }
     }
@@ -39,7 +34,7 @@ impl App {
         if !self.screens.add_host.is_complete() {
             return;
         }
-        let Some(idx) = self.screens.edit_host_index else {
+        let Some(idx) = self.screens.host_menu_index else {
             return;
         };
         let Some(HostEntry::Known(old)) = self.hosts.entries.get(idx).cloned() else {
@@ -47,8 +42,7 @@ impl App {
         };
         let (host, port) = self.screens.add_host.host_and_port();
         if host == old.addr && port == old.port {
-            self.screens.edit_host_index = None;
-            self.nav.screen = Screen::Home;
+            self.close_edit_host();
             return;
         }
 
@@ -70,19 +64,24 @@ impl App {
         self.persist();
         self.rebuild_entries();
 
-        // Keep selection updated to new address
         if self.library.selected_host.as_ref() == Some(&(old.addr.clone(), old.port)) {
             self.library.selected_host = Some((host.clone(), port));
         }
-        self.set_home_focus(HomeFocus::Sidebar(
-            self.hosts
-                .entries
-                .iter()
-                .position(|e| e.host() == host && e.port() == port)
-                .unwrap_or(0),
-        ));
-        self.screens.edit_host_index = None;
+        // `rebuild_entries` may have moved the row, and the host menu behind this dialog acts
+        // on the index, so both focus and that index follow the host to its new position.
+        if let Some(row) = self.hosts.entry_index(&host, port) {
+            self.set_home_focus(HomeFocus::Sidebar(row));
+            self.screens.host_menu_index = Some(row);
+        }
         self.render.grid.dirty = true;
-        self.nav.screen = Screen::Home;
+        self.close_edit_host();
+    }
+
+    /// Back to the host menu this dialog was opened from — `resume`, not `enter`, so the
+    /// cursor stays on the Connect row whose pencil opened it. The latch is
+    /// `handle_host_power_event`'s: the menu's subtitle carries the address just changed.
+    fn close_edit_host(&mut self) {
+        self.latch_host_menu_power();
+        self.nav.resume(Screen::HostMenu);
     }
 }


### PR DESCRIPTION
## Summary
- Pencil-editing a host's Connect row now closes back into the host menu, matching every other action that menu opens (power settings' Back does the same).
- Committing a new address rebuilds the sidebar; Home focus and the host-menu index now both follow the host to its new row instead of only focus, with no more row-0 fallback on a failed lookup.
- Dropped `edit_host_index` (duplicated the host-menu index) in favor of a shared `HostsState::entry_index(host, port)`, used by both add-host and edit-host commit paths.

## Test plan
- [x] `task docker:lint` clean (`-D warnings`)
- [x] `task docker:test`, 51 unit tests pass
- [ ] Manual: open host menu, edit Connect address via pencil, confirm return to host menu with Connect row focused and power row subtitle updated