### PR TITLE
fix(audio): stop narrowing surround to stereo by Sound Out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "cros-codecs"
 version = "0.0.5"
-source = "git+https://git.unom.io/unom/punktfunk?rev=3c77c9d49#3c77c9d4928dc1e74bdfa05ba5e313b2ae9d225d"
+source = "git+https://git.unom.io/unom/punktfunk?rev=332e52d41#332e52d41f77b96a46d8162021a4e367ac535a10"
 dependencies = [
  "log",
 ]
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=3c77c9d49#3c77c9d4928dc1e74bdfa05ba5e313b2ae9d225d"
+source = "git+https://git.unom.io/unom/punktfunk?rev=332e52d41#332e52d41f77b96a46d8162021a4e367ac535a10"
 
 [[package]]
 name = "fiat-crypto"
@@ -1283,7 +1283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "pf-bitstream"
 version = "0.36.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=3c77c9d49#3c77c9d4928dc1e74bdfa05ba5e313b2ae9d225d"
+source = "git+https://git.unom.io/unom/punktfunk?rev=332e52d41#332e52d41f77b96a46d8162021a4e367ac535a10"
 dependencies = [
  "cros-codecs",
  "tracing",
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "pf-client-core"
 version = "0.36.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=3c77c9d49#3c77c9d4928dc1e74bdfa05ba5e313b2ae9d225d"
+source = "git+https://git.unom.io/unom/punktfunk?rev=332e52d41#332e52d41f77b96a46d8162021a4e367ac535a10"
 dependencies = [
  "anyhow",
  "punktfunk-core",
@@ -1305,7 +1305,7 @@ dependencies = [
 [[package]]
 name = "pf-console-ui"
 version = "0.36.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=3c77c9d49#3c77c9d4928dc1e74bdfa05ba5e313b2ae9d225d"
+source = "git+https://git.unom.io/unom/punktfunk?rev=332e52d41#332e52d41f77b96a46d8162021a4e367ac535a10"
 dependencies = [
  "anyhow",
  "pf-client-core",
@@ -1405,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "punktfunk-core"
 version = "0.36.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=3c77c9d49#3c77c9d4928dc1e74bdfa05ba5e313b2ae9d225d"
+source = "git+https://git.unom.io/unom/punktfunk?rev=332e52d41#332e52d41f77b96a46d8162021a4e367ac535a10"
 dependencies = [
  "aes-gcm",
  "cbindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cros-codecs"
+version = "0.0.5"
+source = "git+https://git.unom.io/unom/punktfunk?rev=3c77c9d49#3c77c9d4928dc1e74bdfa05ba5e313b2ae9d225d"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,7 +694,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=a7cd5ff8e#a7cd5ff8ef77546270e3d45066ea000bfe1f0146"
+source = "git+https://git.unom.io/unom/punktfunk?rev=3c77c9d49#3c77c9d4928dc1e74bdfa05ba5e313b2ae9d225d"
 
 [[package]]
 name = "fiat-crypto"
@@ -1273,9 +1281,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pf-bitstream"
+version = "0.36.0"
+source = "git+https://git.unom.io/unom/punktfunk?rev=3c77c9d49#3c77c9d4928dc1e74bdfa05ba5e313b2ae9d225d"
+dependencies = [
+ "cros-codecs",
+ "tracing",
+]
+
+[[package]]
 name = "pf-client-core"
-version = "0.35.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=a7cd5ff8e#a7cd5ff8ef77546270e3d45066ea000bfe1f0146"
+version = "0.36.0"
+source = "git+https://git.unom.io/unom/punktfunk?rev=3c77c9d49#3c77c9d4928dc1e74bdfa05ba5e313b2ae9d225d"
 dependencies = [
  "anyhow",
  "punktfunk-core",
@@ -1287,8 +1304,8 @@ dependencies = [
 
 [[package]]
 name = "pf-console-ui"
-version = "0.35.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=a7cd5ff8e#a7cd5ff8ef77546270e3d45066ea000bfe1f0146"
+version = "0.36.0"
+source = "git+https://git.unom.io/unom/punktfunk?rev=3c77c9d49#3c77c9d4928dc1e74bdfa05ba5e313b2ae9d225d"
 dependencies = [
  "anyhow",
  "pf-client-core",
@@ -1387,8 +1404,8 @@ dependencies = [
 
 [[package]]
 name = "punktfunk-core"
-version = "0.35.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=a7cd5ff8e#a7cd5ff8ef77546270e3d45066ea000bfe1f0146"
+version = "0.36.0"
+source = "git+https://git.unom.io/unom/punktfunk?rev=3c77c9d49#3c77c9d4928dc1e74bdfa05ba5e313b2ae9d225d"
 dependencies = [
  "aes-gcm",
  "cbindgen",
@@ -1399,6 +1416,7 @@ dependencies = [
  "libc",
  "log",
  "opus",
+ "pf-bitstream",
  "quinn",
  "rand 0.9.5",
  "rcgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 # 🛑 REV (not tag), same across all drei crates: tag+rev mix builds two copies, types won't unify.
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "a7cd5ff8e", features = ["quic"] }
-pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "a7cd5ff8e", default-features = false }
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "3c77c9d49", features = ["quic"] }
+pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "3c77c9d49", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # mDNS LAN discovery; direct dep (not via pf-client-core — see session.rs docs).
@@ -61,7 +61,7 @@ libc = "0.2"
 # Logs must say "DOWNLOAD AND INSTALL SUCCEEDED". Keep default features for the archive key
 # (`gl-jpegd-jpege-pdf-textlayout`, both sources publish). textlayout is pinned: `skunicode_icu`
 # (icudt74_dat, 10.5 MB) is 43% of the binary; kit shapes every string through `Paragraph`.
-pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "a7cd5ff8e", default-features = false, features = ["gl"] }
+pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "3c77c9d49", default-features = false, features = ["gl"] }
 skia-safe = { version = "0.99", features = ["gl", "textlayout"] }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 # 🛑 REV (not tag), same across all drei crates: tag+rev mix builds two copies, types won't unify.
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "3c77c9d49", features = ["quic"] }
-pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "3c77c9d49", default-features = false }
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "332e52d41", features = ["quic"] }
+pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "332e52d41", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # mDNS LAN discovery; direct dep (not via pf-client-core — see session.rs docs).
@@ -61,7 +61,7 @@ libc = "0.2"
 # Logs must say "DOWNLOAD AND INSTALL SUCCEEDED". Keep default features for the archive key
 # (`gl-jpegd-jpege-pdf-textlayout`, both sources publish). textlayout is pinned: `skunicode_icu`
 # (icudt74_dat, 10.5 MB) is 43% of the binary; kit shapes every string through `Paragraph`.
-pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "3c77c9d49", default-features = false, features = ["gl"] }
+pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "332e52d41", default-features = false, features = ["gl"] }
 skia-safe = { version = "0.99", features = ["gl", "textlayout"] }
 
 [build-dependencies]

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -174,7 +174,7 @@ CX/G5 are 32-bit userland on ARMv8-A. RustCrypto's `aes` crate has ARMv8 intrins
 
 ## Audio: two routes, one pipeline (SDL is the default)
 
-`Settings` → **Experimental** → **Audio processing** picks the route
+`Settings` → **Audio** → **Audio processing** picks the route
 (`core::model::AudioRoutePref`), and both are
 built on the same pipeline: `session::audio::AudioStage` decodes (or forwards) into whatever
 `core::media::AudioSink` the route selected, and one pump drives it. Adding a third route is one
@@ -183,16 +183,26 @@ built on the same pipeline: `session::audio::AudioStage` decodes (or forwards) i
 | Route | Label | Path | Layouts |
 | --- | --- | --- | --- |
 | `Software` (default) | Software (SDL) | libopus here → SDL device, NDL's clock plane on its metronome | up to 7.1 |
-| `NdlOpus` | Offload (NDL) | the wire's Opus, decoded by the TV | 2 |
+| `NdlOpus` | Offload (NDL) | Opus decoded by the TV; 5.1 re-encoded into NDL's layout first | 2, 5.1 |
 
 **Why software is the default.** NDL paces the picture against a *fed* audio plane, so a plane fed
 from the network inherits the stream's arrival jitter — which is the stutter the silent clock plane
 was introduced to cure. The offload route is shorter and stays selectable for exactly that
 comparison; the overlay names which one ran (`Opus SW` / `Opus HW`).
 
-**The offload route is stereo, and stereo only.** NDL's Opus struct has no multistream mapping
-field, so there is no 5.1 to negotiate — and some sets accept the load and then play nothing, which
-no runtime probe detects. That is why it lives under Experimental rather than beside the codec pick.
+**Offload is also the surround route.** NDL decodes stereo Opus and exactly one 5.1 layout:
+GameStream's, `(FL,FR)+(RL,RR)` coupled with FC and LFE mono (`ndl::OPUS_51_LAYOUT`, ss4s's
+`IsOpusPassthroughSupported`). The wire couples `(FC,LFE)` instead, so a 5.1 session is decoded here
+and re-encoded into NDL's layout, one 5 ms packet per frame — ss4s's `opus_fix`, and the path
+aurora-tv ships. Some sets accept the load and then play nothing, which no runtime probe detects,
+so it stays a choice rather than the default.
+
+**Surround reaches a receiver only through the Opus plane.** Measured on a G5 (webOS 10.3) into a
+Denon AVC-X3800H over HDMI, with NDL reporting multi-channel PCM `Supported`: the SDL route plays
+into `PulseAudio`'s one hardware sink, `pcm_output`, which is s16le 2ch; and a plane loaded as
+6-channel PCM (`NDL_DIRECTAUDIO_PCM_INFO_T`, `channelMode = "6-channel"`) confirms and plays, but
+the AVR reports PCM 2.0. aurora-tv dropped its NDL PCM 5.1 path too. Read the AVR, not the ears:
+a Denon answers `OPINFINS ?` on telnet port 23 with one digit per input channel (`2` = present).
 
 **Offload is not free of the metronome.** `run_clock_plane` still runs on that route, yielding to
 the real stream and filling silence only after `REAL_FEED_GRACE_MS` without a packet — a dead host
