### PR TITLE
fix(app): replay the host menu's row entrance on every arrival

### DIFF
--- a/src/app/draw/mod.rs
+++ b/src/app/draw/mod.rs
@@ -488,17 +488,18 @@ impl App {
         dialog::draw(f, title, &confirm, focus, motion.as_ref(), alpha, dy);
     }
 
-    /// The kit list for `screen`, made fresh when the screen changes so a new card enters
-    /// with its own rise and no scroll carried over from the last one.
+    /// The kit list for `screen`, seated fresh when the seat is empty or holds another
+    /// screen's — so a card enters with its own rise and no scroll carried over. `advance_frame`
+    /// empties the seat on every screen change; the screen it is tagged with is what keeps the
+    /// two cards of a cross-fade from sharing one widget, since the leaving one is drawn too.
     pub(crate) fn kit_list(&mut self, screen: Screen) -> &mut pf_console_ui::widgets::MenuList {
         let cursor = self.nav.cursor(crate::app::nav::ScreenKey::of(screen));
-        let fresh = !matches!(&self.render.list, Some((s, _)) if *s == screen);
-        if fresh {
+        if !matches!(&self.render.list, Some((s, _)) if *s == screen) {
             let mut list = pf_console_ui::widgets::MenuList::new();
             list.jump_to(cursor);
             self.render.list = Some((screen, list));
         }
-        &mut self.render.list.as_mut().expect("just set").1
+        &mut self.render.list.as_mut().expect("just seated").1
     }
 
     /// `None` on any other screen.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -842,6 +842,11 @@ impl App {
         if screen_changed {
             let left = self.nav.last_screen;
             self.nav.last_screen = self.nav.screen;
+            // A list screen's rows rise on every arrival, whether it is being opened or
+            // returned to: dropping the widget here is what makes the entrance replay, and
+            // doing it on the one transition hook means a screen reached across a text form
+            // (the address dialog, which seats no list of its own) enters like any other.
+            self.render.list = None;
             // Modal-to-modal cross-fades: `ui::fade` makes the leaving card the entering
             // one's inverse. Anything involving Home is a plain open or close.
             if !matches!(left, Screen::Home) {

--- a/src/app/state/hostpower.rs
+++ b/src/app/state/hostpower.rs
@@ -263,7 +263,7 @@ impl App {
                 // The exit behaviour may just have changed, and it is what the host menu's
                 // power row is named after.
                 self.latch_host_menu_power();
-                self.nav.screen = Screen::HostMenu;
+                self.nav.resume(Screen::HostMenu);
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary

Returning from the edit-address dialog left the host menu's rows settled,
while every other return leg (power settings, profile picker) replayed the
rise. This made the address-dialog return the odd one out.

The render state seats one kit-list widget tagged with the screen it was
built for; a fresh widget is what plays the row entrance. A nested list
screen replaces that widget on the way in, so returning built a new one and
the rows rose. The address dialog is a text form and never touches the
widget, so returning from it left the old one in place, settled.

The fix drops the seated widget in the per-frame transition hook that
already runs on every screen change (it advances the modal fade there too),
so every arrival at a list screen seats a fresh widget and rises — including
one reached back across a text form. The widget keeps its screen tag,
because a cross-fade draws the leaving card as well as the entering one and
the two must not share a widget.

Also: the host power screen's Back now goes through the existing `resume`
nav helper instead of writing the screen field directly, matching the other
return legs. No behaviour change there.

## Test plan
- [x] `task docker:lint` (clippy, `-D warnings`) clean
- [x] `task docker:test` — 51 unit tests pass
- [ ] Not yet verified on the TV