### PR TITLE
feat(stats): draw the shared stats overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "cros-codecs"
 version = "0.0.5"
-source = "git+https://git.unom.io/unom/punktfunk?rev=31d52f34d#31d52f34d6205609763594afc49179ee87a2931a"
+source = "git+https://git.unom.io/unom/punktfunk?rev=66a890923#66a890923fbf2f674e96eb4e831c4661fa008ba4"
 dependencies = [
  "log",
 ]
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=31d52f34d#31d52f34d6205609763594afc49179ee87a2931a"
+source = "git+https://git.unom.io/unom/punktfunk?rev=66a890923#66a890923fbf2f674e96eb4e831c4661fa008ba4"
 
 [[package]]
 name = "fiat-crypto"
@@ -1283,7 +1283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "pf-bitstream"
 version = "0.36.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=31d52f34d#31d52f34d6205609763594afc49179ee87a2931a"
+source = "git+https://git.unom.io/unom/punktfunk?rev=66a890923#66a890923fbf2f674e96eb4e831c4661fa008ba4"
 dependencies = [
  "cros-codecs",
  "tracing",
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "pf-client-core"
 version = "0.36.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=31d52f34d#31d52f34d6205609763594afc49179ee87a2931a"
+source = "git+https://git.unom.io/unom/punktfunk?rev=66a890923#66a890923fbf2f674e96eb4e831c4661fa008ba4"
 dependencies = [
  "anyhow",
  "punktfunk-core",
@@ -1305,7 +1305,7 @@ dependencies = [
 [[package]]
 name = "pf-console-ui"
 version = "0.36.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=31d52f34d#31d52f34d6205609763594afc49179ee87a2931a"
+source = "git+https://git.unom.io/unom/punktfunk?rev=66a890923#66a890923fbf2f674e96eb4e831c4661fa008ba4"
 dependencies = [
  "anyhow",
  "pf-client-core",
@@ -1405,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "punktfunk-core"
 version = "0.36.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=31d52f34d#31d52f34d6205609763594afc49179ee87a2931a"
+source = "git+https://git.unom.io/unom/punktfunk?rev=66a890923#66a890923fbf2f674e96eb4e831c4661fa008ba4"
 dependencies = [
  "aes-gcm",
  "cbindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "cros-codecs"
 version = "0.0.5"
-source = "git+https://git.unom.io/unom/punktfunk?rev=332e52d41#332e52d41f77b96a46d8162021a4e367ac535a10"
+source = "git+https://git.unom.io/unom/punktfunk?rev=31d52f34d#31d52f34d6205609763594afc49179ee87a2931a"
 dependencies = [
  "log",
 ]
@@ -694,7 +694,7 @@ dependencies = [
 [[package]]
 name = "fec-rs"
 version = "0.1.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=332e52d41#332e52d41f77b96a46d8162021a4e367ac535a10"
+source = "git+https://git.unom.io/unom/punktfunk?rev=31d52f34d#31d52f34d6205609763594afc49179ee87a2931a"
 
 [[package]]
 name = "fiat-crypto"
@@ -1283,7 +1283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "pf-bitstream"
 version = "0.36.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=332e52d41#332e52d41f77b96a46d8162021a4e367ac535a10"
+source = "git+https://git.unom.io/unom/punktfunk?rev=31d52f34d#31d52f34d6205609763594afc49179ee87a2931a"
 dependencies = [
  "cros-codecs",
  "tracing",
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "pf-client-core"
 version = "0.36.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=332e52d41#332e52d41f77b96a46d8162021a4e367ac535a10"
+source = "git+https://git.unom.io/unom/punktfunk?rev=31d52f34d#31d52f34d6205609763594afc49179ee87a2931a"
 dependencies = [
  "anyhow",
  "punktfunk-core",
@@ -1305,7 +1305,7 @@ dependencies = [
 [[package]]
 name = "pf-console-ui"
 version = "0.36.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=332e52d41#332e52d41f77b96a46d8162021a4e367ac535a10"
+source = "git+https://git.unom.io/unom/punktfunk?rev=31d52f34d#31d52f34d6205609763594afc49179ee87a2931a"
 dependencies = [
  "anyhow",
  "pf-client-core",
@@ -1405,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "punktfunk-core"
 version = "0.36.0"
-source = "git+https://git.unom.io/unom/punktfunk?rev=332e52d41#332e52d41f77b96a46d8162021a4e367ac535a10"
+source = "git+https://git.unom.io/unom/punktfunk?rev=31d52f34d#31d52f34d6205609763594afc49179ee87a2931a"
 dependencies = [
  "aes-gcm",
  "cbindgen",
@@ -1422,6 +1422,7 @@ dependencies = [
  "rcgen",
  "reed-solomon-simd",
  "rustls",
+ "serde",
  "sha2 0.11.0",
  "socket2",
  "spake2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 # 🛑 REV (not tag), same across all drei crates: tag+rev mix builds two copies, types won't unify.
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "31d52f34d", features = ["quic"] }
-pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "31d52f34d", default-features = false }
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "66a890923", features = ["quic"] }
+pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "66a890923", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # mDNS LAN discovery; direct dep (not via pf-client-core — see session.rs docs).
@@ -61,7 +61,7 @@ libc = "0.2"
 # Logs must say "DOWNLOAD AND INSTALL SUCCEEDED". Keep default features for the archive key
 # (`gl-jpegd-jpege-pdf-textlayout`, both sources publish). textlayout is pinned: `skunicode_icu`
 # (icudt74_dat, 10.5 MB) is 43% of the binary; kit shapes every string through `Paragraph`.
-pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "31d52f34d", default-features = false, features = ["gl"] }
+pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "66a890923", default-features = false, features = ["gl"] }
 skia-safe = { version = "0.99", features = ["gl", "textlayout"] }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 # 🛑 REV (not tag), same across all drei crates: tag+rev mix builds two copies, types won't unify.
-punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "332e52d41", features = ["quic"] }
-pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "332e52d41", default-features = false }
+punktfunk-core = { git = "https://git.unom.io/unom/punktfunk", rev = "31d52f34d", features = ["quic"] }
+pf-client-core = { git = "https://git.unom.io/unom/punktfunk", rev = "31d52f34d", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # mDNS LAN discovery; direct dep (not via pf-client-core — see session.rs docs).
@@ -61,7 +61,7 @@ libc = "0.2"
 # Logs must say "DOWNLOAD AND INSTALL SUCCEEDED". Keep default features for the archive key
 # (`gl-jpegd-jpege-pdf-textlayout`, both sources publish). textlayout is pinned: `skunicode_icu`
 # (icudt74_dat, 10.5 MB) is 43% of the binary; kit shapes every string through `Paragraph`.
-pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "332e52d41", default-features = false, features = ["gl"] }
+pf-console-ui = { git = "https://git.unom.io/unom/punktfunk", rev = "31d52f34d", default-features = false, features = ["gl"] }
 skia-safe = { version = "0.99", features = ["gl", "textlayout"] }
 
 [build-dependencies]

--- a/src/app/state/settingspage.rs
+++ b/src/app/state/settingspage.rs
@@ -134,6 +134,7 @@ fn page_rows(page: Page, scope: &Scope) -> Rows {
             } else {
                 push(Row::Kit(K::AutoWake), Some("Session"));
                 push(Row::Kit(K::Stats), Some("Statistics"));
+                push(Row::Kit(K::AdvancedStats), None);
                 push(Row::Kit(K::Palette), Some("Interface"));
                 push(Row::Kit(K::GamepadUi), None);
                 push(Row::Kit(K::GamepadUiMode), None);
@@ -804,6 +805,7 @@ fn absence(id: RowId) -> Option<&'static str> {
         | RowId::PadHaptics
         | RowId::PadSpeaker
         | RowId::Stats
+        | RowId::AdvancedStats
         | RowId::AutoWake
         | RowId::Palette
         | RowId::GamepadUi

--- a/src/core/settings.rs
+++ b/src/core/settings.rs
@@ -84,7 +84,6 @@ pub trait TvSettings {
     fn set_codec_pref(&mut self, codec: CodecPref);
     fn gamepad_type(&self) -> GamepadType;
     fn set_gamepad_type(&mut self, kind: GamepadType);
-    fn stats_overlay(&self) -> bool;
     /// Shared `pad_speaker` is a DESTINATION ("pad", "mix", "off"); this client offers
     /// pad-or-nothing.
     fn pad_speaker_on(&self) -> bool;
@@ -153,10 +152,6 @@ impl TvSettings for Settings {
 
     fn set_gamepad_type(&mut self, kind: GamepadType) {
         self.gamepad = gamepad_pref(kind).as_str().to_string();
-    }
-
-    fn stats_overlay(&self) -> bool {
-        self.show_stats
     }
 
     fn pad_speaker_on(&self) -> bool {

--- a/src/runtime/overlay.rs
+++ b/src/runtime/overlay.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 
 use anyhow::Result;
 use pf_console_ui::theme::{self, Fonts, PanelStroke, W};
+use punktfunk_core::hud::{HudLine, Role};
 use skia_safe::{Color4f, RRect, Rect};
 
 use crate::app::draw::dialog::{self, Motion};
@@ -68,14 +69,27 @@ pub(super) fn wipe(gl: &mut Option<ConsoleGl>, canvas: &sdl2::render::WindowCanv
     Ok(())
 }
 
-pub(super) fn stats(f: &Frame<'_>, lines: &[String], hint: &str, alpha: f32) {
+/// The log tail's WARN tone, shared with the stats card's warning lines.
+const WARN_AMBER: Color4f = Color4f::new(1.0, 0.76, 0.03, 1.0);
+
+/// Headline bright, breakdowns softer, asides dimmer, warnings amber.
+fn role_tone(role: Role) -> Color4f {
+    match role {
+        Role::Primary => theme::fg(1.0),
+        Role::Detail => theme::fg(0.78),
+        Role::Muted => theme::fg(0.6),
+        Role::Warn => WARN_AMBER,
+    }
+}
+
+pub(super) fn stats(f: &Frame<'_>, lines: &[HudLine], hint: &str, alpha: f32) {
     let k = f.k;
     let size = STATS_LINE * f64::from(k);
     let stride = line_h(size) as f32;
     let hint_size = STATS_HINT * f64::from(k);
     let widest = lines
         .iter()
-        .map(|l| f.fonts.measure(l, W::Medium, size))
+        .map(|l| f.fonts.measure(&l.text, W::Medium, size))
         .fold(f.fonts.measure(hint, W::Regular, hint_size), f32::max);
     let w = widest + 2.0 * STATS_PAD * k;
     let h = stride * lines.len() as f32 + line_h(hint_size) as f32 + 2.0 * STATS_PAD * k;
@@ -89,15 +103,14 @@ pub(super) fn stats(f: &Frame<'_>, lines: &[String], hint: &str, alpha: f32) {
     theme::panel(c, card, STATS_CORNER, None, PanelStroke::Plain(0.12), k);
     let x = f64::from(card.left + STATS_PAD * k);
     for (i, line) in lines.iter().enumerate() {
-        let tone = theme::fg(if i == 0 { 1.0 } else { 0.7 });
         f.fonts.draw(
             c,
-            line,
+            &line.text,
             x,
             f64::from(card.top + STATS_PAD * k + stride * (i as f32 + 0.8)),
             W::Medium,
             size,
-            tone,
+            role_tone(line.role),
         );
     }
     let hint_w = f.fonts.measure(hint, W::Regular, hint_size);
@@ -116,7 +129,7 @@ pub(super) fn stats(f: &Frame<'_>, lines: &[String], hint: &str, alpha: f32) {
 fn log_tone(line: &str) -> Color4f {
     match line.split_whitespace().next() {
         Some("ERROR") => theme::ERROR,
-        Some("WARN") => Color4f::new(1.0, 0.76, 0.03, 1.0),
+        Some("WARN") => WARN_AMBER,
         Some("INFO") => theme::fg(1.0),
         _ => theme::fg(0.6),
     }

--- a/src/runtime/session_ext.rs
+++ b/src/runtime/session_ext.rs
@@ -131,40 +131,17 @@ impl Connected {
         self.client.disconnect_quit();
     }
 
-    /// The stats overlay's figures. Grouped into one call so the overlay block has one lookup
-    /// rather than six.
-    pub(crate) fn overlay_info(&self) -> OverlayInfo {
-        let client = &self.client;
-        let mode = client.mode();
-        OverlayInfo {
-            width: mode.width,
-            height: mode.height,
-            refresh_hz: mode.refresh_hz,
-            codec: session::codec_name(client.codec).to_string(),
-            hdr: client.color.is_hdr(),
-            frames_dropped: Some(client.frames_dropped()),
-            fec_recovered: Some(client.fec_recovered_shards()),
-            // The CURRENT total wire budget, not the session-start negotiation: on Automatic the
-            // ABR re-targets mid-session. Core v0.32 changed this from encoder rate to wire budget;
-            // `0` means a host too old to report.
-            target_kbps: match client.current_bitrate_kbps() {
-                0 => client.resolved_bitrate_kbps,
-                live => live,
-            },
-        }
+    /// Close the overlay window: the connector's figures, decoded by NDL.
+    pub(crate) fn hud_snapshot(&self) -> punktfunk_core::hud::StatsSnapshot {
+        let mut snap = self.client.hud_snapshot();
+        snap.decoder = "NDL".into();
+        snap
     }
-}
 
-/// See [`Connected::overlay_info`].
-pub(crate) struct OverlayInfo {
-    pub width: u32,
-    pub height: u32,
-    pub refresh_hz: u32,
-    pub codec: String,
-    pub hdr: bool,
-    pub frames_dropped: Option<u64>,
-    pub fec_recovered: Option<u64>,
-    pub target_kbps: u32,
+    /// Sample for the overlay only while it shows.
+    pub(crate) fn set_hud_enabled(&self, on: bool) {
+        self.client.set_hud_enabled(on);
+    }
 }
 
 /// Ceiling on feedback events handled per tick.

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -6,6 +6,7 @@ use crate::platform::webos::input::{
     webos_scancode_down as key_down, WEBOS_BLUE_KEYCODE, WEBOS_EXIT_SCANCODE, WEBOS_GREEN_SCANCODE,
     WEBOS_HOME_SCANCODE, WEBOS_YELLOW_SCANCODE,
 };
+use punktfunk_core::hud::{self, Extra, HudLine, Role, StatsSnapshot, StatsVerbosity};
 
 /// How long the finished launch frame is held waiting for the first frame to reach the decoder
 /// before uncovering the video plane regardless. `None` only when the loading screen never
@@ -433,13 +434,16 @@ pub(super) fn run_inner() -> Result<()> {
             let mut hid_device_seen = false;
             // Stats overlay: refreshed ~2Hz onto the transparent stream window, over the
             // punch-through video plane via per-pixel alpha — window is never shown/hidden (that
-            // crashed an earlier attempt, see docs/NOTES.md). Green button flips it live, session-only.
+            // crashed an earlier attempt, see docs/NOTES.md). Green button cycles the tier, session-only.
             // The pumps read this too — with nothing on glass to show them, the video thread skips
             // every counter the overlay is the only reader of. Seeded here; from the first tick on it
             // is DERIVED from the fade below rather than set alongside the toggle, so there is one
             // writer and no second copy of the state to keep in step.
-            let mut stats_enabled = settings.stats_overlay();
+            let mut stats_tier = settings.stats_verbosity();
+            let mut stats_enabled = stats_tier != StatsVerbosity::Off;
+            let advanced_stats = settings.advanced_stats;
             connected.stats().set_diagnostics(stats_enabled);
+            connected.set_hud_enabled(stats_enabled);
             // Fades in/out on the same curve as the toast below — see `ModalFade::visibility_alpha`.
             let mut stats_fade = crate::ui::fade::ModalFade::<()>::overlay();
             if stats_enabled {
@@ -464,16 +468,14 @@ pub(super) fn run_inner() -> Result<()> {
             let mut hold_since: Option<Instant> = None;
             let mut hold_toasted = false;
             let mut overlay_was_active = false;
-            // The stats card's lines and the log tail, rebuilt on their 500 ms cadence and drawn
-            // as they stand on every overlay frame between.
-            let mut stats_lines: Vec<String> = Vec::new();
+            // The stats card's lines, rebuilt from the core's window once a second (and on a
+            // tier change), and the log tail on its 500 ms cadence; drawn as they stand between.
+            let mut stats_lines: Vec<HudLine> = Vec::new();
+            let mut stats_snap: Option<StatsSnapshot> = None;
             let mut log_lines: Vec<String> = Vec::new();
             let mut stats_built_at: Option<Instant> = None;
             let mut overlay_last: Option<Instant> = None;
-            let mut overlay_prev_frames: u64 = 0;
-            let mut overlay_prev_bytes: u64 = 0;
-            let mut overlay_prev_cpu_ticks: Option<u64> = None;
-            let mut overlay_prev_at = Instant::now();
+            let mut prev_cpu: Option<(u64, Instant)> = None;
             // 0 = "Disconnect" focused, 1 = "Cancel" (default on open — safer).
             let mut disconnect = ConfirmDialog::new(
                 "Stop streaming?",
@@ -791,12 +793,18 @@ pub(super) fn run_inner() -> Result<()> {
                 // SDL2 lacks these colour scancodes. Ignore them while the dialog owns input.
                 let dialog_open = disconnect.is_open();
                 if rising_edge(!dialog_open && key_down(WEBOS_GREEN_SCANCODE), &mut green_held) {
-                    stats_enabled = !stats_enabled;
+                    stats_tier = stats_tier.next();
+                    let was_enabled = stats_enabled;
+                    stats_enabled = stats_tier != StatsVerbosity::Off;
                     overlay_last = None; // force an immediate redraw
-                    if stats_enabled {
+                    if stats_enabled && !was_enabled {
                         stats_fade.reopen();
-                    } else {
+                    } else if !stats_enabled {
                         stats_fade.close(());
+                    }
+                    // A fading-out card keeps its last lines; a visible one re-renders at once.
+                    if let (true, Some(snap)) = (stats_enabled, &stats_snap) {
+                        stats_lines = hud::format(snap, stats_tier, advanced_stats);
                     }
                 }
                 if rising_edge(!dialog_open && key_down(WEBOS_YELLOW_SCANCODE), &mut yellow_held) {
@@ -885,6 +893,7 @@ pub(super) fn run_inner() -> Result<()> {
                 // The counters follow what is VISIBLE, fade included — stopping them at the toggle
                 // freezes the figures for the last frames of the fade-out.
                 connected.stats().set_diagnostics(stats_alpha.is_some());
+                connected.set_hud_enabled(stats_alpha.is_some());
                 let log_overlay_on = log_overlay_state() != LogOverlayState::Off;
                 let log_alpha = log_fade.visibility_alpha(log_overlay_on);
                 let overlay_active = stats_alpha.is_some() || log_alpha.is_some() || notif_active;
@@ -905,114 +914,13 @@ pub(super) fn run_inner() -> Result<()> {
                     && overlay_last.is_none_or(|t| t.elapsed() >= redraw_interval)
                 {
                     overlay_last = Some(Instant::now());
-                    // Content stays on a 500ms cadence even when a toast fade runs the loop faster.
-                    if stats_enabled && stats_built_at.is_none_or(|t| t.elapsed() >= Duration::from_millis(500)) {
+                    // The core window closes once a second: every rate it reports is per window.
+                    if stats_enabled && stats_built_at.is_none_or(|t| t.elapsed() >= Duration::from_secs(1)) {
                         stats_built_at = Some(Instant::now());
-                        let frames = connected.stats().frames.load(Ordering::Relaxed);
-                        let bytes = connected.stats().bytes.load(Ordering::Relaxed);
-                        let dt = overlay_prev_at.elapsed().as_secs_f32().max(0.001);
-                        let fps = (frames.saturating_sub(overlay_prev_frames)) as f32 / dt;
-                        // Measured, vs. negotiated `resolved_bitrate_kbps`.
-                        let actual_kbps = (bytes.saturating_sub(overlay_prev_bytes)) as f32 * 8.0 / 1000.0 / dt;
-                        overlay_prev_frames = frames;
-                        overlay_prev_bytes = bytes;
-                        overlay_prev_at = Instant::now();
-                        let info = connected.overlay_info();
-                        let feed_ms = connected.stats().feed_us.load(Ordering::Relaxed) as f32 / 1000.0;
-                        let holding = connected.stats().holding.load(Ordering::Relaxed);
-                        // CPU% (one core) + RSS, only read while the overlay is up.
-                        let cpu_mem_line = device::process_cpu_mem().map(|(cpu_ticks, mem_bytes)| {
-                            // No baseline on the first sample, so CPU shows from the 2nd on.
-                            let cpu = overlay_prev_cpu_ticks.map(|prev| {
-                                let pct =
-                                    (cpu_ticks.saturating_sub(prev)) as f32 / device::clock_ticks_per_sec() as f32 / dt
-                                        * 100.0;
-                                format!("CPU {pct:.0}% · ")
-                            });
-                            overlay_prev_cpu_ticks = Some(cpu_ticks);
-                            format!(
-                                "{}RAM {:.0} MB",
-                                cpu.unwrap_or_default(),
-                                mem_bytes as f32 / (1024.0 * 1024.0)
-                            )
-                        });
-                        let mut lines = vec![
-                            format!(
-                                "{}x{}@{} {}{}",
-                                info.width,
-                                info.height,
-                                info.refresh_hz,
-                                info.codec,
-                                if info.hdr { " HDR" } else { "" },
-                            ),
-                            format!("Video {fps:.1} fps · {frames} frames"),
-                            {
-                                // NDL's undecoded/unpresented depth: rising means decode is behind,
-                                // flat-near-zero while stuttering means the problem is upstream.
-                                let backlog = connected.stats().render_backlog.load(Ordering::Relaxed);
-                                let backlog = if backlog < 0 {
-                                    "n/a".to_string()
-                                } else {
-                                    backlog.to_string()
-                                };
-                                // "n/a" rather than 0 where there is no such counter — a zero would
-                                // read as "no loss", which is a different claim.
-                                let or_na = |v: Option<u64>| v.map_or_else(|| "n/a".to_string(), |v| v.to_string());
-                                format!(
-                                    "Drop {} · FEC {} · hold {} · buf {backlog}",
-                                    or_na(info.frames_dropped),
-                                    or_na(info.fec_recovered),
-                                    if holding { "yes" } else { "no" },
-                                )
-                            },
-                            format!(
-                                "Feed {feed_ms:.1} ms · {:.0}/{} Mbps",
-                                actual_kbps / 1000.0,
-                                info.target_kbps / 1000,
-                            ),
-                        ];
-                        // Audio's own line. Before this the plane published nothing a surface could
-                        // render, so "the audio is late" had no instrument behind it at all — and on
-                        // this client the A/V offset is the number that says whether the sync loop is
-                        // working. `buf` is what is queued ahead of the speaker; `A/V` is positive when
-                        // audio plays BEHIND the picture. Both read 0 until the loop has evidence
-                        // (100 observations, and a frame on the glass to compare against).
-                        //
-                        // Which decoder is running leads the line: the two paths fail differently
-                        // (HW plays or is silent with nothing to measure; SW underruns visibly in
-                        // `buf`), so reading the numbers without knowing which one produced them
-                        // has already cost real debugging time. HW carries no ring and no sync loop
-                        // of its own — NDL owns both — so the two figures are omitted there rather
-                        // than printed as a pair of zeroes that look like a stalled plane.
-                        let layout = connected.audio_layout();
-                        if connected.audio_route.on_ndl_plane() {
-                            // `lead` is how far the plane's stamps run ahead of NDL's player clock —
-                            // the one figure this route does publish, and the one that matters most:
-                            // NDL paces the PICTURE on that depth, so a lead sagging towards zero
-                            // reads as video stutter, not as an audio fault (see `PLANE_LEAD_MS`).
-                            lines.push(format!(
-                                "{} {layout} · NDL · lead {} ms",
-                                connected.audio_route.overlay_tag(),
-                                connected.stats().audio_plane_lead_ms.load(Ordering::Relaxed),
-                            ));
-                        } else {
-                            lines.push(format!(
-                                "{} {layout} · buf {} ms",
-                                connected.audio_route.overlay_tag(),
-                                connected.audio_buffer_ms()
-                            ));
-                        }
-                        // `late` is the judder, counted: frames NDL was handed too late to pace them.
-                        // `jitter` is what the cadence loop sizes its cushion from.
-                        let late = connected.stats().pacing_late.load(Ordering::Relaxed);
-                        lines.push(format!(
-                            "Pace jitter {:.1} ms · late {late}",
-                            connected.stats().pacing_jitter_us.load(Ordering::Relaxed) as f32 / 1000.0,
-                        ));
-                        if let Some(line) = cpu_mem_line {
-                            lines.push(line);
-                        }
-                        stats_lines = lines;
+                        let mut snap = connected.hud_snapshot();
+                        snap.extras = tv_extras(&connected, &mut prev_cpu);
+                        stats_lines = hud::format(&snap, stats_tier, advanced_stats);
+                        stats_snap = Some(snap);
                     }
                     // `None` during fade-out once the toggle flips Off — the fade keeps drawing
                     // the last lines read.
@@ -1027,7 +935,7 @@ pub(super) fn run_inner() -> Result<()> {
                         overlay::TRANSPARENT,
                         |f| {
                             if let Some(alpha) = stats_alpha {
-                                overlay::stats(f, &stats_lines, "Press green button to hide this overlay", alpha);
+                                overlay::stats(f, &stats_lines, stats_hint(stats_tier), alpha);
                             }
                             if let Some(alpha) = log_alpha {
                                 overlay::log(f, &log_lines, alpha);
@@ -1142,4 +1050,72 @@ pub(super) fn run_inner() -> Result<()> {
     }
     tracing::info!("punktfunk-webos exiting cleanly");
     Ok(())
+}
+
+/// What the green button does next: more detail, or hide from the top tier.
+fn stats_hint(tier: StatsVerbosity) -> &'static str {
+    match tier {
+        StatsVerbosity::Detailed | StatsVerbosity::Off => "Press green to hide this overlay",
+        StatsVerbosity::Compact | StatsVerbosity::Normal => "Press green for more detail",
+    }
+}
+
+/// Lines only this client measures: NDL's feed, backlog and hold, the audio route, the pacing
+/// loop, and this process's CPU and memory. `prev_cpu` spans CPU ticks between two calls.
+fn tv_extras(connected: &session::Connected, prev_cpu: &mut Option<(u64, Instant)>) -> Vec<Extra> {
+    let stats = connected.stats();
+    let backlog = stats.render_backlog.load(Ordering::Relaxed);
+    let mut ndl = format!(
+        "NDL feed {:.1} ms · backlog {}",
+        stats.feed_us.load(Ordering::Relaxed) as f32 / 1000.0,
+        if backlog < 0 {
+            "n/a".to_string()
+        } else {
+            backlog.to_string()
+        },
+    );
+    if stats.holding.load(Ordering::Relaxed) {
+        ndl.push_str(" · holding");
+    }
+    // NDL paces the picture on the plane's lead, so a lead sagging towards zero reads as stutter.
+    let layout = connected.audio_layout();
+    let audio = if connected.audio_route.on_ndl_plane() {
+        format!(
+            "{} {layout} · NDL · lead {} ms",
+            connected.audio_route.overlay_tag(),
+            stats.audio_plane_lead_ms.load(Ordering::Relaxed),
+        )
+    } else {
+        format!(
+            "{} {layout} · buf {} ms",
+            connected.audio_route.overlay_tag(),
+            connected.audio_buffer_ms()
+        )
+    };
+    let pacing = format!(
+        "pace jitter {:.1} ms · late {}",
+        stats.pacing_jitter_us.load(Ordering::Relaxed) as f32 / 1000.0,
+        stats.pacing_late.load(Ordering::Relaxed),
+    );
+    let mut out = vec![Extra::detail(ndl), Extra::detail(audio), Extra::detail(pacing)];
+    // The set's own headroom, in both vocabularies. CPU shows from the second sample on.
+    if let Some((ticks, mem_bytes)) = device::process_cpu_mem() {
+        let cpu = prev_cpu.map(|(prev, at)| {
+            let secs = at.elapsed().as_secs_f64().max(0.001);
+            let pct = ticks.saturating_sub(prev) as f64 / device::clock_ticks_per_sec() as f64 / secs * 100.0;
+            format!("CPU {pct:.0}% · ")
+        });
+        *prev_cpu = Some((ticks, Instant::now()));
+        out.push(Extra {
+            text: format!(
+                "{}RAM {:.0} MB",
+                cpu.unwrap_or_default(),
+                mem_bytes as f64 / (1024.0 * 1024.0)
+            ),
+            tier: StatsVerbosity::Detailed,
+            advanced_only: false,
+            role: Role::Muted,
+        });
+    }
+    out
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -29,4 +29,4 @@ mod timeline;
 
 pub use connect::{connect, ConnectParams, Connected};
 pub use pump::{join_audio_feed, spawn_audio_feed};
-pub use stats::{codec_name, StreamStats};
+pub use stats::StreamStats;

--- a/src/session/pump.rs
+++ b/src/session/pump.rs
@@ -59,8 +59,6 @@ struct VideoPump {
     /// Whether the host's per-content HDR metadata is worth draining. False on every session
     /// where nothing would apply it: an SDR or non-HEVC stream.
     is_hdr: bool,
-    /// Bytes taken off the transport this session — see [`Self::on_frame`].
-    bytes: u64,
     /// Core's cumulative drop count as of the last frame, to edge-detect new drops.
     last_dropped_seen: u64,
     /// Frame-index gaps pre-cover the reassembler's delayed drop accounting.
@@ -78,7 +76,6 @@ impl VideoPump {
             stage,
             stats,
             is_hdr,
-            bytes: 0,
             last_dropped_seen,
             drop_credit: 0,
             drop_credit_expiry: None,
@@ -111,22 +108,18 @@ impl VideoPump {
                 }
             }
             self.forward_hdr_meta();
+            // The connector matches each 0xCF timing to its frame for the overlay. Drained here
+            // so the bounded plane never fills.
+            while self.client.next_host_timing(Duration::ZERO).is_ok() {}
         }
     }
 
-    /// Pictures the decoder took this session — the counter the overlay reads, owned by this
-    /// thread and mirrored into [`StreamStats`] per delivery.
+    /// Pictures the decoder took this session: the heartbeat log's figure.
     fn frames(&self) -> u64 {
         self.stage.frames()
     }
 
     fn on_frame(&mut self, frame: &punktfunk_core::session::Frame) {
-        // Counted on this thread, then mirrored with a relaxed store — the point is to drop the
-        // atomic read-modify-write, not the freshness: the overlay reads both as deltas over its
-        // own 500ms window, so publishing them on the 2s heartbeat instead would leave three
-        // samples in four reading zero fps and the fourth spiking.
-        self.bytes = self.bytes.saturating_add(frame.data.len() as u64);
-        self.stats.bytes.store(self.bytes, Ordering::Relaxed);
         self.heartbeat();
 
         // Everything wire-shaped, and nothing else: whether this delivery is decodable at all,
@@ -171,8 +164,6 @@ impl VideoPump {
                 }
             }
         }
-        // After the submit, so the published count includes the AU this delivery completed.
-        self.stats.frames.store(self.frames(), Ordering::Relaxed);
     }
 
     /// Refreshes the overlay's backlog figure, and on a slower cadence logs the pump's state.

--- a/src/session/stats.rs
+++ b/src/session/stats.rs
@@ -2,16 +2,9 @@
 
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, Ordering};
 
-use punktfunk_core::quic;
-
 /// Live video-pump counters for stats overlay (read at ~2Hz); relaxed atomics written per frame.
 #[derive(Default)]
 pub struct StreamStats {
-    /// Pictures the decoder took. Counted by the video pump on its own thread and mirrored here
-    /// with a relaxed store, so the feed path pays no atomic read-modify-write per frame.
-    pub frames: AtomicU64,
-    /// Bytes received, mirrored the same way as `frames`; deltas give measured bitrate.
-    pub bytes: AtomicU64,
     /// Freeze-until-reanchor hold active.
     pub holding: AtomicBool,
     /// Most recent decoder feed duration (µs).
@@ -48,15 +41,5 @@ impl StreamStats {
     /// The one writer, so the flag never has a second copy to keep in sync with.
     pub fn set_diagnostics(&self, on: bool) {
         self.diagnostics.store(on, Ordering::Relaxed);
-    }
-}
-
-/// Short display name for a resolved wire codec id (the stats overlay's header).
-pub fn codec_name(codec: u8) -> &'static str {
-    match codec {
-        c if c == quic::CODEC_HEVC => "HEVC",
-        c if c == quic::CODEC_H264 => "H264",
-        c if c == quic::CODEC_AV1 => "AV1",
-        _ => "?",
     }
 }


### PR DESCRIPTION
The TV adopts the stats rework merged on the monorepo (unom/punktfunk #938 to #946).

- The overlay draws the shared formatter lines, in the Standard or Advanced vocabulary. Settings gain the Advanced statistics row, and the green button cycles the four tiers for the session.
- NDL decodes out of sight, so the headline stops at capture to received. The hand-off to NDL shows as an Advanced Detailed "NDL feed" line instead of posing as decode time.
- The TV now drains the host per-frame timing, so the host share and its split reach the overlay.
- Sampling pauses while the overlay is hidden.
- Pins core at 66a890923, the merged rework.

Verified on the new pin: task docker:check, docker:lint (armv7 clippy, -D warnings) and docker:test (58 pass).
Not verified: not run on the TV.