### PR TITLE
Refine frosted glass and keep modal backdrops in sync

### DIFF
--- a/src/app/draw/card_material.rs
+++ b/src/app/draw/card_material.rs
@@ -1,63 +1,29 @@
-//! The lit surface of the frosted card — its rim and its face: the `SkSL` and the one function
-//! that builds its shader.
-//!
-//! Split out of [`super::glass`] because it is the only part of the material written in
-//! another language — the shader source stays whole and adjacent to the uniforms it declares.
+//! Frosted-card surface lighting and its shader uniforms.
 
 use pf_console_ui::theme;
 use skia_safe::{Canvas, RRect, Rect};
 
-/// How far in from the edge the rim ramp reaches, design units. Past ~40 it covers enough of
-/// the card to read as shading rather than as an edge; kept narrow so it reads as a chamfer.
-const CARD_BEVEL: f32 = 14.0;
-/// The lit surface of the liquid-glass material, ported from plx-native's `shaders/fs_glass.frag`.
-///
-/// THE SDF THE ROUNDED RECT ALREADY NEEDS IS THE WHOLE EFFECT. The distance that rounds the
-/// corners is exactly the "how deep into the bevel am I" term, and the analytic gradient of
-/// the same field is the surface normal to light along.
-///
-/// Three parts make it up:
-///  - A DIRECTIONAL EDGE LIGHT, not a uniform ring. A slab lit from above has a bright top
-///    chamfer and a dark bottom one, and that asymmetry is most of what says "solid object at
-///    an angle" rather than "rectangle with a glow". The lit side goes white, the shaded side
-///    black, so a dark edge can exist at all — an added near-black rim adds near-nothing.
-///  - A HAIRLINE SPECULAR, a couple of pixels off the edge.
-///  - A DIFFUSION GRADIENT over the whole face, with a GRAIN over it. The backdrop under the
-///    card comes back up from a downscaled 8-bit blur, so its smooth regions land as visible
-///    steps; a dither of a couple of levels is what breaks them, and the same noise is what
-///    keeps this gradient from banding in its turn.
-///
-/// NOT here: the lens, plx's part 1 — the refraction that displaces the backdrop sample
-/// outward along the normal. That one needs the blurred backdrop as a shader INPUT, and the
-/// only way to get it (`SkImageFilters::RuntimeShader` as the layer's backdrop) sampled to
-/// transparent in this app's coordinate space, which `mix(0, frost, .72)` turned into a solid
-/// frost-coloured card — the "not transparent" regression. This draws OVER the frost instead
-/// and samples nothing, so it cannot reintroduce that.
+/// Broad, faint edge lighting in design units.
+const CARD_BEVEL: f32 = 20.0;
+/// Drawn over the frost without sampling the backdrop; backdrop shader sampling previously
+/// returned transparent pixels in this coordinate space.
 const CARD_SKSL: &str = r#"
 uniform float2 u_c;
-uniform float2 u_ch;
+uniform float2 u_inner;
 uniform float  u_r;
-// Reciprocals inverted on the CPU rather than divided here: 1/bevel for the depth ramp,
-// and 1/(2*u_ch.y) for the face gradient.
+// CPU-computed reciprocals of bevel width and card height.
 uniform float  u_ibevel;
 uniform float  u_iheight;
 
-// Deliberately faint: the rim states the card's edge, the frost states the material.
 const float2 LIGHT = float2(-0.35, -0.94);
-const float EDGE = 0.02;
-const float DARK = 0.015;
-const float SPEC = 0.025;
-// The face: a top-lit sheen and a floor shade, wide enough to read as diffusion through the
-// material rather than as a second edge.
-const float SHEEN = 0.03;
-const float FLOOR = 0.04;
-// Dither amplitude, peak half this. About two 8-bit levels: enough to dissolve the upscaled
-// backdrop's steps, under the threshold where it reads as grain in its own right on a
-// television — which is where a wider one lands, contouring or not.
+const float EDGE = 0.016;
+const float DARK = 0.010;
+const float SHEEN = 0.028;
+const float FLOOR = 0.030;
+// Dither masks banding in the upscaled 8-bit backdrop and face gradient.
 const float GRAIN = 0.024;
 