@@ -202,7 +212,7 @@ capture would otherwise starve the plane and freeze the picture.
 so `caps::VideoCaps::audio_plane` is false there and
 `AudioRoutePref::available` collapses to `Software` — the row locks, and `Settings::clamp_to_caps`
 rewrites a document carried over from a v2 set. The Audio row's layouts follow the *selected*
-route, so picking `Offload (NDL)` locks that row to stereo with the reason on it.
+route, so picking `Offload (NDL)` offers stereo and 5.1, not 7.1.
 
 **Nothing is ever mixed down, and the layout row is a preference.** `Settings::audio_channels` says
 "5.1 where it can play"; `Negotiated::clamp` is the one place it becomes a width on the wire, narrowing it by
@@ -212,9 +222,8 @@ change instead of being rewritten out of the document. A width mismatch at `Audi
 error, not a downmix.
 
 **The menu is narrowed by the static limits only.** The Audio row lists what this client can
-decode, capped by what the *selected* route can put on a speaker — the Opus plane carries nothing
-above stereo, so those widths are never offered, and a route left with one entry locks the row with
-the reason on it. The stored `audio_channels` is never rewritten (`menu::audio_row_channels` shows
+decode, capped by what the *selected* route can put on a speaker — the Opus plane stops at 5.1, so
+7.1 is never offered there, and a route left with one entry locks the row with the reason on it. The stored `audio_channels` is never rewritten (`menu::audio_row_channels` shows
 the preference held down to the route), so a 5.1 pick comes back whole on the route that plays it.
 
 - **Sound Out narrows nothing.** `NDL_DirectAudioSupportMultiChannel` says whether multi-channel
@@ -235,9 +244,9 @@ the preference held down to the route), so a 5.1 pick comes back whole on the ro
   until something has `dlopen`'d `libNDL_directmedia` — and the capability probes run at startup,
   before any decode session. `ffi::optional_sym` forces `ffi::common()` first; without it every
   optional symbol reads as absent and the TV silently loses 5.1.
-- **Samples are never converted.** libopus decodes straight into f32, which is exactly what the SDL
-  device takes; the offload route decodes nothing at all. There is no second buffer and no
-  conversion pass on either route.
+- **Samples are converted only where NDL needs its own layout.** libopus decodes straight into
+  f32, which is exactly what the SDL device takes; offload forwards stereo Opus untouched and
+  re-encodes only 5.1. There is no second buffer and no conversion pass on the SDL route.
 - **The software route's latency is buffering, not decode.** Software Opus is 5% of a core and the
   target is hardware-FP (`-soft-float`, § "Toolchain"), so the only client-side terms are the ring
   depth and the device quantum. Two things follow, and they are the whole lever list here:

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -206,29 +206,25 @@ route, so picking `Offload (NDL)` locks that row to stereo with the reason on it
 
 **Nothing is ever mixed down, and the layout row is a preference.** `Settings::audio_channels` says
 "5.1 where it can play"; `Negotiated::clamp` is the one place it becomes a width on the wire, narrowing it by
-what the selected route carries (`AudioRoutePref::max_channels`) and by what the TV's Sound Out
-passes right now (`ndl::audio_output_width`). So a layout the sink can't put on a speaker is never
-encoded, never sent, never decoded and never folded — and the preference survives a route change or
-an unplugged receiver instead of being rewritten out of the document. A width mismatch at
-`AudioStage::new` is an error, not a downmix.
+what the selected route carries (`AudioRoutePref::max_channels`). So a layout the route can't carry
+is never encoded, sent or decoded, this client never folds, and the preference survives a route
+change instead of being rewritten out of the document. A width mismatch at `AudioStage::new` is an
+error, not a downmix.
 
 **The menu is narrowed by the static limits only.** The Audio row lists what this client can
 decode, capped by what the *selected* route can put on a speaker — the Opus plane carries nothing
 above stereo, so those widths are never offered, and a route left with one entry locks the row with
-the reason on it. The TV's Sound Out is deliberately not in that filter: it changes under a running
-app, so it applies per session and lands in the log, not in a menu that would be stale by the time
-it was drawn. The stored `audio_channels` is still never rewritten (`menu::audio_row_channels` shows
+the reason on it. The stored `audio_channels` is never rewritten (`menu::audio_row_channels` shows
 the preference held down to the route), so a 5.1 pick comes back whole on the route that plays it.
 
-- **Capability and routing are different questions, asked in different places.**
-  `NDL_DirectAudioSupportMultiChannel` answers the second: whether 5.1 reaches a speaker *right
-  now*, which also depends on Sound Out (TV speakers are 2.0/2.2 and ARC/optical carry 2-channel
-  PCM only). ss4s declines to check it at all and lets webOS fold. Here `ndl::audio_output_width`
-  reads it **once per session, at connect** — fresh, after `NDL_DirectMediaInit`, and early enough
-  to size the wire request. Never in the menu: the answer would be stale by the time it was drawn.
-  It initialises NDL a moment before the load would have anyway (process-global and idempotent),
-  so it costs no extra call. It narrows the SOFTWARE route too: 5.1 the TV would only fold down is
-  airlink, host CPU and local decode spent on nothing.
+- **Sound Out narrows nothing.** `NDL_DirectAudioSupportMultiChannel` says whether multi-channel
+  PCM leaves the set *right now*. It reads "will play" only with Sound Out on Pass Through, and it
+  describes NDL's own PCM path, not the SDL device the software route plays through — so gating
+  the handshake on it turns a 5.1 pick on a default-configured TV into a stereo session. Like
+  ss4s, the client asks for the chosen layout and lets webOS fold. `ndl::log_audio_output` logs
+  the answer at connect for sessions wider than stereo: the first line to read when 5.1 sounds
+  like stereo. It initialises NDL a moment before the load would have anyway (process-global and
+  idempotent), so it costs no extra call.
 - ⚠ **`NDL_DirectAudioSupportMultiChannel` has an out-parameter**:
   `int NDL_DirectAudioSupportMultiChannel(int *isSupported)`, returning 0/-1, with the code written
   through the pointer — `0` unsupported, `1` no device, `2` device but not passthrough, `3` will

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -190,12 +190,14 @@ from the network inherits the stream's arrival jitter — which is the stutter t
 was introduced to cure. The offload route is shorter and stays selectable for exactly that
 comparison; the overlay names which one ran (`Opus SW` / `Opus HW`).
 
-**Offload is also the surround route.** NDL decodes stereo Opus and exactly one 5.1 layout:
-GameStream's, `(FL,FR)+(RL,RR)` coupled with FC and LFE mono (`ndl::OPUS_51_LAYOUT`, ss4s's
-`IsOpusPassthroughSupported`). The wire couples `(FC,LFE)` instead, so a 5.1 session is decoded here
-and re-encoded into NDL's layout, one 5 ms packet per frame — ss4s's `opus_fix`, and the path
-aurora-tv ships. Some sets accept the load and then play nothing, which no runtime probe detects,
-so it stays a choice rather than the default.
+**Offload is also the surround route.** NDL decodes stereo Opus and exactly one 5.1 layout: the
+standard coupling, `(FL,FR)+(RL,RR)` with FC and LFE mono (`AudioLayout::Standard`,
+`ndl::OPUS_51_LAYOUT`, ss4s's `IsOpusPassthroughSupported`). Every session asks the host for it
+(`Hello::audio_layout`); a host that knows it encodes it, and the plane is fed the wire untouched.
+An older host answers legacy — `(FC,LFE)` coupled — and `session::audio` decodes and re-encodes
+into NDL's layout, one 5 ms packet per frame (ss4s's `opus_fix`, the path aurora-tv ships). Some
+sets accept the load and then play nothing, which no runtime probe detects, so it stays a choice
+rather than the default.
 
 **Surround reaches a receiver only through the Opus plane.** Measured on a G5 (webOS 10.3) into a
 Denon AVC-X3800H over HDMI, with NDL reporting multi-channel PCM `Supported`: the SDL route plays

--- a/src/app/menu.rs
+++ b/src/app/menu.rs
@@ -207,8 +207,8 @@ pub fn log_level_dropdown_current_index(level: LogLevelOverride) -> usize {
 const AUDIO_CHANNELS: [(u8, &str); 3] = [(2, "Stereo"), (6, "5.1 surround"), (8, "7.1 surround")];
 
 /// The channel counts offered: what this client can decode, capped by what the selected route
-/// can put on a speaker (`AudioRoutePref::max_channels`). Not filtered by the TV's current
-/// Sound Out: that one changes under a running app and is applied per session instead.
+/// can put on a speaker (`AudioRoutePref::max_channels`). Not filtered by the TV's Sound Out:
+/// webOS folds what its output can't pass.
 pub fn audio_channel_options(settings: &Settings) -> &'static [(u8, &'static str)] {
     channel_options_up_to(settings.audio_route().max_channels(video_caps()))
 }

--- a/src/app/state/settingspage.rs
+++ b/src/app/state/settingspage.rs
@@ -348,6 +348,8 @@ impl App {
             pads: &pads,
             deck: false,
             fallback_ui: true,
+            // NDL decodes H.264 and HEVC only; the Hello never offers PyroWave.
+            pyrowave_ok: false,
             device_name: "webOS TV",
             t: 0.0,
         };

--- a/src/core/media.rs
+++ b/src/core/media.rs
@@ -109,7 +109,7 @@ pub trait VideoSink: Send {
 /// nothing converts afterwards.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AudioFormat {
-    /// The wire's own Opus, handed over undecoded — the sink decodes.
+    /// Opus the sink decodes: the wire's stereo as-is, or 5.1 re-encoded into NDL's layout.
     Opus { channels: u8 },
     /// Interleaved f32 in punktfunk's own channel order — what libopus decodes to, so this is the
     /// format that costs no conversion at all.

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -413,13 +413,13 @@ pub enum CodecPref {
 #[serde(rename_all = "lowercase")]
 pub enum AudioRoutePref {
     /// Software Opus decode → the TV's SDL audio device, with NDL's silent clock plane keeping
-    /// the picture paced. The longest path, every layout, and the only one whose pacing is proven
-    /// on hardware — so, the default.
+    /// the picture paced. The longest path and the only one whose pacing is proven on hardware —
+    /// so, the default. `PulseAudio`'s hardware sink is stereo, so surround folds there.
     #[default]
     Software,
-    /// The wire's Opus, decoded by the TV on its audio plane. No local decode at all. Stereo
-    /// only — NDL's Opus struct has no multistream mapping field — and some sets accept the load
-    /// and then play nothing, which no runtime probe detects.
+    /// Opus decoded by the TV on its audio plane: the wire's stereo as-is, or 5.1 re-encoded here
+    /// into the one layout NDL decodes (`ndl::OPUS_51_LAYOUT`) — the only route that keeps 5.1
+    /// discrete. Some sets accept the load and then play nothing, which no runtime probe detects.
     NdlOpus,
 }
 
@@ -446,9 +446,10 @@ impl AudioRoutePref {
     /// a route that plays it.
     pub fn max_channels(self, caps: VideoCaps) -> u8 {
         match self {
-            // SDL opens whatever the negotiated layout is; nothing folds.
+            // SDL opens the negotiated layout; `PulseAudio` folds what its stereo sink can't carry.
             Self::Software => caps.max_channels,
-            Self::NdlOpus => caps.max_channels.min(2),
+            // NDL decodes stereo Opus and one 5.1 layout, nothing wider.
+            Self::NdlOpus => caps.max_channels.min(6),
         }
     }
 

--- a/src/core/model.rs
+++ b/src/core/model.rs
@@ -417,9 +417,10 @@ pub enum AudioRoutePref {
     /// so, the default. `PulseAudio`'s hardware sink is stereo, so surround folds there.
     #[default]
     Software,
-    /// Opus decoded by the TV on its audio plane: the wire's stereo as-is, or 5.1 re-encoded here
-    /// into the one layout NDL decodes (`ndl::OPUS_51_LAYOUT`) — the only route that keeps 5.1
-    /// discrete. Some sets accept the load and then play nothing, which no runtime probe detects.
+    /// Opus decoded by the TV on its audio plane, the wire untouched: every host is asked for the
+    /// one 5.1 coupling NDL decodes (`ndl::OPUS_51_LAYOUT`), and an older host's is re-encoded
+    /// here. The only route that keeps 5.1 discrete. Some sets accept the load and then play
+    /// nothing, which no runtime probe detects.
     NdlOpus,
 }
 

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -275,7 +275,7 @@ impl TvSettings for Settings {
             self.set_audio_route(AudioRoutePref::Software);
         }
         // The decoder-wide ceiling, and nothing else: `audio_channels` is a preference the
-        // route's own limit and the TV's Sound Out narrow per session.
+        // route's own limit narrows per session.
         if self.audio_channels > caps.max_channels {
             tracing::info!(
                 "settings: {} audio channels is more than this client can decode ({}) — clamping",

--- a/src/platform/webos/hdr_pattern.rs
+++ b/src/platform/webos/hdr_pattern.rs
@@ -127,6 +127,7 @@ fn run(stop: &Arc<AtomicBool>, rx: &mpsc::Receiver<Command>, meta: HdrMeta, patt
         // The short budget: this screen never routes real audio, it only needs the plane fed so
         // NDL paces the pattern. An unconfirmed plane does that (see `NdlVideo::run_clock_plane`).
         Some(ndl::AUDIO_PRIME_BUDGET),
+        2,
     )?);
     let color = ColorInfo {
         primaries: ColorInfo::CP_BT2020,

--- a/src/platform/webos/ndl/ffi.rs
+++ b/src/platform/webos/ndl/ffi.rs
@@ -419,8 +419,8 @@ pub(super) fn v1() -> Result<&'static V1> {
 /// and ARC/optical carry 2-channel PCM only, so those report [`Self::OutputNotPassthrough`] at
 /// best — 5.1 fed there is folded down inside the TV.
 ///
-/// A transient setting, and the query is meaningful only once `NDL_DirectMediaInit` has run — so
-/// it sizes the wire request per session and never gates a menu.
+/// A transient setting, and the query is meaningful only once `NDL_DirectMediaInit` has run. It
+/// describes NDL's own PCM path, so it is logged per session and gates nothing.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum MultiChannelPcm {
     /// No multi-channel support here.

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -38,6 +38,8 @@ use anyhow::{bail, Result};
 
 use super::device::{self, NdlGeneration};
 
+#[cfg(test)]
+pub use v2::OPUS_51_SILENCE;
 pub use v2::{NdlVideo, OPUS_51_LAYOUT};
 
 /// `NDL_VIDEO_TYPE` values this client can request (matches the codec the host's

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -38,7 +38,7 @@ use anyhow::{bail, Result};
 
 use super::device::{self, NdlGeneration};
 
-pub use v2::NdlVideo;
+pub use v2::{NdlVideo, OPUS_51_LAYOUT};
 
 /// `NDL_VIDEO_TYPE` values this client can request (matches the codec the host's
 /// `Welcome` resolved — see `punktfunk_core::quic::CODEC_*`).

--- a/src/platform/webos/ndl/mod.rs
+++ b/src/platform/webos/ndl/mod.rs
@@ -393,38 +393,24 @@ fn ensure_init(app_id: &str, api2: bool) -> Result<()> {
     Ok(())
 }
 
-/// Widest layout the TV's audio output will actually pass **right now**, or `None` where it
-/// cannot be asked.
+/// Logs whether the TV's Sound Out passes multi-channel PCM right now — the first line to read
+/// when a surround session sounds like stereo. Called by `session::connect` for sessions wider
+/// than stereo.
 ///
-/// It answers whether Sound Out is configured for multi-channel, which the user can change under
-/// a running app. Read once per session by `session::connect` and used to size the wire request,
-/// so channels the TV would only fold down are never encoded, sent or decoded. Never a menu gate —
-/// the answer would be stale by the time it was drawn.
-///
-/// `None` on NDL v1 (nothing to ask) and whenever the query fails, both of which mean "don't
-/// narrow" — the static capability ceiling has already applied by then.
-pub fn audio_output_width() -> Option<u8> {
+/// Diagnostic only: the session asks for the user's layout regardless and webOS folds what its
+/// output can't pass. The answer describes NDL's own PCM path, not the SDL device the software
+/// route plays through, and reads `Supported` only with Sound Out on Pass Through.
+pub fn log_audio_output() {
     if device::ndl_generation() != NdlGeneration::V2 {
-        return None;
+        return;
     }
     // The query answers nothing before `NDL_DirectMediaInit`, and this runs a moment before the
     // load would have called it anyway — process-global and idempotent, so it is the same init.
     if let Err(e) = ensure_init(&app_id(), true) {
         tracing::warn!("NDL init for the audio-output query: {e:#}");
-        return None;
+        return;
     }
-    let status = ffi::multichannel_pcm_status();
-    let width = match status {
-        ffi::MultiChannelPcm::Supported => Some(6),
-        ffi::MultiChannelPcm::Unknown => None,
-        // Capable or not, stereo is what leaves the set.
-        _ => Some(2),
-    };
-    match width {
-        Some(w) => tracing::info!("NDL audio output: {status:?} — passes up to {w} channel(s)"),
-        None => tracing::warn!("NDL audio output: {status:?} — not narrowing the request"),
-    }
-    width
+    tracing::info!("NDL audio output: {:?}", ffi::multichannel_pcm_status());
 }
 
 /// Spawns the metronome that keeps the audio plane fed.

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -10,6 +10,7 @@ use std::sync::{Mutex, MutexGuard, PoisonError};
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Result};
+use punktfunk_core::audio::OpusLayout;
 
 use crate::core::media::{AudioFormat, AudioPlane, AudioSink, MediaClock, NotReady, Samples, VideoSink, VideoSinkCaps};
 
@@ -44,6 +45,32 @@ const _: () = assert!(
 /// One empty Opus frame — `mariotaku/ss4s`'s `opus_empty_frame_211`. Its TOC declares STEREO,
 /// matching the load; the generic `0xF8 0xFF 0xFE` declares mono. (A CX took both.)
 const OPUS_SILENCE: [u8; 3] = [0xec, 0xff, 0xfe];
+
+/// One empty frame in [`OPUS_51_LAYOUT`] — ss4s's `opus_empty_frame_642`: four 5 ms streams,
+/// two coupled, the first three self-delimited.
+const OPUS_51_SILENCE: [u8; 15] = [
+    0xec, 0x02, 0xff, 0xfe, 0xec, 0x02, 0xff, 0xfe, 0xe8, 0x02, 0xff, 0xfe, 0xe8, 0xff, 0xfe,
+];
+
+/// The one 5.1 Opus layout NDL decodes on its plane: `GameStream`'s, the one ss4s's
+/// `IsOpusPassthroughSupported` checks for — (FL,FR) and (RL,RR) coupled, FC and LFE mono. The
+/// wire couples (FC,LFE) instead, so `session::audio` re-encodes a 5.1 session into this one.
+pub const OPUS_51_LAYOUT: OpusLayout = OpusLayout {
+    channels: 6,
+    streams: 4,
+    coupled: 2,
+    mapping: &[0, 1, 4, 5, 2, 3],
+    bitrate: 512_000,
+};
+
+/// One [`PRIME_PACKET_MS`] silent packet for a plane loaded with `channels`.
+fn silence(channels: u8) -> &'static [u8] {
+    if channels == OPUS_51_LAYOUT.channels {
+        &OPUS_51_SILENCE
+    } else {
+        &OPUS_SILENCE
+    }
+}
 
 /// Packet duration of the prime's stamps (ms), matching the real audio plane's 48 kHz / 5 ms
 /// (`SAMPLE_RATE` in `platform::webos::audio`).
@@ -111,17 +138,17 @@ const REAL_FEED_GRACE_MS: i64 = 300;
 /// to name it rather than to act on a guess — the whole of #188 was a misread of this signal.
 const PLANE_CONFIRM_GRACE: Duration = Duration::from_millis(750);
 
-/// The audio plane every V2 load asks for: Opus, stereo, 48 kHz.
+/// The audio plane every V2 load asks for: Opus at 48 kHz, stereo or [`OPUS_51_LAYOUT`].
 ///
 /// **Every accepted V2 load asks for a plane** — NDL only paces the picture against a fed audio
-/// plane (docs/NOTES.md § "NDL's audio plane"). The offload route puts the wire's own Opus on it;
-/// every other session runs [`NdlVideo::run_clock_plane`]'s metronome instead, and the silent
-/// frame's TOC declares stereo either way, so the config is the same one.
-fn plane_config() -> ffi::AudioUnion {
+/// plane (docs/NOTES.md § "NDL's audio plane"). The offload route puts the session's Opus on it;
+/// every other session runs [`NdlVideo::run_clock_plane`]'s metronome instead, whose silence
+/// [`silence`] shapes to the same channel count.
+fn plane_config(channels: u8) -> ffi::AudioUnion {
     ffi::AudioOpusInfo {
         kind: 3, // NDL_AUDIO_TYPE_OPUS
         unknown1: 0,
-        channels: 2,
+        channels: std::ffi::c_int::from(channels),
         unknown2: 0,
         // kHz, not Hz — NDL's own unit, and what ss4s passes (`info->sampleRate / 1000.0`).
         sample_rate: 48.0,
@@ -185,6 +212,8 @@ pub struct NdlVideo {
     /// confirmation on an ingest-gated set), but it must not be the only audio path: nothing
     /// downstream can re-pick the route once the session is running.
     plane_proven: bool,
+    /// Channels the plane was loaded with: 2, or 6 in [`OPUS_51_LAYOUT`]. Fixed for the handle.
+    plane_channels: u8,
     /// HDR mastering metadata that arrived before the video plane had taken a frame.
     /// `NDL_DirectVideoSetHDRInfo` returns success against a pipeline that isn't ingesting yet
     /// but does nothing — the panel never enters HDR mode, and since the host only sends the
@@ -207,11 +236,19 @@ pub struct NdlVideo {
 impl NdlVideo {
     /// Load NDL video stream. Calls `NDL_DirectMediaInit` on first use.
     ///
-    /// `audio` is the plane's prime budget, or `None` for a video-only load. The budget is how
-    /// long the load waits for `LOADCOMPLETED` before starting the stream unconfirmed — see
-    /// [`super::AUDIO_PRIME_BUDGET`] and [`super::AUDIO_PROVE_BUDGET`]. The audio request itself
-    /// is a probe: it fails silently on unsupported models, which retries video-only.
-    pub fn load(app_id: &str, width: i32, height: i32, codec: NdlCodec, audio: Option<Duration>) -> Result<Self> {
+    /// `audio` is the plane's prime budget, or `None` for a video-only load; `plane_channels` is
+    /// its width, 2 or 6. The budget is how long the load waits for `LOADCOMPLETED` before
+    /// starting the stream unconfirmed — see [`super::AUDIO_PRIME_BUDGET`] and
+    /// [`super::AUDIO_PROVE_BUDGET`]. The audio request itself is a probe: it fails silently on
+    /// unsupported models, which retries video-only.
+    pub fn load(
+        app_id: &str,
+        width: i32,
+        height: i32,
+        codec: NdlCodec,
+        audio: Option<Duration>,
+        plane_channels: u8,
+    ) -> Result<Self> {
         ensure_not_poisoned()?;
         let fns = ffi::v2()?;
         ensure_init(app_id, true)?;
@@ -240,7 +277,7 @@ impl NdlVideo {
             // resources, docs/NOTES.md), and the snapshot precedes the attempt so a settle cannot
             // wait out an `UNLOADCOMPLETED` already spent.
             let unloads_before = super::unload_count();
-            match Self::try_load(fns, video, Some(budget)) {
+            match Self::try_load(fns, video, Some(budget), plane_channels) {
                 Ok(loaded) => return Ok(loaded),
                 // Loud, because a video-only load streams unpaced for the rest of the session
                 // (issue #188) and every later symptom reads as something else.
@@ -253,7 +290,7 @@ impl NdlVideo {
             // land BEFORE arming below rather than racing them.
             settle_before_retry(unloads_before);
         }
-        Self::try_load(fns, video, None)
+        Self::try_load(fns, video, None, plane_channels)
     }
 
     /// One `NDL_DirectMediaLoad` attempt, given its budget to report `LOADCOMPLETED` — priming
@@ -261,11 +298,16 @@ impl NdlVideo {
     ///
     /// An audio-enabled attempt that does not confirm is still returned: unconfirmed is a normal
     /// state for one, not a failure (see [`Self::load`]).
-    fn try_load(fns: &'static ffi::V2, video: ffi::VideoInfo, audio: Option<Duration>) -> Result<Self> {
+    fn try_load(
+        fns: &'static ffi::V2,
+        video: ffi::VideoInfo,
+        audio: Option<Duration>,
+        plane_channels: u8,
+    ) -> Result<Self> {
         let mut info = ffi::DataInfo {
             video,
             audio: if audio.is_some() {
-                plane_config()
+                plane_config(plane_channels)
             } else {
                 ffi::AudioUnion::SILENT
             },
@@ -280,7 +322,7 @@ impl NdlVideo {
         // not one budget twice: the audio one buys a fast confirmation and gives up cheaply, the
         // video one is the picture's own bound.
         let (primed_pts_ms, confirmed) = match audio {
-            Some(budget) => Self::prime_audio(fns, load_instant, budget),
+            Some(budget) => Self::prime_audio(fns, load_instant, budget, silence(plane_channels)),
             None => (0, wait_load_completed()),
         };
         // FATAL is not "unconfirmed", it is gone — and unconfirmed is the only state an
@@ -300,12 +342,13 @@ impl NdlVideo {
             feed_unblocked: AtomicBool::new(confirmed),
             plane_check_ms: AtomicI64::new(i64::MAX),
             plane_proven: audio.is_some() && confirmed,
+            plane_channels,
             pending_hdr: Mutex::new(None),
             applied_hdr: Mutex::new(None),
         })
     }
 
-    /// Feed silent Opus packets until the audio-enabled load reports `LOADCOMPLETED`, bounded by
+    /// Feed `silence` packets until the audio-enabled load reports `LOADCOMPLETED`, bounded by
     /// `budget`. Returns the highest stamp fed and whether the load confirmed.
     ///
     /// Not confirming is not a refusal. Sets differ in what they report the callback against, and
@@ -336,8 +379,7 @@ impl NdlVideo {
     /// the player-clock domain: the ceiling sits exactly [`PRIME_LEAD`] packets above the clock,
     /// the same lead every later feeder targets, so the clock overtakes it within one lead however
     /// long the load took.
-    fn prime_audio(fns: &'static ffi::V2, load_instant: Instant, budget: Duration) -> (i64, bool) {
-        let silence = &OPUS_SILENCE[..];
+    fn prime_audio(fns: &'static ffi::V2, load_instant: Instant, budget: Duration, silence: &[u8]) -> (i64, bool) {
         let mut pts_ms = 0;
         while !LOAD_COMPLETED.fired() {
             // A reported fatal state is the one answer that will not change by waiting, so the
@@ -451,7 +493,7 @@ impl NdlVideo {
     /// audio plane's only feed path, so no real packet can land mid-burst and read a stale ceiling
     /// — it either precedes this and is picked up by the floor, or follows the final publish.
     fn burst_silence(&self, from_ms: i64, target_ms: i64) -> Result<i64> {
-        let silence = &OPUS_SILENCE[..];
+        let silence = silence(self.plane_channels);
         let _ffi = lock_ffi();
         let mut pts_ms = from_ms.max(self.last_audio_pts_ms.load(Ordering::Relaxed));
         while pts_ms < target_ms {
@@ -775,7 +817,9 @@ impl AudioSink for NdlVideo {
     /// What the load asked for, and what every silence burst here already speaks — see
     /// [`plane_config`].
     fn format(&self) -> AudioFormat {
-        AudioFormat::Opus { channels: 2 }
+        AudioFormat::Opus {
+            channels: self.plane_channels,
+        }
     }
 
     /// `host_pts_ns` is ignored — the plane stamps off the player clock, which is the whole point

--- a/src/platform/webos/ndl/v2.rs
+++ b/src/platform/webos/ndl/v2.rs
@@ -48,20 +48,15 @@ const OPUS_SILENCE: [u8; 3] = [0xec, 0xff, 0xfe];
 
 /// One empty frame in [`OPUS_51_LAYOUT`] — ss4s's `opus_empty_frame_642`: four 5 ms streams,
 /// two coupled, the first three self-delimited.
-const OPUS_51_SILENCE: [u8; 15] = [
+pub const OPUS_51_SILENCE: [u8; 15] = [
     0xec, 0x02, 0xff, 0xfe, 0xec, 0x02, 0xff, 0xfe, 0xe8, 0x02, 0xff, 0xfe, 0xe8, 0xff, 0xfe,
 ];
 
-/// The one 5.1 Opus layout NDL decodes on its plane: `GameStream`'s, the one ss4s's
-/// `IsOpusPassthroughSupported` checks for — (FL,FR) and (RL,RR) coupled, FC and LFE mono. The
-/// wire couples (FC,LFE) instead, so `session::audio` re-encodes a 5.1 session into this one.
-pub const OPUS_51_LAYOUT: OpusLayout = OpusLayout {
-    channels: 6,
-    streams: 4,
-    coupled: 2,
-    mapping: &[0, 1, 4, 5, 2, 3],
-    bitrate: 512_000,
-};
+/// The one 5.1 Opus layout NDL decodes on its plane — the standard coupling, which ss4s's
+/// `IsOpusPassthroughSupported` checks for. Every session asks the host for it
+/// (`Hello::audio_layout`); `session::audio` re-encodes into it against a host that answers
+/// legacy.
+pub const OPUS_51_LAYOUT: OpusLayout = punktfunk_core::audio::LAYOUT_51_STANDARD;
 
 /// One [`PRIME_PACKET_MS`] silent packet for a plane loaded with `channels`.
 fn silence(channels: u8) -> &'static [u8] {

--- a/src/runtime/console_flow.rs
+++ b/src/runtime/console_flow.rs
@@ -80,6 +80,8 @@ pub(super) fn run(
         // "Controller-optimized UI" row is gated on saying so — turning it off there is the
         // way back to the cursor menus.
         fallback_ui: true,
+        // NDL decodes H.264 and HEVC only; the Hello never offers PyroWave.
+        pyrowave_ok: false,
         store: Some(store.clone()),
         platform: Platform::WebOS,
         gpu_cache_bytes: crate::console::GPU_CACHE_BYTES,

--- a/src/runtime/session_ext.rs
+++ b/src/runtime/session_ext.rs
@@ -59,6 +59,11 @@ impl Connected {
         }
     }
 
+    /// The coupling the host encodes (`Welcome::audio_layout`, verbatim), for the audio stage.
+    pub(crate) fn audio_layout_id(&self) -> u8 {
+        self.client.audio_layout
+    }
+
     /// The negotiated channel layout, for the overlay's audio line. Names the layout rather than
     /// the count — "5.1" is what the user picked in Settings, `6` is not.
     pub(crate) fn audio_layout(&self) -> &'static str {

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -329,7 +329,11 @@ pub(super) fn run_inner() -> Result<()> {
                         connected.audio_buffer_cell(),
                     )
                     .and_then(|(player, sink)| {
-                        let stage = crate::session::audio::AudioStage::new(std::sync::Arc::new(sink), channels)?;
+                        let stage = crate::session::audio::AudioStage::new(
+                            std::sync::Arc::new(sink),
+                            channels,
+                            connected.audio_layout_id(),
+                        )?;
                         Ok((player, connected.spawn_audio_feed(stage)?))
                     }) {
                         Ok(pair) => Some(pair),

--- a/src/session/audio.rs
+++ b/src/session/audio.rs
@@ -1,9 +1,10 @@
 //! The audio stage: transport packets → whatever the session's [`AudioSink`] takes.
 //!
 //! One implementation covers both routes. What differs between them is the sink's declared
-//! [`AudioFormat`], and the stage produces exactly that: raw Opus goes through untouched where the
-//! TV decodes it, and libopus decodes here where the SDL device plays it — with concealment,
-//! written once into a reused buffer.
+//! [`AudioFormat`], and the stage produces exactly that: stereo Opus goes through untouched where
+//! the TV decodes it, 5.1 is re-encoded into the one layout NDL decodes ([`OPUS_51_LAYOUT`]), and
+//! libopus decodes here where the SDL device plays it — with concealment, written once into a
+//! reused buffer.
 //!
 //! **Nothing is mixed down.** A layout the selected route cannot carry is not requested from the
 //! host in the first place (`core::model::AudioRoutePref::max_channels`), so a width mismatch here
@@ -14,6 +15,7 @@ use anyhow::{bail, Result};
 use punktfunk_core::audio::{layout_for, AudioGapTracker};
 
 use crate::core::media::{AudioFormat, AudioSink, Samples};
+use crate::platform::webos::ndl::OPUS_51_LAYOUT;
 
 /// 48 kHz, 5 ms frames — punktfunk's fixed audio framing (see punktfunk-core's audio.rs docs and
 /// its `multistream_layout_roundtrips_with_channel_identity` test, the canonical reference for
@@ -24,12 +26,18 @@ const SAMPLES_PER_FRAME: usize = 240;
 const FRAME_MS: i64 = 5;
 /// Max channels punktfunk ever negotiates (7.1) — sizes the scratch decode buffer.
 const MAX_CHANNELS: usize = 8;
+/// Room for one re-encoded 5 ms packet: 320 bytes at [`OPUS_51_LAYOUT`]'s bitrate.
+const MAX_PACKET: usize = 4000;
 
 /// Decodes (or forwards) one session's audio into its sink.
 pub struct AudioStage {
     sink: Arc<dyn AudioSink>,
-    /// `None` on the Opus route, where the TV decodes and this stage only forwards.
+    /// `None` where the TV takes the wire's stereo Opus as-is and this stage only forwards.
     decoder: Option<opus::MSDecoder>,
+    /// 5.1 offload only: re-encodes every decoded frame into [`OPUS_51_LAYOUT`].
+    reencoder: Option<opus::MSEncoder>,
+    /// The re-encoder's output, one packet at a time.
+    packet: Vec<u8>,
     /// Negotiated channel count — the decode width, and what libopus sizes a frame by.
     channels: usize,
     /// Detects packets lost on the wire so they can be concealed rather than skipped.
@@ -58,16 +66,25 @@ impl AudioStage {
             );
         }
         let layout = layout_for(channels, false);
-        let decoder = match format {
-            AudioFormat::Opus { .. } => None,
-            _ => Some(
-                opus::MSDecoder::new(SAMPLE_RATE, layout.streams, layout.coupled, layout.mapping)
-                    .map_err(|e| anyhow::anyhow!("opus MSDecoder::new: {e}"))?,
-            ),
+        let decoder = || {
+            opus::MSDecoder::new(SAMPLE_RATE, layout.streams, layout.coupled, layout.mapping)
+                .map_err(|e| anyhow::anyhow!("opus MSDecoder::new: {e}"))
+        };
+        let (decoder, reencoder) = match format {
+            // The wire's stereo Opus is exactly what NDL's stereo plane decodes.
+            AudioFormat::Opus { channels: 2 } => (None, None),
+            // The wire couples (FC,LFE); NDL decodes only a layout that couples (RL,RR).
+            AudioFormat::Opus { channels } if channels == OPUS_51_LAYOUT.channels => {
+                (Some(decoder()?), Some(reencoder_51()?))
+            }
+            AudioFormat::Opus { channels } => bail!("NDL's Opus plane takes stereo or 5.1, not {channels} channels"),
+            AudioFormat::PcmF32 { .. } => (Some(decoder()?), None),
         };
         Ok(Self {
             sink,
             decoder,
+            reencoder,
+            packet: vec![0; MAX_PACKET],
             channels: layout.channels as usize,
             gaps: AudioGapTracker::new(),
             // One packet plus the concealment burst that can precede it, so steady state never
@@ -83,12 +100,15 @@ impl AudioStage {
 
     /// One packet, concealment included, into the sink.
     ///
-    /// Concealment sits in the hole BEFORE the packet, so the buffer starts that many
-    /// milliseconds earlier than the packet's own stamp and is fed at `pts - lead`.
+    /// Concealment sits in the hole BEFORE the packet, so its frames are stamped that many
+    /// milliseconds earlier than the packet's own stamp. The SDL device takes them as one buffer;
+    /// NDL takes one Opus packet per call, so a re-encoded frame is fed on its own.
     pub fn play(&mut self, seq: u32, pts_ns: u64, payload: &[u8]) -> Result<()> {
         // Destructured so the decode loop can hold `decoder`, `pcm` and `f32` at once.
         let Self {
             decoder,
+            reencoder,
+            packet,
             f32,
             pcm,
             channels,
@@ -112,19 +132,28 @@ impl AudioStage {
                 SAMPLES_PER_FRAME * MAX_CHANNELS
             }
         };
+        let stamp = |i: u32| pts_ns.saturating_sub((i64::from(missing - i) * FRAME_MS) as u64 * 1_000_000);
         // Concealment frames first (libopus PLC — decode with empty input interpolates a frame;
         // the alternative is a hard gap, i.e. a click), then the packet itself. `f32` is both what
-        // libopus produces and what the SDL device takes, so there is no conversion pass and no
-        // second buffer.
+        // libopus produces and what the SDL device takes, so there is no conversion pass there.
         for i in 0..=missing {
             let input: &[u8] = if i < missing { &[] } else { payload };
             let frames = decoder
                 .decode_float(input, &mut pcm[..cap(i)], false)
                 .map_err(|e| anyhow::anyhow!("opus decode: {e}"))?;
-            f32.extend_from_slice(&pcm[..frames * channels]);
+            let decoded = &pcm[..frames * channels];
+            f32.extend_from_slice(decoded);
+            if let Some(encoder) = reencoder.as_mut() {
+                let n = encoder
+                    .encode_float(decoded, packet)
+                    .map_err(|e| anyhow::anyhow!("opus 5.1 re-encode: {e}"))?;
+                sink.feed(Samples::Opus(&packet[..n]), stamp(i))?;
+            }
         }
-        let pts_ns = pts_ns.saturating_sub((i64::from(missing) * FRAME_MS) as u64 * 1_000_000);
-        sink.feed(Samples::F32(f32), pts_ns)
+        if reencoder.is_some() {
+            return Ok(());
+        }
+        sink.feed(Samples::F32(f32), stamp(0))
     }
 
     /// The sink's own queue depth in ms, where it knows one — NDL's plane lead, or the SDL ring's
@@ -134,10 +163,104 @@ impl AudioStage {
     }
 
     /// Peak sample of the last decoded buffer — a diagnostic that separates "the host is sending
-    /// silence" from "the speaker is not working". `None` on the Opus route, which decodes nothing.
+    /// silence" from "the speaker is not working". `None` where stereo Opus is forwarded undecoded.
     pub fn peak(&self) -> Option<f32> {
         self.decoder
             .is_some()
             .then(|| self.f32.iter().fold(0f32, |m, &s| m.max(s.abs())))
+    }
+}
+
+/// An encoder for [`OPUS_51_LAYOUT`]. `LowDelay` keeps it CELT-only, so the re-encode adds one
+/// 5 ms frame and 2.5 ms of look-ahead.
+fn reencoder_51() -> Result<opus::MSEncoder> {
+    let l = OPUS_51_LAYOUT;
+    let mut encoder = opus::MSEncoder::new(
+        SAMPLE_RATE,
+        l.streams,
+        l.coupled,
+        l.mapping,
+        opus::Application::LowDelay,
+    )
+    .map_err(|e| anyhow::anyhow!("opus MSEncoder::new: {e}"))?;
+    encoder
+        .set_bitrate(opus::Bitrate::Bits(l.bitrate))
+        .map_err(|e| anyhow::anyhow!("opus set_bitrate: {e}"))?;
+    Ok(encoder)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// Stands in for NDL's 5.1 plane: keeps every packet it is fed.
+    struct Plane(Mutex<Vec<Vec<u8>>>);
+
+    impl AudioSink for Plane {
+        fn name(&self) -> &'static str {
+            "test plane"
+        }
+
+        fn format(&self) -> AudioFormat {
+            AudioFormat::Opus { channels: 6 }
+        }
+
+        fn feed(&self, samples: Samples<'_>, _host_pts_ns: u64) -> Result<()> {
+            let Samples::Opus(packet) = samples else {
+                bail!("the plane takes Opus only");
+            };
+            self.0.lock().unwrap().push(packet.to_vec());
+            Ok(())
+        }
+    }
+
+    /// A tone on the wire's rear-left comes out rear-left in NDL's layout: the re-encode moves
+    /// streams, never channels.
+    #[test]
+    fn reencode_keeps_channel_identity() {
+        const REAR_LEFT: usize = 4;
+        let wire = layout_for(6, false);
+        let mut wire_encoder = opus::MSEncoder::new(
+            SAMPLE_RATE,
+            wire.streams,
+            wire.coupled,
+            wire.mapping,
+            opus::Application::LowDelay,
+        )
+        .unwrap();
+        let plane = Arc::new(Plane(Mutex::new(Vec::new())));
+        let mut stage = AudioStage::new(plane.clone(), 6).unwrap();
+
+        let mut phase = 0f32;
+        let mut packet = [0u8; MAX_PACKET];
+        for seq in 0..40 {
+            let mut frame = vec![0f32; SAMPLES_PER_FRAME * 6];
+            for sample in frame.chunks_exact_mut(6) {
+                phase += 0.05;
+                sample[REAR_LEFT] = phase.sin() * 0.5;
+            }
+            let len = wire_encoder.encode_float(&frame, &mut packet).unwrap();
+            stage.play(seq, 0, &packet[..len]).unwrap();
+        }
+
+        let l = OPUS_51_LAYOUT;
+        let mut ndl = opus::MSDecoder::new(SAMPLE_RATE, l.streams, l.coupled, l.mapping).unwrap();
+        let mut out = vec![0f32; SAMPLES_PER_FRAME * 6];
+        let mut energy = [0f32; 6];
+        for (i, packet) in plane.0.lock().unwrap().iter().enumerate() {
+            let frames = ndl.decode_float(packet, &mut out, false).unwrap();
+            // The first frames carry both codecs' warm-up.
+            if i >= 10 {
+                for sample in out[..frames * 6].chunks_exact(6) {
+                    for (e, v) in energy.iter_mut().zip(sample) {
+                        *e += v * v;
+                    }
+                }
+            }
+        }
+        let loudest = (0..6).max_by(|&a, &b| energy[a].total_cmp(&energy[b])).unwrap();
+        assert_eq!(loudest, REAR_LEFT, "energy per channel: {energy:?}");
     }
 }

--- a/src/session/audio.rs
+++ b/src/session/audio.rs
@@ -1,10 +1,10 @@
 //! The audio stage: transport packets → whatever the session's [`AudioSink`] takes.
 //!
 //! One implementation covers both routes. What differs between them is the sink's declared
-//! [`AudioFormat`], and the stage produces exactly that: stereo Opus goes through untouched where
-//! the TV decodes it, 5.1 is re-encoded into the one layout NDL decodes ([`OPUS_51_LAYOUT`]), and
-//! libopus decodes here where the SDL device plays it — with concealment, written once into a
-//! reused buffer.
+//! [`AudioFormat`], and the stage produces exactly that: Opus goes through untouched where the TV
+//! decodes it, and libopus decodes here where the SDL device plays it — with concealment, written
+//! once into a reused buffer. The one exception is 5.1 from a host that answered the legacy
+//! coupling: NDL decodes only [`OPUS_51_LAYOUT`], so that stream is re-encoded into it.
 //!
 //! **Nothing is mixed down.** A layout the selected route cannot carry is not requested from the
 //! host in the first place (`core::model::AudioRoutePref::max_channels`), so a width mismatch here
@@ -12,7 +12,7 @@
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
-use punktfunk_core::audio::{layout_for, AudioGapTracker};
+use punktfunk_core::audio::{layout_for, AudioGapTracker, AudioLayout, AudioTier};
 
 use crate::core::media::{AudioFormat, AudioSink, Samples};
 use crate::platform::webos::ndl::OPUS_51_LAYOUT;
@@ -52,9 +52,9 @@ pub struct AudioStage {
 }
 
 impl AudioStage {
-    /// `channels` is host-resolved — the decoder MUST be built from what the handshake settled on,
-    /// never from what was requested.
-    pub fn new(sink: Arc<dyn AudioSink>, channels: u8) -> Result<Self> {
+    /// `channels` and `layout` are host-resolved — the decoder MUST be built from what the
+    /// handshake settled on, never from what was requested.
+    pub fn new(sink: Arc<dyn AudioSink>, channels: u8, layout: u8) -> Result<Self> {
         let format = sink.format();
         if format.channels() != channels {
             // Not a fold: see the module docs. A route is only ever selected for a layout it
@@ -65,15 +65,25 @@ impl AudioStage {
                 format.channels(),
             );
         }
-        let layout = layout_for(channels, false);
+        // A coupling this build does not know would pair channels wrongly, not loudly.
+        let Some(layout) = AudioLayout::from_wire(layout) else {
+            bail!("the host encodes audio layout {layout}, which this client does not know");
+        };
+        let wire = layout_for(channels, layout);
         let decoder = || {
-            opus::MSDecoder::new(SAMPLE_RATE, layout.streams, layout.coupled, layout.mapping)
+            opus::MSDecoder::new(SAMPLE_RATE, wire.streams, wire.coupled, wire.mapping)
                 .map_err(|e| anyhow::anyhow!("opus MSDecoder::new: {e}"))
         };
         let (decoder, reencoder) = match format {
             // The wire's stereo Opus is exactly what NDL's stereo plane decodes.
             AudioFormat::Opus { channels: 2 } => (None, None),
-            // The wire couples (FC,LFE); NDL decodes only a layout that couples (RL,RR).
+            // The host was asked for NDL's one 5.1 layout and encodes it: forwarded untouched.
+            AudioFormat::Opus { channels }
+                if channels == OPUS_51_LAYOUT.channels && layout == AudioLayout::Standard =>
+            {
+                (None, None)
+            }
+            // An older host couples (FC,LFE); NDL decodes only the standard pairing.
             AudioFormat::Opus { channels } if channels == OPUS_51_LAYOUT.channels => {
                 (Some(decoder()?), Some(reencoder_51()?))
             }
@@ -85,7 +95,7 @@ impl AudioStage {
             decoder,
             reencoder,
             packet: vec![0; MAX_PACKET],
-            channels: layout.channels as usize,
+            channels: wire.channels as usize,
             gaps: AudioGapTracker::new(),
             // One packet plus the concealment burst that can precede it, so steady state never
             // reallocates.
@@ -184,7 +194,7 @@ fn reencoder_51() -> Result<opus::MSEncoder> {
     )
     .map_err(|e| anyhow::anyhow!("opus MSEncoder::new: {e}"))?;
     encoder
-        .set_bitrate(opus::Bitrate::Bits(l.bitrate))
+        .set_bitrate(opus::Bitrate::Bits(l.bitrate_for(AudioTier::High)))
         .map_err(|e| anyhow::anyhow!("opus set_bitrate: {e}"))?;
     Ok(encoder)
 }
@@ -221,7 +231,7 @@ mod tests {
     #[test]
     fn reencode_keeps_channel_identity() {
         const REAR_LEFT: usize = 4;
-        let wire = layout_for(6, false);
+        let wire = layout_for(6, AudioLayout::Legacy);
         let mut wire_encoder = opus::MSEncoder::new(
             SAMPLE_RATE,
             wire.streams,
@@ -231,7 +241,7 @@ mod tests {
         )
         .unwrap();
         let plane = Arc::new(Plane(Mutex::new(Vec::new())));
-        let mut stage = AudioStage::new(plane.clone(), 6).unwrap();
+        let mut stage = AudioStage::new(plane.clone(), 6, AudioLayout::Legacy.wire()).unwrap();
 
         let mut phase = 0f32;
         let mut packet = [0u8; MAX_PACKET];
@@ -262,5 +272,17 @@ mod tests {
         }
         let loudest = (0..6).max_by(|&a, &b| energy[a].total_cmp(&energy[b])).unwrap();
         assert_eq!(loudest, REAR_LEFT, "energy per channel: {energy:?}");
+    }
+
+    /// A host that already encodes NDL's layout is forwarded byte for byte; a layout this build
+    /// does not know is refused rather than decoded with a guess.
+    #[test]
+    fn standard_layout_is_forwarded_untouched() {
+        let plane = Arc::new(Plane(Mutex::new(Vec::new())));
+        let mut stage = AudioStage::new(plane.clone(), 6, AudioLayout::Standard.wire()).unwrap();
+        let packet = crate::platform::webos::ndl::OPUS_51_SILENCE;
+        stage.play(0, 0, &packet).unwrap();
+        assert_eq!(plane.0.lock().unwrap().as_slice(), &[packet.to_vec()]);
+        assert!(AudioStage::new(plane, 6, 9).is_err());
     }
 }

--- a/src/session/connect.rs
+++ b/src/session/connect.rs
@@ -122,36 +122,25 @@ impl Negotiated {
     fn clamp(params: &ConnectParams) -> Self {
         let caps = video_caps();
         // `params.audio_channels` is the user's PREFERENCE; this is where it becomes a width.
-        // Two things narrow it, both settled before the handshake because channels the session
-        // cannot put on a speaker are airlink, host CPU and local decode spent on silence:
-        // what the selected route can carry at all, and what the TV's Sound Out passes right now.
-        // Nothing is folded down later — see `AudioRoutePref::max_channels`.
+        // Only the static limits narrow it: what this client decodes and what the route carries.
+        // Sound Out does not — webOS folds what its output can't pass (`ndl::log_audio_output`).
         let route_max = params.audio_route.max_channels(caps);
-        let output_max = crate::platform::webos::ndl::audio_output_width();
-        let audio_channels = params
-            .audio_channels
-            .min(caps.max_channels)
-            .min(route_max)
-            .min(output_max.unwrap_or(u8::MAX));
+        let audio_channels = params.audio_channels.min(caps.max_channels).min(route_max);
+        if audio_channels > 2 {
+            crate::platform::webos::ndl::log_audio_output();
+        }
         if audio_channels < params.audio_channels {
-            // Names the limit that actually bound, because the three are indistinguishable from
-            // the width alone and "why is this stereo" is the question the log has to answer.
-            let reason = if audio_channels == output_max.unwrap_or(u8::MAX) {
-                "the TV's audio output passes no more"
-            } else if audio_channels == route_max {
+            // Names the limit that bound: "why is this stereo" is the question the log answers.
+            let reason = if audio_channels == route_max {
                 "the audio route carries no more"
             } else {
                 "this client decodes no more"
             };
             tracing::info!(
                 "audio: {} channel(s) requested, asking for {audio_channels} — {reason} \
-                 (client {}, route {route_max}, output {})",
+                 (client {}, route {route_max})",
                 params.audio_channels,
                 caps.max_channels,
-                match output_max {
-                    Some(w) => w.to_string(),
-                    None => "unknown".to_string(),
-                },
             );
         }
         let codecs = caps.codec_prefs();

--- a/src/session/connect.rs
+++ b/src/session/connect.rs
@@ -178,7 +178,7 @@ impl Negotiated {
 
 /// Runs the handshake. Everything wire-facing has already been clamped by [`Negotiated::clamp`].
 fn dial(params: &ConnectParams, negotiated: &Negotiated) -> Result<NativeClient> {
-    NativeClient::connect(
+    NativeClient::connect_with_audio_format(
         &params.host,
         params.port,
         params.mode,
@@ -194,6 +194,12 @@ fn dial(params: &ConnectParams, negotiated: &Negotiated) -> Result<NativeClient>
         // `AudioPlayer::new` is built from the RESOLVED `client.audio_channels`,
         // never from this.
         negotiated.audio_channels,
+        // Opus at 48 kHz/16-bit: this client has no lossless ask.
+        0,
+        0,
+        // The standard coupling on every session: libopus here decodes either, and NDL's plane
+        // takes only this one. A host that answers legacy is re-encoded (`session::audio`).
+        punktfunk_core::audio::AudioLayout::Standard,
         negotiated.video_codecs,
         negotiated.preferred_codec,
         negotiated.display_hdr,
@@ -221,6 +227,8 @@ fn dial(params: &ConnectParams, negotiated: &Negotiated) -> Result<NativeClient>
         params.pin,
         Some(params.identity.clone()),
         params.timeout,
+        // Uncancelable: the connect has its own thread and the caller joins it.
+        None,
     )
     .context("connect")
 }
@@ -233,13 +241,14 @@ fn log_handshake(client: &NativeClient, negotiated: &Negotiated) {
     });
     tracing::info!(
         "connected: codec={} (offered=0x{:02x} preferred=0x{:02x}) \
-         compositor={:?} audio_ch={} color={:?} wire_budget_kbps={} \
+         compositor={:?} audio_ch={} audio_layout={} color={:?} wire_budget_kbps={} \
          decode_latency={} caps=0x{:02x} fp={fp_hex}",
         client.codec,
         negotiated.video_codecs,
         negotiated.preferred_codec,
         client.resolved_compositor,
         client.audio_channels,
+        client.audio_layout,
         client.color,
         client.resolved_bitrate_kbps,
         client.wants_decode_latency(),

--- a/src/session/pipeline.rs
+++ b/src/session/pipeline.rs
@@ -55,7 +55,7 @@ impl MediaPipeline {
         // plane means silent audio.
         let plane = player.audio_plane();
         let proven = plane.as_ref().is_some_and(|p| p.accepts_stream());
-        let route = resolve_route(params.audio_route, client.audio_channels, proven);
+        let route = resolve_route(params.audio_route, proven);
         tracing::info!(
             "audio path: {} on {} (host resolved {} channel(s))",
             audio_path_label(params.audio_route, route, plane.is_some(), proven),
@@ -108,11 +108,10 @@ impl MediaPipeline {
 /// route with known-good pacing: NDL paces against a fed plane, which inherits network jitter
 /// (silence plane cures this). Plane routes are kept selectable for comparison but unproven.
 /// `has_plane` is the proven plane, not the requested one — see the call site.
-fn resolve_route(pref: AudioRoutePref, channels: u8, has_plane: bool) -> AudioRoutePref {
-    // Stereo or nothing: `Settings::clamp` already holds the document to it, and a session the
-    // host resolved wider must not silently land on a plane whose decoder has no mode for it.
+fn resolve_route(pref: AudioRoutePref, has_plane: bool) -> AudioRoutePref {
+    // The plane was loaded at the session's own width (stereo or 5.1), so only proof decides.
     match pref {
-        AudioRoutePref::NdlOpus if has_plane && channels == 2 => AudioRoutePref::NdlOpus,
+        AudioRoutePref::NdlOpus if has_plane => AudioRoutePref::NdlOpus,
         AudioRoutePref::Software | AudioRoutePref::NdlOpus => AudioRoutePref::Software,
     }
 }
@@ -121,13 +120,10 @@ fn resolve_route(pref: AudioRoutePref, channels: u8, has_plane: bool) -> AudioRo
 /// proof — metronome paces unconfirmed planes fine, but wrong audio route is silent forever. Issue
 /// #188: some sets report the callback only after the first video frame; extra waiting during load
 /// just adds black screen.
-fn plane_budget(pref: AudioRoutePref, channels: u8) -> std::time::Duration {
-    // Same test as `resolve_route`, deliberately: only a session that will actually END UP on the
-    // plane is worth waiting for one. A wider layout takes the software route whatever the load
-    // says, so paying the long budget there is black screen bought for an answer nobody reads.
+fn plane_budget(pref: AudioRoutePref) -> std::time::Duration {
     match pref {
-        AudioRoutePref::NdlOpus if channels == 2 => crate::platform::webos::ndl::AUDIO_PROVE_BUDGET,
-        AudioRoutePref::NdlOpus | AudioRoutePref::Software => crate::platform::webos::ndl::AUDIO_PRIME_BUDGET,
+        AudioRoutePref::NdlOpus => crate::platform::webos::ndl::AUDIO_PROVE_BUDGET,
+        AudioRoutePref::Software => crate::platform::webos::ndl::AUDIO_PRIME_BUDGET,
     }
 }
 
@@ -153,7 +149,13 @@ fn load_player(client: &NativeClient, params: &ConnectParams) -> Result<(Box<dyn
                 width,
                 height,
                 codec,
-                Some(plane_budget(params.audio_route, client.audio_channels)),
+                Some(plane_budget(params.audio_route)),
+                // Offload loads the plane at the session's width; the metronome rides stereo.
+                if params.audio_route == AudioRoutePref::NdlOpus {
+                    client.audio_channels
+                } else {
+                    2
+                },
             )
             .context("NDL load")?,
         )),
@@ -198,9 +200,8 @@ fn load_player(client: &NativeClient, params: &ConnectParams) -> Result<(Box<dyn
 fn audio_path_label(pref: AudioRoutePref, route: AudioRoutePref, has_plane: bool, proven: bool) -> &'static str {
     match (route, has_plane) {
         (AudioRoutePref::NdlOpus, _) => "NDL hardware Opus decode (+ clock plane standing by)",
-        // The user asked for the plane and the load never confirmed it in its budget. Stereo was
-        // already negotiated on the strength of that request and cannot be widened now. Gated on
-        // `proven` because a >2ch session takes the same downgrade for an unrelated reason.
+        // The user asked for the plane and the load never confirmed it in its budget, so the
+        // session plays through SDL at the width it already negotiated.
         (AudioRoutePref::Software, true) if pref == AudioRoutePref::NdlOpus && !proven => {
             "software Opus decode -> SDL2 + NDL clock plane (offload asked for, plane unconfirmed)"
         }

--- a/src/session/pipeline.rs
+++ b/src/session/pipeline.rs
@@ -264,11 +264,12 @@ fn spawn_plane_threads(
     };
     // Folded into the spawn's own error type to keep ONE failure path: an early `?` here would
     // return before the clock thread above is joined, detaching a thread still feeding NDL.
-    let audio_thread = match AudioStage::new(sink, client.audio_channels) {
+    let audio_thread = match AudioStage::new(sink, client.audio_channels, client.audio_layout) {
         Ok(stage) => {
             tracing::info!(
-                "audio stage: {} channel(s) into {}",
+                "audio stage: {} channel(s), layout {} into {}",
                 client.audio_channels,
+                client.audio_layout,
                 stage.sink_name()
             );
             spawn_audio_feed(client.clone(), stage, stop.clone())


### PR DESCRIPTION
Report: 5.1 does not work in the webOS client. Four commits, each a layer of it:

**`7259b9a` — the Sound Out gate.** Since #157 (0.18.0), connect narrowed the channel request by `NDL_DirectAudioSupportMultiChannel`, which reads "will play" only with Sound Out on Pass Through and describes NDL's own PCM path, not the SDL device the software route plays through. Every 5.1 pick on a default-configured TV became a stereo session. Removed; the probe stays as one connect-time log line.

**`4a6d3ff` — 5.1 through NDL's Opus plane.** With the gate gone, surround still reached the AVR as PCM 2.0: PulseAudio's one hardware sink on the G5 is s16le 2ch, and a plane loaded as 6-channel PCM (`"6-channel"`) plays but is folded too, even with NDL reporting `Supported` (aurora-tv dropped that path for the same reason). NDL's Opus plane decodes exactly one 5.1 layout — the standard coupling, (FL,FR)+(RL,RR) with FC and LFE mono — and punktfunk/1 coupled (FC,LFE), so the Offload route decodes and re-encodes into NDL's layout (ss4s's `opus_fix`). Offload now carries stereo or 5.1. Re-encode cost on the G5: ~1.2% of one core, +7.5 ms.

**`0432bb9` + `133da44` — ask the host for that coupling.** unom/punktfunk#937 (merged, `332e52d41`) makes the coupling negotiable (`Hello::audio_layout` / `Welcome::audio_layout`, `AudioLayout::Standard` = NDL's). Every session asks for it; a host that knows it encodes it and the plane is fed the wire untouched. An older host answers legacy and the re-encode above remains the fallback; an unknown id is refused. Core pinned to the merge commit.

**Verified on glass (G5, webOS 10.3 → Denon AVC-X3800H over eARC):**
- `4a6d3ff` against a 0.34 host: AVR `OPINFINS 222222…` / `MSDIRECT`, rears and sub discrete.
- `133da44` against a host from `332e52d41` (.173, `0.37.24151`): TV connect line `audio_ch=6 audio_layout=1`, `audio stage: 6 channel(s), layout 1 into NDL Opus plane` (forwarded, no decoder built), host `audio streaming … layout=Standard`, AVR six input channels for the whole speaker test.
- Gates: `task docker:lint`, `task docker:test` (58, incl. a rear-left-only tone surviving the re-encode and a standard-layout packet forwarded byte-identical), `task docker:package`.

**Not in this PR:** the console kit hard-codes the Audio-processing captions (`WEBOS_AUDIO_ROUTES`); Offload's caption still says stereo only.
