### PR TITLE
perf(menu): cut render-thread cost in menus and controller shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Build](https://github.com/punktfunk/client-webos/actions/workflows/build.yml/badge.svg)](https://github.com/punktfunk/client-webos/actions/workflows/build.yml)
 [![Release](https://img.shields.io/github/v/release/punktfunk/client-webos?color=6c5bf3&label=release)](https://github.com/punktfunk/client-webos/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/punktfunk/client-webos/latest/total?color=a79ff8&label=downloads)](https://github.com/punktfunk/client-webos/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/punktfunk/client-webos/total?color=a79ff8&label=downloads)](https://github.com/punktfunk/client-webos/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-d2c9fb)](#license)
 
 **Native LG webOS TV client for [punktfunk](https://git.unom.io/unom/punktfunk) — low-latency desktop & game streaming.**

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,28 +1,18 @@
-# `build`/`check`/`package`/`lint` run directly on the host — meaningful only on
-# a Linux aarch64 box with Rust installed (CI, already such a runner). The
-# `docker:*` variants wrap the same logic in Docker for local dev, since the
-# webOS cross-toolchain only ships a Linux aarch64 build.
-# webOS-specific plumbing lives in `taskfiles/toolchain.yml`, kept separate so
-# this file stays short.
+# build/check/package/lint run on host (Linux aarch64+Rust only; CI). docker:* wraps for local dev.
+# webOS-specific plumbing in taskfiles/toolchain.yml keeps this file short.
 version: '3'
 
-# Suppress go-task's echo of each command before it runs — keeps task output
-# to just the command's own output (less noise, fewer tokens when read back).
+# Suppress command echo to reduce noise and token usage.
 silent: true
 
-# TV_HOST (used by deploy below) can live in a local, gitignored .env
-# instead of being typed on every invocation — see .env.example.
+# TV_HOST and friends come from a gitignored .env — see .env.example.
 dotenv: ['.env']
 
 env:
-  # Modern CMake refuses vendored libopus's old cmake_minimum_required
-  # (audiopus_sys, pulled in transitively by punktfunk-core's `quic` feature).
+  # CMake workaround for vendored libopus (audiopus_sys via punktfunk-core quic feature).
   CMAKE_POLICY_VERSION_MINIMUM: '3.5'
-  # Prebuilt Skia for the console shell. rust-skia publishes no armv7 archive for any OS, so
-  # this one is ours — built against this very sysroot; sha256 in the release notes.
-  # 🛑 Without it skia-bindings does not fail. It silently builds Skia from source for about an
-  # hour. Every build must log `DOWNLOAD AND INSTALL SUCCEEDED`, and that line is NOT on stdout
-  # under `cargo build -v` — read target/<triple>/<profile>/build/skia-bindings-*/output.
+  # Prebuilt Skia for armv7 (rust-skia ships x86_64/aarch64 only). Without this, skia-bindings
+  # silently builds from source (~1 hour); check target/<triple>/<profile>/build/skia-bindings-*/output for "DOWNLOAD AND INSTALL SUCCEEDED".
   SKIA_BINARIES_URL: 'https://git.unom.io/unom/skia-binaries/releases/download/0.99.0/skia-binaries-{key}.tar.gz'
 
 includes:
@@ -59,16 +49,12 @@ vars:
 tasks:
   build:
     desc: >-
-      Cross-compile the release binary directly on the host, no Docker — only
-      meaningful on a Linux aarch64 box with Rust already installed (used by CI;
-      `docker:build` is the local dev entry point). Thin LTO (fast); override
-      with RELEASE_LTO=fat for an optimized build.
+      Cross-compile release binary on host (Linux aarch64 with Rust only; CI uses this,
+      `docker:build` for local dev). Thin LTO; override with RELEASE_LTO=fat for optimized.
     deps: [toolchain:all]
     env:
-      # Thread the packaged version into the binary (`core::VERSION` reads it through
-      # `option_env!`) so the UI's build marker matches the .ipk — Cargo.toml stays a
-      # fixed 0.0.1. Under `docker:build` the host's value arrives as `-e PKG_VERSION`,
-      # so the container reuses it rather than re-deriving it from the mounted git.
+      # Bakes package version into binary (core::VERSION) so UI build marker matches .ipk.
+      # Cargo.toml stays 0.0.1; docker:build receives via -e.
       PKG_VERSION: '{{.PKG_VERSION}}'
     cmds:
       - rustup target add {{.TARGET}}
@@ -83,21 +69,16 @@ tasks:
 
   test:
     desc: >-
-      Run the unit tests on the HOST target. The armv7 cross build cannot execute on a runner,
-      and `lint` only type-checks the tests — this is the only task that runs them. Needs native
-      SDL2, fontconfig and FreeType (`libsdl2-dev libfontconfig-dev libfreetype-dev`);
-      `docker:test` brings its own.
+      Run unit tests on host target. armv7 cross build cannot execute on runner, and lint only
+      type-checks. Needs native SDL2, fontconfig, FreeType; docker:test brings its own.
     env:
-      # The host's Skia comes from rust-skia's own release: our mirror only carries the armv7
-      # archive that upstream does not build. Same version, same key, different host.
+      # rust-skia upstream (our mirror carries armv7 only).
       SKIA_BINARIES_URL: 'https://github.com/rust-skia/skia-binaries/releases/download/0.99.0/skia-binaries-{key}.tar.gz'
     cmds:
       - cargo test --bins
 
   lint:
-    desc: >-
-      rustfmt check plus cross-target `cargo clippy` (the lint set in Cargo.toml's
-      `[lints.clippy]`), no Docker (used by CI)
+    desc: rustfmt check plus cross-target cargo clippy (Cargo.toml [lints.clippy])
     deps: [toolchain:all]
     cmds:
       - cargo fmt --check
@@ -107,9 +88,8 @@ tasks:
 
   package:
     desc: >-
-      Build and package dist/*.ipk, no Docker (used by CI). Thin LTO (fast); override with
-      RELEASE_LTO=fat for optimized. PROBES=1 also ships `pfprobe` for on-device
-      diagnostics over SSH.
+      Build and package dist/*.ipk (CI only). Thin LTO; RELEASE_LTO=fat for optimized.
+      PROBES=1 ships pfprobe for on-device SSH diagnostics.
     deps: [build, toolchain:ares-package]
     cmds:
       - task: toolchain:stage-and-package
@@ -118,12 +98,12 @@ tasks:
           PROBES: '{{.PROBES}}'
 
   fmt:
-    desc: Format the whole crate with rustfmt (native — formatting doesn't need the cross toolchain)
+    desc: Format crate with rustfmt (no cross toolchain needed)
     cmds:
       - cargo fmt
 
   docker:build:
-    desc: Cross-compile the release binary inside Docker with thin LTO (fast) — the local dev entry point. Override with RELEASE_LTO=fat for optimized build.
+    desc: Cross-compile release binary in Docker (local dev entry point). Thin LTO; RELEASE_LTO=fat for optimized.
     cmds:
       - task: toolchain:docker-run
         vars:
@@ -131,13 +111,13 @@ tasks:
           RELEASE_LTO: '{{.RELEASE_LTO}}'
 
   docker:check:
-    desc: Quick cross-target `cargo check`, inside Docker — the local dev entry point
+    desc: Quick cross-target cargo check in Docker (local dev entry point)
     cmds:
       - task: toolchain:docker-run
         vars: {TARGET_TASK: check}
 
   docker:test:
-    desc: Run the unit tests inside Docker — the local dev entry point for `test`
+    desc: Run unit tests in Docker (local dev entry point)
     cmds:
       - task: toolchain:docker-run
         vars:
@@ -145,13 +125,13 @@ tasks:
           EXTRA_APT: libsdl2-dev libfontconfig-dev libfreetype-dev
 
   docker:lint:
-    desc: Cross-target `cargo clippy` (the lint set in Cargo.toml's `[lints.clippy]`), inside Docker
+    desc: Cross-target cargo clippy in Docker (Cargo.toml [lints.clippy])
     cmds:
       - task: toolchain:docker-run
         vars: {TARGET_TASK: lint}
 
   docker:package:
-    desc: Build and package dist/*.ipk, inside Docker with thin LTO (fast) — the local dev entry point. Override with RELEASE_LTO=fat for optimized.
+    desc: Build and package dist/*.ipk in Docker (local dev entry point). Thin LTO; RELEASE_LTO=fat for optimized.
     cmds:
       - task: toolchain:docker-run
         vars:
@@ -178,12 +158,11 @@ tasks:
 
   deploy:
     desc: >-
-      Build, package, install, and launch on a real TV via ares-cli-rs only.
-      Usage: task deploy TV_HOST=root@<tv-ip> (or set TV_HOST in .env).
-      TELEMETRY=<host:port> streams logs; TELEMETRY=auto uses this machine's LAN IP
-      and a random port. TELEMETRY_LEVEL (debug/info/warn/error, default debug)
-      sets the minimum streamed level. UI_SCALE=<factor> replaces the panel-size UI
-      scale, so a set this machine cannot measure can be tuned on glass.
+      Build, package, install, and launch on real TV via ares-cli-rs.
+      Usage: task deploy TV_HOST=root@<tv-ip> (or set in .env).
+      TELEMETRY=<host:port> streams logs; TELEMETRY=auto uses LAN IP and random port.
+      TELEMETRY_LEVEL (debug/info/warn/error, default debug) sets minimum level.
+      UI_SCALE=<factor> overrides panel size for tuning on glass.
     deps: [docker:package, register-device]
     vars:
       IPK: dist/{{.APP_ID}}_{{.PKG_VERSION}}_arm.ipk
@@ -225,8 +204,8 @@ tasks:
 
   docker:deploy:
     desc: >-
-      Same as `deploy`, but to a container instead of a TV — a virtual 1080p display served
-      over VNC at http://localhost:6080/vnc.html, logs streamed to this terminal.
+      Like deploy but to container: virtual 1080p over VNC at http://localhost:6080/vnc.html,
+      logs to terminal.
     cmds:
       - task: toolchain:docker-run
         vars:
@@ -238,8 +217,7 @@ tasks:
           EXTRA_DOCKER: -p 127.0.0.1:6080:6080 -v punktfunk-webos-client-home:/root
 
   docker:host:
-    desc: >-
-      Run a punktfunk host in a container to connect the app to.
+    desc: Run a punktfunk host in a container
     cmds:
       - |
         set -eu
@@ -275,7 +253,7 @@ tasks:
           '{"telemetry":"127.0.0.1:9000","telemetry_level":"{{.TELEMETRY_LEVEL}}","webos_sdk":"{{.WEBOS_SDK}}"}'
 
   clean:
-    desc: Remove everything — dist/, .toolchains/, target/, and the Docker volumes
+    desc: Remove dist/, .toolchains/, target/, and Docker volumes
     cmds:
       - rm -rf ./dist ./.toolchains ./target
       - docker volume ls -q --filter name=punktfunk-webos- | xargs docker volume rm -f

--- a/packaging/description.md
+++ b/packaging/description.md
@@ -1,18 +1,22 @@
+[Punktfunk](https://punktfunk.unom.io/) is a low-latency desktop and game streaming solution.
 
-# Punktfunk — Low-latency desktop and game streaming client for LG webOS.
+![Download Stats](https://img.shields.io/github/downloads/punktfunk/client-webos/total)
+![GitHub Stars](https://img.shields.io/github/stars/punktfunk/client-webos?style=social)
+![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-d2c9fb)
 
-![Home screen](https://raw.githubusercontent.com/punktfunk/client-webos/main/assets/screenshots/controller-ui-game.jpg)
+## Features
 
 * **Video.** Up to 4K120 with HDR. HEVC or H.264, decoded by the TV's media pipeline.
 * **Bitrate.** Automatic mode adapts to the network, or set a fixed rate up to 200 Mbps.
 * **Audio.** Stereo, 5.1 or 7.1 (webOS 5+), decoded in software or offloaded to media pipeline.
-* **Per-game overrides.** Any game can override the global resolution, frame rate, bitrate, codec, HDR, audio or controller settings.
+* **Per-game profiles.** Any game can override the global resolution, frame rate, bitrate, codec, HDR, audio or controller settings.
 * **Input.** Magic Remote pointer, gamepads, USB keyboard and mouse. Cursor capture for games or absolute for the desktop, gestures.
 * **DualSense.** Adaptive triggers, lightbar, player LEDs, touchpad, gyro, speakers and haptics over Bluetooth or wired.
 * **Host power.** Wake-on-LAN, and configurable host power management for sleep or full shut down.
 * **Game mode (rooted TVs).** Switches picture and sound to Game mode while streaming, and restores the previous settings on exit.
 * **Pairing.** Hosts are found on your network automatically, or added by IP.
 * **Library.** Browse the host's games and launch straight into it, custom game collections.
+* **Input-Optimized UI.** A full-screen interface for gamepads, and a console interface for remote/mouse/keyboard.
 
 Some features are limited on older webOS versions:
 
@@ -23,7 +27,12 @@ Some features are limited on older webOS versions:
 Needs a [punktfunk](https://git.unom.io/unom/punktfunk) host running on your PC — see the
 [host setup guide](https://git.unom.io/unom/punktfunk#readme) to get started.
 
-This app is created by [dyptan-io](https://github.com/dyptan-io).
-**Punktfunk** is created by Enrico Bühler ([unom](https://unom.io)).
-
+This app is created by [dyptan-io](https://github.com/dyptan-io) and Enrico Bühler ([unom](https://unom.io)).
 MIT / Apache-2.0.
+
+## Screenshots
+
+![Controller - Game](https://raw.githubusercontent.com/punktfunk/client-webos/main/assets/screenshots/controller-ui-game.jpg)
+![Controller - Home](https://raw.githubusercontent.com/punktfunk/client-webos/main/assets/screenshots/controller-ui-home.jpg)
+![Console - Home](https://raw.githubusercontent.com/punktfunk/client-webos/main/assets/screenshots/console-kit-home.jpg)
+![Console - Settings](https://raw.githubusercontent.com/punktfunk/client-webos/main/assets/screenshots/console-kit-settings.jpg)

--- a/src/app/draw/about.rs
+++ b/src/app/draw/about.rs
@@ -6,7 +6,7 @@ use pf_console_ui::icons::{by_name, draw_icon};
 use pf_console_ui::theme::{self, Fonts, W};
 use skia_safe::{Contains, Point, Rect};
 
-use super::{glass_card, line_h, wrap, Frame};
+use super::{alpha_layer, glass_card, line_h, wrap, Frame};
 
 const WIDTH_FRAC: f32 = 0.78;
 const HEIGHT_FRAC: f32 = 0.84;
@@ -108,7 +108,7 @@ pub(crate) fn draw(
     let k = f.k;
     c.save();
     c.translate((0.0, dy));
-    c.save_layer_alpha_f(Some(l.card), alpha);
+    alpha_layer(c, l.card, alpha);
     glass_card(f, l.card, CORNER);
     let x = f64::from(l.card.left + PAD * k);
     f.fonts.draw(

--- a/src/app/draw/dialog.rs
+++ b/src/app/draw/dialog.rs
@@ -11,7 +11,7 @@ use skia_safe::{Canvas, Color4f, Contains, Point, RRect, Rect};
 
 use pf_console_ui::theme::Fonts;
 
-use super::{glass_card, line_h, scale, ui_rect, wrap, Frame};
+use super::{alpha_layer, glass_card, line_h, scale, ui_rect, wrap, Frame};
 use crate::app::screens::confirm::{Confirm, Tone};
 use crate::app::view;
 use crate::app::App;
@@ -167,7 +167,7 @@ fn draw_on(
     let k = f.k;
     c.save();
     c.translate((0.0, dy));
-    c.save_layer_alpha_f(Some(l.card), alpha);
+    alpha_layer(c, l.card, alpha);
     glass_card(f, l.card, CORNER);
     f.fonts.draw_clipped(
         c,

--- a/src/app/draw/form.rs
+++ b/src/app/draw/form.rs
@@ -9,7 +9,7 @@ use pf_console_ui::icons::{by_name, draw_icon};
 use pf_console_ui::theme::{self, Fonts, PanelStroke, W};
 use skia_safe::{Contains, Point, RRect, Rect};
 
-use super::{glass_card, line_h, wrap, Frame};
+use super::{alpha_layer, glass_card, line_h, wrap, Frame};
 use crate::core::screen::PairingFocus;
 use crate::ui;
 
@@ -169,7 +169,7 @@ pub(crate) fn draw(
     let k = f.k;
     c.save();
     c.translate((0.0, dy));
-    c.save_layer_alpha_f(Some(l.card), alpha);
+    alpha_layer(c, l.card, alpha);
     glass_card(f, l.card, CORNER);
     header(f, l.card, title, l.title_baseline, &l.body, l.body_top, hover_close);
     theme::panel(
@@ -330,7 +330,7 @@ pub(crate) fn draw_pair(f: &Frame<'_>, l: &PairLayout, s: &PairState<'_>, hover_
     let k = f.k;
     c.save();
     c.translate((0.0, dy));
-    c.save_layer_alpha_f(Some(l.card), alpha);
+    alpha_layer(c, l.card, alpha);
     glass_card(f, l.card, CORNER);
     header(
         f,

--- a/src/app/draw/home.rs
+++ b/src/app/draw/home.rs
@@ -14,7 +14,7 @@ use skia_safe::{
     Rect,
 };
 
-use super::{focus_face, line_h, linear, panel, sk, with_pop, Frame};
+use super::{alpha_layer, focus_face, line_h, linear, panel, sk, with_pop, Frame};
 use crate::app::draw::glass;
 use crate::app::grid::{Entrance, GridLayout};
 use crate::app::hosts::HostEntry;
@@ -58,38 +58,6 @@ const SPINNER_R: f64 = 24.0;
 /// `theme::drop_shadow` runs a `MaskFilter` blur per draw, and on this chip that is not the
 /// analytic rounded-rect path it is on a desktop GPU — one per visible card cost about 6ms of
 /// the grid's ~14ms of GPU time per frame, which is most of what made scrolling drop frames.
-///
-/// A nine-patch rather than one raster per card size, because there is never just one size: the
-/// focused card is zoomed and entering cards are mid-pop, so a cache keyed on size would re-bake
-/// several times a frame — worse than what it replaced. Only the corners carry the shape, so a
-/// single bake stretches to every card, and the alpha rides the paint so cards still fade in.
-fn card_shadow() -> Option<Image> {
-    thread_local! {
-        static SHADOW: std::cell::RefCell<Option<Option<Image>>> = const { std::cell::RefCell::new(None) };
-    }
-    SHADOW.with(|c| c.borrow_mut().get_or_insert_with(bake_card_shadow).clone())
-}
-
-/// The shadow's own bed: a rounded rect blurred with [`SHADOW_MARGIN`] of room to spread into on
-/// every side. The body is wide enough that the middle of each edge reaches full opacity before
-/// the opposite corner's blur reaches it — a narrower one stretches out lighter than the shadow
-/// it is standing in for, since the nine-patch repeats that midpoint across the whole card.
-fn bake_card_shadow() -> Option<Image> {
-    let bed = 2 * SHADOW_MARGIN + SHADOW_BODY;
-    let mut surface = skia_safe::surfaces::raster_n32_premul((bed, bed))?;
-    let canvas = surface.canvas();
-    canvas.clear(Color4f::new(0.0, 0.0, 0.0, 0.0));
-    let mut p = Paint::new(Color4f::new(0.0, 0.0, 0.0, 1.0), None);
-    p.set_anti_alias(true);
-    p.set_mask_filter(MaskFilter::blur(BlurStyle::Normal, SHADOW_SIGMA, None));
-    let (m, side) = (SHADOW_MARGIN as f32, SHADOW_BODY as f32);
-    canvas.draw_rrect(
-        RRect::new_rect_xy(Rect::from_xywh(m, m, side, side), CARD_RADIUS, CARD_RADIUS),
-        &p,
-    );
-    Some(surface.image_snapshot())
-}
-
 /// The blur's reach, its room to spread, and its drop — the kit's own values at `k = 1`
 /// (`theme::drop_shadow`), transcribed because it exports none, so the picture is the one it
 /// drew. A kit bump that retunes them leaves these stale.
@@ -102,17 +70,62 @@ const SHADOW_BODY: i32 = 80;
 /// The corner the nine-patch must not stretch: the radius plus what the blur carries past it.
 const SHADOW_EDGE: i32 = CARD_RADIUS as i32;
 
-/// Draw the cached shadow under `r`. A no-op if the bed could not be rasterized — a card with no
-/// shadow beats no card.
-fn draw_card_shadow(c: &skia_safe::Canvas, r: Rect, alpha: f32) {
-    let Some(shadow) = card_shadow() else {
+/// A blurred rounded rect with [`SHADOW_MARGIN`] of room to spread into on every side, painted
+/// with whatever `paint` builds, baked once and kept.
+///
+/// A nine-patch rather than one raster per card size, because there is never just one size: the
+/// focused card is zoomed and entering cards are mid-pop, so a cache keyed on size would re-bake
+/// several times a frame — worse than what it replaced. Only the corners carry the shape, so a
+/// single bake stretches to every card, and the alpha rides the paint so cards still fade in.
+/// The body is wide enough that the middle of each edge saturates before the opposite corner's
+/// blur reaches it — a narrower one stretches out lighter than what it stands in for.
+fn bake_bed(paint: impl FnOnce() -> Paint) -> Option<Image> {
+    let bed = 2 * SHADOW_MARGIN + SHADOW_BODY;
+    let mut surface = skia_safe::surfaces::raster_n32_premul((bed, bed))?;
+    let canvas = surface.canvas();
+    canvas.clear(Color4f::new(0.0, 0.0, 0.0, 0.0));
+    let mut p = paint();
+    p.set_anti_alias(true);
+    let (m, side) = (SHADOW_MARGIN as f32, SHADOW_BODY as f32);
+    canvas.draw_rrect(
+        RRect::new_rect_xy(Rect::from_xywh(m, m, side, side), CARD_RADIUS, CARD_RADIUS),
+        &p,
+    );
+    Some(surface.image_snapshot())
+}
+
+/// Draw a baked bed over `r`, dropped by `dy`. Graceful on bake failure.
+fn draw_bed(c: &skia_safe::Canvas, bed: Option<&Image>, r: Rect, dy: f32, paint: &Paint) {
+    let Some(bed) = bed else {
         return;
     };
     let edge = SHADOW_MARGIN + SHADOW_EDGE;
-    let centre = IRect::new(edge, edge, shadow.width() - edge, shadow.height() - edge);
+    let centre = IRect::new(edge, edge, bed.width() - edge, bed.height() - edge);
     let m = SHADOW_MARGIN as f32;
-    let bed = r.with_outset((m, m)).with_offset((0.0, SHADOW_DROP));
-    c.draw_image_nine(&shadow, centre, bed, FilterMode::Linear, Some(&alpha_paint(alpha)));
+    c.draw_image_nine(
+        bed,
+        centre,
+        r.with_outset((m, m)).with_offset((0.0, dy)),
+        FilterMode::Linear,
+        Some(paint),
+    );
+}
+
+fn draw_card_shadow(c: &skia_safe::Canvas, r: Rect, alpha: f32) {
+    thread_local! {
+        static SHADOW: std::cell::OnceCell<Option<Image>> = const { std::cell::OnceCell::new() };
+    }
+    let bed = SHADOW.with(|cell| {
+        cell.get_or_init(|| {
+            bake_bed(|| {
+                let mut p = Paint::new(Color4f::new(0.0, 0.0, 0.0, 1.0), None);
+                p.set_mask_filter(MaskFilter::blur(BlurStyle::Normal, SHADOW_SIGMA, None));
+                p
+            })
+        })
+        .clone()
+    });
+    draw_bed(c, bed.as_ref(), r, SHADOW_DROP, &alpha_paint(alpha));
 }
 
 fn px(f: &Frame<'_>, size: f32) -> f64 {
@@ -193,6 +206,56 @@ pub(crate) fn menu_rows_h(rows: usize) -> f32 {
     rows as f32 * MENU_ROW_H + 2.0 * MENU_ROWS_PAD
 }
 
+/// Draw cover art rounded to the card as a rrect shader, not a clipped draw. The clip costs a
+/// GPU coverage mask pass per card per frame; the shader folds the rounding into coverage itself.
+fn draw_cover(c: &skia_safe::Canvas, img: &Image, r: Rect, alpha: f32) {
+    let mut m = skia_safe::Matrix::new_identity();
+    m.set_scale(
+        (
+            r.width() / img.width().max(1) as f32,
+            r.height() / img.height().max(1) as f32,
+        ),
+        None,
+    );
+    m.post_translate((r.left, r.top));
+    // `to_shader` safe here: all images in `render.covers` are GPU-ready.
+    let Some(shader) = img.to_shader((skia_safe::TileMode::Clamp, skia_safe::TileMode::Clamp), linear(), &m) else {
+        return;
+    };
+    let mut p = alpha_paint(alpha);
+    p.set_anti_alias(true);
+    p.set_shader(shader);
+    c.draw_rrect(rr(r), &p);
+}
+
+/// Draw focus halo, baked and white so accent tint at draw time avoids re-bake on palette change.
+/// A blur pass on GPU per frame during nav would drop smoothness.
+fn draw_focus_glow(c: &skia_safe::Canvas, r: Rect, alpha: f32) {
+    if alpha <= 0.0 {
+        return;
+    }
+    thread_local! {
+        static GLOW: std::cell::OnceCell<Option<Image>> = const { std::cell::OnceCell::new() };
+    }
+    let bed = GLOW.with(|cell| {
+        cell.get_or_init(|| {
+            bake_bed(|| {
+                let mut p = theme::stroke(Color4f::new(1.0, 1.0, 1.0, 1.0), 6.0);
+                p.set_mask_filter(MaskFilter::blur(BlurStyle::Normal, GLOW_BLUR / 2.0, None));
+                p
+            })
+        })
+        .clone()
+    });
+    let mut paint = alpha_paint(alpha);
+    // The bed is white; `SrcIn` paints the accent through its alpha.
+    paint.set_color_filter(skia_safe::color_filters::blend(
+        theme::accent(1.0).to_color(),
+        BlendMode::SrcIn,
+    ));
+    draw_bed(c, bed.as_ref(), r, 0.0, &paint);
+}
+
 impl App {
     /// Everything under the modals: the grid or what stands in for it, the status band, the
     /// sidebar. Skipped over live video, where all of it would cover the picture.
@@ -242,7 +305,7 @@ impl App {
         let box_h = 2.0 * stride + 2.0 * STATUS_BG_PAD as f32;
         let block = Rect::from_xywh(grid_x, f.h - box_h, available_w, box_h);
         let c = f.canvas;
-        c.save_layer_alpha_f(Some(block), alpha);
+        alpha_layer(c, block, alpha);
         // Square-cornered: a full-width cut across the bottom edge, not a card.
         c.draw_rect(block, &theme::fill(super::surface()));
         let max_w = available_w - 2.0 * view::home::GRID_PAD as f32;
@@ -450,10 +513,7 @@ impl App {
     fn poster(&self, f: &Frame<'_>, r: Rect, game: &GameEntry, alpha: f32) {
         let c = f.canvas;
         if let Some(img) = self.render.covers.get(&game.id) {
-            c.save();
-            c.clip_rrect(rr(r), ClipOp::Intersect, true);
-            c.draw_image_rect_with_sampling_options(img, None, r, linear(), &alpha_paint(alpha));
-            c.restore();
+            draw_cover(c, img, r, alpha);
             return;
         }
         c.draw_rrect(rr(r), &theme::fill(fade(face_for(&game.title), alpha)));
@@ -544,9 +604,7 @@ impl App {
         let (pop, shrink) = Entrance::progress_of(self.render.grid.arrivals.pop(&game.id), now);
         let r = sk(pop_in_rect(zoom_rect(base, focus, CARD_GROWTH), pop, shrink));
         // Glow first — a halo behind the card, blooming over the whole travel.
-        let mut glow = theme::stroke(theme::accent(0.85 * focus * pop), 6.0);
-        glow.set_mask_filter(MaskFilter::blur(BlurStyle::Normal, GLOW_BLUR / 2.0, None));
-        c.draw_rrect(rr(r), &glow);
+        draw_focus_glow(c, r, 0.85 * focus * pop);
         draw_card_shadow(c, r, 0.5 * pop);
         self.poster(f, r, game, pop);
         self.running_dot(f, r, game, pop);

--- a/src/app/draw/list.rs
+++ b/src/app/draw/list.rs
@@ -11,7 +11,7 @@ use pf_console_ui::theme::{self, Fonts, W};
 use pf_console_ui::widgets::{MenuList, RowSpec, ROW_H};
 use skia_safe::{Contains, Point, Rect};
 
-use super::{glass_card, line_h, wrap, Frame};
+use super::{alpha_layer, glass_card, line_h, wrap, Frame};
 use crate::app::screens::rowbuttons::RowButton;
 use crate::ui::widgets::{FocusRow, RowKind};
 
@@ -128,7 +128,7 @@ pub(crate) fn draw(
     let k = f.k;
     c.save();
     c.translate((0.0, dy));
-    c.save_layer_alpha_f(Some(l.card), alpha);
+    alpha_layer(c, l.card, alpha);
     glass_card(f, l.card, CORNER);
     f.fonts.draw_clipped(
         c,

--- a/src/app/draw/mod.rs
+++ b/src/app/draw/mod.rs
@@ -178,6 +178,10 @@ pub(crate) fn line_h(size: f64) -> f64 {
 /// Greedy word wrap on the kit's single-line measure, in device pixels. A word wider than
 /// `max_w` stands alone and overflows rather than being split mid-word.
 pub(crate) fn wrap(fonts: &Fonts, text: &str, w: W, size: f64, max_w: f64) -> Vec<String> {
+    // One `Font` for the whole wrap. `Fonts::measure` builds one (and clones a typeface) per
+    // call, and this measures once per word — on a coverless card, every frame.
+    let font = fonts.font(w, size);
+    let measure = |s: &str| f64::from(font.measure_str(s, None).0);
     let mut lines = Vec::new();
     let mut line = String::new();
     for word in text.split_whitespace() {
@@ -186,7 +190,7 @@ pub(crate) fn wrap(fonts: &Fonts, text: &str, w: W, size: f64, max_w: f64) -> Ve
         } else {
             format!("{line} {word}")
         };
-        if line.is_empty() || f64::from(fonts.measure(&candidate, w, size)) <= max_w {
+        if line.is_empty() || measure(&candidate) <= max_w {
             line = candidate;
         } else {
             lines.push(std::mem::replace(&mut line, word.to_string()));
@@ -732,9 +736,52 @@ pub(crate) struct ListCard {
     pub rows: Vec<pf_console_ui::widgets::RowSpec>,
 }
 
+/// Layer with optional alpha, skipped at full alpha. Caller must pair with one `restore`.
+///
+/// The clip prevents overflow (unwrapped words, shadows). No AA: hard rect clip requires match.
+pub(crate) fn alpha_layer(c: &Canvas, r: Rect, alpha: f32) {
+    if alpha >= 1.0 {
+        c.save();
+        c.clip_rect(r, skia_safe::ClipOp::Intersect, false);
+        return;
+    }
+    c.save_layer_alpha_f(Some(r), alpha);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Verify `alpha_layer` at full alpha is pixel-identical to the layer, by drawing overflow
+    /// that would escape without the clip.
+    #[test]
+    fn skipping_the_layer_at_full_alpha_changes_nothing() {
+        let r = Rect::from_xywh(20.0, 20.0, 60.0, 60.0);
+        let paint = theme::fill(skia_safe::Color4f::new(1.0, 0.0, 0.0, 1.0));
+        let render = |layer: bool| {
+            let mut surface = skia_safe::surfaces::raster_n32_premul((100, 100)).unwrap();
+            let c = surface.canvas();
+            c.clear(skia_safe::Color4f::new(0.0, 0.0, 0.0, 1.0));
+            if layer {
+                c.save_layer_alpha_f(Some(r), 1.0);
+            } else {
+                alpha_layer(c, r, 1.0);
+            }
+            // Deliberately over the card's edge, the way an unwrappable word is.
+            c.draw_rect(Rect::from_xywh(0.0, 40.0, 100.0, 10.0), &paint);
+            c.draw_rect(r, &theme::fill(skia_safe::Color4f::new(0.0, 0.0, 1.0, 0.5)));
+            c.restore();
+            let mut pixels = vec![0u8; 100 * 100 * 4];
+            assert!(surface.read_pixels(
+                &skia_safe::ImageInfo::new_n32_premul((100, 100), None),
+                &mut pixels,
+                100 * 4,
+                (0, 0),
+            ));
+            pixels
+        };
+        assert_eq!(render(true), render(false));
+    }
 
     #[test]
     fn scale_follows_the_consoles_rule() {

--- a/src/app/draw/settings.rs
+++ b/src/app/draw/settings.rs
@@ -8,7 +8,7 @@ use pf_console_ui::theme::{self, W};
 use pf_console_ui::widgets::{MenuList, RowSpec};
 use skia_safe::{Contains, Point, Rect};
 
-use super::{focus_face, glass_card, with_pop, FocusEase, Frame};
+use super::{alpha_layer, focus_face, glass_card, with_pop, FocusEase, Frame};
 use crate::app::state::settingspage::Page;
 
 /// The card as a share of the screen, both axes.
@@ -108,7 +108,7 @@ pub(crate) fn draw(
     let k = f.k;
     c.save();
     c.translate((0.0, dy));
-    c.save_layer_alpha_f(Some(l.card), alpha);
+    alpha_layer(c, l.card, alpha);
     glass_card(f, l.card, CORNER);
     f.fonts.draw(
         c,

--- a/src/console/model.rs
+++ b/src/console/model.rs
@@ -489,9 +489,13 @@ impl Service {
 
     fn drain_art(&mut self) {
         let Some(rx) = &self.art else { return };
-        // Bounded per tick: a warm host answers faster than the panel refreshes, and draining
-        // the whole channel here would hold the frame for as long as art keeps arriving.
-        for _ in 0..8 {
+        // Time budget prevents render-thread decode of encoded posters (~50ms each). Count-based
+        // limit cannot stop mid-decode.
+        let started = Instant::now();
+        loop {
+            if started.elapsed() >= ART_DRAIN_BUDGET {
+                return;
+            }
             let Ok((id, item)) = rx.try_recv() else { return };
             match item {
                 ArtItem::Decoded(poster) => self.handles.library.push_decoded(id, poster),
@@ -654,8 +658,12 @@ impl Service {
         };
         tracing::info!("console: forgot {} ({}:{})", gone.name, gone.addr, gone.port);
         // Its covers are keyed by host and would otherwise outlive the record. This is the
-        // last moment the address is known.
-        crate::services::art::reconcile_host_caches(&self.store.snapshot().known_hosts);
+        // last moment the address is known. Off the render thread: cache walk costs during frame.
+        let known = self.store.with(|s| s.known_hosts.clone());
+        std::thread::Builder::new()
+            .name("punktfunk-webos-art-reconcile".into())
+            .spawn(move || crate::services::art::reconcile_host_caches(&known))
+            .ok();
         // It may still be advertising, in which case it comes straight back as a discovered
         // row — unsaved and unpaired, which is the honest state.
         self.last_sweep = None;
@@ -951,40 +959,96 @@ fn spawn_art(
             let Ok(agent) = library::agent(&identity, pin) else {
                 return;
             };
+            // Scale published only on shelf's first frame; fetch thread arrives early. Park to
+            // avoid render-thread decode (~50ms per poster on this `SoC`).
+            let mut sink = ArtSink {
+                tx: &tx,
+                library: &library,
+                parked: Vec::new(),
+            };
             for game in games {
-                let hand_over = |bytes: Vec<u8>| {
-                    let item = library
-                        .art_scale()
-                        .and_then(|k| pf_console_ui::decode_poster_off_thread(&bytes, k))
-                        .map_or(ArtItem::Encoded(bytes), ArtItem::Decoded);
-                    tx.send((game.id.clone(), item))
-                };
-                if let Some(bytes) = crate::services::art::cached_cover(&addr, port, &game.id) {
-                    // A closed channel means the shelf moved on; stop fetching for it.
-                    if hand_over(bytes).is_err() {
-                        return;
-                    }
-                    continue;
-                }
-                // Portrait first (the card's aspect), then the wider art as a fallback — the
-                // same order `services::art` asks in for the old UI's covers.
-                let candidates = [&game.art.portrait, &game.art.header, &game.art.hero];
-                for path in candidates.into_iter().flatten() {
-                    match library::fetch_art(&agent, &addr, mgmt, path) {
-                        Ok(bytes) => {
-                            crate::services::art::store_cover(&addr, port, &game.id, &bytes);
-                            if hand_over(bytes).is_err() {
-                                return;
+                let bytes = crate::services::art::cached_cover(&addr, port, &game.id).or_else(|| {
+                    // Match `services::art`'s priority for old UI covers: portrait, then header, then hero.
+                    [&game.art.portrait, &game.art.header, &game.art.hero]
+                        .into_iter()
+                        .flatten()
+                        .find_map(|path| match library::fetch_art(&agent, &addr, mgmt, path) {
+                            Ok(bytes) => {
+                                crate::services::art::store_cover(&addr, port, &game.id, &bytes);
+                                Some(bytes)
                             }
-                            break;
-                        }
-                        Err(e) => tracing::debug!("console: art {path} for {}: {e}", game.id),
+                            Err(e) => {
+                                tracing::debug!("console: art {path} for {}: {e}", game.id);
+                                None
+                            }
+                        })
+                });
+                // A closed channel means the shelf moved on; stop fetching for it.
+                if let Some(bytes) = bytes {
+                    if sink.push(game.id.clone(), bytes).is_err() {
+                        return;
                     }
                 }
             }
+            sink.finish();
         })
         .ok();
     rx
+}
+
+/// Max time per tick to adopt art. ~33ms = 2 frames @ 60Hz; burst costs a visible beat, not stall.
+const ART_DRAIN_BUDGET: Duration = Duration::from_millis(8);
+
+/// Timeout for fetched covers waiting for shelf's decode scale. Bounds the wait if shelf never opens.
+const ART_SCALE_WAIT: Duration = Duration::from_secs(5);
+
+/// Fetched covers: decoded at shelf's scale if published, parked otherwise. Parking avoids
+/// render-thread decode (~50ms per poster on this `SoC`).
+struct ArtSink<'a> {
+    tx: &'a std::sync::mpsc::Sender<(String, ArtItem)>,
+    library: &'a pf_console_ui::LibraryShared,
+    parked: Vec<(String, Vec<u8>)>,
+}
+
+impl ArtSink<'_> {
+    /// Park until scale arrives, maintaining order. Flush any pending first.
+    fn push(&mut self, id: String, bytes: Vec<u8>) -> Result<(), std::sync::mpsc::SendError<(String, ArtItem)>> {
+        let Some(k) = self.library.art_scale() else {
+            self.parked.push((id, bytes));
+            return Ok(());
+        };
+        self.flush(Some(k))?;
+        self.tx.send((id, decode_at(&bytes, Some(k))))
+    }
+
+    /// Timeout for scale; fallback to encoded if shelf never opens.
+    fn finish(&mut self) {
+        let waited = Instant::now();
+        while self.library.art_scale().is_none() && !self.parked.is_empty() {
+            if waited.elapsed() >= ART_SCALE_WAIT {
+                tracing::debug!(
+                    "console: art scale never published — {} covers go encoded",
+                    self.parked.len()
+                );
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(16));
+        }
+        let _ = self.flush(self.library.art_scale());
+    }
+
+    fn flush(&mut self, k: Option<f64>) -> Result<(), std::sync::mpsc::SendError<(String, ArtItem)>> {
+        for (id, bytes) in std::mem::take(&mut self.parked) {
+            self.tx.send((id, decode_at(&bytes, k)))?;
+        }
+        Ok(())
+    }
+}
+
+/// Decode at scale, or hand over encoded for shell to size.
+fn decode_at(bytes: &[u8], k: Option<f64>) -> ArtItem {
+    k.and_then(|k| pf_console_ui::decode_poster_off_thread(bytes, k))
+        .map_or_else(|| ArtItem::Encoded(bytes.to_vec()), ArtItem::Decoded)
 }
 
 /// The wire catalog in the shell's terms.

--- a/src/runtime/console_flow.rs
+++ b/src/runtime/console_flow.rs
@@ -116,6 +116,20 @@ pub(super) fn run(
     let mut nav = MenuNav::new();
     let mut sample = MenuSample::default();
     let mut pads: Vec<PadInfo> = Vec::new();
+    // The open pad's name, or `None` when what SDL has open is the Magic Remote. Refreshed on
+    // hotplug only to avoid per-frame string allocations.
+    let mut pad_name: Option<String> = controller
+        .as_ref()
+        .map(sdl2::controller::GameController::name)
+        .filter(|n| !crate::platform::webos::gamepad::is_tv_remote(n));
+    // Both answers SDL's device list can give, sampled on the same hotplug events. Polling them
+    // per frame walked every device and allocated a name for each.
+    let mut pad_connected = crate::platform::webos::gamepad::any_pad_connected(game_controller);
+    let mut pad_kind = crate::platform::webos::gamepad::detect_type(game_controller);
+    // What the shell was told last frame, so `pads` is rebuilt only when it changes.
+    // `None` means "not built yet": an inner `None` is a real answer (no pad), so a plain
+    // `Option` could not tell the two apart and left a removed pad's legend standing.
+    let mut last_pref: Option<Option<punktfunk_core::config::GamepadPref>> = None;
     let mut menu_out: Vec<MenuEvent> = Vec::new();
     let mut last_input = Instant::now();
     let mut home_held = false;
@@ -187,6 +201,15 @@ pub(super) fn run(
                             Err(e) => tracing::warn!("controller open failed: {e}"),
                         }
                     }
+                    resample_pads(
+                        game_controller,
+                        controller,
+                        &mut pad_name,
+                        &mut pad_connected,
+                        &mut pad_kind,
+                    );
+                    // The legend describes the handle, so it is rebuilt with it.
+                    last_pref = None;
                 }
                 Event::ControllerDeviceRemoved { which, .. } => {
                     // Only the pad we hold: webOS enumerates the Magic Remote as a controller
@@ -198,6 +221,14 @@ pub(super) fn run(
                         nav.reset();
                         sample = MenuSample::default();
                     }
+                    resample_pads(
+                        game_controller,
+                        controller,
+                        &mut pad_name,
+                        &mut pad_connected,
+                        &mut pad_kind,
+                    );
+                    last_pref = None;
                 }
                 Event::KeyDown {
                     keycode: Some(k),
@@ -287,9 +318,7 @@ pub(super) fn run(
         // The controller SDL has open, unless it is the TV's own remote — webOS enumerates the
         // Magic Remote as a game controller, and treating it as a pad would claim a pad that is
         // not in the room. Its buttons still reach the shell, as keys.
-        let pad = controller
-            .as_ref()
-            .filter(|c| !crate::platform::webos::gamepad::is_tv_remote(&c.name()));
+        let pad = controller.as_ref().filter(|_| pad_name.is_some());
         // The pad through the shared synthesizer, so repeats, dead zone and hysteresis match
         // every other client rather than being re-invented here.
         if let Some(pad) = pad {
@@ -399,17 +428,19 @@ pub(super) fn run(
             idled = IDLE_FRAME_STEP;
         }
         let (w, h) = canvas.window().drawable_size();
-        pads.clear();
         // The switch, watched the way the cursor menus watch theirs: the shell's own
         // "Controller-optimized UI" row writes it, and under "With a controller" an unplugged
         // pad withdraws it without writing anything. Plain `Reenter` — `leave_for_classic`
         // would turn the switch off, and a pad going flat is not the user saying "off".
-        let state = store.snapshot();
-        // 🛑 The SAME expression `stream`'s menu loop enters on, not the open handle: a handle
-        // that went stale while a pad is still attached made the loop enter here, leave, and
-        // enter again forever, drawing no frame — a freeze on the way out of a stream.
-        let pad_connected = crate::platform::webos::gamepad::any_pad_connected(game_controller);
-        if !state.settings.gamepad_ui_active(pad_connected) {
+        // 🛑 `pad_connected`, not the open handle: a handle that went stale while a pad is still
+        // attached made the loop enter here, leave, and enter again forever, drawing no frame —
+        // a freeze on the way out of a stream. It is refreshed on the hotplug events below.
+        //
+        // Two fields, read in place: the whole-document clone `snapshot` does was allocating
+        // every known host and every string in it, once a frame, to answer them.
+        let (ui_active, stored_kind) =
+            store.with(|s| (s.settings.gamepad_ui_active(pad_connected), s.settings.gamepad_type()));
+        if !ui_active {
             tracing::info!("console: the controller UI no longer applies — back to the cursor menus");
             break 'ui UiOutcome::Reenter;
         }
@@ -417,22 +448,24 @@ pub(super) fn run(
         // LEGEND, and claiming a pad prints button marks for buttons that are not in the room.
         // It is also what the home screen reads to put Options and Settings on the d-pad
         // instead of on Y and X (`pads.is_empty()`).
-        // Automatic means "whatever is plugged in", so the legend asks SDL rather than
-        // printing the host's Xbox default over a DualSense. An explicit pick still wins:
-        // someone who chose a pad kind wants its glyphs whatever is attached.
         let pad_pref = pad.map(|_| {
-            let stored = state.settings.gamepad_type();
-            let kind = if stored == store::GamepadType::Auto {
-                crate::platform::webos::gamepad::detect_type(game_controller).unwrap_or(stored)
+            let kind = if stored_kind == store::GamepadType::Auto {
+                pad_kind.unwrap_or(stored_kind)
             } else {
-                stored
+                stored_kind
             };
             crate::core::settings::gamepad_pref(kind)
         });
-        if let (Some(pad), Some(pref)) = (pad, pad_pref) {
-            pads.push(pad_info(pad, pref));
+        // Rebuilt only when the legend it prints changes: every field but `pref` is fixed for
+        // the life of the handle, and building it allocated four strings a frame.
+        if last_pref != Some(pad_pref) {
+            last_pref = Some(pad_pref);
+            pads.clear();
+            if let (Some(name), Some(pref)) = (pad_name.clone(), pad_pref) {
+                pads.push(pad_info(name, pref));
+            }
         }
-        let label = pads.first().map(|p| p.name.clone());
+        let label = pad_name.as_deref();
         {
             let surface = console_gl.surface(w, h)?;
             console.frame(
@@ -446,7 +479,7 @@ pub(super) fn run(
                 // box and the screens run off the bottom instead of reflowing. Growing this
                 // one is a kit change, not a client change.
                 &Viewport::plain(w, h),
-                label.as_deref(),
+                label,
                 pad_pref,
                 &pads,
             );
@@ -622,9 +655,9 @@ fn pad_sample(pad: &GameController) -> MenuSample {
 /// The controller chip's entry. Battery and rumble are reported absent rather than guessed:
 /// this client reads neither here, and the actions that would use them
 /// (`ConsoleCmd::PadAction`) are Android's `InputDevice` API.
-fn pad_info(pad: &GameController, pref: punktfunk_core::config::GamepadPref) -> PadInfo {
+fn pad_info(name: String, pref: punktfunk_core::config::GamepadPref) -> PadInfo {
     PadInfo {
-        name: pad.name(),
+        name,
         key: "0".into(),
         pref,
         steam_virtual: false,
@@ -633,6 +666,28 @@ fn pad_info(pad: &GameController, pref: punktfunk_core::config::GamepadPref) -> 
         forwarded: false,
         rumble: false,
     }
+}
+
+/// Re-read everything SDL's device list can tell us, on the hotplug events that change it.
+///
+/// Every answer here walks the device list and allocates a name per device, so it is worth
+/// asking only when a pad actually arrives or leaves — and the events are exact, where a timer
+/// would only approximate them. `pad_name` is `None` when what is open is the TV's own remote:
+/// webOS enumerates the Magic Remote as a controller, and claiming it would print pad glyphs
+/// for buttons that are not in the room.
+fn resample_pads(
+    subsystem: &sdl2::GameControllerSubsystem,
+    controller: &Option<GameController>,
+    pad_name: &mut Option<String>,
+    connected: &mut bool,
+    kind: &mut Option<store::GamepadType>,
+) {
+    *pad_name = controller
+        .as_ref()
+        .map(sdl2::controller::GameController::name)
+        .filter(|n| !crate::platform::webos::gamepad::is_tv_remote(n));
+    *connected = crate::platform::webos::gamepad::any_pad_connected(subsystem);
+    *kind = crate::platform::webos::gamepad::detect_type(subsystem);
 }
 
 /// Window pixels to surface pixels. One is what SDL reports pointer events in, the other is

--- a/src/runtime/overlay.rs
+++ b/src/runtime/overlay.rs
@@ -10,7 +10,7 @@ use pf_console_ui::theme::{self, Fonts, PanelStroke, W};
 use skia_safe::{Color4f, RRect, Rect};
 
 use crate::app::draw::dialog::{self, Motion};
-use crate::app::draw::{line_h, wrap, Frame};
+use crate::app::draw::{alpha_layer, line_h, wrap, Frame};
 use crate::app::screens::confirm::{Confirm, Tone};
 use crate::console::ConsoleGl;
 use crate::core::event::MenuEvent;
@@ -81,7 +81,7 @@ pub(super) fn stats(f: &Frame<'_>, lines: &[String], hint: &str, alpha: f32) {
     let h = stride * lines.len() as f32 + line_h(hint_size) as f32 + 2.0 * STATS_PAD * k;
     let card = Rect::from_xywh(f.w - STATS_INSET * k - w, STATS_INSET * k, w, h);
     let c = f.canvas;
-    c.save_layer_alpha_f(Some(card), alpha);
+    alpha_layer(c, card, alpha);
     c.draw_rrect(
         RRect::new_rect_xy(card, STATS_CORNER * k, STATS_CORNER * k),
         &theme::fill(crate::app::draw::surface()),
@@ -141,7 +141,7 @@ pub(super) fn log(f: &Frame<'_>, lines: &[String], alpha: f32) {
     let h = stride * rows.len().max(1) as f32 + 2.0 * LOG_PAD * k;
     let strip = Rect::from_xywh(0.0, f.h - h, f.w, h);
     let c = f.canvas;
-    c.save_layer_alpha_f(Some(strip), alpha);
+    alpha_layer(c, strip, alpha);
     c.draw_rect(strip, &theme::fill(crate::app::draw::surface()));
     for (i, (dx, text, tone)) in rows.iter().enumerate() {
         f.fonts.draw(
@@ -164,7 +164,7 @@ pub(super) fn toast(f: &Frame<'_>, text: &str, alpha: f32) {
     let h = line_h(size) as f32 + 2.0 * TOAST_PAD_Y * k;
     let pill = Rect::from_xywh((f.w - w) / 2.0, TOAST_TOP * k, w, h);
     let c = f.canvas;
-    c.save_layer_alpha_f(Some(pill), alpha);
+    alpha_layer(c, pill, alpha);
     c.draw_rrect(
         RRect::new_rect_xy(pill, h / 2.0, h / 2.0),
         &theme::fill(crate::app::draw::surface()),

--- a/src/services/art.rs
+++ b/src/services/art.rs
@@ -270,8 +270,57 @@ pub fn reconcile_host_caches(known: &[crate::core::model::KnownHost]) {
 /// this loader does and so cannot use the `.raw` beside it. One cache either way: whichever UI
 /// browsed last warms the other, and the same per-host budget and orphan sweep bound both.
 pub(crate) fn cached_cover(host: &str, port: u16, game_id: &str) -> Option<Vec<u8>> {
-    let path = cache_path(&cache_dir(host, port), game_id, ArtKind::Card, false);
-    std::fs::read(path).ok().filter(|b| !b.is_empty())
+    let dir = cache_dir(host, port);
+    let bytes = std::fs::read(cache_path(&dir, game_id, ArtKind::Card, false))
+        .ok()
+        .filter(|b| !b.is_empty())?;
+    // An entry written by a build that cached full-size covers costs ~99 ms to decode, every
+    // visit, forever. Shrink it the first time it is read and this visit is the last one.
+    let Some(shrunk) = shrink_cover(&bytes) else {
+        return Some(bytes);
+    };
+    write_cover(&dir, game_id, &shrunk);
+    Some(shrunk)
+}
+
+/// The size a cached cover is kept at. No client draws one larger than a grid card, which is
+/// a few hundred pixels wide on a 1080p panel even zoomed; everything above this is decode time
+/// nobody sees, paid on every visit.
+const COVER_MAX_W: u32 = 480;
+const COVER_MAX_H: u32 = 720;
+/// Re-encode quality. A cover is photographic and is seen from a couch.
+const COVER_QUALITY: u8 = 85;
+
+/// A cover re-encoded small, as JPEG. `None` when the bytes will not decode or are already
+/// within the cap in both axes AND already JPEG — nothing to gain then.
+///
+/// Only task that actually removes work: a full-size PNG costs ~99 ms to decode here,
+/// re-decoded on every library visit. Sixty of them = six seconds, three-core CPU.
+/// Re-encoded once at draw size, the same cover decodes in a fraction — and as JPEG,
+/// the shell's scaled-decode path takes it (PNG never allowed).
+fn shrink_cover(bytes: &[u8]) -> Option<Vec<u8>> {
+    // Already a small JPEG: nothing to gain, and re-encoding would only lose a generation.
+    let small = image::ImageReader::new(std::io::Cursor::new(bytes))
+        .with_guessed_format()
+        .ok()
+        .filter(|r| r.format() == Some(image::ImageFormat::Jpeg))
+        .and_then(|r| r.into_dimensions().ok())
+        .is_some_and(|(w, h)| w <= COVER_MAX_W && h <= COVER_MAX_H);
+    if small {
+        return None;
+    }
+    let img = image::load_from_memory(bytes).ok()?;
+    let img = if img.width() > COVER_MAX_W || img.height() > COVER_MAX_H {
+        img.resize(COVER_MAX_W, COVER_MAX_H, image::imageops::FilterType::Triangle)
+    } else {
+        img
+    };
+    let mut out = Vec::new();
+    let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(std::io::Cursor::new(&mut out), COVER_QUALITY);
+    // `into_rgb8`, not `to_rgb8`: `img` is owned and dead after this, so the buffer moves
+    // instead of being copied.
+    img.into_rgb8().write_with_encoder(encoder).ok()?;
+    Some(out)
 }
 
 /// Store encoded cover bytes, then bring the host's directory back inside its budget.
@@ -281,14 +330,24 @@ pub(crate) fn store_cover(host: &str, port: u16, game_id: &str, bytes: &[u8]) {
     if std::fs::create_dir_all(&dir).is_err() {
         return;
     }
-    let path = cache_path(&dir, game_id, ArtKind::Card, false);
+    // Shrunk on the way in, so what every later visit decodes is already small — this is the
+    // single funnel both UIs' covers pass through, which is why it belongs here rather than at
+    // one caller.
+    let shrunk = shrink_cover(bytes);
+    write_cover(&dir, game_id, shrunk.as_deref().unwrap_or(bytes));
+    prune_cache(&dir);
+}
+
+/// The cached bytes for `game_id`, without the prune — the caller decides when the directory is
+/// worth walking.
+fn write_cover(dir: &std::path::Path, game_id: &str, bytes: &[u8]) {
+    let path = cache_path(dir, game_id, ArtKind::Card, false);
     let tmp = path.with_extension("tmp");
     // Write-then-rename, like the raw path above: a kill mid-write must not leave a truncated
     // file that later reads as a cover.
     if std::fs::write(&tmp, bytes).is_ok() && std::fs::rename(&tmp, &path).is_err() {
         let _ = std::fs::remove_file(&tmp);
     }
-    prune_cache(&dir);
 }
 
 fn cache_path(dir: &std::path::Path, game_id: &str, kind: ArtKind, raw: bool) -> PathBuf {
@@ -520,7 +579,16 @@ impl ArtLoader {
             return;
         }
         requested.insert(game_id.to_string());
-        let paths = paths();
+        let mut paths = paths();
+        // Dropped before anything is fetched: a format this build cannot decode costs a full
+        // download and a cache write to end in `load_from_memory` failing.
+        paths.retain(|p| {
+            let keep = decodable(p);
+            if !keep {
+                tracing::debug!("art: {game_id} skipping {p} — not a format this build decodes");
+            }
+            keep
+        });
         if paths.is_empty() {
             return;
         }
@@ -696,6 +764,18 @@ fn worker(config: &WorkerConfig, rx: &Receiver<ArtRequest>, tx: &Sender<ArtLoade
             }
         };
 
+        // Sniffed before the decoder is handed 8 MB it will refuse: the extension filter at
+        // queue time cannot see through a content-negotiating CDN, so the bytes are the last
+        // word on what actually arrived.
+        if !decodable_bytes(&bytes) {
+            tracing::warn!(
+                "art: {} served a format this build cannot decode ({} bytes) — dropping it",
+                req.game_id,
+                bytes.len()
+            );
+            let _ = std::fs::remove_file(&cached);
+            continue;
+        }
         let decoded = match image::load_from_memory(&bytes) {
             Ok(d) => d,
             Err(e) => {
@@ -741,6 +821,65 @@ fn worker(config: &WorkerConfig, rx: &Receiver<ArtRequest>, tx: &Sender<ArtLoade
         }
         if tx.send(loaded).is_err() {
             return;
+        }
+    }
+}
+
+/// Formats the `image` crate decodes (from `Cargo.toml`: `png`, `jpeg`).
+/// Anything else fails no matter how well it downloads.
+const DECODABLE: [&str; 4] = ["png", "jpg", "jpeg", "jfif"];
+
+/// Whether to fetch `path`. An undecidable extension skips a wasted download;
+/// missing extension is fine (hosts serve extensionless art; bytes decide).
+fn decodable(path: &str) -> bool {
+    let tail = path
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(path)
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(path);
+    match tail.rsplit_once('.') {
+        // A trailing dot is not a claim about format.
+        Some((_, ext)) if !ext.is_empty() => DECODABLE.iter().any(|k| ext.eq_ignore_ascii_case(k)),
+        _ => true,
+    }
+}
+
+/// Whether `bytes` are a format this build decodes, from the bytes themselves. The URL test
+/// above cannot see through a content-negotiating CDN, so this is the last word.
+fn decodable_bytes(bytes: &[u8]) -> bool {
+    image::guess_format(bytes).is_ok_and(|f| matches!(f, image::ImageFormat::Png | image::ImageFormat::Jpeg))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decodable, decodable_bytes};
+
+    #[test]
+    fn only_formats_this_build_decodes_are_fetched() {
+        for ok in [
+            "/appasset?asset=box-art",
+            "https://cdn.example/covers/1234.jpg",
+            "cover.PNG",
+            "a.jpeg?w=600&h=900",
+            "art/cover.",
+        ] {
+            assert!(decodable(ok), "{ok}");
+        }
+        assert!(decodable_bytes(&[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a, 0, 0]));
+        assert!(decodable_bytes(&[0xff, 0xd8, 0xff, 0xe0, 0, 0]));
+        // "RIFF....WEBP", the 8 MB the CX downloaded and threw away.
+        assert!(!decodable_bytes(b"RIFF\0\0\0\0WEBPVP8 "));
+        assert!(!decodable_bytes(b""));
+        for no in [
+            "https://cdn.example/covers/1234.webp",
+            "cover.AVIF",
+            "hero.gif#frag",
+            "icon.svg",
+            "tile.bmp?v=2",
+        ] {
+            assert!(!decodable(no), "{no}");
         }
     }
 }

--- a/src/services/library.rs
+++ b/src/services/library.rs
@@ -200,6 +200,10 @@ pub fn load_games_async(
 /// host-relative `art_path` (one of `GameEntry::art`'s fields), reusing an
 /// already-built `agent` (see `fetch_games`) to avoid a fresh mTLS handshake per
 /// cover. Decoding happens in `art.rs`, off this module's REST concern.
+/// Content types this build can decode. CDNs ignoring this header (Steam) send WebP, caught
+/// from the header before body downloads. `q=0.1` on wildcard keeps hosts that ignore headers working.
+const ART_ACCEPT: &str = "image/jpeg,image/png,image/*;q=0.1";
+
 pub fn fetch_art(agent: &ureq::Agent, addr: &str, mgmt_port: u16, art_path: &str) -> Result<Vec<u8>, LibraryError> {
     // Some hosts hand back a full external URL (e.g. a SteamGridDB CDN link) instead
     // of a host-relative path — that can't go through the pinned agent (wrong CA,
@@ -208,24 +212,39 @@ pub fn fetch_art(agent: &ureq::Agent, addr: &str, mgmt_port: u16, art_path: &str
         return fetch_external_art(art_path);
     }
     let url = format!("{}{art_path}", base_url(addr, mgmt_port));
-    match agent.get(url.as_str()).call() {
-        Ok(mut resp) => resp
-            .body_mut()
-            .read_to_vec()
-            .map_err(|e| LibraryError::BadReply(format!("read art body: {e}"))),
+    match agent.get(url.as_str()).header("Accept", ART_ACCEPT).call() {
+        Ok(mut resp) => read_art_body(&mut resp, art_path),
         Err(e) => Err(classify(e)),
     }
+}
+
+/// The response body, unless `Content-Type` says this build cannot decode it.
+///
+/// Header arrives before body, so early rejection saves downloads from CDNs that ignore
+/// [`ART_ACCEPT`] (e.g. Steam's 8.7 MB covers). Type-less bodies are read; the bytes will tell.
+fn read_art_body(resp: &mut ureq::http::Response<ureq::Body>, what: &str) -> Result<Vec<u8>, LibraryError> {
+    let kind = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.split(';').next().unwrap_or(v).trim().to_ascii_lowercase());
+    if let Some(kind) = kind {
+        if kind.starts_with("image/") && !matches!(kind.as_str(), "image/jpeg" | "image/png") {
+            tracing::debug!("art: {what} offered {kind} — not fetching a format this build cannot decode");
+            return Err(LibraryError::BadReply(format!("undecodable art type {kind}")));
+        }
+    }
+    resp.body_mut()
+        .read_to_vec()
+        .map_err(|e| LibraryError::BadReply(format!("read art body: {e}")))
 }
 
 /// Fetches art from a full external URL with the system's default CA trust (no
 /// client cert) — the host's pinned `agent` would reject this CA.
 fn fetch_external_art(url: &str) -> Result<Vec<u8>, LibraryError> {
     let agent = ureq::Agent::new_with_defaults();
-    match agent.get(url).call() {
-        Ok(mut resp) => resp
-            .body_mut()
-            .read_to_vec()
-            .map_err(|e| LibraryError::BadReply(format!("read external art body: {e}"))),
+    match agent.get(url).header("Accept", ART_ACCEPT).call() {
+        Ok(mut resp) => read_art_body(&mut resp, url),
         Err(e) => Err(classify(e)),
     }
 }

--- a/src/services/store/console.rs
+++ b/src/services/store/console.rs
@@ -46,6 +46,13 @@ impl ConsoleStore {
         self.state.lock().expect(POISONED).clone()
     }
 
+    /// Read part of the document in place. The whole-document [`Self::snapshot`] clone costs
+    /// every known host and every string in it, which is a lot to pay for two booleans - and
+    /// the console's render loop asks once a frame.
+    pub fn with<T>(&self, read: impl FnOnce(&Persisted) -> T) -> T {
+        read(&self.state.lock().expect(POISONED))
+    }
+
     /// Change the document and persist all of it. The host-list commands (save, edit, forget)
     /// go through here for the same reason [`SettingsStore::save`] does: one writer, whole
     /// document, so a host edit and a settings change cannot race into disagreeing files.

--- a/taskfiles/toolchain.yml
+++ b/taskfiles/toolchain.yml
@@ -1,6 +1,6 @@
 version: '3'
 
-# Match the root Taskfile: suppress go-task's per-command echo.
+# Suppress command echo (like root Taskfile).
 silent: true
 
 vars:
@@ -81,11 +81,10 @@ tasks:
       - cargo install --locked --git https://github.com/webosbrew/ares-cli-rs ares-package
 
   ares-device:
-    # Kept separate from ares-package: these link libssh/OpenSSL/GTK and take
-    # minutes to build, and only `deploy` needs them — CI packages without them.
+    # Separate; links SSH/TLS/GTK, slow build, only deploy uses.
     desc: >-
-      Install the ares-cli-rs device tools (setup-device/install/launch) that
-      deploy uses instead of raw ssh/scp, if they aren't already on PATH
+      Install ares-cli-rs device tools (setup-device/install/launch) for deploy,
+      if not already on PATH
     status:
       - command -v ares-setup-device
       - command -v ares-install
@@ -108,20 +107,13 @@ tasks:
         mkdir -p "$STAGE_DIR/bin" "$STAGE_DIR/lib"
         cp target/{{.TARGET}}/release/punktfunk-webos "$STAGE_DIR/bin/"
         cp -L {{.SYSROOT}}/usr/lib/libSDL2-2.0.so.0 "$STAGE_DIR/lib/libSDL2-2.0.so.0"
-        # No libstdc++ here: it is linked statically (scripts/cc-shim.sh). A bundled one wins
-        # over the TV's through DT_RPATH and is then used by the TV's own libraries too, which
-        # breaks the moment a firmware wants a newer GLIBCXX than this SDK ever had.
-        # Skia calls FreeType 2.13's COLRv1 and variable-font entry points (FT_Get_Paint,
-        # FT_Palette_Select, FT_Set_Default_Properties); webOS ships a FreeType that has them
-        # only from 9.0, and below that the app dies before `main` the same way. Ships on every
-        # firmware so one binary covers the whole range.
+        # libstdc++ linked statically; bundled versions break TV's DT_RPATH.
+        # Bundle FreeType 2.13 COLRv1 support; webOS 9.0+ has entry points Skia needs.
         cp -L {{.SYSROOT}}/usr/lib/libfreetype.so.6 "$STAGE_DIR/lib/libfreetype.so.6"
         {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-strip \
           "$STAGE_DIR/bin/punktfunk-webos" "$STAGE_DIR/lib/libSDL2-2.0.so.0" \
           "$STAGE_DIR/lib/libfreetype.so.6"
-        # PROBES=1 ships the headless diagnostic CLI (`pfprobe`) alongside the app, for running
-        # over SSH against a host. Off by default: it is a quarter megabyte the store package has
-        # no use for, and nothing in the app launches it.
+        # PROBES=1 ships pfprobe (diagnostics CLI); omit by default (250KB, SSH-only).
         if [ -n "{{.PROBES}}" ]; then
           cp "target/{{.TARGET}}/release/pfprobe" "$STAGE_DIR/bin/"
           {{.NDK_DIR}}/bin/arm-webos-linux-gnueabi-strip "$STAGE_DIR/bin/pfprobe"
@@ -138,8 +130,7 @@ tasks:
         mkdir -p dist
         ares-package "$STAGE_DIR" -o dist --force-arch arm
 
-        # Homebrew manifest is generated in CI by webosbrew-toolbox-gen-manifest
-        # (.github/workflows/webosbrew.yml), not here.
+        # Homebrew manifest generated in CI (webosbrew-toolbox-gen-manifest).
         if [ "$PKG_VERSION" != "$APP_VERSION" ]; then
           mv "dist/${APP_ID}_${APP_VERSION}_arm.ipk" "dist/${APP_ID}_${PKG_VERSION}_arm.ipk"
         fi


### PR DESCRIPTION
Menus stutter on a CX. Measured on the TV: the client's own painting is ~1.5ms/frame and almost all the rest is GPU raster, but cover art decode was one real client-side cost — ~99ms per cover, on every library visit, on the render thread.

**Art.** Covers are now cached downscaled (480x720 JPEG), which halves decode to ~49ms and lets the shell's scaled-decode path fire at all — it only works on JPEG. Old cache entries shrink in place on first read, decoding moved off the render thread, and undecodable art is rejected by Accept header, Content-Type and magic bytes instead of being downloaded in full (one Steam cover was an 8.7MB WebP, fetched every run).

**Drawing.** Covers draw as one AA rounded-rect with an image shader rather than an image inside an AA rounded clip, which cost a coverage mask per card per frame. The focus halo was a mask-filter blur every frame on the focused card and is now a baked nine-patch sharing a helper with the card shadow. Group-alpha layers are skipped at alpha 1.0, keeping the bounds clip so the result is pixel-identical (there's a test).

**Controller shell.** Stopped cloning the whole settings document every frame to read two bools, stopped walking SDL's device list twice a frame (it's refreshed on the controller add/remove events the loop already receives), and moved the art-cache directory walk on host-forget off the render thread.

The remaining stutter is GPU raster inside `pf-console-ui` and can't be fixed from here. Reduced-resolution rendering was tried and rejected as too soft on a TV. Re-encoding PNG covers to JPEG loses a generation, judged worth it against seconds of decode per visit. No config or migration changes — the cover cache upgrades itself.