-// White noise rather than an interleaved gradient: IGN's structure rules the flat face
-// diagonally, and on a card this large that is its own artefact.
+// White noise avoids the diagonal patterns of interleaved gradient noise.
 float hash(float2 c) {
   float3 f = fract(c.xyx * float3(0.1031, 0.1030, 0.0973));
   f += dot(f, f.yzx + 33.33);
@@ -66,56 +32,42 @@ float hash(float2 c) {
 
 half4 main(float2 coord) {
   float2 p = coord - u_c;
-  float2 q = abs(p) - u_ch + u_r;
-  // Rounded-box SDF, but the sqrt only where a corner needs it: inside both edges the distance
-  // IS the larger coordinate, and that is the whole face. The same `q` is the analytic
-  // gradient, so the normal below costs nothing beyond a normalize.
+  float2 q = abs(p) - u_inner;
   float mq = max(q.x, q.y);
-  float d = (mq < 0.0 ? mq : length(max(q, 0.0))) - u_r;
+  bool corner = min(q.x, q.y) > 0.0;
+  float cornerLength = corner ? length(q) : 0.0;
+  float d = (corner ? cornerLength : mq) - u_r;
   if (d >= 1.0) { return half4(0.0); }
 
-  // Every term is a signed amount of light split into a white part and a black part: a
-  // premultiplied shader cannot emit negative light, and the split is also what hazes the face,
-  // since the alpha is the sum and the colour only the white.
-  //
-  // Squared on both sides so the ramp is long and neither end states an edge of its own.
-  float v = clamp(0.5 + p.y * u_iheight, 0.0, 1.0);
-  // The dither rides it, with no sign branch: per-pixel divergence buys nothing over two maxes.
+  // Split signed lighting into white and black contributions for premultiplied output.
+  float v = smoothstep(0.0, 1.0, 0.5 + p.y * u_iheight);
   float g = (hash(coord) - 0.5) * GRAIN;
   float white = SHEEN * (1.0 - v) * (1.0 - v) + max(g, 0.0);
   float dark = FLOOR * v * v + max(-g, 0.0);
 
-  // Past the bevel the card is flat face, and neither the rim terms nor the edge coverage
-  // reach it. That branch is what keeps the smoothsteps off the face; it is coherent across a
-  // tile, which is what pays for it.
+  // Skip edge lighting and coverage calculations across the flat interior.
   float t = 1.0 + d * u_ibevel;
   float cov = 1.0;
   if (t > 0.0) {
-    // A hairline specular in PIXELS off the edge, not as a fraction of the bevel: its thinness
-    // is most of why it reads as an edge rather than as lighting.
-    white += smoothstep(-2.2, -0.9, d) * (1.0 - smoothstep(-0.6, 0.4, d)) * SPEC;
-
-    // The chamfer band peaks just INSIDE the rim: on it, coverage eats most of it and the line
-    // reads as aliasing instead of as a highlight. Outside the band no normal is needed, which
-    // keeps the normalize off the hairline-only and antialiasing pixels.
-    float band = smoothstep(0.55, 1.0, t) * (1.0 - smoothstep(0.94, 1.0, t));
+    // Peak inside the rim to avoid attenuating the highlight with edge coverage.
+    float band = smoothstep(0.35, 1.0, t) * (1.0 - smoothstep(0.90, 1.0, t));
     if (band > 0.0) {
-      // On a straight edge the gradient is the axis itself; only corners need normalizing.
-      float2 n = mq > 0.0 ? normalize(max(q, 0.0) + 1e-5) : (q.x > q.y ? float2(1.0, 0.0) : float2(0.0, 1.0));
-      float ndl = dot(sign(p) * n, LIGHT);
+      // Blend adjoining edge lights without boosting the curved contour.
+      float ndl = corner
+        ? dot(sign(p) * q, LIGHT) / (q.x + q.y)
+        : (q.x > q.y ? sign(p.x) * LIGHT.x : sign(p.y) * LIGHT.y);
       white += band * max(ndl, 0.0) * EDGE;
       dark += band * max(-ndl, 0.0) * DARK;
     }
     cov = 1.0 - smoothstep(-1.0, 1.0, d);
   }
 
-  // No clamp: every constant above is hundredths, so the sum cannot reach 1.
+  // Lighting amplitudes keep premultiplied alpha below 1 without clamping.
   return half4(half3(white * cov), half((white + dark) * cov));
 }
 "#;
 
-/// Compiled once per thread — `RuntimeEffect` is refcounted but not `Send`, so this cannot be
-/// a `OnceLock`. Each draw clones a handle rather than recompiling `SkSL`.
+/// Cached per thread because `RuntimeEffect` is not `Send`.
 fn shader(rect: Rect, corner: f32, k: f32) -> Option<skia_safe::Shader> {
     thread_local! {
         static EFFECT: std::cell::OnceCell<Option<skia_safe::RuntimeEffect>> =
@@ -129,21 +81,44 @@ fn shader(rect: Rect, corner: f32, k: f32) -> Option<skia_safe::Shader> {
         })
         .clone()
     })?;
+    let radius = corner * k;
     let mut b = skia_safe::runtime_effect::RuntimeShaderBuilder::new(effect);
     b.set_uniform_float("u_c", &[rect.center_x(), rect.center_y()])
-        .and(b.set_uniform_float("u_ch", &[rect.width() / 2.0, rect.height() / 2.0]))
-        .and(b.set_uniform_float("u_r", &[corner * k]))
+        .and(b.set_uniform_float("u_inner", &[rect.width() / 2.0 - radius, rect.height() / 2.0 - radius]))
+        .and(b.set_uniform_float("u_r", &[radius]))
         .and(b.set_uniform_float("u_ibevel", &[1.0 / (CARD_BEVEL * k)]))
         .and(b.set_uniform_float("u_iheight", &[1.0 / rect.height().max(1.0)]))
         .ok()?;
     b.make_shader(&skia_safe::Matrix::default())
 }
 
-/// A no-op if the shader fails to compile: graceful degradation to a chamferless card.
 pub(super) fn draw(canvas: &Canvas, rr: RRect, rect: Rect, corner: f32, k: f32) {
-    if let Some(shader) = shader(rect, corner, k) {
+    thread_local! {
+        static SHADER: std::cell::RefCell<Option<(Rect, f32, f32, skia_safe::Shader)>> =
+            const { std::cell::RefCell::new(None) };
+    }
+    let shader = SHADER.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        if !matches!(&*cache, Some((r, c, scale, _)) if *r == rect && *c == corner && *scale == k) {
+            *cache = shader(rect, corner, k).map(|shader| (rect, corner, k, shader));
+        }
+        cache.as_ref().map(|(_, _, _, shader)| shader.clone())
+    });
+    if let Some(shader) = shader {
         let mut p = theme::shaded();
         p.set_shader(shader);
         canvas.draw_rrect(rr, &p);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn material_compiles_and_accepts_tv_uniforms() {
+        for k in [0.5, 1.0, 2.0] {
+            assert!(shader(Rect::from_xywh(30.0, 40.0, 800.0 * k, 600.0 * k), 20.0, k).is_some());
+        }
     }
 }

--- a/src/app/draw/glass.rs
+++ b/src/app/draw/glass.rs
@@ -1,10 +1,5 @@
-//! The frosted-glass material every modal card is made of, ported from plx-native's
-//! `shaders/fs_glass.frag`.
-//!
-//! One seam: all five modal painters call [`glass_card`], so the material lives in one
-//! function rather than in each of them. A card frosts only when its [`Frame`] carries a
-//! [`Backdrop`] — the page as it stood before any modal drew. Without one it is the flat
-//! opaque card it has always been, which is what a frame over live video must stay.
+//! Shared frosted-glass modal material, ported from plx-native’s `shaders/fs_glass.frag`.
+//! Frames without a backdrop use an opaque card, including frames over live video.
 
 use pf_console_ui::theme::{self, PanelStroke};
 use skia_safe::{Canvas, RRect, Rect};
@@ -12,49 +7,23 @@ use skia_safe::{Canvas, RRect, Rect};
 use super::card_material;
 use super::{surface, Frame};
 
-/// The page as it stood before any modal drew, already blurred by [`blur_page`], for
-/// [`glass_card`].
-///
-/// A snapshot rather than `save_layer`'s `backdrop` filter, which is the obvious answer and did
-/// nothing here: the layer was composited but came back unfiltered, so the card read as
-/// transparent-but-sharp. An explicit image is also the only form the lens could ever use,
-/// since a refraction has to SAMPLE the backdrop at a displaced coordinate.
-///
-/// Blurred once by whoever takes the snapshot rather than per draw: the page behind a settled
-/// modal does not change, and re-running [`CARD_BLUR`] over the whole card every frame was most
-/// of what the card cost.
+/// Preblurred page snapshot shared by modal draws. Explicit snapshots avoid the
+/// unfiltered output observed with `save_layer` backdrop filters.
 #[derive(Clone, Copy)]
 pub(crate) struct Backdrop<'a> {
     pub page: &'a skia_safe::Image,
 }
 
-/// How far the backdrop is smeared under a frosted card, in design units (scaled by `k`).
-const CARD_BLUR: f32 = 20.0;
-/// Frost opacity. plx-native measured 0.72 as the legibility floor on a television: more
-/// transparent shows more backdrop and costs the contrast a couch reader needs, and the
-/// binding constraint is the text on the card, not the material. Tuned denser than that.
-const CARD_FROST: f32 = 0.93;
-/// The frosted face's tint, against the flat card's 0.16. The blurred page under it lifts the
-/// card, so the glass needs less accent to land at the same weight on screen. Through
-/// `card_face` rather than a plain multiply, so it keeps moving with the palette: on a dark
-/// field a lower tint sits nearer black, on a pale one nearer white.
+/// Blur sigma in design units, scaled by `k`.
+const CARD_BLUR: f32 = 28.0;
+const CARD_FROST: f32 = 0.88;
+/// The blurred backdrop lifts the face, so it needs less tint than the opaque card.
 const CARD_TINT: f32 = 0.10;
-/// How much smaller everything is blurred than it is drawn. A `CARD_BLUR` gaussian destroys
-/// detail far finer than the downscale does, so the two are indistinguishable while the blur
-/// covers a fraction of the pixels — and that is the difference between a modal appearing at
-/// once and visibly arriving, since a full 1080p blur cost hundreds of milliseconds on this
-/// chip. Both callers draw the result stretched back over the source rect.
-///
-/// Half, not the quarter it was: bilinear puts a slope break at every source texel on the way
-/// back up, and at a quarter those breaks are far enough apart to read as contour lines across
-/// the card. Doubling the source halves their spacing, which is what actually removes them —
-/// the grain in `card_material` dithers quantization, but contouring is real signal and no
-/// amount of noise hides it. Still a quarter of the pixels of a full-resolution blur.
+/// Half resolution keeps blur cost down without the visible interpolation contours
+/// of quarter resolution. Grain dithers quantization, but cannot hide those contours.
 const DOWNSCALE: i32 = 2;
 
-/// `img` blurred into a [`DOWNSCALE`]-smaller copy of itself on `target`, which is what decides
-/// whether the work lands on the GPU or the CPU: a GPU offscreen for the page, a raster one for a
-/// cover small enough that the deferred GPU filter would cost more than the blur.
+/// The target chooses GPU storage for pages or raster storage for small covers.
 fn downscaled_blur(
     target: impl FnOnce(i32, i32) -> Option<skia_safe::Surface>,
     img: &skia_safe::Image,
@@ -63,7 +32,6 @@ fn downscaled_blur(
     let (w, h) = ((img.width() / DOWNSCALE).max(1), (img.height() / DOWNSCALE).max(1));
     let mut surface = target(w, h)?;
     let mut p = theme::layer();
-    // Sigma comes down with the image, so the blur covers the same fraction of it.
     let sigma = sigma / DOWNSCALE as f32;
     p.set_image_filter(skia_safe::image_filters::blur(
         (sigma, sigma),
@@ -77,10 +45,7 @@ fn downscaled_blur(
     Some(surface.image_snapshot())
 }
 
-/// The page, downscaled and blurred once, ready to be a [`Backdrop`].
-///
-/// `surface` is the live one, only to spawn a compatible offscreen to downscale into: a surface
-/// made from it shares the GPU context, so this never leaves the device.
+/// Blur into a compatible offscreen surface to keep the page on the GPU.
 pub(crate) fn blur_page(surface: &mut skia_safe::Surface, page: &skia_safe::Image, k: f32) -> Option<skia_safe::Image> {
     let info = surface.image_info();
     downscaled_blur(
@@ -90,7 +55,6 @@ pub(crate) fn blur_page(surface: &mut skia_safe::Surface, page: &skia_safe::Imag
     )
 }
 
-/// The card's tint over a backdrop: the flat face, darker and translucent.
 fn frosted_face() -> skia_safe::Color4f {
     skia_safe::Color4f {
         a: CARD_FROST,
@@ -103,15 +67,8 @@ fn draw_card_backdrop(f: &Frame<'_>, bd: Backdrop<'_>, rr: RRect) {
     let p = theme::layer();
     canvas.save();
     canvas.clip_rrect(rr, None, Some(true));
-    // The page covers the whole surface, and the whole surface in layout units is the frame:
-    // taking the size from the frame rather than from the image keeps the two in step on both
-    // axes, which a single device-pixels-per-unit ratio cannot when the drawable's aspect is
-    // not the display mode's. The clip is what bounds the work to the card.
-    //
-    // Placed against the surface, not against the card: every painter translates by the modal
-    // rise before it gets here, so drawing at the frame's origin would slide the backdrop down
-    // with the card and show the page off-register for the whole open animation. The CTM's own
-    // translation, back in layout units, is exactly what has to come off again.
+    // Use both frame dimensions for nonuniform display scaling. Cancel modal-rise
+    // translation so the backdrop stays registered with the page during animation.
     let m = canvas.local_to_device_as_3x3();
     let (sx, sy) = (m.scale_x(), m.scale_y());
     let origin = if sx == 0.0 || sy == 0.0 {
@@ -119,8 +76,6 @@ fn draw_card_backdrop(f: &Frame<'_>, bd: Backdrop<'_>, rr: RRect) {
     } else {
         (-m.translate_x() / sx, -m.translate_y() / sy)
     };
-    // Linear: the page is a `DOWNSCALE`-smaller blur, so it comes back up scaled and default
-    // sampling would stair-step it.
     canvas.draw_image_rect_with_sampling_options(
         bd.page,
         None,
@@ -131,8 +86,7 @@ fn draw_card_backdrop(f: &Frame<'_>, bd: Backdrop<'_>, rr: RRect) {
     canvas.restore();
 }
 
-/// The card's top-to-bottom hairline: the flat panel's stroke, kept over the glass because the
-/// rim shader lights the chamfer but does not draw the edge itself.
+/// The rim shader lights the chamfer; this stroke defines the edge.
 fn card_hairline(canvas: &Canvas, rect: Rect, rr: RRect, k: f32) {
     let mut p = theme::shaded_stroke(k);
     p.set_shader(skia_safe::gradient::shaders::linear_gradient(
@@ -142,7 +96,7 @@ fn card_hairline(canvas: &Canvas, rect: Rect, rr: RRect, k: f32) {
         ),
         &skia_safe::gradient::Gradient::new(
             skia_safe::gradient::Colors::new_evenly_spaced(
-                &[theme::fg(0.22), theme::fg(0.04)],
+                &[theme::fg(0.18), theme::fg(0.035)],
                 skia_safe::TileMode::Clamp,
                 None,
             ),
@@ -153,9 +107,6 @@ fn card_hairline(canvas: &Canvas, rect: Rect, rr: RRect, k: f32) {
     canvas.draw_rrect(rr, &p);
 }
 
-/// A raised card. Over the menu it is a pane of frosted glass: the page behind it blurred,
-/// under a translucent face, with [`card_material`]'s light and hairline over that.
-/// Without a backdrop on the frame it stays the opaque face it has always been.
 pub(crate) fn glass_card(f: &Frame<'_>, rect: Rect, corner: f32) {
     let (canvas, k) = (f.canvas, f.k);
     let rr = RRect::new_rect_xy(rect, corner * k, corner * k);
@@ -166,30 +117,15 @@ pub(crate) fn glass_card(f: &Frame<'_>, rect: Rect, corner: f32) {
     };
     draw_card_backdrop(f, bd, rr);
     canvas.draw_rrect(rr, &theme::fill(frosted_face()));
-    // Skip theme::panel on frosted path: its glass fill would re-opacify the translucent face.
+    // theme::panel would re-opacify the translucent face.
     card_material::draw(canvas, rr, rect, corner, k);
     card_hairline(canvas, rect, rr, k);
 }
 
-/// Frost `window` over the cover already drawn at `art`, same blur and face as [`glass_card`].
-///
-/// The card menu grows out of one card, so the only thing behind it is that card's cover:
-/// blurring the image straight into the rect it was drawn at needs no surface grab and stays
-/// registered through the card's zoom. `false` when the blur could not be baked, and the caller
-/// draws the strip opaque. No rim and no grain: the strip is small enough that the upscale has
-/// no room to band.
-///
-/// The blurred cover is cached under `id`: the menu holds still once it is up, and re-blurring
-/// the same cover every frame is what made it lag on the way in.
-pub(crate) fn frost_over_art(
-    canvas: &Canvas,
-    id: &str,
-    img: &skia_safe::Image,
-    art: Rect,
-    window: Rect,
-    k: f32,
-) -> bool {
-    let Some(blurred) = blurred_cover(id, img, art, k) else {
+/// Frost the cover in its original rect to preserve registration during zoom.
+/// Returns false when blur fails so the caller can draw an opaque strip.
+pub(crate) fn frost_over_art(canvas: &Canvas, img: &skia_safe::Image, art: Rect, window: Rect, k: f32) -> bool {
+    let Some(blurred) = blurred_cover(img, art, k) else {
         return false;
     };
     canvas.draw_image_rect_with_sampling_options(&blurred, None, art, super::linear(), &theme::layer());
@@ -197,33 +133,23 @@ pub(crate) fn frost_over_art(
     true
 }
 
-/// The one cover the open card menu sits on, blurred. One entry, because one card menu is open
-/// at a time.
-///
-/// The blur is baked at the SOURCE image's scale so it looks the same once drawn into `art`, and
-/// the sigma is quantized because `art` is the focus-zoomed, pop-animated card rect: keyed on the
-/// exact float, every sub-pixel of that animation would re-bake, which is the cost this cache
-/// exists to avoid. A blur drawn stretched cannot show the rounding.
-fn blurred_cover(id: &str, img: &skia_safe::Image, art: Rect, k: f32) -> Option<skia_safe::Image> {
+/// One cached cover for the single open card menu. Quantize source-space sigma
+/// to avoid rebuilding the blur for every subpixel of the card's zoom animation.
+fn blurred_cover(img: &skia_safe::Image, art: Rect, k: f32) -> Option<skia_safe::Image> {
     thread_local! {
-        static COVER: std::cell::RefCell<Option<(String, i32, skia_safe::Image)>> =
+        static COVER: std::cell::RefCell<Option<(u32, i32, skia_safe::Image)>> =
             const { std::cell::RefCell::new(None) };
     }
     if art.width() <= 0.0 {
         return None;
     }
-    // Sigma in the source image's pixels: the canvas blur is CARD_BLUR * k across a card of
-    // `art.width()`, and the image is squeezed into that, so it scales by the same ratio.
     let sigma = (CARD_BLUR * k * img.width() as f32 / art.width()).round() as i32;
     COVER.with(|c| {
         let mut c = c.borrow_mut();
-        if !matches!(&*c, Some((cached, s, _)) if cached == id && *s == sigma) {
-            // Raster rather than a GPU offscreen: the source is already a raster image and a
-            // `DOWNSCALE`-smaller cover is cheap on the CPU, where a GPU filter would instead
-            // land, deferred, on the flush of the frame the menu opened. Cached, because at
-            // this downscale it is no longer free enough to redo per frame.
+        if !matches!(&*c, Some((image_id, s, _)) if *image_id == img.unique_id() && *s == sigma) {
+            // Raster blur avoids deferring GPU filter work to the menu's opening frame.
             *c = downscaled_blur(|w, h| skia_safe::surfaces::raster_n32_premul((w, h)), img, sigma as f32)
-                .map(|blurred| (id.to_owned(), sigma, blurred));
+                .map(|blurred| (img.unique_id(), sigma, blurred));
         }
         c.as_ref().map(|(_, _, img)| img.clone())
     })

--- a/src/app/draw/home.rs
+++ b/src/app/draw/home.rs
@@ -645,7 +645,7 @@ impl App {
         let frosted = menu.is_some()
             && (self.render.covers)
                 .get(&game.id)
-                .is_some_and(|img| glass::frost_over_art(c, pin_id, img, r, window, f.k));
+                .is_some_and(|img| glass::frost_over_art(c, img, r, window, f.k));
         if !frosted {
             c.draw_rect(window, &theme::fill(super::surface()));
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -587,16 +587,14 @@ impl App {
         self.handle_menu_event(MenuEvent::Back, screen_w, screen_h)
     }
 
-    /// Advances every live animation one tick — the eased scroll, the focus pop,
-    /// the modal fade — and reports whether anything is still moving (the main
-    /// loop keeps rendering while true). Expired animations report one final
-    /// `true` so their end state gets drawn.
-    pub fn tick_animations(&mut self) -> bool {
+    /// Returns `(redraw, backdrop_changed)`, including a final redraw when animations settle.
+    pub fn tick_animations(&mut self) -> (bool, bool) {
         let now = Instant::now();
         let dt = self.last_tick.map_or(ui::animation::SCROLL_STEP_TICK, |t| now - t);
         self.last_tick = Some(now);
-        let mut animating =
+        let mut backdrop_changed =
             ui::animation::ease_scroll(&mut self.render.grid.scroll, self.render.grid.scroll_target, dt);
+        let mut animating = false;
         if let Some(t) = self.render.focus_anim {
             let duration = match self.home_focus {
                 HomeFocus::Grid(_) => ui::animation::CARD_FOCUS_POP,
@@ -605,13 +603,12 @@ impl App {
             if t.elapsed() >= duration {
                 self.render.focus_anim = None;
             }
-            animating = true;
+            backdrop_changed = true;
         }
         if self.render.modal.fade.tick() {
             animating = true;
         }
-        // The hero loading screen keeps panning for as long as the launch is on screen,
-        // which (unlike the fade) is however long the handshake takes.
+        // Keep panning until the launch handshake finishes.
         if self
             .launch_anim
             .is_some_and(|t| t.elapsed() < hero::LAUNCH_FADE || self.render.hero.showing())
@@ -624,9 +621,9 @@ impl App {
             }
             animating = true;
         }
-        // Disarmed by `poll_press` (the render loop retires the dip), not here.
+        // `poll_press` disarms the dip.
         if self.render.press.armed() {
-            animating = true;
+            backdrop_changed = true;
         }
         if let Some((t, _, _)) = self.render.modal.switch_anim {
             if t.elapsed() >= ui::animation::FOCUS_POP {
@@ -634,23 +631,18 @@ impl App {
             }
             animating = true;
         }
-        // The lifetime outranks `home_status_sticky`: sticky defends a line against the
-        // library reload's clear, not against the clock.
-        // Only the expiring frame reports `animating` — the idle branch's `wait_for_event`
-        // still times out at `TICK_BUDGET`, so this runs on schedule without holding the
-        // SoC at 60Hz for the whole 15s.
+        // Idle polling handles deadlines without continuous redraws.
         if let Some((_, line)) = self
             .library_status_due
             .take_if(|(t, _)| t.elapsed() >= LIBRARY_STATUS_DELAY)
         {
-            // A fetch that already landed needs no line — and must not overwrite whatever
-            // `drain_games` put up instead. Only a line that actually goes up is a redraw.
+            // Preserve the status set by `drain_games` if the fetch has finished.
             if self.library_fetch_in_flight() {
                 self.set_home_status(Some(line), false);
-                animating = true;
+                backdrop_changed = true;
             }
         }
-        // Every frame of the fade out is a redraw; the frame after it is the clear.
+        // Sticky status survives library reloads, but still expires.
         if self
             .home_status_shown_at
             .is_some_and(|t| t.elapsed() >= HOME_STATUS_LIFETIME)
@@ -658,40 +650,33 @@ impl App {
             if self.home_status_alpha().is_none() {
                 self.set_home_status(None, false);
             }
-            animating = true;
+            backdrop_changed = true;
         }
-        // The held card's submenu: its rise, and the selection band's slide between rows.
-        // Both run off clocks on `CardMenu`, not off `focus_anim` — without reporting them
-        // here the loop parks in `wait_for_event` mid-rise (the auto-repeat KeyDowns the
-        // hold swallows set no `dirty`), and the panel finishes only when OK is released.
         if self.card_menu.as_mut().is_some_and(state::cardmenu::CardMenu::tick) {
-            animating = true;
+            backdrop_changed = true;
         }
         if self.render.grid.card_pops_running() || self.render.grid.reveal.dissolving() {
+            backdrop_changed = true;
+        }
+        if self.render.list.as_ref().is_some_and(|(_, l)| l.animating()) {
             animating = true;
         }
-        // The kit list and the two focus eases settle on their own clocks, past the pop.
-        if self.render.list.as_ref().is_some_and(|(_, l)| l.animating())
-            || self.render.sidebar_focus.animating()
-            || self.render.tab_focus.animating()
-        {
-            animating = true;
+        if self.render.sidebar_focus.animating() || self.render.tab_focus.animating() {
+            backdrop_changed = true;
         }
-        // Stepped animation: always tick for state consistency, but only animate when
-        // visible (Home + running game). See RunningPulse.
+        // Tick even while hidden to keep pulse state consistent.
         let dot_live = self.nav.screen == Screen::Home && !self.library.running.is_empty();
         if self.render.running_pulse.tick(now, dot_live) {
-            animating = true;
+            backdrop_changed = true;
         }
-        // The mark's entrance, from the sidebar's first frame.
         if self
             .render
             .mark_shown_at
             .is_some_and(|t| t.elapsed().as_secs_f32() < pf_console_ui::brand::INTRO_SECS)
         {
-            animating = true;
+            backdrop_changed = true;
         }
-        animating
+        (animating || backdrop_changed, backdrop_changed)
     }
 
     /// Queues the whole document for the background writer. Every mutation of settings, hosts or

--- a/src/runtime/overlay.rs
+++ b/src/runtime/overlay.rs
@@ -261,7 +261,14 @@ impl ConfirmDialog {
     }
 
     pub(super) fn tick(&mut self) -> bool {
-        self.fade.tick()
+        let mut animating = self.fade.tick();
+        if let Some(t) = self.focus_anim {
+            if t.elapsed() >= ui::animation::FOCUS_POP {
+                self.focus_anim = None;
+            }
+            animating = true;
+        }
+        animating
     }
 
     /// Pointer and pad input while open. The layout is the same one [`Self::draw`] draws.
@@ -283,12 +290,15 @@ impl ConfirmDialog {
         );
         match *event {
             Event::MouseMotion { x, y, .. } => {
-                self.hover_close = l.on_close(x, y);
+                let hover_close = l.on_close(x, y);
+                let hover_changed = self.hover_close != hover_close;
+                self.hover_close = hover_close;
                 return match l.button_at(x, y) {
                     Some(i) if i != focus => {
                         self.set_focus(i);
                         Some(ConfirmAction::Navigated)
                     }
+                    _ if hover_changed => Some(ConfirmAction::Navigated),
                     _ => None,
                 };
             }
@@ -386,5 +396,46 @@ impl Notification {
                 None
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod dialog_tests {
+    use super::*;
+
+    #[test]
+    fn close_hover_requests_redraw_only_when_changed() {
+        let fonts = theme::build_fonts().unwrap();
+        let mut dialog = ConfirmDialog::new("Quit?", "Close app", None, "Quit", Tone::Danger);
+        dialog.focus = Some(0);
+        let l = dialog::layout(&fonts, 1920.0, 1080.0, crate::app::draw::scale(1080), "Close app");
+        let motion = |x, y| sdl2::event::Event::MouseMotion {
+            timestamp: 0,
+            window_id: 0,
+            which: 0,
+            mousestate: sdl2::mouse::MouseState::from_sdl_state(0),
+            x,
+            y,
+            xrel: 0,
+            yrel: 0,
+        };
+        let enter = motion(l.close.center_x() as i32, l.close.center_y() as i32);
+        assert!(dialog.handle_event(&enter, &fonts, 1920, 1080).is_some());
+        assert!(dialog.hover_close);
+        assert!(dialog.handle_event(&enter, &fonts, 1920, 1080).is_none());
+        assert!(dialog.handle_event(&motion(0, 0), &fonts, 1920, 1080).is_some());
+        assert!(!dialog.hover_close);
+    }
+
+    #[test]
+    fn settled_dialog_stays_visible_without_requesting_frames() {
+        let mut dialog = ConfirmDialog::new("Quit?", "Close app", None, "Quit", Tone::Danger);
+        dialog.focus = Some(0);
+        dialog.focus_anim = Some(Instant::now() - ui::animation::FOCUS_POP);
+        assert!(dialog.tick());
+        assert!(!dialog.tick());
+        assert!(dialog.frame().is_some());
+        dialog.dismiss();
+        assert!(dialog.tick());
     }
 }

--- a/src/runtime/ui_flow.rs
+++ b/src/runtime/ui_flow.rs
@@ -112,6 +112,8 @@ pub(super) fn run_ui_flow(
     let mut quit_dialog_was_active = false;
     // The blurred page a frosted modal card sits on, held across frames — see the frame block.
     let mut page: Option<skia_safe::Image> = None;
+    let mut drawable_size = canvas.window().drawable_size();
+    let mut backdrop_was_moving = false;
     'ui: loop {
         // Start of this tick, for the loop's own pacing against `TICK_BUDGET`.
         let frame_start = Instant::now();
@@ -347,12 +349,8 @@ pub(super) fn run_ui_flow(
                 .map(|r| sdl2::rect::Rect::new(r.x(), r.y(), r.width(), r.height()))
         });
         text_input.set_active(wants_text, rect.flatten());
-        // Five reasons to render: dirty, animations running, tiles pending,
-        // spinner animating, or log overlay due for refresh (~2Hz).
-        // 16ms sleep when none holds keeps SoC idle.
-        // The quit dialog runs its own open/close fade and focus-pop, so keep ticking
-        // while it (or its close-fade) is on screen, and force one redraw on the frame it
-        // finally clears so it doesn't linger over the menu.
+        // Redraw once after the quit dialog's close fade clears.
+        let quit_dialog_animating = quit_dialog.tick();
         let quit_dialog_active = quit_dialog.frame().is_some();
         if quit_dialog_was_active && !quit_dialog_active {
             dirty = true;
@@ -361,46 +359,45 @@ pub(super) fn run_ui_flow(
         if let Some(msg) = app.take_toast() {
             notif.show(msg);
         }
-        // Polled every tick like the streaming loop's toast, not gated behind
-        // `content_dirty` — its own fade needs frames regardless of anything else.
+        // Toast fades need frames even when content is idle.
         let notif_frame = notif.frame().map(|(t, a)| (t.to_string(), a));
         if app.poll_press() {
             dirty = true;
         }
-        let animating = app.tick_animations()
+        let (app_animating, backdrop_changed) = app.tick_animations();
+        let animating = app_animating
+            || backdrop_was_moving
             || !app.render.grid.reveal.is_revealed()
-            || quit_dialog_active
+            || quit_dialog_animating
             || notif_frame.is_some();
+        let (dw, dh) = canvas.window().drawable_size();
+        dirty |= drawable_size != (dw, dh);
+        drawable_size = (dw, dh);
         let log_overlay_due = log_overlay_state() != LogOverlayState::Off
             && log_overlay_last.is_none_or(|t| t.elapsed() >= Duration::from_millis(500));
         if !dirty && !animating && !log_overlay_due {
-            // Blocked on the event queue rather than asleep for the rest of the budget:
-            // nothing on this branch is animating, so the next thing that can change a pixel
-            // is an SDL event, and waiting for it both wakes the SoC less often and drops the
-            // up-to-16ms delay a plain sleep put between a keypress and the poll that sees it.
-            // The timeout keeps the loop's own polling (discovery, art, reachability) on the
-            // same cadence it had.
+            // Wake on input; the timeout preserves background polling cadence.
             let elapsed = frame_start.elapsed();
             if elapsed < TICK_BUDGET {
                 crate::platform::webos::input::wait_for_event(TICK_BUDGET - elapsed);
             }
             continue;
         }
+        let backdrop_dirty = dirty || backdrop_changed || backdrop_was_moving || !app.render.grid.reveal.is_revealed();
+        backdrop_was_moving = backdrop_changed;
         dirty = false;
+        // Publish the palette before clearing or caching any pixels from this frame.
+        app.apply_ink();
         app.advance_frame(display_mode.w as u32);
         app.prepare_frame(Size::new(display_mode.w as u32, display_mode.h as u32));
-        // The log tail's text is read on the 500 ms cadence; between reads the last lines
-        // are drawn as they were, so an animating menu does not lock the log per frame.
+        // Cache log lines between refreshes to avoid locking the log per frame.
         if log_overlay_due {
             log_overlay_last = Some(Instant::now());
             log_lines = log_overlay_lines();
         } else if log_overlay_state() == LogOverlayState::Off {
             log_lines = None;
         }
-        // The frame, on the GL context. Layout is in `display_mode` units; the drawable is
-        // documented to differ from the window on webOS (handoff trap 10), so it is scaled
-        // rather than assumed equal.
-        let (dw, dh) = canvas.window().drawable_size();
+        // webOS drawable dimensions can differ from the layout's display_mode units.
         let dt = last_frame.elapsed().as_secs_f64().min(0.1);
         last_frame = Instant::now();
         {
@@ -411,23 +408,18 @@ pub(super) fn run_ui_flow(
                 dw as f32 / display_mode.w.max(1) as f32,
                 dh as f32 / display_mode.h.max(1) as f32,
             ));
-            app.apply_ink();
             kit_fonts.begin_frame();
             // Scoped so the frame's borrow of the canvas ends before the snapshot below.
             {
                 let frame = crate::app::draw::Frame::new(c, &kit_fonts, display_mode.w as u32, display_mode.h as u32);
                 app.draw_home(&frame, dt);
             }
-            // The page a frosted card blurs: snapshotted and blurred ONCE, on the first frame
-            // that something frosts, and held until nothing does. Both cost GPU time on the frame
-            // a card opens, and neither result changes while the card is up, because the page it
-            // froze is exactly the page behind it. The quit dialog counts as a frosting card: it
-            // is the same glass, and it only ever opens over Home.
+            // Overlay frames reuse the blur; content events and background motion invalidate it.
             if !(app.modal_visible() || quit_dialog_active) {
                 page = None;
-            } else if page.is_none() {
+            } else if page.is_none() || backdrop_dirty {
                 let snap = surface.image_snapshot_with_bounds(skia_safe::IRect::from_wh(dw as i32, dh as i32));
-                let k = crate::app::draw::scale(display_mode.h as u32);
+                let k = crate::app::draw::scale(display_mode.h as u32) * dh as f32 / display_mode.h.max(1) as f32;
                 page = snap.and_then(|snap| crate::app::draw::glass::blur_page(surface, &snap, k));
             }
             let c = surface.canvas();


### PR DESCRIPTION
Theme changes could leave a modal showing a blurred backdrop from the previous palette. Apply the palette before drawing and refresh the cached blur when the background changes or the drawable resizes, while reusing it for overlay animation. Settled quit dialogs now stop requesting frames and still redraw on hover changes.

Make the glass more diffuse with stronger half-resolution blur, a lighter frost tint, softer gradients and more even corner lighting. Simplify the shader math, cache shaders for unchanged geometry, and key cover blurs by image identity.

Validated with Docker lint and all 56 tests, including shader compilation and dialog idle/hover regressions. Formatting and diff checks pass. TV appearance and GPU timings still need hardware verification; stronger blur may increase backdrop refresh cost.
